### PR TITLE
feat(cli): centralize Vue extraction

### DIFF
--- a/.changeset/bright-vue-extractor.md
+++ b/.changeset/bright-vue-extractor.md
@@ -1,0 +1,8 @@
+---
+'@generaltranslation/vue-extractor': minor
+'gt': minor
+---
+
+Add package-owned Vue source extraction and integrate it with the CLI while
+preserving the existing extraction paths for React, Next.js, React Native,
+TanStack Start, Node.js, and Python projects.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
         shell: bash
         run: cd tests/apps/cli-test-app && pnpm install && pnpm gt --help
 
+      - name: Test compiled CLI Vue extraction
+        if: >-
+          steps.gt_cli_changed.outputs.changed == 'true' &&
+          ((matrix.arch == 'x64' && runner.arch == 'X64') ||
+          (matrix.arch == 'arm64' && runner.arch == 'ARM64'))
+        shell: bash
+        run: pnpm --filter gt test:bin:vue
+
   size:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,11 +173,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if gt-vue changed
+      - name: Check if gt-vue or the Vue extractor changed
         id: gt_vue_changed
         shell: bash
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^packages/vue/"; then
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(vue|vue-extractor)/"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT
@@ -200,14 +200,16 @@ jobs:
 
       - name: Use Vue ${{ matrix.vue }}
         if: steps.gt_vue_changed.outputs.changed == 'true'
-        run: pnpm --filter gt-vue add --save-dev --save-exact --lockfile=false vue@${{ matrix.vue }}
+        run: pnpm --filter gt-vue --filter @generaltranslation/vue-extractor add --save-dev --save-exact --lockfile=false vue@${{ matrix.vue }}
 
-      - name: Build and test gt-vue
+      - name: Build and test gt-vue and the Vue extractor
         if: steps.gt_vue_changed.outputs.changed == 'true'
         run: |
-          pnpm exec turbo build --filter=gt-vue...
+          pnpm exec turbo build --filter=gt-vue... --filter=@generaltranslation/vue-extractor...
           pnpm --filter gt-vue typecheck
           pnpm --filter gt-vue test
+          pnpm --filter @generaltranslation/vue-extractor typecheck
+          pnpm --filter @generaltranslation/vue-extractor test
 
   test-cli-binaries:
     strategy:
@@ -235,11 +237,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check if CLI or Python extractor changed
+      - name: Check if CLI or an external extractor changed
         id: gt_cli_changed
         shell: bash
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|python-extractor)/"; then
+          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -qE "^packages/(cli|python-extractor|vue-extractor)/"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -18,6 +18,7 @@
     "examples/next-chatbot/lib/db/migrations/**",
     "tests/seeds/*",
     "tests/apps/compiler-cli-parity/**",
+    "packages/vue-extractor/src/internal/__tests__/fixtures/template-runtime-parity.vue",
     "**/next-env.d.ts",
     "**/routeTree.gen.ts"
   ]

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -113,6 +113,62 @@
                 "translations/[locale].json"
               ]
             },
+            "parsingFlags": {
+              "type": "object",
+              "description": "Options controlling inline source extraction",
+              "properties": {
+                "autoderive": {
+                  "oneOf": [
+                    { "type": "boolean" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "jsx": { "type": "boolean" },
+                        "strings": { "type": "boolean" }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "includeSourceCodeContext": {
+                  "type": "boolean"
+                },
+                "enableAutoJsxInjection": {
+                  "type": "boolean"
+                },
+                "legacyGtReactImportSource": {
+                  "type": "boolean"
+                },
+                "viteConfigPath": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "\\S",
+                  "description": "Vite config path relative to the project root"
+                },
+                "vueCompilerOptions": {
+                  "type": "object",
+                  "description": "Hash-affecting Vue template compiler options",
+                  "properties": {
+                    "whitespace": {
+                      "type": "string",
+                      "enum": ["condense", "preserve"]
+                    },
+                    "delimiters": {
+                      "type": "array",
+                      "items": [
+                        { "type": "string", "minLength": 1 },
+                        { "type": "string", "minLength": 1 }
+                      ],
+                      "additionalItems": false,
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
             "includeSourceCodeContext": {
               "type": "boolean",
               "description": "Include surrounding source code lines as context for translations. Only applies to library users that send GT JSON for translation.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,7 @@
     "build:bin:linux-arm64": "bash scripts/build-exe.sh linux-arm64",
     "build:bin:windows-x64": "bash scripts/build-exe.sh windows-x64",
     "test": "pnpm run generate-version && vitest run --config=./vitest.config.ts",
+    "test:bin:vue": "node scripts/test-vue-binary-extraction.mjs",
     "test:watch": "pnpm run generate-version && vitest --config=./vitest.config.ts",
     "release": "pnpm run release:normal && pnpm run release:bin",
     "release:normal": "pnpm run build:clean && pnpm publish",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -118,6 +118,7 @@
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/python-extractor": "workspace:*",
     "@generaltranslation/supported-locales": "workspace:*",
+    "@generaltranslation/vue-extractor": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",
@@ -171,6 +172,7 @@
     "tsdown": "catalog:",
     "tslib": "catalog:",
     "typescript": "catalog:",
+    "vue": "^3.5.0",
     "vitest": "catalog:"
   }
 }

--- a/packages/cli/scripts/test-vue-binary-extraction.mjs
+++ b/packages/cli/scripts/test-vue-binary-extraction.mjs
@@ -1,0 +1,130 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { stripVTControlCharacters } from 'node:util';
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const packageDirectory = path.resolve(scriptDirectory, '..');
+const requireFromScript = createRequire(import.meta.url);
+const binaryNames = {
+  'darwin-arm64': 'gt-darwin-arm64',
+  'darwin-x64': 'gt-darwin-x64',
+  'linux-arm64': 'gt-linux-arm64',
+  'linux-x64': 'gt-linux-x64',
+  'win32-x64': 'gt-win32-x64.exe',
+};
+const platformKey = `${process.platform}-${process.arch}`;
+const defaultBinaryName = binaryNames[platformKey];
+const binaryPath = process.argv[2]
+  ? path.resolve(process.cwd(), process.argv[2])
+  : defaultBinaryName
+    ? path.join(packageDirectory, 'binaries', defaultBinaryName)
+    : undefined;
+
+if (!binaryPath) {
+  throw new Error(`No compiled CLI binary supports ${platformKey}.`);
+}
+if (!fs.existsSync(binaryPath)) {
+  throw new Error(`Compiled CLI binary was not found at ${binaryPath}.`);
+}
+
+const fixtureRoot = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'gt-cli-vue-binary-')
+);
+
+try {
+  writeFixture('package.json', {
+    name: 'gt-cli-vue-binary-fixture',
+    private: true,
+    dependencies: {
+      'gt-react': '*',
+      'gt-vue': '*',
+      vue: '*',
+    },
+  });
+  writeFixture('gt.config.json', {
+    defaultLocale: 'en',
+    locales: ['fr'],
+  });
+  writeFixture(
+    'src/Ambiguous.vue',
+    `'Copyright 2026';
+<template><T>Compiled ambiguous legacy message</T></template>;
+import { T } from 'gt-react';
+`
+  );
+  writeFixture(
+    'src/Leading.vue',
+    `<template><T>Compiled leading legacy message</T></template>;
+import { T } from 'gt-react';
+`
+  );
+  linkInstalledVue();
+
+  validateLegacyModule('src/Ambiguous.vue');
+  validateLegacyModule('src/Leading.vue');
+  process.stdout.write(
+    `Validated compiled Vue extraction with ${path.basename(binaryPath)}.\n`
+  );
+} finally {
+  fs.rmSync(fixtureRoot, { force: true, recursive: true });
+}
+
+/** Writes one JSON or source fixture beneath the temporary project root. */
+function writeFixture(relativePath, contents) {
+  const filePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(
+    filePath,
+    typeof contents === 'string'
+      ? contents
+      : `${JSON.stringify(contents, null, 2)}\n`
+  );
+}
+
+/** Makes the workspace Vue compiler resolvable from the isolated fixture. */
+function linkInstalledVue() {
+  const vueDirectory = path.dirname(
+    requireFromScript.resolve('vue/package.json')
+  );
+  const nodeModules = path.join(fixtureRoot, 'node_modules');
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(
+    vueDirectory,
+    path.join(nodeModules, 'vue'),
+    process.platform === 'win32' ? 'junction' : 'dir'
+  );
+}
+
+/** Requires the actual executable to preserve one historical React extraction. */
+function validateLegacyModule(relativePath) {
+  const result = spawnSync(
+    binaryPath,
+    [
+      '--skip-version-check',
+      '--suppress-id-compatibility-warning',
+      'validate',
+      relativePath,
+    ],
+    {
+      cwd: fixtureRoot,
+      encoding: 'utf8',
+      env: { ...process.env, NO_COLOR: '1' },
+    }
+  );
+  if (result.error) throw result.error;
+
+  const output = stripVTControlCharacters(
+    `${result.stdout ?? ''}${result.stderr ?? ''}`
+  );
+  const expected = 'Success! Found 1 translatable entries for gt-react.';
+  if (result.status !== 0 || !output.includes(expected)) {
+    throw new Error(
+      `Compiled CLI failed to extract ${relativePath}.\n` +
+        `Exit status: ${result.status ?? 'unknown'}\n${output}`
+    );
+  }
+}

--- a/packages/cli/src/__tests__/index.vue-routing.test.ts
+++ b/packages/cli/src/__tests__/index.vue-routing.test.ts
@@ -1,0 +1,249 @@
+import type { Command } from 'commander';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Libraries } from '../types/libraries.js';
+
+const mocks = vi.hoisted(() => ({
+  baseConstruct: vi.fn(),
+  baseExecute: vi.fn(),
+  baseInit: vi.fn(),
+  detectVueProject: vi.fn(),
+  determineLibrary: vi.fn(),
+  nextConstruct: vi.fn(),
+  nextExecute: vi.fn(),
+  nextInit: vi.fn(),
+  nodeConstruct: vi.fn(),
+  nodeExecute: vi.fn(),
+  nodeInit: vi.fn(),
+  pythonConstruct: vi.fn(),
+  pythonExecute: vi.fn(),
+  pythonInit: vi.fn(),
+  reactConstruct: vi.fn(),
+  reactExecute: vi.fn(),
+  reactInit: vi.fn(),
+  vueConstruct: vi.fn(),
+  vueExecute: vi.fn(),
+  vueInit: vi.fn(),
+}));
+
+vi.mock('@generaltranslation/vue-extractor/detect', () => ({
+  detectVueProject: mocks.detectVueProject,
+}));
+
+vi.mock('../fs/determineFramework/index.js', () => ({
+  determineLibrary: mocks.determineLibrary,
+}));
+
+vi.mock('../cli/base.js', () => ({
+  BaseCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.baseConstruct(...args);
+    }
+
+    init() {
+      mocks.baseInit();
+    }
+
+    execute() {
+      mocks.baseExecute();
+    }
+  },
+}));
+
+vi.mock('../cli/next.js', () => ({
+  NextCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.nextConstruct(...args);
+    }
+
+    init() {
+      mocks.nextInit();
+    }
+
+    execute() {
+      mocks.nextExecute();
+    }
+  },
+}));
+
+vi.mock('../cli/react.js', () => ({
+  ReactCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.reactConstruct(...args);
+    }
+
+    init() {
+      mocks.reactInit();
+    }
+
+    execute() {
+      mocks.reactExecute();
+    }
+  },
+}));
+
+vi.mock('../cli/node.js', () => ({
+  NodeCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.nodeConstruct(...args);
+    }
+
+    init() {
+      mocks.nodeInit();
+    }
+
+    execute() {
+      mocks.nodeExecute();
+    }
+  },
+}));
+
+vi.mock('../cli/python.js', () => ({
+  PythonCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.pythonConstruct(...args);
+    }
+
+    init() {
+      mocks.pythonInit();
+    }
+
+    execute() {
+      mocks.pythonExecute();
+    }
+  },
+}));
+
+vi.mock('../cli/vue.js', () => ({
+  VueCLI: class {
+    constructor(...args: unknown[]) {
+      mocks.vueConstruct(...args);
+    }
+
+    init() {
+      mocks.vueInit();
+    }
+
+    execute() {
+      mocks.vueExecute();
+    }
+  },
+}));
+
+import { main } from '../index.js';
+
+const additionalModules = ['i18next-icu'] as const;
+
+function createProgram(): Command {
+  return { name: vi.fn() } as unknown as Command;
+}
+
+describe('main Vue routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.detectVueProject.mockReturnValue(false);
+  });
+
+  it.each([
+    [Libraries.GT_NEXT, mocks.nextConstruct, mocks.nextInit, mocks.nextExecute],
+    [
+      Libraries.GT_REACT,
+      mocks.reactConstruct,
+      mocks.reactInit,
+      mocks.reactExecute,
+    ],
+    [
+      Libraries.GT_REACT_NATIVE,
+      mocks.reactConstruct,
+      mocks.reactInit,
+      mocks.reactExecute,
+    ],
+    [
+      Libraries.GT_TANSTACK_START,
+      mocks.reactConstruct,
+      mocks.reactInit,
+      mocks.reactExecute,
+    ],
+    [Libraries.GT_NODE, mocks.nodeConstruct, mocks.nodeInit, mocks.nodeExecute],
+    [
+      Libraries.GT_FLASK,
+      mocks.pythonConstruct,
+      mocks.pythonInit,
+      mocks.pythonExecute,
+    ],
+    [
+      Libraries.GT_FASTAPI,
+      mocks.pythonConstruct,
+      mocks.pythonInit,
+      mocks.pythonExecute,
+    ],
+  ])(
+    'keeps %s authoritative without consulting Vue discovery',
+    (library, construct, init, execute) => {
+      const program = createProgram();
+      mocks.determineLibrary.mockReturnValue({
+        library,
+        additionalModules,
+      });
+      mocks.detectVueProject.mockReturnValue(true);
+
+      main(program);
+
+      expect(construct).toHaveBeenCalledWith(
+        program,
+        library,
+        additionalModules
+      );
+      expect(init).toHaveBeenCalledOnce();
+      expect(execute).toHaveBeenCalledOnce();
+      expect(mocks.detectVueProject).not.toHaveBeenCalled();
+      expect(mocks.vueConstruct).not.toHaveBeenCalled();
+      expect(mocks.baseConstruct).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['base', 'next-intl', 'i18next'] as const)(
+    'selects VueCLI for a Vue-owned %s project',
+    (library) => {
+      const program = createProgram();
+      mocks.determineLibrary.mockReturnValue({
+        library,
+        additionalModules,
+      });
+      mocks.detectVueProject.mockReturnValue(true);
+
+      main(program);
+
+      expect(mocks.detectVueProject).toHaveBeenCalledOnce();
+      expect(mocks.vueConstruct).toHaveBeenCalledWith(
+        program,
+        additionalModules
+      );
+      expect(mocks.vueInit).toHaveBeenCalledOnce();
+      expect(mocks.vueExecute).toHaveBeenCalledOnce();
+      expect(mocks.baseConstruct).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['base', 'next-intl', 'i18next'] as const)(
+    'preserves BaseCLI for an undetected %s project',
+    (library) => {
+      const program = createProgram();
+      mocks.determineLibrary.mockReturnValue({
+        library,
+        additionalModules,
+      });
+
+      main(program);
+
+      expect(mocks.detectVueProject).toHaveBeenCalledOnce();
+      expect(mocks.baseConstruct).toHaveBeenCalledWith(
+        program,
+        library,
+        additionalModules
+      );
+      expect(mocks.baseInit).toHaveBeenCalledOnce();
+      expect(mocks.baseExecute).toHaveBeenCalledOnce();
+      expect(mocks.vueConstruct).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/packages/cli/src/cli/__tests__/vue.test.ts
+++ b/packages/cli/src/cli/__tests__/vue.test.ts
@@ -1,0 +1,105 @@
+import { Command } from 'commander';
+import { describe, expect, it } from 'vitest';
+import type { SetupOptions, TranslateFlags } from '../../types/index.js';
+import { Libraries } from '../../types/libraries.js';
+import { VueCLI } from '../vue.js';
+
+class TestVueCLI extends VueCLI {
+  readonly initCalls: SetupOptions[] = [];
+  readonly setupCalls: TranslateFlags[] = [];
+
+  get configuredLibrary() {
+    return this.library;
+  }
+
+  protected override async handleSetupProject(
+    options: TranslateFlags
+  ): Promise<void> {
+    this.setupCalls.push(options);
+  }
+
+  protected override async handleVueInit(options: SetupOptions): Promise<void> {
+    this.initCalls.push(options);
+  }
+}
+
+function createCLI(): { cli: TestVueCLI; program: Command } {
+  const program = new Command();
+  program.name('gt').exitOverride();
+  const cli = new TestVueCLI(program);
+  cli.init();
+  return { cli, program };
+}
+
+describe('VueCLI', () => {
+  it('registers the inherited setup command exactly once', () => {
+    const { program } = createCLI();
+
+    expect(
+      program.commands.filter((command) => command.name() === 'setup')
+    ).toHaveLength(1);
+  });
+
+  it('handles setup through the inherited project setup flow', async () => {
+    const { cli, program } = createCLI();
+
+    await program.parseAsync(['--quiet', 'setup', '--dry-run'], {
+      from: 'user',
+    });
+
+    expect(cli.setupCalls).toHaveLength(1);
+    expect(cli.setupCalls[0]).toMatchObject({
+      dryRun: true,
+      timeout: 900,
+    });
+  });
+
+  it('routes init through the Vue-specific configuration flow', async () => {
+    const { cli, program } = createCLI();
+
+    await program.parseAsync(['init', '--src', 'src/**/*.vue'], {
+      from: 'user',
+    });
+
+    expect(cli.initCalls).toEqual([{ src: ['src/**/*.vue'] }]);
+  });
+
+  it('includes inline source flags on setup', () => {
+    const { program } = createCLI();
+    const setup = program.commands.find(
+      (command) => command.name() === 'setup'
+    );
+
+    expect(setup?.options.map(({ long }) => long)).toEqual(
+      expect.arrayContaining([
+        '--dictionary',
+        '--ignore-errors',
+        '--inline',
+        '--jsconfig',
+        '--src',
+      ])
+    );
+  });
+
+  it('keeps every inline extraction command available', () => {
+    const { program } = createCLI();
+
+    expect(program.commands.map((command) => command.name())).toEqual(
+      expect.arrayContaining([
+        'download',
+        'enqueue',
+        'generate',
+        'setup',
+        'stage',
+        'translate',
+        'validate',
+      ])
+    );
+  });
+
+  it('configures inherited setup handling for gt-vue', () => {
+    const { cli } = createCLI();
+
+    expect(cli.configuredLibrary).toBe(Libraries.GT_VUE);
+  });
+});

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -102,7 +102,7 @@ const electronSetupError = createDiagnosticMessage({
   docsUrl: 'https://generaltranslation.com/docs/react',
 });
 
-async function exitIfUnsupportedSetupTarget(): Promise<void> {
+export async function exitIfUnsupportedSetupTarget(): Promise<void> {
   const packageJson = await searchForPackageJson();
   if (packageJson && isPackageInstalled('electron', packageJson, false, true)) {
     logErrorAndExit(electronSetupError);

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -195,6 +195,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
     Libraries.GT_TANSTACK_START,
     Libraries.GT_FLASK,
     Libraries.GT_FASTAPI,
+    Libraries.GT_VUE,
   ].includes(library as Libraries)
     ? (library as
         | typeof Libraries.GT_NEXT
@@ -202,6 +203,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
         | typeof Libraries.GT_REACT_NATIVE
         | typeof Libraries.GT_TANSTACK_START
         | typeof Libraries.GT_FLASK
-        | typeof Libraries.GT_FASTAPI)
+        | typeof Libraries.GT_FASTAPI
+        | typeof Libraries.GT_VUE)
     : Libraries.GT_REACT;
 }

--- a/packages/cli/src/cli/vue.ts
+++ b/packages/cli/src/cli/vue.ts
@@ -1,0 +1,79 @@
+import type { Command } from 'commander';
+import type {
+  SetupOptions,
+  SupportedLibraries,
+  TranslateFlags,
+} from '../types/index.js';
+import { Libraries } from '../types/libraries.js';
+import { attachInlineTranslateFlags, attachTranslateFlags } from './flags.js';
+import { displayHeader, promptConfirm } from '../console/logging.js';
+import { logger } from '../console/logger.js';
+import { generateSettings } from '../config/generateSettings.js';
+import { DEFAULT_VITE_TRANSLATIONS_DIR } from '../utils/constants.js';
+import { exitIfUnsupportedSetupTarget } from './base.js';
+import { InlineCLI } from './inline.js';
+
+/** Thin command registration for projects whose primary inline runtime is Vue. */
+export class VueCLI extends InlineCLI {
+  constructor(command: Command, additionalModules?: SupportedLibraries[]) {
+    super(command, Libraries.GT_VUE, additionalModules);
+  }
+
+  /** Registers the standard inline commands and the Vue setup command. */
+  public init(): void {
+    super.init();
+    this.setupSetupProjectCommand();
+  }
+
+  /** Registers Vue initialization without invoking the React Vite wizard. */
+  protected override setupInitCommand(): void {
+    this.program
+      .command('init')
+      .description(
+        'Run the setup wizard to configure your project for General Translation'
+      )
+      .option(
+        '--src <paths...>',
+        'Space-separated list of glob patterns containing the app source code'
+      )
+      .option(
+        '-c, --config <path>',
+        'Filepath to config file, by default gt.config.json'
+      )
+      .action((options: SetupOptions) => this.handleVueInit(options));
+  }
+
+  /** Configures Vue defaults while leaving application source untouched. */
+  protected async handleVueInit(options: SetupOptions): Promise<void> {
+    await exitIfUnsupportedSetupTarget();
+    await generateSettings(options);
+    displayHeader('Running setup wizard...');
+
+    const useDefaults = await promptConfirm({
+      message: `Would you like to use the recommended General Translation defaults? (gt-vue, Vue, Files saved locally in ${DEFAULT_VITE_TRANSLATIONS_DIR})`,
+      defaultValue: true,
+    });
+    await this.handleInitCommand(false, useDefaults, true);
+
+    logger.endCommand(
+      'Done! Check out our docs for more information on how to use General Translation: https://generaltranslation.com/docs'
+    );
+  }
+
+  /** Registers inline extraction flags for the setup upload workflow. */
+  protected override setupSetupProjectCommand(): void {
+    attachInlineTranslateFlags(
+      attachTranslateFlags(
+        this.program
+          .command('setup')
+          .description(
+            'Upload source files and setup the project for translation'
+          )
+      )
+    ).action(async (options: TranslateFlags) => {
+      displayHeader('Uploading source files and setting up project...');
+      await this.handleSetupProject(options);
+      logger.endCommand('Done!');
+    });
+  }
+}

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -4,6 +4,7 @@ import { resolveFiles } from '../../fs/config/parseFilesConfig';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { logger } from '../../console/logger.js';
 import { resolveConfig } from '../resolveConfig.js';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
 
 // Mock resolveFiles
 vi.mock('../../fs/config/parseFilesConfig', () => ({
@@ -15,6 +16,10 @@ vi.mock('../../fs/determineFramework/index.js', () => ({
     library: 'base',
     additionalModules: [],
   })),
+}));
+
+vi.mock('@generaltranslation/vue-extractor/detect', () => ({
+  detectVueProject: vi.fn(() => false),
 }));
 
 // Mock other dependencies
@@ -71,6 +76,7 @@ vi.mock('../optionPresets.js', () => ({
 }));
 
 const mockDetermineLibrary = vi.mocked(determineLibrary);
+const mockDetectVueProject = vi.mocked(detectVueProject);
 const mockLogWarning = vi.mocked(logger.warn);
 const mockResolveConfig = vi.mocked(resolveConfig);
 
@@ -98,6 +104,7 @@ describe('generateSettings - composite patterns', () => {
       library: 'base',
       additionalModules: [],
     });
+    mockDetectVueProject.mockReturnValue(false);
   });
 
   it('should extract composite patterns from jsonSchema options and pass to resolveFiles', async () => {
@@ -186,6 +193,17 @@ describe('generateSettings - composite patterns', () => {
       '/test/cwd'
     );
 
+    expect(mockLogWarning).not.toHaveBeenCalledWith(
+      expect.stringContaining('No package.json')
+    );
+  });
+
+  it('suppresses the warning when the package detector owns a Vue project', async () => {
+    mockDetectVueProject.mockReturnValue(true);
+
+    await generateSettings({}, '/test/cwd');
+
+    expect(mockDetectVueProject).toHaveBeenCalledWith('/test/cwd');
     expect(mockLogWarning).not.toHaveBeenCalledWith(
       expect.stringContaining('No package.json')
     );

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -29,6 +29,7 @@ import { GT_PARSING_FLAGS_DEFAULT } from './defaults.js';
 import { normalizeFilesOptions } from '../formats/files/transformFormat.js';
 import { determineLibrary } from '../fs/determineFramework/index.js';
 import { logger } from '../console/logger.js';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
 
 export const DEFAULT_SRC_PATTERNS = [
   'src/**/*.{js,jsx,ts,tsx}',
@@ -182,7 +183,8 @@ export async function generateSettings(
 
   if (
     determineLibrary().library === 'base' &&
-    !hasConfiguredTranslationFiles(mergedOptions.files)
+    !hasConfiguredTranslationFiles(mergedOptions.files) &&
+    !detectVueProject(cwd)
   ) {
     logger.warn(
       chalk.yellow(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,8 @@ import { determineLibrary } from './fs/determineFramework/index.js';
 import { Command } from 'commander';
 import { NodeCLI } from './cli/node.js';
 import { Libraries, isPythonLibrary } from './types/libraries.js';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
+import { VueCLI } from './cli/vue.js';
 
 export function main(program: Command) {
   program.name('gt');
@@ -24,6 +26,8 @@ export function main(program: Command) {
     cli = new NodeCLI(program, library, additionalModules);
   } else if (isPythonLibrary(library)) {
     cli = new PythonCLI(program, library, additionalModules);
+  } else if (detectVueProject()) {
+    cli = new VueCLI(program, additionalModules);
   } else {
     cli = new BaseCLI(program, library, additionalModules);
   }

--- a/packages/cli/src/translation/__tests__/extractInline.final-boundary.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.final-boundary.test.ts
@@ -1,0 +1,277 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
+import { GT_PARSING_FLAGS_DEFAULT } from '../../config/defaults.js';
+import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
+import { Libraries } from '../../types/libraries.js';
+import type { ParsingConfigOptions } from '../../types/parsing.js';
+import { extractInlineFromProject } from '../extractInline.js';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+const parsingOptions: ParsingConfigOptions = {
+  conditionNames: ['development', 'browser', 'module', 'import', 'default'],
+};
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('final React/Vue ownership boundary', () => {
+  it.each([
+    {
+      lexicalSource: `
+        const fakeSfc = "<script setup>import { VueT } from '@fixture/multi/vue'; const Fake = VueT;</script>";
+        void fakeSfc;
+      `,
+      name: 'a JavaScript string',
+    },
+    {
+      lexicalSource: `
+        const fakeSfc = \`<script setup>import { VueT } from '@fixture/multi/vue'; const Fake = VueT;</script>\`;
+        void fakeSfc;
+      `,
+      name: 'a JavaScript template literal',
+    },
+    {
+      lexicalSource: `
+        /* <script setup>import { VueT } from '@fixture/multi/vue'; const Fake = VueT;</script> */
+      `,
+      name: 'a JavaScript block comment',
+    },
+    {
+      lexicalSource: `
+        // <script setup>import { VueT } from '@fixture/multi/vue'; const Fake = VueT;</script>
+      `,
+      name: 'a JavaScript line comment',
+    },
+  ])(
+    'does not activate Vue for SFC-shaped text inside $name',
+    async ({ lexicalSource }) => {
+      createReactWrapperFixture({
+        'src/Legacy.vue': `
+          import { T } from 'gt-react';
+          ${lexicalSource}
+          export const App = () => <T>Stable legacy React message</T>;
+        `,
+      });
+
+      const historical = await extractHistorical(['src/Legacy.vue']);
+      const dispatched = await extractDispatched(['src/Legacy.vue']);
+
+      expect(dispatched).toEqual(historical);
+      expect(dispatched.errors).toEqual([]);
+      expect(dispatched.updates.map(({ source }) => source)).toEqual([
+        'Stable legacy React message',
+      ]);
+      expect(detectVueProject()).toBe(false);
+    }
+  );
+
+  it.each(['cjs', 'esm', 'generated', 'lib', 'lib-esm'])(
+    'ignores a stale public entry in the root %s output directory',
+    async (outputDirectory) => {
+      createReactWrapperFixture(
+        {
+          [`${outputDirectory}/index.js`]: `
+            import { VueT } from '@fixture/multi/vue';
+            export const staleComponent = VueT;
+          `,
+          'src/App.tsx': reactMessage('Stable generated-boundary message'),
+        },
+        { main: `./${outputDirectory}/index.js` }
+      );
+
+      const historical = await extractHistorical();
+      const dispatched = await extractDispatched();
+
+      expect(dispatched).toEqual(historical);
+      expect(dispatched.errors).toEqual([]);
+      expect(dispatched.updates.map(({ source }) => source)).toEqual([
+        'Stable generated-boundary message',
+      ]);
+      expect(detectVueProject()).toBe(false);
+    }
+  );
+
+  it.each([
+    {
+      extraFile: 'src/FakeLegacy.vue',
+      extraSource: `
+        const fakeSfc = "<script setup>import { VueT } from '@fixture/multi/vue'; const Fake = VueT;</script>";
+        export const fake = fakeSfc;
+      `,
+      name: 'SFC-shaped JavaScript data',
+      packageFields: {},
+    },
+    {
+      extraFile: 'lib/index.js',
+      extraSource: `
+        import { VueT } from '@fixture/multi/vue';
+        export const staleComponent = VueT;
+      `,
+      name: 'a generated CommonJS entry',
+      packageFields: { main: './lib/index.js' },
+    },
+  ])(
+    'does not let $name poison an unrelated React extraction',
+    async ({ extraFile, extraSource, packageFields }) => {
+      createReactWrapperFixture(
+        {
+          [extraFile]: extraSource,
+          'src/App.tsx': reactMessage('Stable poisoned-boundary message'),
+          'src/Unrelated.vue': '<template><main>Ordinary SFC</main></template>',
+        },
+        packageFields
+      );
+
+      const historical = await extractHistorical();
+      const dispatched = await extractDispatched();
+
+      expect(dispatched).toEqual(historical);
+      expect(dispatched.errors).toEqual([]);
+      expect(dispatched.updates.map(({ source }) => source)).toEqual([
+        'Stable poisoned-boundary message',
+      ]);
+      expect(detectVueProject()).toBe(false);
+    }
+  );
+
+  it('retains legitimate wrapper usage in a nested src/lib directory', async () => {
+    createReactWrapperFixture({
+      'src/App.tsx': reactMessage('Stable nested-lib message'),
+      'src/lib/vue.ts': `
+        import { VueT } from '@fixture/multi/vue';
+        export const component = VueT;
+      `,
+    });
+
+    const historical = await extractHistorical();
+    const dispatched = await extractDispatched();
+
+    expect(dispatched).toEqual(historical);
+    expect(dispatched.errors).toEqual([]);
+    expect(dispatched.updates.map(({ source }) => source)).toEqual([
+      'Stable nested-lib message',
+    ]);
+    expect(detectVueProject()).toBe(true);
+  });
+
+  it.each([
+    {
+      file: 'src/App.vue',
+      name: 'a real Vue SFC',
+      source: `
+        <script setup>
+        import { VueT } from '@fixture/multi/vue';
+        </script>
+        <template><VueT>Real SFC usage</VueT></template>
+      `,
+    },
+    {
+      file: 'src/Legacy.vue',
+      name: 'a legacy JSX module with real runtime usage',
+      source: `
+        import { VueT } from '@fixture/multi/vue';
+        export const View = () => <VueT>Real JSX usage</VueT>;
+      `,
+    },
+    {
+      file: 'src/ScriptOnly.vue',
+      name: 'a script-only SFC with a default import',
+      source: `
+        <script setup>
+        import VueT from '@fixture/multi/vue';
+        const component = VueT;
+        </script>
+      `,
+    },
+    {
+      file: 'src/NamespaceScriptOnly.vue',
+      name: 'a script-only SFC with a namespace import',
+      source: `
+        <script setup>
+        import * as Mixed from '@fixture/multi/vue';
+        const component = Mixed.VueT;
+        </script>
+      `,
+    },
+  ])('continues to activate Vue for $name', ({ file, source }) => {
+    createReactWrapperFixture({ [file]: source });
+
+    expect(detectVueProject()).toBe(true);
+  });
+});
+
+function createReactWrapperFixture(
+  sourceFiles: Record<string, string>,
+  packageFields: Record<string, unknown> = {}
+): string {
+  const root = createFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      ...packageFields,
+      dependencies: {
+        '@fixture/multi': 'file:./vendor/multi',
+        'gt-react': '*',
+      },
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: { './vue': './src/vue.ts' },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/vue.ts':
+      "export { T as VueT, T as default } from 'gt-vue';\n",
+    ...sourceFiles,
+  });
+  const destination = path.join(root, 'node_modules/@fixture/multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  return root;
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-final-boundary-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+  process.chdir(root);
+  return root;
+}
+
+function extractHistorical(filePatterns?: string[]) {
+  return createInlineUpdates(
+    Libraries.GT_REACT,
+    false,
+    filePatterns,
+    GT_PARSING_FLAGS_DEFAULT,
+    parsingOptions
+  );
+}
+
+function extractDispatched(filePatterns?: string[]) {
+  return extractInlineFromProject(
+    Libraries.GT_REACT,
+    false,
+    filePatterns,
+    GT_PARSING_FLAGS_DEFAULT,
+    parsingOptions
+  );
+}
+
+function reactMessage(message: string): string {
+  return `
+    import { T } from 'gt-react';
+    export const App = () => <T>${message}</T>;
+  `;
+}

--- a/packages/cli/src/translation/__tests__/extractInline.final-boundary.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.final-boundary.test.ts
@@ -73,7 +73,90 @@ describe('final React/Vue ownership boundary', () => {
     }
   );
 
-  it.each(['cjs', 'esm', 'generated', 'lib', 'lib-esm'])(
+  it.each([
+    {
+      name: 'an unused ordinary named import',
+      vueSource: `<script>
+        import { VueT } from '@fixture/multi/vue';
+        export default {};
+      </script><template><VueT /></template>`,
+    },
+    {
+      name: 'an unused ordinary default import',
+      vueSource: `<script>
+        import VueT from '@fixture/multi/vue';
+        export default {};
+      </script><template><VueT /></template>`,
+    },
+    {
+      name: 'an unused ordinary namespace import',
+      vueSource: `<script>
+        import * as Mixed from '@fixture/multi/vue';
+        export default {};
+      </script><template><Mixed.VueT /></template>`,
+    },
+    {
+      name: 'a normalized tag resolved to a camel setup binding',
+      vueSource: `<script setup>
+        import { VueT } from '@fixture/multi/vue';
+        const vueT = 'section';
+      </script><template><vue-t /></template>`,
+    },
+    {
+      name: 'a namespace tag resolved to a camel setup binding',
+      vueSource: `<script setup>
+        import * as Mixed from '@fixture/multi/vue';
+        const mixed = { VueT: 'section' };
+      </script><template><mixed.VueT /></template>`,
+    },
+    {
+      name: 'an ordinary named import shadowed by an exact setup binding',
+      vueSource: `<script>
+        import { VueT as LocalT } from '@fixture/multi/vue';
+        export default {};
+      </script><script setup>
+        const LocalT = 'section';
+      </script><template><LocalT /></template>`,
+    },
+    {
+      name: 'an ordinary default import shadowed by an exact setup binding',
+      vueSource: `<script>
+        import LocalT from '@fixture/multi/vue';
+        export default {};
+      </script><script setup>
+        const LocalT = 'section';
+      </script><template><LocalT /></template>`,
+    },
+    {
+      name: 'an ordinary namespace import shadowed by an exact setup binding',
+      vueSource: `<script>
+        import * as Mixed from '@fixture/multi/vue';
+        export default {};
+      </script><script setup>
+        const Mixed = { VueT: 'section' };
+      </script><template><Mixed.VueT /></template>`,
+    },
+  ])(
+    'does not let $name activate Vue during React dispatch',
+    async ({ vueSource }) => {
+      createReactWrapperFixture({
+        'src/App.tsx': reactMessage('Stable component-boundary message'),
+        'src/Unrelated.vue': vueSource,
+      });
+
+      const historical = await extractHistorical();
+      const dispatched = await extractDispatched();
+
+      expect(dispatched).toEqual(historical);
+      expect(dispatched.errors).toEqual([]);
+      expect(dispatched.updates.map(({ source }) => source)).toEqual([
+        'Stable component-boundary message',
+      ]);
+      expect(detectVueProject()).toBe(false);
+    }
+  );
+
+  it.each(['cjs', 'es', 'esm', 'generated', 'lib', 'lib-esm'])(
     'ignores a stale public entry in the root %s output directory',
     async (outputDirectory) => {
       createReactWrapperFixture(
@@ -142,25 +225,28 @@ describe('final React/Vue ownership boundary', () => {
     }
   );
 
-  it('retains legitimate wrapper usage in a nested src/lib directory', async () => {
-    createReactWrapperFixture({
-      'src/App.tsx': reactMessage('Stable nested-lib message'),
-      'src/lib/vue.ts': `
+  it.each(['es', 'lib'])(
+    'retains legitimate wrapper usage in a nested src/%s directory',
+    async (sourceDirectory) => {
+      createReactWrapperFixture({
+        'src/App.tsx': reactMessage('Stable nested-lib message'),
+        [`src/${sourceDirectory}/vue.ts`]: `
         import { VueT } from '@fixture/multi/vue';
         export const component = VueT;
       `,
-    });
+      });
 
-    const historical = await extractHistorical();
-    const dispatched = await extractDispatched();
+      const historical = await extractHistorical();
+      const dispatched = await extractDispatched();
 
-    expect(dispatched).toEqual(historical);
-    expect(dispatched.errors).toEqual([]);
-    expect(dispatched.updates.map(({ source }) => source)).toEqual([
-      'Stable nested-lib message',
-    ]);
-    expect(detectVueProject()).toBe(true);
-  });
+      expect(dispatched).toEqual(historical);
+      expect(dispatched.errors).toEqual([]);
+      expect(dispatched.updates.map(({ source }) => source)).toEqual([
+        'Stable nested-lib message',
+      ]);
+      expect(detectVueProject()).toBe(true);
+    }
+  );
 
   it.each([
     {

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -132,6 +132,112 @@ describe('project-level Vue CLI regression boundary', () => {
     expect(sources(output)).toEqual(['Stable React message']);
   });
 
+  it.each([
+    {
+      files: {
+        'src/generated.d.ts': `
+          import { VueT } from '@fixture/multi/vue';
+          export declare const component: typeof VueT;
+        `,
+      },
+      name: 'an ambient declaration import',
+      packageFields: {},
+    },
+    {
+      files: {
+        'lib/index.js': "export { VueT } from '@fixture/multi/vue';\n",
+      },
+      name: 'a stale generated public entry',
+      packageFields: { main: './lib/index.js' },
+    },
+    {
+      files: {
+        'src/types.ts': `
+          import { VueT } from '@fixture/multi/vue';
+          export type Component = typeof VueT;
+        `,
+      },
+      name: 'a type-only wrapper reference',
+      packageFields: {},
+    },
+    {
+      files: {
+        'src/Commented.vue': `
+          <!--
+          <script setup>
+          import { VueT } from '@fixture/multi/vue';
+          </script>
+          -->
+          <template><main>Unrelated fixture</main></template>
+        `,
+      },
+      name: 'an HTML-commented SFC import',
+      packageFields: {},
+    },
+    {
+      files: {
+        'src/StringData.vue': `
+          <script setup>
+          import * as Mixed from '@fixture/multi/vue';
+          </script>
+          <template><main :title="'Mixed.VueT'">Unrelated fixture</main></template>
+        `,
+      },
+      name: 'a namespace name inside template string data',
+      packageFields: {},
+    },
+  ])(
+    'keeps React extraction unchanged with $name',
+    async ({ files, packageFields }) => {
+      const root = createFixture({
+        'package.json': packageJson({
+          ...packageFields,
+          dependencies: {
+            '@fixture/multi': 'file:./vendor/multi',
+            'gt-react': '*',
+          },
+        }),
+        'src/App.tsx': reactMessage('Stable React boundary'),
+        'vendor/multi/package.json': JSON.stringify({
+          name: '@fixture/multi',
+          version: '1.0.0',
+          exports: {
+            '.': './src/react.ts',
+            './vue': './src/vue.ts',
+          },
+          dependencies: { 'gt-vue': '*' },
+        }),
+        'vendor/multi/src/react.ts':
+          "export { T as ReactT } from 'gt-react';\n",
+        'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+        ...files,
+      });
+      const destination = path.join(root, 'node_modules/@fixture/multi');
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+
+      const historical = await createInlineUpdates(
+        Libraries.GT_REACT,
+        false,
+        undefined,
+        GT_PARSING_FLAGS_DEFAULT,
+        parsingOptions
+      );
+      const output = await extractInlineFromProject(
+        Libraries.GT_REACT,
+        false,
+        undefined,
+        GT_PARSING_FLAGS_DEFAULT,
+        parsingOptions
+      );
+
+      expect(detectVueProject()).toBe(false);
+      expect(output).toEqual(historical);
+      expect(output.errors).toEqual([]);
+      expect(sources(output)).toEqual(['Stable React boundary']);
+    }
+  );
+
   it('appends only owned descendant Vue sources to the unchanged React scope', async () => {
     createVueFixture({
       'package.json': packageJson({

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -1,0 +1,320 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GT_PARSING_FLAGS_DEFAULT } from '../../config/defaults.js';
+import { determineLibrary } from '../../fs/determineFramework/index.js';
+import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
+import { isInlineLibrary, Libraries } from '../../types/libraries.js';
+import type { ParsingConfigOptions } from '../../types/parsing.js';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
+import { logger } from '../../console/logger.js';
+import { extractInlineFromProject } from '../extractInline.js';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+const requireFromCli = createRequire(import.meta.url);
+const installedVueDirectory = path.dirname(
+  requireFromCli.resolve('vue/package.json')
+);
+const parsingOptions: ParsingConfigOptions = {
+  conditionNames: ['development', 'browser', 'module', 'import', 'default'],
+};
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('project-level Vue CLI regression boundary', () => {
+  it('extracts a root Vue project through only the package project API', async () => {
+    createVueFixture({
+      'package.json': vuePackageJson('root-vue-app'),
+      'app.vue': translatableSfc('Root Vue message'),
+    });
+    const detection = determineLibrary();
+
+    expect(detection).toEqual({ library: 'base', additionalModules: [] });
+    expect(detectVueProject()).toBe(true);
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_VUE,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.warnings).toEqual([]);
+    expect(sources(output)).toEqual(['Root Vue message']);
+  });
+
+  it('keeps pure React extraction byte-for-byte equivalent to the historical path', async () => {
+    createFixture({
+      'package.json': packageJson({ dependencies: { 'gt-react': '*' } }),
+      'src/App.tsx': reactMessage('Pure React message'),
+    });
+    const detection = determineLibrary();
+
+    expect(detection).toEqual({
+      library: Libraries.GT_REACT,
+      additionalModules: [],
+    });
+    expect(detectVueProject()).toBe(false);
+
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    const dispatched = await dispatchDetected(detection.library);
+
+    expect(dispatched).toEqual(historical);
+    expect(dispatched.errors).toEqual([]);
+    expect(sources(dispatched)).toEqual(['Pure React message']);
+  });
+
+  it('keeps a React root primary and appends only its gt-vue-owned workspace', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*' },
+      }),
+      'src/App.tsx': reactMessage('Root React message'),
+      'src/Unowned.vue': translatableSfc('Unowned root Vue message'),
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Owned Vue message'),
+      'apps/unowned/package.json': packageJson({ name: 'unowned-app' }),
+      'apps/unowned/src/App.vue': translatableSfc(
+        'Unowned workspace Vue message'
+      ),
+    });
+    const detection = determineLibrary();
+
+    expect(detection.library).toBe(Libraries.GT_REACT);
+    expect(detectVueProject()).toBe(true);
+
+    const output = await dispatchDetected(detection.library);
+
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Owned Vue message',
+      'Root React message',
+    ]);
+  });
+
+  it('keeps a file-only root file-only when only a child declares gt-react', () => {
+    createFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'locales/en.json': JSON.stringify({ title: 'File-only title' }),
+      'apps/react/package.json': packageJson({
+        name: 'child-react',
+        dependencies: { 'gt-react': '*' },
+      }),
+      'apps/react/src/App.tsx': reactMessage('Child React message'),
+    });
+
+    const detection = determineLibrary();
+
+    expect(detection).toEqual({ library: 'base', additionalModules: [] });
+    expect(isInlineLibrary(detection.library)).toBe(false);
+    expect(detectVueProject()).toBe(false);
+  });
+
+  it('does not broaden React defaults to unrelated workspaces when Vue is present', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*' },
+      }),
+      'src/App.tsx': reactMessage('Root React only'),
+      'apps/react/package.json': packageJson({
+        name: 'unrelated-react',
+        dependencies: { 'gt-react': '*' },
+      }),
+      'apps/react/src/App.tsx': reactMessage(
+        'Unrelated workspace React message'
+      ),
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Owned workspace Vue message'),
+    });
+
+    const detection = determineLibrary();
+    const output = await dispatchDetected(detection.library);
+
+    expect(detection.library).toBe(Libraries.GT_REACT);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Owned workspace Vue message',
+      'Root React only',
+    ]);
+  });
+
+  it('retains both root gt-node and owned Vue messages', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-node': '*' },
+      }),
+      'src/message.ts': `
+        import { msg } from 'gt-node';
+        export const message = msg('Root Node message');
+      `,
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Node companion Vue message'),
+    });
+
+    const detection = determineLibrary();
+    const output = await dispatchDetected(detection.library);
+
+    expect(detection.library).toBe(Libraries.GT_NODE);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Node companion Vue message',
+      'Root Node message',
+    ]);
+  });
+
+  it('does not resolve a React root dynamic Vite config during child Vue extraction', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*', vite: '*' },
+      }),
+      'vite.config.ts': `
+        export default ({ mode }) => ({
+          resolve: { alias: mode === 'test' ? { '@app': '/one' } : { '@app': '/two' } },
+        });
+      `,
+      'src/App.tsx': reactMessage('React with dynamic config'),
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Scoped Vue config message'),
+    });
+
+    const detection = determineLibrary();
+    const output = await dispatchDetected(detection.library);
+
+    expect(detection.library).toBe(Libraries.GT_REACT);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'React with dynamic config',
+      'Scoped Vue config message',
+    ]);
+  });
+
+  it('splits explicit .vue patterns away from the historical parser', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*', vue: '*' },
+      }),
+      'src/App.tsx': reactMessage('Explicit React message'),
+      'src/App.vue': translatableSfc('Explicit Vue message'),
+    });
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
+
+    const detection = determineLibrary();
+    const output = await dispatchDetected(detection.library, [
+      'src/**/*.{tsx,vue}',
+    ]);
+
+    expect(detection.library).toBe(Libraries.GT_REACT);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Explicit React message',
+      'Explicit Vue message',
+    ]);
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
+});
+
+async function dispatchDetected(library: string, filePatterns?: string[]) {
+  if (!isInlineLibrary(library)) {
+    throw new Error(`Expected an inline library, received ${library}`);
+  }
+  return extractInlineFromProject(
+    library,
+    false,
+    filePatterns,
+    GT_PARSING_FLAGS_DEFAULT,
+    parsingOptions
+  );
+}
+
+function sources(output: Awaited<ReturnType<typeof dispatchDetected>>) {
+  return output.updates.map(({ source }) => source);
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  process.chdir(root);
+  return root;
+}
+
+function createProjectFixture(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-cli-vue-project-'));
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+  return root;
+}
+
+function linkInstalledVue(root: string): void {
+  const nodeModules = path.join(root, 'node_modules');
+  fs.mkdirSync(nodeModules, { recursive: true });
+  fs.symlinkSync(installedVueDirectory, path.join(nodeModules, 'vue'), 'dir');
+}
+
+function removeProjectFixture(root: string): void {
+  fs.rmSync(root, { force: true, recursive: true });
+}
+
+function translatableSfc(message: string): string {
+  return `<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+<template><T>${message}</T></template>
+`;
+}
+
+function createVueFixture(files: Record<string, string>): string {
+  const root = createFixture(files);
+  linkInstalledVue(root);
+  return root;
+}
+
+function packageJson(values: Record<string, unknown> = {}): string {
+  return JSON.stringify({ name: 'fixture-root', ...values }, null, 2);
+}
+
+function vuePackageJson(name: string): string {
+  return packageJson({
+    name,
+    dependencies: { 'gt-vue': '*', vue: '*' },
+  });
+}
+
+function reactMessage(message: string): string {
+  return `
+    import { T } from 'gt-react';
+    export function App() {
+      return <T>${message}</T>;
+    }
+  `;
+}

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -302,6 +302,45 @@ describe('project-level Vue CLI regression boundary', () => {
     ]);
   });
 
+  it('preserves auto-JSX messages in ambiguous standard-tag .vue modules', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/Template.vue': '<template>Template auto JSX message</template>;',
+      'src/Script.vue': '<script>Script auto JSX message</script>;',
+      'src/Style.vue': '<style>Style auto JSX message</style>;',
+    });
+    const patterns = ['src/*.vue'];
+    const flags = {
+      ...GT_PARSING_FLAGS_DEFAULT,
+      enableAutoJsxInjection: true,
+    };
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      flags,
+      parsingOptions
+    );
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      flags,
+      parsingOptions
+    );
+
+    expect(output).toEqual(historical);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Script auto JSX message',
+      'Style auto JSX message',
+      'Template auto JSX message',
+    ]);
+  });
+
   it('partitions real SFCs from legacy JSX across explicit mixed patterns', async () => {
     createVueFixture({
       'package.json': packageJson({
@@ -407,6 +446,108 @@ ${translatableSfc('Text-prefixed Vue SFC message')}`,
 
     expect(output.errors).toEqual([]);
     expect(sources(output)).toEqual(['Targeted React message']);
+  });
+
+  it('keeps one project root when cwd changes while extraction starts', async () => {
+    const projectA = createProjectFixture({
+      'package.json': packageJson({ dependencies: { 'gt-react': '*' } }),
+      'src/App.tsx': reactMessage('Project A React message'),
+    });
+    const projectB = createProjectFixture({
+      'package.json': packageJson({ dependencies: { 'gt-vue': '*' } }),
+      'src/App.vue': translatableSfc('Project B Vue message'),
+    });
+    temporaryDirectories.push(projectA, projectB);
+    linkInstalledVue(projectB);
+    process.chdir(projectA);
+
+    const outputPromise = extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    process.chdir(projectB);
+    const output = await outputPromise;
+
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Project A React message']);
+  });
+
+  it('anchors explicit patterns when cwd changes during Vue inspection', async () => {
+    const projectA = createProjectFixture({
+      'package.json': packageJson({ dependencies: { 'gt-react': '*' } }),
+      'src/App.tsx': reactMessage('Project A explicit message'),
+      'src/Excluded.tsx': reactMessage('Project A excluded message'),
+    });
+    const projectB = createProjectFixture({
+      'package.json': packageJson({ dependencies: { 'gt-react': '*' } }),
+      'src/App.tsx': reactMessage('Project B explicit message'),
+    });
+    temporaryDirectories.push(projectA, projectB);
+    const explicitPatterns = ['src/**/*.{ts,tsx}', '!src/**/Excluded.tsx'];
+
+    process.chdir(projectA);
+    const historicalPromise = createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      explicitPatterns,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    process.chdir(projectB);
+    const historical = await historicalPromise;
+
+    process.chdir(projectA);
+    const outputPromise = extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      explicitPatterns,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    process.chdir(projectB);
+    const output = await outputPromise;
+
+    expect(output).toEqual(historical);
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Project A explicit message']);
+  });
+
+  it('anchors the historical half of an explicitly selected mixed project', async () => {
+    const projectA = createProjectFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/App.tsx': reactMessage('Project A mixed React message'),
+      'src/Excluded.tsx': reactMessage('Project A mixed excluded message'),
+      'src/App.vue': translatableSfc('Project A mixed Vue message'),
+    });
+    const projectB = createProjectFixture({
+      'package.json': packageJson({ dependencies: { 'gt-react': '*' } }),
+      'src/App.tsx': reactMessage('Project B mixed-race message'),
+    });
+    temporaryDirectories.push(projectA, projectB);
+    linkInstalledVue(projectA);
+    const explicitPatterns = ['src/**/*.{ts,tsx,vue}', '!src/**/Excluded.tsx'];
+    process.chdir(projectA);
+
+    const outputPromise = extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      explicitPatterns,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    process.chdir(projectB);
+    const output = await outputPromise;
+
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual([
+      'Project A mixed React message',
+      'Project A mixed Vue message',
+    ]);
   });
 
   it('does not resolve Vue config before proving ownership in a mixed root', async () => {

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -263,6 +263,45 @@ describe('project-level Vue CLI regression boundary', () => {
     expect(sources(output)).toEqual(['Legacy React module']);
   });
 
+  it('preserves Babel-valid standard-tag legacy .vue modules', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/Leading.vue': `
+        <template><T>Leading standard-tag module</T></template>;
+        import { T } from 'gt-react';
+      `,
+      'src/TextPrefixed.vue': `
+        'Copyright 2026';
+        <template><T>Text-prefixed standard-tag module</T></template>;
+        import { T } from 'gt-react';
+      `,
+    });
+    const patterns = ['src/*.vue'];
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
+    expect(output).toEqual(historical);
+    expect(output.errors).toEqual([]);
+    expect(sources(output).sort()).toEqual([
+      'Leading standard-tag module',
+      'Text-prefixed standard-tag module',
+    ]);
+  });
+
   it('partitions real SFCs from legacy JSX across explicit mixed patterns', async () => {
     createVueFixture({
       'package.json': packageJson({

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -80,6 +80,58 @@ describe('project-level Vue CLI regression boundary', () => {
     expect(sources(dispatched)).toEqual(['Pure React message']);
   });
 
+  it('ignores an unused Vue subpath in a local multi-framework dependency', async () => {
+    const root = createFixture({
+      'package.json': packageJson({
+        dependencies: {
+          '@fixture/multi': 'file:./vendor/multi',
+          'gt-react': '*',
+        },
+      }),
+      'src/App.tsx': `
+        import { ordinary } from '@fixture/multi';
+        import { T } from 'gt-react';
+        void ordinary;
+        export const App = () => <T>Stable React message</T>;
+      `,
+      'src/Unrelated.vue': '<template>Unrelated fixture</template>',
+      'vendor/multi/package.json': JSON.stringify({
+        name: '@fixture/multi',
+        version: '1.0.0',
+        exports: {
+          '.': './src/index.ts',
+          './vue': './src/vue.ts',
+        },
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'vendor/multi/src/index.ts': 'export const ordinary = true;\n',
+      'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+    });
+    const destination = path.join(root, 'node_modules/@fixture/multi');
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+    fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
+    expect(detectVueProject()).toBe(false);
+    expect(output).toEqual(historical);
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Stable React message']);
+  });
+
   it('appends only owned descendant Vue sources to the unchanged React scope', async () => {
     createVueFixture({
       'package.json': packageJson({

--- a/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.project-regression.test.ts
@@ -9,7 +9,6 @@ import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
 import { isInlineLibrary, Libraries } from '../../types/libraries.js';
 import type { ParsingConfigOptions } from '../../types/parsing.js';
 import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
-import { logger } from '../../console/logger.js';
 import { extractInlineFromProject } from '../extractInline.js';
 
 const originalCwd = process.cwd();
@@ -81,7 +80,7 @@ describe('project-level Vue CLI regression boundary', () => {
     expect(sources(dispatched)).toEqual(['Pure React message']);
   });
 
-  it('keeps a React root primary and appends only its gt-vue-owned workspace', async () => {
+  it('appends only owned descendant Vue sources to the unchanged React scope', async () => {
     createVueFixture({
       'package.json': packageJson({
         private: true,
@@ -100,14 +99,14 @@ describe('project-level Vue CLI regression boundary', () => {
     const detection = determineLibrary();
 
     expect(detection.library).toBe(Libraries.GT_REACT);
-    expect(detectVueProject()).toBe(true);
+    expect(detectVueProject()).toBe(false);
 
     const output = await dispatchDetected(detection.library);
 
     expect(output.errors).toEqual([]);
-    expect(sources(output).sort()).toEqual([
-      'Owned Vue message',
+    expect(sources(output)).toEqual([
       'Root React message',
+      'Owned Vue message',
     ]);
   });
 
@@ -120,9 +119,27 @@ describe('project-level Vue CLI regression boundary', () => {
       'locales/en.json': JSON.stringify({ title: 'File-only title' }),
       'apps/react/package.json': packageJson({
         name: 'child-react',
-        dependencies: { 'gt-react': '*' },
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
       }),
       'apps/react/src/App.tsx': reactMessage('Child React message'),
+    });
+
+    const detection = determineLibrary();
+
+    expect(detection).toEqual({ library: 'base', additionalModules: [] });
+    expect(isInlineLibrary(detection.library)).toBe(false);
+    expect(detectVueProject()).toBe(false);
+  });
+
+  it('keeps a file-only root file-only when a child declares gt-vue', () => {
+    createVueFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'locales/en.json': JSON.stringify({ title: 'File-only title' }),
+      'apps/vue/package.json': vuePackageJson('child-vue'),
+      'apps/vue/src/App.vue': translatableSfc('Child Vue message'),
     });
 
     const detection = determineLibrary();
@@ -156,13 +173,13 @@ describe('project-level Vue CLI regression boundary', () => {
 
     expect(detection.library).toBe(Libraries.GT_REACT);
     expect(output.errors).toEqual([]);
-    expect(sources(output).sort()).toEqual([
-      'Owned workspace Vue message',
+    expect(sources(output)).toEqual([
       'Root React only',
+      'Owned workspace Vue message',
     ]);
   });
 
-  it('retains both root gt-node and owned Vue messages', async () => {
+  it('appends owned descendant Vue sources to the unchanged Node scope', async () => {
     createVueFixture({
       'package.json': packageJson({
         private: true,
@@ -182,9 +199,9 @@ describe('project-level Vue CLI regression boundary', () => {
 
     expect(detection.library).toBe(Libraries.GT_NODE);
     expect(output.errors).toEqual([]);
-    expect(sources(output).sort()).toEqual([
-      'Node companion Vue message',
+    expect(sources(output)).toEqual([
       'Root Node message',
+      'Node companion Vue message',
     ]);
   });
 
@@ -210,34 +227,211 @@ describe('project-level Vue CLI regression boundary', () => {
 
     expect(detection.library).toBe(Libraries.GT_REACT);
     expect(output.errors).toEqual([]);
-    expect(sources(output).sort()).toEqual([
+    expect(sources(output)).toEqual([
       'React with dynamic config',
       'Scoped Vue config message',
     ]);
   });
 
-  it('splits explicit .vue patterns away from the historical parser', async () => {
+  it('preserves historical parsing for explicitly selected .vue files', async () => {
     createVueFixture({
       'package.json': packageJson({
-        dependencies: { 'gt-react': '*', 'gt-vue': '*', vue: '*' },
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
       }),
-      'src/App.tsx': reactMessage('Explicit React message'),
-      'src/App.vue': translatableSfc('Explicit Vue message'),
+      'src/Legacy.vue': reactMessage('Legacy React module'),
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Unselected Vue message'),
     });
-    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {});
 
     const detection = determineLibrary();
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      ['src/Legacy.vue'],
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
     const output = await dispatchDetected(detection.library, [
-      'src/**/*.{tsx,vue}',
+      'src/Legacy.vue',
     ]);
 
     expect(detection.library).toBe(Libraries.GT_REACT);
+    expect(detectVueProject()).toBe(true);
+    expect(output).toEqual(historical);
+    expect(sources(output)).toEqual(['Legacy React module']);
+  });
+
+  it('partitions real SFCs from legacy JSX across explicit mixed patterns', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/App.tsx': reactMessage('React TSX module'),
+      'src/Legacy.vue': reactMessage('React legacy module'),
+      'src/VueApp.vue': `<i18n lang="json">
+{"en":{"title":"Localized"}}
+</i18n>
+${translatableSfc('Vue SFC message')}`,
+      'src/TextPrefixed.vue': `Copyright Fixture
+${translatableSfc('Text-prefixed Vue SFC message')}`,
+    });
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      ['src/**/*.{tsx,vue}'],
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
     expect(output.errors).toEqual([]);
     expect(sources(output).sort()).toEqual([
-      'Explicit React message',
-      'Explicit Vue message',
+      'React TSX module',
+      'React legacy module',
+      'Text-prefixed Vue SFC message',
+      'Vue SFC message',
     ]);
-    expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('partitions an explicitly selected absolute SFC path', async () => {
+    const root = createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/App.vue': translatableSfc('Absolute Vue SFC message'),
+    });
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      [path.join(root, 'src/App.vue')],
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Absolute Vue SFC message']);
+  });
+
+  it('ignores optional Vue peers in a sibling React workspace', async () => {
+    createFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*' },
+      }),
+      'src/App.tsx': reactMessage('Stable React root'),
+      'apps/optional/package.json': packageJson({
+        name: 'optional-vue-integration',
+        optionalDependencies: { 'gt-vue': '*' },
+        peerDependencies: { vue: '^3.5.0' },
+      }),
+      'apps/optional/src/App.vue': translatableSfc('Optional Vue message'),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '0.1.0',
+        type: 'module',
+        main: 'index.js',
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+
+    const output = await dispatchDetected(Libraries.GT_REACT);
+
+    expect(detectVueProject()).toBe(false);
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Stable React root']);
+  });
+
+  it('does not apply Vue config to targeted React-only validation', async () => {
+    createFixture({
+      'package.json': packageJson({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*' },
+      }),
+      'src/App.tsx': reactMessage('Targeted React message'),
+      'vite.config.ts': `export default ({ mode }) => mode === 'test' ? {} : {};`,
+      'apps/vue/package.json': vuePackageJson('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Separate Vue message'),
+    });
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      true,
+      ['src/App.tsx'],
+      { ...GT_PARSING_FLAGS_DEFAULT, viteConfigPath: 'vite.config.ts' },
+      parsingOptions
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Targeted React message']);
+  });
+
+  it('does not resolve Vue config before proving ownership in a mixed root', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*', vite: '*' },
+      }),
+      'src/App.tsx': reactMessage('Mixed root React message'),
+      'vite.config.ts': `
+        export default ({ mode }) => ({
+          resolve: { alias: mode === 'test' ? { '@app': '/one' } : { '@app': '/two' } },
+        });
+      `,
+    });
+    const flags = {
+      ...GT_PARSING_FLAGS_DEFAULT,
+      viteConfigPath: 'vite.config.ts',
+    };
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      true,
+      ['src/App.tsx'],
+      flags,
+      parsingOptions
+    );
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      true,
+      ['src/App.tsx'],
+      flags,
+      parsingOptions
+    );
+
+    expect(output).toEqual(historical);
+    expect(output.errors).toEqual([]);
+    expect(sources(output)).toEqual(['Mixed root React message']);
+  });
+
+  it('deduplicates identical source context for a mixed-runtime hash', async () => {
+    createVueFixture({
+      'package.json': packageJson({
+        dependencies: { 'gt-react': '*', 'gt-vue': '*' },
+      }),
+      'src/App.tsx': `
+        import { T } from 'gt-react'; import { T as VueT } from 'gt-vue';
+        export const App = () => <><T>Shared message</T><VueT>Shared message</VueT></>;
+      `,
+    });
+
+    const output = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      { ...GT_PARSING_FLAGS_DEFAULT, includeSourceCodeContext: true },
+      parsingOptions
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates).toHaveLength(1);
+    const sourceCode = output.updates[0]?.metadata.sourceCode as
+      | Record<string, unknown[]>
+      | undefined;
+    expect(sourceCode?.['src/App.tsx']).toHaveLength(1);
   });
 });
 

--- a/packages/cli/src/translation/__tests__/extractInline.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.test.ts
@@ -1,0 +1,300 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Updates } from '../../types/index.js';
+import { Libraries, type InlineLibrary } from '../../types/libraries.js';
+import type {
+  GTParsingFlags,
+  ParsingConfigOptions,
+} from '../../types/parsing.js';
+
+const mocks = vi.hoisted(() => ({
+  createInlineUpdates: vi.fn(),
+  createPythonInlineUpdates: vi.fn(),
+  detectVueProject: vi.fn(),
+  extractFromVueProject: vi.fn(),
+  projectModuleLoads: 0,
+}));
+
+vi.mock('@generaltranslation/vue-extractor/detect', () => ({
+  detectVueProject: mocks.detectVueProject,
+}));
+
+vi.mock('@generaltranslation/vue-extractor/project', () => {
+  mocks.projectModuleLoads += 1;
+  return { extractFromVueProject: mocks.extractFromVueProject };
+});
+
+vi.mock('../../react/parse/createInlineUpdates.js', () => ({
+  createInlineUpdates: mocks.createInlineUpdates,
+}));
+
+vi.mock('../../python/parse/createPythonInlineUpdates.js', () => ({
+  createPythonInlineUpdates: mocks.createPythonInlineUpdates,
+}));
+
+import { extractInlineFromProject } from '../extractInline.js';
+
+const parsingFlags: GTParsingFlags = {
+  autoderive: false,
+  enableAutoJsxInjection: false,
+  includeSourceCodeContext: true,
+  legacyGtReactImportSource: false,
+  viteConfigPath: 'vite.config.ts',
+  vueCompilerOptions: { whitespace: 'preserve' },
+};
+const parsingOptions: ParsingConfigOptions = {
+  conditionNames: ['browser', 'import'],
+};
+const patterns = ['src/**/*.{ts,tsx,vue}', '!src/vendor/**'];
+
+function update(
+  source: string,
+  hash: string,
+  filePaths: string[]
+): Updates[number] {
+  return {
+    dataFormat: 'ICU',
+    source,
+    metadata: { hash, filePaths },
+  };
+}
+
+describe('extractInlineFromProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.detectVueProject.mockReturnValue(false);
+  });
+
+  it('does not load or call the Vue project extractor when Vue is absent', async () => {
+    const historicalResult = {
+      updates: [update('React', 'react-hash', ['src/App.tsx'])],
+      errors: [],
+      warnings: [],
+    };
+    mocks.createInlineUpdates.mockResolvedValue(historicalResult);
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      true,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(result).toBe(historicalResult);
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_REACT,
+      true,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+    expect(mocks.projectModuleLoads).toBe(0);
+    expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    Libraries.GT_REACT,
+    Libraries.GT_NEXT,
+    Libraries.GT_REACT_NATIVE,
+    Libraries.GT_TANSTACK_START,
+    Libraries.GT_NODE,
+  ] satisfies InlineLibrary[])(
+    'preserves the historical %s extractor call and result identity',
+    async (library) => {
+      const historicalResult = {
+        updates: [update(library, `${library}-hash`, [`${library}.ts`])],
+        errors: [`${library}-error`],
+        warnings: [`${library}-warning`],
+      };
+      mocks.createInlineUpdates.mockResolvedValue(historicalResult);
+
+      const result = await extractInlineFromProject(
+        library,
+        true,
+        patterns,
+        parsingFlags,
+        parsingOptions
+      );
+
+      expect(mocks.createInlineUpdates).toHaveBeenCalledOnce();
+      expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+        library,
+        true,
+        patterns,
+        parsingFlags,
+        parsingOptions
+      );
+      expect(mocks.createPythonInlineUpdates).not.toHaveBeenCalled();
+      expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
+      expect(result).toBe(historicalResult);
+    }
+  );
+
+  it.each([Libraries.GT_FLASK, Libraries.GT_FASTAPI] satisfies InlineLibrary[])(
+    'preserves the historical %s extractor call and result identity',
+    async (library) => {
+      const historicalResult = {
+        updates: [update(library, `${library}-hash`, [`${library}.py`])],
+        errors: [],
+        warnings: [],
+      };
+      mocks.createPythonInlineUpdates.mockResolvedValue(historicalResult);
+
+      const result = await extractInlineFromProject(
+        library,
+        false,
+        patterns,
+        parsingFlags,
+        parsingOptions
+      );
+
+      expect(mocks.createPythonInlineUpdates).toHaveBeenCalledOnce();
+      expect(mocks.createPythonInlineUpdates).toHaveBeenCalledWith(patterns);
+      expect(mocks.createInlineUpdates).not.toHaveBeenCalled();
+      expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
+      expect(result).toBe(historicalResult);
+    }
+  );
+
+  it('keeps explicit patterns intact for Vue and excludes only .vue from the legacy parser', async () => {
+    mocks.detectVueProject.mockReturnValue(true);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [update('Primary', 'primary-hash', ['src/App.tsx'])],
+      errors: [],
+      warnings: [],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [update('Vue', 'vue-hash', ['src/App.vue'])],
+      errors: [],
+      warnings: [],
+    });
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      true,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_REACT,
+      true,
+      [...patterns, '!**/*.vue'],
+      parsingFlags,
+      parsingOptions
+    );
+    expect(mocks.extractFromVueProject).toHaveBeenCalledWith({
+      filePatterns: patterns,
+      includeSourceCodeContext: true,
+      conditionNames: parsingOptions.conditionNames,
+      vueCompilerOptions: parsingFlags.vueCompilerOptions,
+      viteConfigPath: parsingFlags.viteConfigPath,
+    });
+    expect(result.updates.map(({ source }) => source)).toEqual([
+      'Primary',
+      'Vue',
+    ]);
+  });
+
+  it('appends Vue results while preserving primary ordering and combining diagnostics', async () => {
+    mocks.detectVueProject.mockReturnValue(true);
+    const primaryUpdate = update('Primary', 'primary-hash', ['primary.tsx']);
+    const vueUpdate = update('Vue', 'vue-hash', ['component.vue']);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [primaryUpdate],
+      errors: ['primary error'],
+      warnings: ['shared warning', 'primary warning'],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [vueUpdate],
+      errors: ['vue error'],
+      warnings: ['shared warning', 'vue warning'],
+    });
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_NEXT,
+      false,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_NEXT,
+      false,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+    expect(result.updates).toEqual([primaryUpdate, vueUpdate]);
+    expect(result.errors).toEqual(['primary error', 'vue error']);
+    expect(result.warnings).toEqual([
+      'shared warning',
+      'primary warning',
+      'vue warning',
+    ]);
+  });
+
+  it('deduplicates mixed hash collisions and merges their file paths', async () => {
+    mocks.detectVueProject.mockReturnValue(true);
+    const primaryUpdate = update('Shared', 'shared-hash', ['primary.tsx']);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [primaryUpdate],
+      errors: [],
+      warnings: [],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [
+        update('Shared', 'shared-hash', ['component.vue', 'primary.tsx']),
+      ],
+      errors: [],
+      warnings: [],
+    });
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toBe(primaryUpdate);
+    expect(result.updates[0].metadata.filePaths).toEqual([
+      'primary.tsx',
+      'component.vue',
+    ]);
+  });
+
+  it('uses only the package project API for a Vue-primary project', async () => {
+    const vueResult = {
+      updates: [update('Vue only', 'vue-only-hash', ['App.vue'])],
+      errors: ['vue error'],
+      warnings: ['vue warning'],
+    };
+    mocks.extractFromVueProject.mockResolvedValue(vueResult);
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_VUE,
+      true,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(mocks.detectVueProject).not.toHaveBeenCalled();
+    expect(mocks.createInlineUpdates).not.toHaveBeenCalled();
+    expect(mocks.createPythonInlineUpdates).not.toHaveBeenCalled();
+    expect(mocks.extractFromVueProject).toHaveBeenCalledOnce();
+    expect(mocks.extractFromVueProject).toHaveBeenCalledWith({
+      filePatterns: patterns,
+      includeSourceCodeContext: true,
+      conditionNames: parsingOptions.conditionNames,
+      vueCompilerOptions: parsingFlags.vueCompilerOptions,
+      viteConfigPath: parsingFlags.viteConfigPath,
+    });
+    expect(result).toEqual(vueResult);
+  });
+});

--- a/packages/cli/src/translation/__tests__/extractInline.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.test.ts
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   extractFromVueProject: vi.fn(),
   mergeVueProjectExtraction: vi.fn(),
   inspectVueProjectAsync: vi.fn(),
-  readVueSfcExclusionPatterns: vi.fn(),
+  partitionVueSourcePatterns: vi.fn(),
   projectModuleLoads: 0,
 }));
 
@@ -26,7 +26,7 @@ vi.mock('@generaltranslation/vue-extractor/project', () => {
 
 vi.mock('@generaltranslation/vue-extractor/inspect', () => ({
   inspectVueProjectAsync: mocks.inspectVueProjectAsync,
-  readVueSfcExclusionPatterns: mocks.readVueSfcExclusionPatterns,
+  partitionVueSourcePatterns: mocks.partitionVueSourcePatterns,
 }));
 
 vi.mock('../../react/parse/createInlineUpdates.js', () => ({
@@ -51,6 +51,7 @@ const parsingOptions: ParsingConfigOptions = {
   conditionNames: ['browser', 'import'],
 };
 const patterns = ['src/**/*.{ts,tsx,vue}', '!src/vendor/**'];
+const cwd = process.cwd();
 
 function update(
   source: string,
@@ -67,7 +68,10 @@ function update(
 describe('extractInlineFromProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.readVueSfcExclusionPatterns.mockReturnValue([]);
+    mocks.partitionVueSourcePatterns.mockReturnValue({
+      primaryExclusionPatterns: [],
+      vueExclusionPatterns: [],
+    });
     mocks.inspectVueProjectAsync.mockResolvedValue({
       projectRoot: '/fixture',
       rootOwnsVue: false,
@@ -104,7 +108,7 @@ describe('extractInlineFromProject', () => {
       parsingFlags,
       parsingOptions
     );
-    expect(mocks.inspectVueProjectAsync).toHaveBeenCalledOnce();
+    expect(mocks.inspectVueProjectAsync).toHaveBeenCalledWith(cwd);
     expect(mocks.projectModuleLoads).toBe(0);
     expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
   });
@@ -150,7 +154,10 @@ describe('extractInlineFromProject', () => {
       hasVueScopes: boolean;
     }>();
     mocks.inspectVueProjectAsync.mockReturnValue(inspection.promise);
-    mocks.readVueSfcExclusionPatterns.mockReturnValue(['!src/App.vue']);
+    mocks.partitionVueSourcePatterns.mockReturnValue({
+      primaryExclusionPatterns: ['!src/App.vue'],
+      vueExclusionPatterns: [],
+    });
     mocks.createInlineUpdates.mockResolvedValue({
       updates: [],
       errors: [],
@@ -255,7 +262,10 @@ describe('extractInlineFromProject', () => {
   );
 
   it('partitions explicit SFCs owned by a discovered Vue scope', async () => {
-    mocks.readVueSfcExclusionPatterns.mockReturnValue(['!src/App.vue']);
+    mocks.partitionVueSourcePatterns.mockReturnValue({
+      primaryExclusionPatterns: ['!src/App.vue'],
+      vueExclusionPatterns: [],
+    });
     mocks.inspectVueProjectAsync.mockResolvedValue({
       projectRoot: '/fixture',
       rootOwnsVue: true,
@@ -288,6 +298,7 @@ describe('extractInlineFromProject', () => {
       parsingOptions
     );
     expect(mocks.extractFromVueProject).toHaveBeenCalledWith({
+      cwd,
       filePatterns: patterns,
       inspection: {
         projectRoot: '/fixture',
@@ -303,6 +314,53 @@ describe('extractInlineFromProject', () => {
       'Primary',
       'Vue',
     ]);
+  });
+
+  it('keeps ambiguous JSX modules on the primary pass only', async () => {
+    const ambiguousExclusion = '!src/Ambiguous.vue';
+    mocks.partitionVueSourcePatterns.mockReturnValue({
+      primaryExclusionPatterns: [],
+      vueExclusionPatterns: [ambiguousExclusion],
+    });
+    const inspection = {
+      projectRoot: '/fixture',
+      rootOwnsVue: true,
+      hasVueScopes: true,
+    } as const;
+    mocks.inspectVueProjectAsync.mockResolvedValue(inspection);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [update('Historical', 'historical-hash', ['src/Ambiguous.vue'])],
+      errors: [],
+      warnings: [],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+
+    await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+    expect(mocks.extractFromVueProject).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd,
+        filePatterns: [...patterns, ambiguousExclusion],
+        inspection,
+      })
+    );
   });
 
   it('preserves exact historical patterns for descendant-only Vue scopes', async () => {
@@ -410,6 +468,7 @@ describe('extractInlineFromProject', () => {
     expect(mocks.createPythonInlineUpdates).not.toHaveBeenCalled();
     expect(mocks.extractFromVueProject).toHaveBeenCalledOnce();
     expect(mocks.extractFromVueProject).toHaveBeenCalledWith({
+      cwd,
       filePatterns: patterns,
       includeSourceCodeContext: true,
       conditionNames: parsingOptions.conditionNames,

--- a/packages/cli/src/translation/__tests__/extractInline.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   createPythonInlineUpdates: vi.fn(),
   extractFromVueProject: vi.fn(),
   mergeVueProjectExtraction: vi.fn(),
-  inspectVueProject: vi.fn(),
+  inspectVueProjectAsync: vi.fn(),
   readVueSfcExclusionPatterns: vi.fn(),
   projectModuleLoads: 0,
 }));
@@ -25,7 +25,7 @@ vi.mock('@generaltranslation/vue-extractor/project', () => {
 });
 
 vi.mock('@generaltranslation/vue-extractor/inspect', () => ({
-  inspectVueProject: mocks.inspectVueProject,
+  inspectVueProjectAsync: mocks.inspectVueProjectAsync,
   readVueSfcExclusionPatterns: mocks.readVueSfcExclusionPatterns,
 }));
 
@@ -68,7 +68,7 @@ describe('extractInlineFromProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.readVueSfcExclusionPatterns.mockReturnValue([]);
-    mocks.inspectVueProject.mockReturnValue({
+    mocks.inspectVueProjectAsync.mockResolvedValue({
       projectRoot: '/fixture',
       rootOwnsVue: false,
       hasVueScopes: false,
@@ -104,9 +104,90 @@ describe('extractInlineFromProject', () => {
       parsingFlags,
       parsingOptions
     );
-    expect(mocks.inspectVueProject).toHaveBeenCalledOnce();
+    expect(mocks.inspectVueProjectAsync).toHaveBeenCalledOnce();
     expect(mocks.projectModuleLoads).toBe(0);
     expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
+  });
+
+  it('runs default historical extraction while workspace inspection is pending', async () => {
+    const inspection = deferred<{
+      projectRoot: string;
+      rootOwnsVue: boolean;
+      hasVueScopes: boolean;
+    }>();
+    const historicalResult = {
+      updates: [update('React', 'react-hash', ['src/App.tsx'])],
+      errors: [],
+      warnings: [],
+    };
+    mocks.inspectVueProjectAsync.mockReturnValue(inspection.promise);
+    mocks.createInlineUpdates.mockResolvedValue(historicalResult);
+
+    const resultPromise = extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      parsingFlags,
+      parsingOptions
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.createInlineUpdates).toHaveBeenCalledOnce();
+    });
+    inspection.resolve({
+      projectRoot: '/fixture',
+      rootOwnsVue: false,
+      hasVueScopes: false,
+    });
+
+    await expect(resultPromise).resolves.toBe(historicalResult);
+  });
+
+  it('waits for workspace inspection before partitioning explicit patterns', async () => {
+    const inspection = deferred<{
+      projectRoot: string;
+      rootOwnsVue: boolean;
+      hasVueScopes: boolean;
+    }>();
+    mocks.inspectVueProjectAsync.mockReturnValue(inspection.promise);
+    mocks.readVueSfcExclusionPatterns.mockReturnValue(['!src/App.vue']);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+
+    const resultPromise = extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+
+    await vi.waitFor(() => {
+      expect(mocks.inspectVueProjectAsync).toHaveBeenCalledOnce();
+    });
+    expect(mocks.createInlineUpdates).not.toHaveBeenCalled();
+    inspection.resolve({
+      projectRoot: '/fixture',
+      rootOwnsVue: true,
+      hasVueScopes: true,
+    });
+    await resultPromise;
+
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_REACT,
+      false,
+      [...patterns, '!src/App.vue'],
+      parsingFlags,
+      parsingOptions
+    );
   });
 
   it.each([
@@ -175,7 +256,7 @@ describe('extractInlineFromProject', () => {
 
   it('partitions explicit SFCs owned by a discovered Vue scope', async () => {
     mocks.readVueSfcExclusionPatterns.mockReturnValue(['!src/App.vue']);
-    mocks.inspectVueProject.mockReturnValue({
+    mocks.inspectVueProjectAsync.mockResolvedValue({
       projectRoot: '/fixture',
       rootOwnsVue: true,
       hasVueScopes: true,
@@ -230,7 +311,7 @@ describe('extractInlineFromProject', () => {
       rootOwnsVue: false,
       hasVueScopes: true,
     } as const;
-    mocks.inspectVueProject.mockReturnValue(inspection);
+    mocks.inspectVueProjectAsync.mockResolvedValue(inspection);
     mocks.createInlineUpdates.mockResolvedValue({
       updates: [update('Legacy React', 'react-hash', ['src/Legacy.vue'])],
       errors: [],
@@ -263,7 +344,7 @@ describe('extractInlineFromProject', () => {
   });
 
   it('appends Vue results while preserving primary ordering and combining diagnostics', async () => {
-    mocks.inspectVueProject.mockReturnValue({
+    mocks.inspectVueProjectAsync.mockResolvedValue({
       projectRoot: '/fixture',
       rootOwnsVue: true,
       hasVueScopes: true,
@@ -338,3 +419,14 @@ describe('extractInlineFromProject', () => {
     expect(result).toEqual(vueResult);
   });
 });
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/cli/src/translation/__tests__/extractInline.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.test.ts
@@ -9,19 +9,25 @@ import type {
 const mocks = vi.hoisted(() => ({
   createInlineUpdates: vi.fn(),
   createPythonInlineUpdates: vi.fn(),
-  detectVueProject: vi.fn(),
   extractFromVueProject: vi.fn(),
+  mergeVueProjectExtraction: vi.fn(),
+  inspectVueProject: vi.fn(),
+  readVueSfcExclusionPatterns: vi.fn(),
   projectModuleLoads: 0,
-}));
-
-vi.mock('@generaltranslation/vue-extractor/detect', () => ({
-  detectVueProject: mocks.detectVueProject,
 }));
 
 vi.mock('@generaltranslation/vue-extractor/project', () => {
   mocks.projectModuleLoads += 1;
-  return { extractFromVueProject: mocks.extractFromVueProject };
+  return {
+    extractFromVueProject: mocks.extractFromVueProject,
+    mergeVueProjectExtraction: mocks.mergeVueProjectExtraction,
+  };
 });
+
+vi.mock('@generaltranslation/vue-extractor/inspect', () => ({
+  inspectVueProject: mocks.inspectVueProject,
+  readVueSfcExclusionPatterns: mocks.readVueSfcExclusionPatterns,
+}));
 
 vi.mock('../../react/parse/createInlineUpdates.js', () => ({
   createInlineUpdates: mocks.createInlineUpdates,
@@ -61,7 +67,17 @@ function update(
 describe('extractInlineFromProject', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.detectVueProject.mockReturnValue(false);
+    mocks.readVueSfcExclusionPatterns.mockReturnValue([]);
+    mocks.inspectVueProject.mockReturnValue({
+      projectRoot: '/fixture',
+      rootOwnsVue: false,
+      hasVueScopes: false,
+    });
+    mocks.mergeVueProjectExtraction.mockImplementation((primary, vue) => ({
+      updates: [...primary.updates, ...vue.updates],
+      errors: [...primary.errors, ...vue.errors],
+      warnings: [...new Set([...primary.warnings, ...vue.warnings])],
+    }));
   });
 
   it('does not load or call the Vue project extractor when Vue is absent', async () => {
@@ -88,6 +104,7 @@ describe('extractInlineFromProject', () => {
       parsingFlags,
       parsingOptions
     );
+    expect(mocks.inspectVueProject).toHaveBeenCalledOnce();
     expect(mocks.projectModuleLoads).toBe(0);
     expect(mocks.extractFromVueProject).not.toHaveBeenCalled();
   });
@@ -156,8 +173,13 @@ describe('extractInlineFromProject', () => {
     }
   );
 
-  it('keeps explicit patterns intact for Vue and excludes only .vue from the legacy parser', async () => {
-    mocks.detectVueProject.mockReturnValue(true);
+  it('partitions explicit SFCs owned by a discovered Vue scope', async () => {
+    mocks.readVueSfcExclusionPatterns.mockReturnValue(['!src/App.vue']);
+    mocks.inspectVueProject.mockReturnValue({
+      projectRoot: '/fixture',
+      rootOwnsVue: true,
+      hasVueScopes: true,
+    });
     mocks.createInlineUpdates.mockResolvedValue({
       updates: [update('Primary', 'primary-hash', ['src/App.tsx'])],
       errors: [],
@@ -180,12 +202,17 @@ describe('extractInlineFromProject', () => {
     expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
       Libraries.GT_REACT,
       true,
-      [...patterns, '!**/*.vue'],
+      [...patterns, '!src/App.vue'],
       parsingFlags,
       parsingOptions
     );
     expect(mocks.extractFromVueProject).toHaveBeenCalledWith({
       filePatterns: patterns,
+      inspection: {
+        projectRoot: '/fixture',
+        rootOwnsVue: true,
+        hasVueScopes: true,
+      },
       includeSourceCodeContext: true,
       conditionNames: parsingOptions.conditionNames,
       vueCompilerOptions: parsingFlags.vueCompilerOptions,
@@ -197,8 +224,50 @@ describe('extractInlineFromProject', () => {
     ]);
   });
 
+  it('preserves exact historical patterns for descendant-only Vue scopes', async () => {
+    const inspection = {
+      projectRoot: '/fixture',
+      rootOwnsVue: false,
+      hasVueScopes: true,
+    } as const;
+    mocks.inspectVueProject.mockReturnValue(inspection);
+    mocks.createInlineUpdates.mockResolvedValue({
+      updates: [update('Legacy React', 'react-hash', ['src/Legacy.vue'])],
+      errors: [],
+      warnings: [],
+    });
+    mocks.extractFromVueProject.mockResolvedValue({
+      updates: [update('Child Vue', 'vue-hash', ['apps/vue/App.vue'])],
+      errors: [],
+      warnings: [],
+    });
+
+    await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(mocks.createInlineUpdates).toHaveBeenCalledWith(
+      Libraries.GT_REACT,
+      false,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+    expect(mocks.extractFromVueProject).toHaveBeenCalledWith(
+      expect.objectContaining({ filePatterns: patterns, inspection })
+    );
+  });
+
   it('appends Vue results while preserving primary ordering and combining diagnostics', async () => {
-    mocks.detectVueProject.mockReturnValue(true);
+    mocks.inspectVueProject.mockReturnValue({
+      projectRoot: '/fixture',
+      rootOwnsVue: true,
+      hasVueScopes: true,
+    });
     const primaryUpdate = update('Primary', 'primary-hash', ['primary.tsx']);
     const vueUpdate = update('Vue', 'vue-hash', ['component.vue']);
     mocks.createInlineUpdates.mockResolvedValue({
@@ -234,38 +303,10 @@ describe('extractInlineFromProject', () => {
       'primary warning',
       'vue warning',
     ]);
-  });
-
-  it('deduplicates mixed hash collisions and merges their file paths', async () => {
-    mocks.detectVueProject.mockReturnValue(true);
-    const primaryUpdate = update('Shared', 'shared-hash', ['primary.tsx']);
-    mocks.createInlineUpdates.mockResolvedValue({
-      updates: [primaryUpdate],
-      errors: [],
-      warnings: [],
-    });
-    mocks.extractFromVueProject.mockResolvedValue({
-      updates: [
-        update('Shared', 'shared-hash', ['component.vue', 'primary.tsx']),
-      ],
-      errors: [],
-      warnings: [],
-    });
-
-    const result = await extractInlineFromProject(
-      Libraries.GT_REACT,
-      false,
-      undefined,
-      parsingFlags,
-      parsingOptions
+    expect(mocks.mergeVueProjectExtraction).toHaveBeenCalledWith(
+      expect.objectContaining({ updates: [primaryUpdate] }),
+      expect.objectContaining({ updates: [vueUpdate] })
     );
-
-    expect(result.updates).toHaveLength(1);
-    expect(result.updates[0]).toBe(primaryUpdate);
-    expect(result.updates[0].metadata.filePaths).toEqual([
-      'primary.tsx',
-      'component.vue',
-    ]);
   });
 
   it('uses only the package project API for a Vue-primary project', async () => {
@@ -284,7 +325,6 @@ describe('extractInlineFromProject', () => {
       parsingOptions
     );
 
-    expect(mocks.detectVueProject).not.toHaveBeenCalled();
     expect(mocks.createInlineUpdates).not.toHaveBeenCalled();
     expect(mocks.createPythonInlineUpdates).not.toHaveBeenCalled();
     expect(mocks.extractFromVueProject).toHaveBeenCalledOnce();

--- a/packages/cli/src/translation/__tests__/extractInline.vPreRegression.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.vPreRegression.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GT_PARSING_FLAGS_DEFAULT } from '../../config/defaults.js';
+import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
+import { Libraries } from '../../types/libraries.js';
+import type { ParsingConfigOptions } from '../../types/parsing.js';
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
+import { extractInlineFromProject } from '../extractInline.js';
+
+const originalCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+const parsingOptions: ParsingConfigOptions = {
+  conditionNames: ['development', 'browser', 'module', 'import', 'default'],
+};
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('React extraction with v-pre Vue-like content', () => {
+  it.each([
+    {
+      name: 'a namespace component tag',
+      template: '<section v-pre><Mixed.VueT /></section>',
+    },
+    {
+      name: 'a directive expression',
+      template: '<section v-pre :title="Mixed.VueT" />',
+    },
+    {
+      name: 'an interpolation',
+      template: '<section v-pre>{{ Mixed.VueT }}</section>',
+    },
+    {
+      name: 'a v-pre modifier',
+      template: '<section v-pre.example><Mixed.VueT /></section>',
+    },
+    {
+      name: 'a v-pre argument',
+      template: '<section v-pre:example><Mixed.VueT /></section>',
+    },
+    {
+      name: 'an uppercase component that resembles a void element',
+      template: '<INPUT v-pre :value="Mixed.VueT"><Mixed.VueT /></INPUT>',
+    },
+  ])('preserves historical React dispatch for $name', async ({ template }) => {
+    createFixture(template);
+
+    const historical = await createInlineUpdates(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+    const dispatched = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      false,
+      undefined,
+      GT_PARSING_FLAGS_DEFAULT,
+      parsingOptions
+    );
+
+    expect(dispatched).toEqual(historical);
+    expect(detectVueProject()).toBe(false);
+    expect(dispatched.errors).toEqual([]);
+    expect(dispatched.updates.map(({ source }) => source)).toEqual([
+      'Stable React message',
+    ]);
+  });
+});
+
+function createFixture(template: string): void {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-cli-v-pre-'));
+  temporaryDirectories.push(root);
+  const files = {
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: {
+        '@fixture/multi': 'file:./vendor/multi',
+        'gt-react': '*',
+      },
+    }),
+    'src/App.tsx': `
+      import { T } from 'gt-react';
+      export const App = () => <T>Stable React message</T>;
+    `,
+    'src/Unrelated.vue': `
+      <script setup>
+      import * as Mixed from '@fixture/multi/vue';
+      </script>
+      <template>${template}</template>
+    `,
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: { './vue': './src/vue.ts' },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+  };
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+  const destination = path.join(root, 'node_modules', '@fixture', 'multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  process.chdir(root);
+}

--- a/packages/cli/src/translation/__tests__/validate.vue.test.ts
+++ b/packages/cli/src/translation/__tests__/validate.vue.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Options, Settings } from '../../types/index.js';
+import { Libraries } from '../../types/libraries.js';
+
+const mocks = vi.hoisted(() => ({
+  extractInlineFromProject: vi.fn(),
+}));
+
+vi.mock('../extractInline.js', () => ({
+  extractInlineFromProject: mocks.extractInlineFromProject,
+}));
+
+import { getValidateJson } from '../validate.js';
+
+describe('getValidateJson Vue dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps gt-vue as the programmatic validation runtime', async () => {
+    mocks.extractInlineFromProject.mockResolvedValue({
+      updates: [],
+      errors: ['src/App.vue (2:3): Vue validation error'],
+      warnings: [],
+    });
+    const settings = {
+      files: {
+        gtJson: {
+          parsingFlags: {
+            autoderive: false,
+            enableAutoJsxInjection: false,
+            includeSourceCodeContext: false,
+            legacyGtReactImportSource: false,
+          },
+        },
+      },
+      parsingOptions: { conditionNames: ['browser', 'import'] },
+    } as unknown as Options & Settings;
+
+    const result = await getValidateJson(settings, Libraries.GT_VUE, [
+      'src/App.vue',
+    ]);
+
+    expect(mocks.extractInlineFromProject).toHaveBeenCalledWith(
+      Libraries.GT_VUE,
+      true,
+      ['src/App.vue'],
+      settings.files.gtJson.parsingFlags,
+      settings.parsingOptions
+    );
+    expect(result).toEqual({
+      'src/App.vue': [{ level: 'error', message: 'Vue validation error' }],
+    });
+  });
+});

--- a/packages/cli/src/translation/extractInline.ts
+++ b/packages/cli/src/translation/extractInline.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+import fg from 'fast-glob';
 import type { Updates } from '../types/index.js';
 import type { GTParsingFlags, ParsingConfigOptions } from '../types/parsing.js';
 import {
@@ -32,11 +34,12 @@ export async function extractInlineFromProject(
   parsingFlags: GTParsingFlags,
   parsingOptions: ParsingConfigOptions
 ): Promise<InlineExtractionOutput> {
+  const cwd = process.cwd();
   if (pkg === Libraries.GT_VUE) {
-    return extractVueProject(filePatterns, parsingFlags, parsingOptions);
+    return extractVueProject(filePatterns, parsingFlags, parsingOptions, cwd);
   }
 
-  const inspectionPromise = inspectVueProject();
+  const inspectionPromise = inspectVueProject(cwd);
   const extractPrimary = (primaryPatterns: string[] | undefined) =>
     isPythonLibrary(pkg)
       ? createPythonInlineUpdates(primaryPatterns)
@@ -50,14 +53,23 @@ export async function extractInlineFromProject(
 
   let inspection: VueProjectInspection;
   let primary: InlineExtractionOutput;
+  let vuePatterns = filePatterns;
   if (filePatterns) {
     inspection = await inspectionPromise;
-    const vueSfcExclusions = inspection.hasVueScopes
-      ? await readVueSfcExclusionPatterns(inspection, filePatterns)
-      : [];
+    const partition = inspection.hasVueScopes
+      ? await partitionVueSourcePatterns(inspection, filePatterns)
+      : { primaryExclusionPatterns: [], vueExclusionPatterns: [] };
+    const stablePrimaryPatterns =
+      process.cwd() === cwd
+        ? filePatterns
+        : anchorFilePatterns(cwd, filePatterns);
     const primaryPatterns =
-      vueSfcExclusions.length > 0
-        ? [...filePatterns, ...vueSfcExclusions]
+      partition.primaryExclusionPatterns.length > 0
+        ? [...stablePrimaryPatterns, ...partition.primaryExclusionPatterns]
+        : stablePrimaryPatterns;
+    vuePatterns =
+      partition.vueExclusionPatterns.length > 0
+        ? [...filePatterns, ...partition.vueExclusionPatterns]
         : filePatterns;
     primary = await extractPrimary(primaryPatterns);
   } else {
@@ -69,9 +81,10 @@ export async function extractInlineFromProject(
   if (!inspection.hasVueScopes) return primary;
 
   const vue = await extractVueProject(
-    filePatterns,
+    vuePatterns,
     parsingFlags,
     parsingOptions,
+    cwd,
     inspection
   );
   const { mergeVueProjectExtraction } =
@@ -84,11 +97,13 @@ async function extractVueProject(
   filePatterns: string[] | undefined,
   parsingFlags: GTParsingFlags,
   parsingOptions: ParsingConfigOptions,
+  cwd: string,
   inspection?: VueProjectInspection
 ): Promise<VueProjectExtractionOutput> {
   const { extractFromVueProject } =
     await import('@generaltranslation/vue-extractor/project');
   const output = await extractFromVueProject({
+    cwd,
     filePatterns,
     inspection,
     includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
@@ -100,18 +115,43 @@ async function extractVueProject(
 }
 
 /** Loads workspace inspection without loading the Vue compiler or analyzer. */
-async function inspectVueProject(): Promise<VueProjectInspection> {
+async function inspectVueProject(cwd: string): Promise<VueProjectInspection> {
   const { inspectVueProjectAsync: inspect } =
     await import('@generaltranslation/vue-extractor/inspect');
-  return inspect();
+  return inspect(cwd);
 }
 
-/** Lets the package distinguish Vue SFCs from legacy JSX `.vue` modules. */
-async function readVueSfcExclusionPatterns(
+/** Lets the package partition Vue SFCs from legacy JSX `.vue` modules. */
+async function partitionVueSourcePatterns(
   inspection: VueProjectInspection,
   filePatterns: readonly string[]
-): Promise<string[]> {
-  const { readVueSfcExclusionPatterns: readExclusions } =
+): Promise<{
+  primaryExclusionPatterns: string[];
+  vueExclusionPatterns: string[];
+}> {
+  const { partitionVueSourcePatterns: partition } =
     await import('@generaltranslation/vue-extractor/inspect');
-  return readExclusions(inspection, filePatterns);
+  return partition(inspection, filePatterns);
+}
+
+/**
+ * Preserves explicit file selection when another task changes the process cwd
+ * while Vue workspace inspection is pending.
+ *
+ * The historical extractor still owns matching and parsing. Only its relative
+ * glob base is made explicit, including negative patterns; normal calls whose
+ * cwd has not changed continue receiving their original patterns byte-for-byte.
+ */
+function anchorFilePatterns(cwd: string, filePatterns: readonly string[]) {
+  const rootPattern = fg.convertPathToPattern(cwd).replace(/\/$/, '');
+  return filePatterns.map((pattern) => {
+    const negative = pattern.startsWith('!') && pattern[1] !== '(';
+    const positivePattern = negative ? pattern.slice(1) : pattern;
+    if (path.isAbsolute(positivePattern)) return pattern;
+    const relativePattern = positivePattern.startsWith('./')
+      ? positivePattern.slice(2)
+      : positivePattern;
+    const anchoredPattern = `${rootPattern}/${relativePattern}`;
+    return negative ? `!${anchoredPattern}` : anchoredPattern;
+  });
 }

--- a/packages/cli/src/translation/extractInline.ts
+++ b/packages/cli/src/translation/extractInline.ts
@@ -36,24 +36,36 @@ export async function extractInlineFromProject(
     return extractVueProject(filePatterns, parsingFlags, parsingOptions);
   }
 
-  const inspection = await inspectVueProject();
-  const vueSfcExclusions =
-    filePatterns && inspection.hasVueScopes
+  const inspectionPromise = inspectVueProject();
+  const extractPrimary = (primaryPatterns: string[] | undefined) =>
+    isPythonLibrary(pkg)
+      ? createPythonInlineUpdates(primaryPatterns)
+      : createInlineUpdates(
+          pkg,
+          validate,
+          primaryPatterns,
+          parsingFlags,
+          parsingOptions
+        );
+
+  let inspection: VueProjectInspection;
+  let primary: InlineExtractionOutput;
+  if (filePatterns) {
+    inspection = await inspectionPromise;
+    const vueSfcExclusions = inspection.hasVueScopes
       ? await readVueSfcExclusionPatterns(inspection, filePatterns)
       : [];
-  const primaryPatterns =
-    filePatterns && vueSfcExclusions.length > 0
-      ? [...filePatterns, ...vueSfcExclusions]
-      : filePatterns;
-  const primary = isPythonLibrary(pkg)
-    ? await createPythonInlineUpdates(primaryPatterns)
-    : await createInlineUpdates(
-        pkg,
-        validate,
-        primaryPatterns,
-        parsingFlags,
-        parsingOptions
-      );
+    const primaryPatterns =
+      vueSfcExclusions.length > 0
+        ? [...filePatterns, ...vueSfcExclusions]
+        : filePatterns;
+    primary = await extractPrimary(primaryPatterns);
+  } else {
+    [inspection, primary] = await Promise.all([
+      inspectionPromise,
+      extractPrimary(filePatterns),
+    ]);
+  }
   if (!inspection.hasVueScopes) return primary;
 
   const vue = await extractVueProject(
@@ -87,9 +99,9 @@ async function extractVueProject(
   return output;
 }
 
-/** Loads workspace inspection without loading the Vue source parser. */
+/** Loads workspace inspection without loading the Vue compiler or analyzer. */
 async function inspectVueProject(): Promise<VueProjectInspection> {
-  const { inspectVueProject: inspect } =
+  const { inspectVueProjectAsync: inspect } =
     await import('@generaltranslation/vue-extractor/inspect');
   return inspect();
 }

--- a/packages/cli/src/translation/extractInline.ts
+++ b/packages/cli/src/translation/extractInline.ts
@@ -1,4 +1,3 @@
-import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
 import type { Updates } from '../types/index.js';
 import type { GTParsingFlags, ParsingConfigOptions } from '../types/parsing.js';
 import {
@@ -6,9 +5,12 @@ import {
   Libraries,
   type InlineLibrary,
 } from '../types/libraries.js';
-import { dedupeUpdates } from '../extraction/postProcess.js';
 import { createPythonInlineUpdates } from '../python/parse/createPythonInlineUpdates.js';
 import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
+import type {
+  VueProjectExtractionOutput,
+  VueProjectInspection,
+} from '@generaltranslation/vue-extractor/types';
 
 type InlineExtractionOutput = {
   updates: Updates;
@@ -34,9 +36,15 @@ export async function extractInlineFromProject(
     return extractVueProject(filePatterns, parsingFlags, parsingOptions);
   }
 
-  const includesVue = detectVueProject();
+  const inspection = await inspectVueProject();
+  const vueSfcExclusions =
+    filePatterns && inspection.hasVueScopes
+      ? await readVueSfcExclusionPatterns(inspection, filePatterns)
+      : [];
   const primaryPatterns =
-    includesVue && filePatterns ? [...filePatterns, '!**/*.vue'] : filePatterns;
+    filePatterns && vueSfcExclusions.length > 0
+      ? [...filePatterns, ...vueSfcExclusions]
+      : filePatterns;
   const primary = isPythonLibrary(pkg)
     ? await createPythonInlineUpdates(primaryPatterns)
     : await createInlineUpdates(
@@ -46,36 +54,52 @@ export async function extractInlineFromProject(
         parsingFlags,
         parsingOptions
       );
-  if (!includesVue) return primary;
+  if (!inspection.hasVueScopes) return primary;
 
   const vue = await extractVueProject(
     filePatterns,
     parsingFlags,
-    parsingOptions
+    parsingOptions,
+    inspection
   );
-  const updates: Updates = [...primary.updates, ...vue.updates];
-  dedupeUpdates(updates);
-  return {
-    updates,
-    errors: [...primary.errors, ...vue.errors],
-    warnings: [...new Set([...primary.warnings, ...vue.warnings])],
-  };
+  const { mergeVueProjectExtraction } =
+    await import('@generaltranslation/vue-extractor/project');
+  return mergeVueProjectExtraction(primary, vue);
 }
 
 /** Loads the heavy Vue graph only after lightweight ownership detection. */
 async function extractVueProject(
   filePatterns: string[] | undefined,
   parsingFlags: GTParsingFlags,
-  parsingOptions: ParsingConfigOptions
-): Promise<InlineExtractionOutput> {
+  parsingOptions: ParsingConfigOptions,
+  inspection?: VueProjectInspection
+): Promise<VueProjectExtractionOutput> {
   const { extractFromVueProject } =
     await import('@generaltranslation/vue-extractor/project');
   const output = await extractFromVueProject({
     filePatterns,
+    inspection,
     includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
     conditionNames: parsingOptions.conditionNames,
     vueCompilerOptions: parsingFlags.vueCompilerOptions,
     viteConfigPath: parsingFlags.viteConfigPath,
   });
-  return { ...output, updates: output.updates as Updates };
+  return output;
+}
+
+/** Loads workspace inspection without loading the Vue source parser. */
+async function inspectVueProject(): Promise<VueProjectInspection> {
+  const { inspectVueProject: inspect } =
+    await import('@generaltranslation/vue-extractor/inspect');
+  return inspect();
+}
+
+/** Lets the package distinguish Vue SFCs from legacy JSX `.vue` modules. */
+async function readVueSfcExclusionPatterns(
+  inspection: VueProjectInspection,
+  filePatterns: readonly string[]
+): Promise<string[]> {
+  const { readVueSfcExclusionPatterns: readExclusions } =
+    await import('@generaltranslation/vue-extractor/inspect');
+  return readExclusions(inspection, filePatterns);
 }

--- a/packages/cli/src/translation/extractInline.ts
+++ b/packages/cli/src/translation/extractInline.ts
@@ -1,0 +1,81 @@
+import { detectVueProject } from '@generaltranslation/vue-extractor/detect';
+import type { Updates } from '../types/index.js';
+import type { GTParsingFlags, ParsingConfigOptions } from '../types/parsing.js';
+import {
+  isPythonLibrary,
+  Libraries,
+  type InlineLibrary,
+} from '../types/libraries.js';
+import { dedupeUpdates } from '../extraction/postProcess.js';
+import { createPythonInlineUpdates } from '../python/parse/createPythonInlineUpdates.js';
+import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
+
+type InlineExtractionOutput = {
+  updates: Updates;
+  errors: string[];
+  warnings: string[];
+};
+
+/**
+ * Preserves the existing primary extractor and appends package-owned Vue work.
+ *
+ * Pure React, Node, and Python projects call their historical extractor with
+ * exactly the same arguments and return its object unchanged. Vue project
+ * discovery and extraction remain inside `@generaltranslation/vue-extractor`.
+ */
+export async function extractInlineFromProject(
+  pkg: InlineLibrary,
+  validate: boolean,
+  filePatterns: string[] | undefined,
+  parsingFlags: GTParsingFlags,
+  parsingOptions: ParsingConfigOptions
+): Promise<InlineExtractionOutput> {
+  if (pkg === Libraries.GT_VUE) {
+    return extractVueProject(filePatterns, parsingFlags, parsingOptions);
+  }
+
+  const includesVue = detectVueProject();
+  const primaryPatterns =
+    includesVue && filePatterns ? [...filePatterns, '!**/*.vue'] : filePatterns;
+  const primary = isPythonLibrary(pkg)
+    ? await createPythonInlineUpdates(primaryPatterns)
+    : await createInlineUpdates(
+        pkg,
+        validate,
+        primaryPatterns,
+        parsingFlags,
+        parsingOptions
+      );
+  if (!includesVue) return primary;
+
+  const vue = await extractVueProject(
+    filePatterns,
+    parsingFlags,
+    parsingOptions
+  );
+  const updates: Updates = [...primary.updates, ...vue.updates];
+  dedupeUpdates(updates);
+  return {
+    updates,
+    errors: [...primary.errors, ...vue.errors],
+    warnings: [...new Set([...primary.warnings, ...vue.warnings])],
+  };
+}
+
+/** Loads the heavy Vue graph only after lightweight ownership detection. */
+async function extractVueProject(
+  filePatterns: string[] | undefined,
+  parsingFlags: GTParsingFlags,
+  parsingOptions: ParsingConfigOptions
+): Promise<InlineExtractionOutput> {
+  const { extractFromVueProject } =
+    await import('@generaltranslation/vue-extractor/project');
+  const output = await extractFromVueProject({
+    filePatterns,
+    includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
+    conditionNames: parsingOptions.conditionNames,
+    vueCompilerOptions: parsingFlags.vueCompilerOptions,
+    viteConfigPath: parsingFlags.viteConfigPath,
+  });
+  return { ...output, updates: output.updates as Updates };
+}

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -3,13 +3,12 @@ import fs from 'fs';
 import { logger } from '../console/logger.js';
 import loadJSON from '../fs/loadJSON.js';
 import { createDictionaryUpdates } from '../react/parse/createDictionaryUpdates.js';
-import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
-import { createPythonInlineUpdates } from '../python/parse/createPythonInlineUpdates.js';
 import createESBuildConfig from '../react/config/createESBuildConfig.js';
 import chalk from 'chalk';
 import type { ParsingConfigOptions, GTParsingFlags } from '../types/parsing.js';
 import { exitSync } from '../console/logging.js';
-import { InlineLibrary, isPythonLibrary } from '../types/libraries.js';
+import { InlineLibrary } from '../types/libraries.js';
+import { extractInlineFromProject } from './extractInline.js';
 
 /**
  * Searches for gt-react or gt-next dictionary files and creates updates for them,
@@ -74,15 +73,13 @@ export async function createUpdates(
     updates: newUpdates,
     errors: newErrors,
     warnings: newWarnings,
-  } = isPythonLibrary(pkg)
-    ? await createPythonInlineUpdates(src)
-    : await createInlineUpdates(
-        pkg,
-        validate,
-        src,
-        parsingFlags,
-        parsingOptions
-      );
+  } = await extractInlineFromProject(
+    pkg,
+    validate,
+    src,
+    parsingFlags,
+    parsingOptions
+  );
 
   errors = [...errors, ...newErrors];
   warnings = [...warnings, ...newWarnings];

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -1,11 +1,11 @@
 import { logErrorAndExit, stripAnsi } from '../console/logging.js';
 import chalk from 'chalk';
 import findFilepath from '../fs/findFilepath.js';
-import { Framework, Options, Settings, Updates } from '../types/index.js';
+import { Options, Settings, Updates } from '../types/index.js';
 import { logger } from '../console/logger.js';
 
 import { createUpdates } from './parse.js';
-import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
+import { extractInlineFromProject } from './extractInline.js';
 import { InlineLibrary, Libraries } from '../types/libraries.js';
 
 // Types for programmatic validation API
@@ -27,7 +27,7 @@ async function runValidation(
   files?: string[]
 ): Promise<{ updates: Updates; errors: string[]; warnings: string[] }> {
   if (files && files.length > 0) {
-    return createInlineUpdates(
+    return extractInlineFromProject(
       pkg,
       true,
       files,
@@ -94,15 +94,18 @@ export async function getValidateJson(
   pkg:
     | `${typeof Libraries.GT_REACT}`
     | `${typeof Libraries.GT_NEXT}`
-    | `${typeof Libraries.GT_REACT_NATIVE}`,
+    | `${typeof Libraries.GT_REACT_NATIVE}`
+    | `${typeof Libraries.GT_VUE}`,
   files?: string[]
 ): Promise<ValidationResult> {
-  const validatedPkg: Framework =
-    pkg === Libraries.GT_NEXT
-      ? Libraries.GT_NEXT
-      : pkg === Libraries.GT_REACT_NATIVE
-        ? Libraries.GT_REACT_NATIVE
-        : Libraries.GT_REACT;
+  const validatedPkg: InlineLibrary =
+    pkg === Libraries.GT_VUE
+      ? Libraries.GT_VUE
+      : pkg === Libraries.GT_NEXT
+        ? Libraries.GT_NEXT
+        : pkg === Libraries.GT_REACT_NATIVE
+          ? Libraries.GT_REACT_NATIVE
+          : Libraries.GT_REACT;
   const { errors, warnings } = await runValidation(
     settings,
     validatedPkg,

--- a/packages/cli/src/types/__tests__/libraries.test.ts
+++ b/packages/cli/src/types/__tests__/libraries.test.ts
@@ -3,6 +3,7 @@ import {
   Libraries,
   isPythonLibrary,
   INLINE_LIBRARIES,
+  GT_LIBRARIES,
   GT_LIBRARIES_UPSTREAM,
   PYTHON_LIBRARIES,
 } from '../libraries.js';
@@ -49,5 +50,13 @@ describe('Python library types', () => {
     expect(PYTHON_LIBRARIES).toContain(Libraries.GT_FLASK);
     expect(PYTHON_LIBRARIES).toContain(Libraries.GT_FASTAPI);
     expect(PYTHON_LIBRARIES).toHaveLength(2);
+  });
+});
+
+describe('Vue library boundaries', () => {
+  it('supports Vue orchestration without trusting Vue-only imports in React parsing', () => {
+    expect(INLINE_LIBRARIES).toContain(Libraries.GT_VUE);
+    expect(GT_LIBRARIES).not.toContain(Libraries.GT_VUE);
+    expect(GT_LIBRARIES_UPSTREAM).not.toHaveProperty(Libraries.GT_VUE);
   });
 });

--- a/packages/cli/src/types/libraries.ts
+++ b/packages/cli/src/types/libraries.ts
@@ -14,9 +14,7 @@ export enum Libraries {
   GT_FASTAPI = 'gt-fastapi',
 }
 
-/**
- * A list of all the libraries that support the CLI
- */
+/** Import sources trusted by the historical JavaScript/React parser. */
 export const GT_LIBRARIES = [
   Libraries.GT_REACT,
   Libraries.GT_NEXT,
@@ -25,7 +23,6 @@ export const GT_LIBRARIES = [
   Libraries.GT_I18N,
   Libraries.GT_REACT_CORE,
   Libraries.GT_TANSTACK_START,
-  Libraries.GT_VUE,
   Libraries.GT_FLASK,
   Libraries.GT_FASTAPI,
 ] as const;
@@ -83,9 +80,7 @@ export function isPythonLibrary(lib: string): lib is PythonLibrary {
   return (PYTHON_LIBRARIES as readonly string[]).includes(lib);
 }
 
-/**
- * A mapping of each library to their upstream dependencies for filtering imports
- */
+/** Historical parser import sources grouped by their upstream dependencies. */
 export const GT_LIBRARIES_UPSTREAM: Record<GTLibrary, GTLibrary[]> = {
   [Libraries.GT_NEXT]: [
     Libraries.GT_I18N,
@@ -114,7 +109,6 @@ export const GT_LIBRARIES_UPSTREAM: Record<GTLibrary, GTLibrary[]> = {
     Libraries.GT_TANSTACK_START,
   ],
   [Libraries.GT_I18N]: [Libraries.GT_I18N],
-  [Libraries.GT_VUE]: [Libraries.GT_VUE],
   [Libraries.GT_FLASK]: [Libraries.GT_FLASK],
   [Libraries.GT_FASTAPI]: [Libraries.GT_FASTAPI],
 } as const;

--- a/packages/cli/src/types/libraries.ts
+++ b/packages/cli/src/types/libraries.ts
@@ -9,6 +9,7 @@ export enum Libraries {
   GT_I18N = 'gt-i18n',
   GT_REACT_CORE = '@generaltranslation/react-core',
   GT_TANSTACK_START = 'gt-tanstack-start',
+  GT_VUE = 'gt-vue',
   GT_FLASK = 'gt-flask',
   GT_FASTAPI = 'gt-fastapi',
 }
@@ -24,6 +25,7 @@ export const GT_LIBRARIES = [
   Libraries.GT_I18N,
   Libraries.GT_REACT_CORE,
   Libraries.GT_TANSTACK_START,
+  Libraries.GT_VUE,
   Libraries.GT_FLASK,
   Libraries.GT_FASTAPI,
 ] as const;
@@ -39,6 +41,7 @@ export const INLINE_LIBRARIES = [
   Libraries.GT_REACT_NATIVE,
   Libraries.GT_REACT_CORE,
   Libraries.GT_TANSTACK_START,
+  Libraries.GT_VUE,
   Libraries.GT_I18N,
   Libraries.GT_FLASK,
   Libraries.GT_FASTAPI,
@@ -111,6 +114,7 @@ export const GT_LIBRARIES_UPSTREAM: Record<GTLibrary, GTLibrary[]> = {
     Libraries.GT_TANSTACK_START,
   ],
   [Libraries.GT_I18N]: [Libraries.GT_I18N],
+  [Libraries.GT_VUE]: [Libraries.GT_VUE],
   [Libraries.GT_FLASK]: [Libraries.GT_FLASK],
   [Libraries.GT_FASTAPI]: [Libraries.GT_FASTAPI],
 } as const;

--- a/packages/cli/src/types/parsing.ts
+++ b/packages/cli/src/types/parsing.ts
@@ -1,4 +1,5 @@
 import type { SupportedFileExtension } from './index.js';
+import type { VueCompilerOptions } from '@generaltranslation/vue-extractor/types';
 
 /**
  * For monorepo projects, checking for extra exports fields in resolved internal packages.
@@ -43,6 +44,10 @@ export type GTParsingFlags = BaseParsingFlags & {
   includeSourceCodeContext: boolean;
   enableAutoJsxInjection: boolean;
   legacyGtReactImportSource: boolean;
+  /** Vite config used to resolve hash-affecting Vue compiler behavior. */
+  viteConfigPath?: string;
+  /** Hash-affecting Vue template compiler options. */
+  vueCompilerOptions?: VueCompilerOptions;
 };
 
 /**

--- a/packages/vue-extractor/package.json
+++ b/packages/vue-extractor/package.json
@@ -1,0 +1,93 @@
+{
+  "name": "@generaltranslation/vue-extractor",
+  "version": "0.0.0",
+  "description": "Vue source code extraction for General Translation",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "type": "module",
+  "sideEffects": false,
+  "imports": {
+    "#vue-compiler-sfc": {
+      "bun": "@vue/compiler-sfc/dist/compiler-sfc.esm-browser.js",
+      "default": "@vue/compiler-sfc"
+    }
+  },
+  "author": "General Translation, Inc.",
+  "license": "FSL-1.1-ALv2",
+  "scripts": {
+    "emit-types": "sh ../../scripts/emit-types.sh",
+    "transpile": "tsdown && pnpm run emit-types",
+    "build": "pnpm run transpile",
+    "build:watch": "tsdown --watch",
+    "build:clean": "sh ../../scripts/clean.sh && pnpm run build",
+    "build:release": "pnpm run build:clean",
+    "format": "oxfmt src",
+    "patch": "pnpm version patch",
+    "release": "pnpm run build:clean && pnpm publish",
+    "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",
+    "release:beta": "pnpm run build:clean && pnpm publish --tag beta",
+    "release:latest": "pnpm run build:clean && pnpm publish --tag latest",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    },
+    "./detect": {
+      "import": "./dist/detect.js",
+      "types": "./dist/detect.d.ts"
+    },
+    "./project": {
+      "import": "./dist/project.js",
+      "types": "./dist/project.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "types": "./dist/types.d.ts"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/generaltranslation/gt.git"
+  },
+  "keywords": [
+    "vue",
+    "extraction",
+    "translation",
+    "i18n"
+  ],
+  "dependencies": {
+    "@babel/parser": "^7.25.7",
+    "@babel/traverse": "^7.25.7",
+    "@babel/types": "^7.25.7",
+    "@generaltranslation/format": "workspace:*",
+    "@vue/shared": "^3.5.0",
+    "enhanced-resolve": "^5.18.3",
+    "es-module-lexer": "^2.3.1",
+    "fast-glob": "^3.3.3",
+    "generaltranslation": "workspace:*",
+    "tsconfig-paths": "^4.2.0",
+    "yaml": "^2.8.0"
+  },
+  "devDependencies": {
+    "@types/babel__traverse": "^7.20.6",
+    "@types/node": "catalog:",
+    "@vue/compiler-dom": "^3.5.0",
+    "@vue/compiler-sfc": "^3.5.0",
+    "tsdown": "catalog:",
+    "typescript": "catalog:",
+    "vue": "^3.5.0",
+    "vite": "^7.1.7",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/vue-extractor/package.json
+++ b/packages/vue-extractor/package.json
@@ -44,6 +44,10 @@
       "import": "./dist/detect.js",
       "types": "./dist/detect.d.ts"
     },
+    "./inspect": {
+      "import": "./dist/inspect.js",
+      "types": "./dist/inspect.d.ts"
+    },
     "./project": {
       "import": "./dist/project.js",
       "types": "./dist/project.d.ts"
@@ -76,12 +80,14 @@
     "es-module-lexer": "^2.3.1",
     "fast-glob": "^3.3.3",
     "generaltranslation": "workspace:*",
+    "semver": "^7.8.5",
     "tsconfig-paths": "^4.2.0",
     "yaml": "^2.8.0"
   },
   "devDependencies": {
     "@types/babel__traverse": "^7.20.6",
     "@types/node": "catalog:",
+    "@types/semver": "^7.7.1",
     "@vue/compiler-dom": "^3.5.0",
     "@vue/compiler-sfc": "^3.5.0",
     "tsdown": "catalog:",

--- a/packages/vue-extractor/src/config.ts
+++ b/packages/vue-extractor/src/config.ts
@@ -1,0 +1,5 @@
+export { resolveVueCompilerOptions } from './internal/config/resolveVueCompilerOptions.js';
+export type {
+  VueCompilerOptionsResolution,
+  VueCompilerOptionsResolverOptions,
+} from './internal/config/resolveVueCompilerOptions.js';

--- a/packages/vue-extractor/src/detect.ts
+++ b/packages/vue-extractor/src/detect.ts
@@ -1,0 +1,7 @@
+/**
+ * Detects declared gt-vue ownership without loading the parser or Vue compiler.
+ *
+ * This lightweight entrypoint is safe for host CLIs to import during command
+ * routing; the heavier project extractor remains behind the `project` export.
+ */
+export { detectVueProject } from './internal/project/detectVueProject.js';

--- a/packages/vue-extractor/src/detect.ts
+++ b/packages/vue-extractor/src/detect.ts
@@ -1,7 +1,8 @@
 /**
- * Detects declared gt-vue ownership without loading the parser or Vue compiler.
+ * Detects declared or publicly re-exported gt-vue ownership without loading
+ * the Vue compiler.
  *
- * This lightweight entrypoint is safe for host CLIs to import during command
- * routing; the heavier project extractor remains behind the `project` export.
+ * Local wrapper packages are parsed only to prove their public provenance.
+ * The full template and project extractor remains behind the `project` export.
  */
 export { detectVueProject } from './internal/project/detectVueProject.js';

--- a/packages/vue-extractor/src/index.ts
+++ b/packages/vue-extractor/src/index.ts
@@ -1,0 +1,13 @@
+export { extractFromVueSource } from './internal/extractFromVueSource.js';
+export type {
+  VueCompilerOptions,
+  VueCompiler,
+  VueExtractionMetadata,
+  VueExtractionOptions,
+  VueExtractionOutput,
+  VueExtractionResult,
+  VueProjectExtractionOptions,
+  VueProjectExtractionOutput,
+  VueProjectExtractionResult,
+  VueSourceCode,
+} from './types.js';

--- a/packages/vue-extractor/src/index.ts
+++ b/packages/vue-extractor/src/index.ts
@@ -9,5 +9,6 @@ export type {
   VueProjectExtractionOptions,
   VueProjectExtractionOutput,
   VueProjectExtractionResult,
+  VueProjectInspection,
   VueSourceCode,
 } from './types.js';

--- a/packages/vue-extractor/src/inspect.ts
+++ b/packages/vue-extractor/src/inspect.ts
@@ -8,6 +8,7 @@
 export {
   inspectVueProject,
   inspectVueProjectAsync,
+  partitionVueSourcePatterns,
   readVueSfcExclusionPatterns,
 } from './internal/project/inspectVueProject.js';
 export type { VueProjectInspection } from './types.js';

--- a/packages/vue-extractor/src/inspect.ts
+++ b/packages/vue-extractor/src/inspect.ts
@@ -1,11 +1,13 @@
 /**
- * Inspects root and workspace Vue ownership without loading source parsers.
+ * Inspects root and workspace Vue ownership without loading the Vue compiler
+ * or full source analyzer.
  *
  * Pass the returned plan to `extractFromVueProject` to avoid repeating
  * workspace traversal during mixed-framework extraction.
  */
 export {
   inspectVueProject,
+  inspectVueProjectAsync,
   readVueSfcExclusionPatterns,
 } from './internal/project/inspectVueProject.js';
 export type { VueProjectInspection } from './types.js';

--- a/packages/vue-extractor/src/inspect.ts
+++ b/packages/vue-extractor/src/inspect.ts
@@ -1,0 +1,11 @@
+/**
+ * Inspects root and workspace Vue ownership without loading source parsers.
+ *
+ * Pass the returned plan to `extractFromVueProject` to avoid repeating
+ * workspace traversal during mixed-framework extraction.
+ */
+export {
+  inspectVueProject,
+  readVueSfcExclusionPatterns,
+} from './internal/project/inspectVueProject.js';
+export type { VueProjectInspection } from './types.js';

--- a/packages/vue-extractor/src/internal/__tests__/SCRIPT_PARITY.md
+++ b/packages/vue-extractor/src/internal/__tests__/SCRIPT_PARITY.md
@@ -1,0 +1,32 @@
+# Script extraction parity matrix
+
+The Vue script tests port the React extractor's applicable adversarial cases:
+
+- named, aliased, namespace, CommonJS, and TypeScript import-equals imports;
+- deep callback aliases, lexical shadowing, reassignment safety, and static
+  assignment/destructuring flows;
+- direct, optional, non-null, and TypeScript-wrapped calls;
+- static identifiers, concatenations, template expressions, bigint values,
+  `as const`, and `satisfies` wrappers;
+- Composition API bindings plus Options API `setup` returns, object spreads,
+  concise arrows, component registration, and `defineComponent` aliases;
+- shared `<script>`/`<script setup>` imports and Vue's digit tag
+  normalization;
+- Vue JSX/TSX `<T>` trees, namespace members such as `<GT.T>`, Vue Fragment
+  spellings, local ESM re-exports, and statically traceable local callback
+  forwarding.
+
+The initial `gt-vue` API intentionally does not port React-only behavior:
+
+- rich/ICU string interpolation and derived runtime placeholders;
+- metadata other than `$context`, including `$id`, `$maxChars`, and formatting;
+- `getGT`, async translator creation, tagged templates, or React JSX semantics;
+- extraction through arbitrary runtime callbacks, package re-exports, or
+  cross-file data flow beyond statically resolved local ESM modules. When a
+  callback or conditional value can still be a translator but cannot be
+  resolved safely, extraction fails closed instead of silently omitting a
+  catalog entry.
+
+Unsupported dynamic `gt()`/`msg()` content receives an extraction diagnostic.
+Dynamic `useMessages()` input remains unreported because it may be an encoded
+value produced by `msg()` at runtime.

--- a/packages/vue-extractor/src/internal/__tests__/analyzerPerformance.ts
+++ b/packages/vue-extractor/src/internal/__tests__/analyzerPerformance.ts
@@ -1,0 +1,60 @@
+import {
+  createVueScriptAnalysis,
+  createVueScriptAnalysisStats,
+  parseVueScript,
+  type VueScriptAnalysisStats,
+} from '../script.js';
+import type { TemplateBindings, VueExtractionContext } from '../types.js';
+
+/** Runs only the script analyzer and returns deterministic hot-path counters. */
+export function collectAnalyzerStats(source: string): VueScriptAnalysisStats {
+  const stats = createVueScriptAnalysisStats();
+  const context: VueExtractionContext = {
+    errors: [],
+    file: '/fixtures/AnalyzerPerformance.ts',
+    includeSourceCodeContext: false,
+    relativeFile: 'AnalyzerPerformance.ts',
+    results: [],
+    source,
+    surroundingLineCount: 0,
+    warnings: new Set(),
+  };
+  const valid = parseVueScript(
+    source,
+    'ts',
+    context,
+    createTemplateBindings(),
+    true,
+    createVueScriptAnalysis(stats)
+  );
+  if (!valid || context.errors.length > 0) {
+    throw new Error(context.errors.join('\n') || 'Script analysis failed');
+  }
+  return stats;
+}
+
+/** Creates the binding registry required by the low-level script analyzer. */
+function createTemplateBindings(): TemplateBindings {
+  return {
+    arrayLengths: new Map(),
+    componentFactories: new Set(),
+    components: new Map(),
+    containerKinds: new Map(),
+    directBindings: new Set(),
+    gtComponentFactories: new Set(),
+    gtContainerFactories: new Set(),
+    identityFunctions: new Set(),
+    possibleGTContainers: new Set(),
+    possibleStaticStrings: new Map(),
+    registeredComponents: new Map(),
+    registeredVueBuiltins: new Map(),
+    staticValues: new Map(),
+    stringFunctions: new Map(),
+    uncertainComponents: new Set(),
+    uncertainGTComponents: new Set(),
+    uncertainRegisteredComponents: new Set(),
+    uncertainRegisteredGTComponents: new Set(),
+    uncertainStringFunctions: new Set(),
+    vueBuiltins: new Map(),
+  };
+}

--- a/packages/vue-extractor/src/internal/__tests__/branchAttributeParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/branchAttributeParity.test.ts
@@ -1,0 +1,530 @@
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { hashSource } from 'generaltranslation/id';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+type BranchCase = {
+  name: string;
+  setup?: string;
+  source: JsxChildren;
+  template: string;
+};
+
+const primitiveCases: BranchCase[] = [
+  {
+    name: 'plain string attribute',
+    template: '<T><Branch branch="formal" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'bound string literal',
+    template:
+      '<T><Branch branch="formal" :formal="\'Hello\'">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'script-exposed string',
+    setup: "const label = 'Hello';",
+    template:
+      '<T><Branch branch="formal" :formal="label">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'deterministic string expression',
+    template:
+      '<T><Branch branch="formal" :formal="\'Hel\' + `lo`">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'number',
+    template: '<T><Branch branch="count" :count="12">Fallback</Branch></T>',
+    source: branchSource({ count: '12' }),
+  },
+  {
+    name: 'negative number',
+    template: '<T><Branch branch="count" :count="-12">Fallback</Branch></T>',
+    source: branchSource({ count: '-12' }),
+  },
+  {
+    name: 'bigint',
+    template: '<T><Branch branch="large" :large="12n">Fallback</Branch></T>',
+    source: branchSource({ large: '12' }),
+  },
+  {
+    name: 'true',
+    template: '<T><Branch branch="flag" :flag="true">Fallback</Branch></T>',
+    source: branchSource({ flag: [] }),
+  },
+  {
+    name: 'false',
+    template: '<T><Branch branch="flag" :flag="false">Fallback</Branch></T>',
+    source: branchSource({ flag: [] }),
+  },
+  {
+    name: 'null',
+    template: '<T><Branch branch="empty" :empty="null">Fallback</Branch></T>',
+    source: branchSource({ empty: [] }),
+  },
+  {
+    name: 'empty bare attribute',
+    template: '<T><Branch branch="empty" empty>Fallback</Branch></T>',
+    source: branchSource({ empty: '' }),
+  },
+];
+
+const knownNonPrimitiveCases: BranchCase[] = [
+  {
+    name: 'object literal',
+    template:
+      '<T><Branch branch="formal" :formal="{ label: \'Hello\' }">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'array literal',
+    template:
+      '<T><Branch branch="formal" :formal="[\'Hello\']">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'arrow function',
+    template:
+      '<T><Branch branch="formal" :formal="() => \'Hello\'">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'regular expression',
+    template:
+      '<T><Branch branch="formal" :formal="/Hello/">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'new expression',
+    template:
+      '<T><Branch branch="formal" :formal="new Date(0)">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'global undefined',
+    template:
+      '<T><Branch branch="formal" :formal="undefined">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+  {
+    name: 'void expression',
+    template:
+      '<T><Branch branch="formal" :formal="void 0">Fallback</Branch></T>',
+    source: branchSource(),
+  },
+];
+
+const ignoredNameCases: BranchCase[] = [
+  {
+    name: 'static class',
+    template:
+      '<T><Branch branch="formal" class="secret" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'dynamic class object',
+    setup: 'const classes = { secret: true };',
+    template:
+      '<T><Branch branch="formal" :class="classes" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'static style',
+    template:
+      '<T><Branch branch="formal" style="color: red" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'dynamic style object',
+    setup: "const styles = { color: 'red' };",
+    template:
+      '<T><Branch branch="formal" :style="styles" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'static ARIA attribute',
+    template:
+      '<T><Branch branch="formal" aria-label="secret" formal="Hello">Fallback</Branch></T>',
+    source: {
+      t: 'Branch',
+      i: 1,
+      d: { arl: 'secret', b: { formal: 'Hello' }, t: 'b' },
+      c: 'Fallback',
+    },
+  },
+  {
+    name: 'static data attribute',
+    template:
+      '<T><Branch branch="formal" data-note="secret" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'dynamic data attribute',
+    setup: 'const note = String(Date.now());',
+    template:
+      '<T><Branch branch="formal" :data-note="note" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'event directive',
+    setup: 'const handler = () => undefined;',
+    template:
+      '<T><Branch branch="formal" @click="handler" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'event directive with modifiers',
+    setup: 'const handler = () => undefined;',
+    template:
+      '<T><Branch branch="formal" @click.stop="handler" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'object v-on directive',
+    setup: 'const listeners = { click: () => undefined };',
+    template:
+      '<T><Branch branch="formal" v-on="listeners" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'camel-case listener prop',
+    setup: 'const handler = () => undefined;',
+    template:
+      '<T><Branch branch="formal" :onClick="handler" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'kebab-case listener prop',
+    setup: 'const handler = () => undefined;',
+    template:
+      '<T><Branch branch="formal" :on-click="handler" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'VNode listener prop',
+    setup: 'const handler = () => undefined;',
+    template:
+      '<T><Branch branch="formal" :onVnodeMounted="handler" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+  {
+    name: 'GT and VNode control props',
+    template:
+      '<T><Branch branch="formal" :n="2" :locales="[\'en\']" key="stable" ref="branchRef" ref-for ref-key="branch" ref_for ref_key="branch" formal="Hello">Fallback</Branch></T>',
+    source: branchSource({ formal: 'Hello' }),
+  },
+];
+
+describe('Branch attribute runtime parity', () => {
+  it.each(primitiveCases)('serializes $name', async (testCase) => {
+    const output = await extractCase(testCase);
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output)).toEqual([testCase.source]);
+  });
+
+  it.each(knownNonPrimitiveCases)(
+    'ignores statically known non-branch $name values',
+    async (testCase) => {
+      const output = await extractCase(testCase);
+
+      expect(output.errors).toEqual([]);
+      expect(richSources(output)).toEqual([testCase.source]);
+    }
+  );
+
+  it.each(ignoredNameCases)(
+    'does not turn the $name into a branch',
+    async (testCase) => {
+      const output = await extractCase(testCase);
+
+      expect(output.errors).toEqual([]);
+      expect(richSources(output)).toEqual([testCase.source]);
+    }
+  );
+
+  it('fails closed for dynamic translatable ARIA content', async () => {
+    const output = await extractCase({
+      name: 'dynamic ARIA content',
+      setup: 'const label = String(Date.now());',
+      template:
+        '<T><Branch branch="formal" :aria-label="label" formal="Hello">Fallback</Branch></T>',
+      source: [],
+    });
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'dynamic translatable prop "aria-label"'
+    );
+    expect(output.errors.join('\n')).not.toContain('dynamic branch prop');
+  });
+
+  it('matches runtime content-prop and Branch interaction', async () => {
+    const output = await extractCase({
+      name: 'Branch content props',
+      template:
+        '<T><Branch branch="title" title="Title" alt="Alt" aria-labelledby="Labelled" aria-describedby="Described">Fallback</Branch></T>',
+      source: {
+        t: 'Branch',
+        i: 1,
+        d: {
+          ti: 'Title',
+          alt: 'Alt',
+          arb: 'Labelled',
+          ard: 'Described',
+          b: { title: 'Title', alt: 'Alt' },
+          t: 'b',
+        },
+        c: 'Fallback',
+      },
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output)).toEqual([
+      {
+        t: 'Branch',
+        i: 1,
+        d: {
+          ti: 'Title',
+          alt: 'Alt',
+          arb: 'Labelled',
+          ard: 'Described',
+          b: { title: 'Title', alt: 'Alt' },
+          t: 'b',
+        },
+        c: 'Fallback',
+      },
+    ]);
+  });
+
+  it('keeps Plural content props out of its accepted form map', async () => {
+    const output = await extractCase({
+      name: 'Plural content props',
+      template:
+        '<T><Plural :n="2" title="Title" alt="Alt" aria-labelledby="Labelled" aria-describedby="Described" other="Other">Fallback</Plural></T>',
+      source: {
+        t: 'Plural',
+        i: 1,
+        d: {
+          ti: 'Title',
+          alt: 'Alt',
+          arb: 'Labelled',
+          ard: 'Described',
+          b: { other: 'Other' },
+          t: 'p',
+        },
+        c: 'Fallback',
+      },
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output)).toEqual([
+      {
+        t: 'Plural',
+        i: 1,
+        d: {
+          ti: 'Title',
+          alt: 'Alt',
+          arb: 'Labelled',
+          ard: 'Described',
+          b: { other: 'Other' },
+          t: 'p',
+        },
+        c: 'Fallback',
+      },
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'static Branch prop',
+      setup: '',
+      template:
+        '<T><Branch branch="formal" formal="Attribute"><template #formal>Slot</template>Fallback</Branch></T>',
+      source: branchSource({ formal: 'Slot' }),
+    },
+    {
+      name: 'dynamic Branch prop',
+      setup: 'const value = String(Date.now());',
+      template:
+        '<T><Branch branch="formal" :formal="value"><template #formal>Slot</template>Fallback</Branch></T>',
+      source: branchSource({ formal: 'Slot' }),
+    },
+    {
+      name: 'modified Branch prop',
+      setup: 'const value = String(Date.now());',
+      template:
+        '<T><Branch branch="formal" :formal.camel="value"><template #formal>Slot</template>Fallback</Branch></T>',
+      source: branchSource({ formal: 'Slot' }),
+    },
+    {
+      name: 'dynamic Plural prop',
+      setup: 'const value = String(Date.now());',
+      template:
+        '<T><Plural :n="1" :one="value"><template #one>Slot</template>Fallback</Plural></T>',
+      source: pluralSource({ one: 'Slot' }),
+    },
+  ])('gives a named slot precedence over a $name', async (testCase) => {
+    const output = await extractCase(testCase);
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output)).toEqual([testCase.source]);
+  });
+
+  it('serializes only accepted primitive Plural forms', async () => {
+    const output = await extractCase({
+      name: 'plural primitive matrix',
+      setup: 'const ignored = String(Date.now());',
+      template:
+        '<T><Plural :n="2" zero="None" :one="1" :two="2n" :few="false" :many="null" other="Other" :label="ignored" class="secret" @click="ignored">Fallback</Plural></T>',
+      source: pluralSource({
+        zero: 'None',
+        one: '1',
+        two: '2',
+        few: [],
+        many: [],
+        other: 'Other',
+      }),
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output)).toEqual([
+      pluralSource({
+        zero: 'None',
+        one: '1',
+        two: '2',
+        few: [],
+        many: [],
+        other: 'Other',
+      }),
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'dynamic identifier',
+      setup: 'const value = String(Date.now());',
+      attribute: ':formal="value"',
+      key: 'formal',
+      component: 'Branch',
+    },
+    {
+      name: 'function call',
+      setup: "const getValue = () => 'Hello';",
+      attribute: ':formal="getValue()"',
+      key: 'formal',
+      component: 'Branch',
+    },
+    {
+      name: 'member expression',
+      setup: "const state = { value: 'Hello' };",
+      attribute: ':formal="state.value"',
+      key: 'formal',
+      component: 'Branch',
+    },
+    {
+      name: 'dynamic Plural form',
+      setup: 'const value = String(Date.now());',
+      attribute: ':one="value"',
+      key: 'one',
+      component: 'Plural',
+    },
+  ])('fails closed for a $name', async (testCase) => {
+    const template = `<T><${testCase.component} ${testCase.component === 'Plural' ? ':n="1"' : 'branch="formal"'} ${testCase.attribute}>Fallback</${testCase.component}></T>`;
+    const output = await extractCase({
+      name: testCase.name,
+      setup: testCase.setup,
+      source: [],
+      template,
+    });
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      `dynamic branch prop "${testCase.key}"`
+    );
+  });
+
+  it('matches the exact hash captured from the finalized gt-vue runtime', async () => {
+    const testCase: BranchCase = {
+      name: 'exact runtime hash',
+      setup: 'const handler = () => undefined;',
+      template:
+        '<T><Branch branch="formal" class="secret" :style="{ color: \'red\' }" @click="handler" formal="Hello">Fallback</Branch></T>',
+      source: branchSource({ formal: 'Hello' }),
+    };
+    const output = await extractCase(testCase);
+    const source = richSources(output)[0];
+
+    expect(output.errors).toEqual([]);
+    expect(source).toEqual(testCase.source);
+    expect(hashSource({ dataFormat: 'JSX', source })).toBe('dab20b4518607f20');
+  });
+});
+
+function branchSource(branches?: Record<string, JsxChildren>): JsxChildren {
+  return {
+    t: 'Branch',
+    i: 1,
+    ...(branches && Object.keys(branches).length > 0
+      ? { d: { b: branches, t: 'b' as const } }
+      : {}),
+    c: 'Fallback',
+  };
+}
+
+function pluralSource(branches: Record<string, JsxChildren>): JsxChildren {
+  return {
+    t: 'Plural',
+    i: 1,
+    d: { b: branches, t: 'p' },
+    c: 'Fallback',
+  };
+}
+
+async function extractCase(testCase: BranchCase) {
+  const source = createSfc(testCase.setup ?? '', testCase.template);
+  assertVueCompiles(source, testCase.name);
+  return extractFromVueSource(source, `/fixtures/${testCase.name}.vue`, {
+    projectRoot: '/fixtures',
+  });
+}
+
+function createSfc(setup: string, template: string): string {
+  return `<script setup lang="ts">import { Branch, Plural, T } from 'gt-vue';${setup}</script><template>${template}</template>`;
+}
+
+function assertVueCompiles(source: string, name: string): void {
+  const filename = `/fixtures/${name}.vue`;
+  const parsed = parse(source, { filename });
+  expect(parsed.errors, name).toEqual([]);
+  const script = compileScript(parsed.descriptor, {
+    babelParserPlugins: ['typescript'],
+    id: `branch-parity-${name}`,
+  });
+  const template = parsed.descriptor.template;
+  expect(template, name).not.toBeNull();
+  if (!template) return;
+
+  const compiled = compileTemplate({
+    compilerOptions: {
+      bindingMetadata: script.bindings,
+      expressionPlugins: ['typescript'],
+    },
+    filename,
+    id: `branch-parity-${name}`,
+    source: template.content,
+  });
+  expect(compiled.errors, name).toEqual([]);
+}
+
+function richSources(
+  output: Awaited<ReturnType<typeof extractFromVueSource>>
+): JsxChildren[] {
+  return output.results
+    .filter((result) => result.dataFormat === 'JSX')
+    .map((result) => result.source);
+}

--- a/packages/vue-extractor/src/internal/__tests__/compilerAst.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/compilerAst.test.ts
@@ -1,0 +1,53 @@
+import {
+  ElementTypes as VueElementTypes,
+  NodeTypes as VueNodeTypes,
+} from '@vue/compiler-dom';
+import { describe, expect, it } from 'vitest';
+import {
+  ElementTypes,
+  NodeTypes,
+  shiftCompilerAstLocations,
+} from '../compilerAst.js';
+
+describe('local Vue compiler AST discriminants', () => {
+  it('matches the installed Vue compiler', () => {
+    expect(NodeTypes).toEqual({
+      ELEMENT: VueNodeTypes.ELEMENT,
+      TEXT: VueNodeTypes.TEXT,
+      COMMENT: VueNodeTypes.COMMENT,
+      SIMPLE_EXPRESSION: VueNodeTypes.SIMPLE_EXPRESSION,
+      INTERPOLATION: VueNodeTypes.INTERPOLATION,
+      ATTRIBUTE: VueNodeTypes.ATTRIBUTE,
+      DIRECTIVE: VueNodeTypes.DIRECTIVE,
+    });
+    expect(ElementTypes).toEqual({
+      COMPONENT: VueElementTypes.COMPONENT,
+      SLOT: VueElementTypes.SLOT,
+    });
+  });
+
+  it('rebases shared compiler positions only once across nested locations', () => {
+    const sharedStart = { column: 2, line: 1, offset: 1 };
+    const sharedEnd = { column: 4, line: 2, offset: 8 };
+    const ast = {
+      children: [
+        {
+          loc: { end: sharedEnd, source: 'outer', start: sharedStart },
+          nested: {
+            loc: { end: sharedEnd, source: 'inner', start: sharedStart },
+          },
+        },
+      ],
+      loc: {
+        end: { column: 1, line: 3, offset: 9 },
+        source: 'root',
+        start: { column: 1, line: 1, offset: 0 },
+      },
+    };
+
+    shiftCompilerAstLocations(ast, { column: 7, line: 5, offset: 100 });
+
+    expect(sharedStart).toEqual({ column: 8, line: 5, offset: 101 });
+    expect(sharedEnd).toEqual({ column: 4, line: 6, offset: 108 });
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/compilerOptions.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/compilerOptions.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest';
+import * as testVueCompiler from '#vue-compiler-sfc';
+import { parse as parseTemplate } from '@vue/compiler-dom';
+import { hashSource } from 'generaltranslation/id';
+import type { VueCompiler } from '../../types.js';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue compiler option parity', () => {
+  it('fails closed for custom delimiters on an explicit legacy compiler', async () => {
+    const legacyCompiler = {
+      ...testVueCompiler,
+      parse(source: string, options: Record<string, unknown> = {}) {
+        const { templateParseOptions: _ignored, ...legacyOptions } = options;
+        return testVueCompiler.parse(source, legacyOptions);
+      },
+      parseTemplate,
+      version: '3.3.13',
+    } as unknown as VueCompiler;
+    const source = `<script setup>import { T } from 'gt-vue';</script><template><T>[[ '</template>' ]] after</T></template>`;
+
+    const output = await extractFromVueSource(
+      source,
+      '/fixtures/explicit-legacy-delimiters.vue',
+      {
+        compiler: legacyCompiler,
+        compilerOptions: { delimiters: ['[[', ']]'] },
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not safely apply custom Vue template delimiters'
+    );
+  });
+
+  it('recovers v-for scopes when compiler metadata is absent', async () => {
+    const compiler = {
+      ...testVueCompiler,
+      parseTemplate: parseTemplateWithoutForMetadata,
+    } as unknown as VueCompiler;
+    const source = `<script setup>import { Fragment as F } from 'vue'; import { T } from 'gt-vue'; const choices = [String];</script><template><div v-for="F in choices"><T><component :is="F"><span>Opaque child</span></component><b>After</b></T></div></template>`;
+
+    const output = await extractFromVueSource(
+      source,
+      '/fixtures/vue-3.3-v-for.vue',
+      { compiler }
+    );
+
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain(
+      'Found a dynamic <component> inside a gt-vue <T> component'
+    );
+    expect(output.results).toEqual([]);
+  });
+
+  it('recovers v-for sources, defaults, and iterators without metadata', async () => {
+    const compiler = {
+      ...testVueCompiler,
+      parseTemplate: parseTemplateWithoutForMetadata,
+    } as unknown as VueCompiler;
+    const source = `<script setup>import { useGT } from 'gt-vue'; const gt = useGT(); const rows = [];</script><template><div v-for="{ value = gt('VFor default') } in gt('VFor source')" :title="value" /><div v-for="(value, gt, index) in rows" :title="gt('Shadowed iterator')" /></template>`;
+
+    const output = await extractFromVueSource(
+      source,
+      '/fixtures/vue-3.3-v-for-expressions.vue',
+      { compiler }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results
+        .filter((result) => result.dataFormat === 'STRING')
+        .map((result) => result.source)
+    ).toEqual(['VFor default', 'VFor source']);
+  });
+
+  it('uses custom delimiters while locating the SFC template boundary', async () => {
+    const source = `<script setup>import { T } from 'gt-vue';</script><template><T>[[ '</template>' ]] after</T></template>`;
+    const custom = await extractFromVueSource(
+      source,
+      '/fixtures/structural-delimiters.vue',
+      {
+        compilerOptions: { delimiters: ['[[', ']]'] },
+        projectRoot: '/fixtures',
+      }
+    );
+
+    expect(custom.errors).toEqual([]);
+    expect(custom.results.map(({ source }) => source)).toEqual([
+      '</template> after',
+    ]);
+  });
+
+  it('changes extracted rich content when Vue preserves whitespace', async () => {
+    const source = `
+      <script setup>
+      import { T } from 'gt-vue';
+      </script>
+      <template>
+        <T>First
+          second</T>
+      </template>
+    `;
+
+    const condensed = await extractFromVueSource(source, 'Component.vue', {
+      compilerOptions: { whitespace: 'condense' },
+    });
+    const preserved = await extractFromVueSource(source, 'Component.vue', {
+      compilerOptions: { whitespace: 'preserve' },
+    });
+
+    expect(condensed.errors).toEqual([]);
+    expect(preserved.errors).toEqual([]);
+    expect(condensed.results).toHaveLength(1);
+    expect(preserved.results).toHaveLength(1);
+    expect(preserved.results[0].source).not.toEqual(
+      condensed.results[0].source
+    );
+    expect(hashFor(preserved.results[0])).not.toBe(
+      hashFor(condensed.results[0])
+    );
+  });
+
+  it('uses the application interpolation delimiters', async () => {
+    const source = `
+      <script setup>
+      import { T, Var } from 'gt-vue';
+      const name = 'Ada';
+      </script>
+      <template><T>Hello <Var>[[ name ]]</Var></T></template>
+    `;
+
+    const result = await extractFromVueSource(source, 'Component.vue', {
+      compilerOptions: { delimiters: ['[[', ']]'] },
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.results).toEqual([
+      expect.objectContaining({
+        dataFormat: 'JSX',
+        source: ['Hello ', { i: 1, k: '_gt_value_1', v: 'v' }],
+      }),
+    ]);
+  });
+
+  it.each(['condense', 'preserve'] as const)(
+    'rejects comment-driven %s whitespace that changes in production',
+    async (whitespace) => {
+      const source = `
+        <script setup>import { T } from 'gt-vue';</script>
+        <template>
+          <T><i>First</i> <!-- separator --> <b>Second</b></T>
+          <T><p><i>Nested</i> <!-- separator --> <b>content</b></p></T>
+        </template>
+      `;
+
+      const result = await extractFromVueSource(source, 'Component.vue', {
+        compilerOptions: { whitespace },
+      });
+
+      expect(result.results).toEqual([]);
+      expect(result.errors.join('\n')).toContain(
+        'comment adjacent to translatable whitespace'
+      );
+    }
+  );
+
+  it.each(['condense', 'preserve'] as const)(
+    'allows comments that do not change %s translation content',
+    async (whitespace) => {
+      const source = `
+        <script setup>import { T } from 'gt-vue';</script>
+        <template><T>Hello<!-- translator note -->world</T></template>
+      `;
+
+      const result = await extractFromVueSource(source, 'Component.vue', {
+        compilerOptions: { whitespace },
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.results.map(({ source }) => source)).toEqual([
+        'Helloworld',
+      ]);
+    }
+  );
+});
+
+function hashFor(
+  result: Awaited<ReturnType<typeof extractFromVueSource>>['results'][number]
+) {
+  return hashSource({
+    dataFormat: result.dataFormat,
+    source: result.source,
+    ...(result.metadata.context && { context: result.metadata.context }),
+  });
+}
+
+/** Simulates Vue 3.3's compiler AST without installing a second Vue copy. */
+function parseTemplateWithoutForMetadata(
+  ...args: Parameters<typeof parseTemplate>
+): ReturnType<typeof parseTemplate> {
+  const ast = parseTemplate(...args);
+  removeForParseResults(ast);
+  return ast;
+}
+
+/** Removes only the normalized field that Vue added after the 3.3 line. */
+function removeForParseResults(value: unknown, seen = new WeakSet<object>()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return;
+  seen.add(value);
+  if ('forParseResult' in value) delete value.forParseResult;
+  for (const child of Object.values(value)) {
+    removeForParseResults(child, seen);
+  }
+}

--- a/packages/vue-extractor/src/internal/__tests__/componentAliasPerformance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/componentAliasPerformance.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { collectAnalyzerStats } from './analyzerPerformance.js';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS = 15_000;
+
+function createScalarAliasScript(aliasCount: number): string {
+  const declarations = ["import { T } from 'gt-vue';", 'const Component0 = T;'];
+  for (let index = 1; index <= aliasCount; index += 1) {
+    declarations.push(`const Component${index} = Component${index - 1};`);
+  }
+  declarations.push(`const registry = [Component${aliasCount}];`);
+  declarations.push('const key = getIndex();');
+  return declarations.join('\n');
+}
+describe('direct component alias performance', () => {
+  it(
+    'keeps analyzer visits linear for a long scalar alias chain',
+    () => {
+      const smaller = collectAnalyzerStats(createScalarAliasScript(500));
+      const larger = collectAnalyzerStats(createScalarAliasScript(1_000));
+
+      for (const key of Object.keys(larger) as Array<keyof typeof larger>) {
+        expect(larger[key], key).toBeLessThanOrEqual(smaller[key] * 2 + 10);
+      }
+
+      expect(
+        Object.values(larger).reduce((total, visits) => total + visits, 0)
+      ).toBeLessThanOrEqual(10_000);
+    },
+    ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'fails closed for a thousand aliases without a timing assertion',
+    async () => {
+      const source = `<script setup>${createScalarAliasScript(1_000)}</script>
+        <template>
+          <component :is="registry[key]">Hidden</component>
+        </template>`;
+
+      const output = await extractFromVueSource(
+        source,
+        '/fixtures/ComponentAliasPerformance.vue',
+        { projectRoot: '/fixtures' }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    },
+    ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS
+  );
+
+  it.each([
+    {
+      name: 'mutable assignment',
+      source: `import { msg } from 'gt-vue'; let candidate = {}; candidate = msg; const alias = candidate; alias('Mutable translator');`,
+      translation: 'Mutable translator',
+    },
+    {
+      name: 'local callback return',
+      source: `import { msg } from 'gt-vue'; const factory = () => msg; const alias = factory(); alias('Callback translator');`,
+      translation: 'Callback translator',
+    },
+  ])('does not hide translator provenance through $name', async (testCase) => {
+    const output = await extractFromVueSource(
+      testCase.source,
+      `/fixtures/${testCase.name}.ts`,
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      testCase.translation,
+    ]);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/consumerNonRuntimeRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerNonRuntimeRegression.test.ts
@@ -154,6 +154,123 @@ describe('non-runtime local Vue wrapper references', () => {
     expect(detectVueProject(root)).toBe(false);
   });
 
+  it.each([
+    {
+      importSource: "import { VueT } from '@fixture/multi/vue';",
+      name: 'a named ordinary-script import',
+      template: '<VueT />',
+    },
+    {
+      importSource: "import VueT from '@fixture/multi/vue';",
+      name: 'a default ordinary-script import',
+      template: '<VueT />',
+    },
+    {
+      importSource: "import * as Mixed from '@fixture/multi/vue';",
+      name: 'a namespace ordinary-script import',
+      template: '<Mixed.VueT />',
+    },
+  ])('does not expose $name to the template', ({ importSource, template }) => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script>
+${importSource}
+export default {};
+</script>
+<template>${template}</template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    {
+      importSource: "import { VueT } from '@fixture/multi/vue';",
+      name: 'a named import shadowed by a camel setup binding',
+      setupSource: "const vueT = 'section';",
+      template: '<vue-t />',
+    },
+    {
+      importSource: "import VueT from '@fixture/multi/vue';",
+      name: 'a default import shadowed by a camel setup binding',
+      setupSource: "const vueT = 'section';",
+      template: '<vue-t />',
+    },
+    {
+      importSource: "import * as Mixed from '@fixture/multi/vue';",
+      name: 'a namespace import shadowed by a camel setup binding',
+      setupSource: "const mixed = { VueT: 'section' };",
+      template: '<mixed.VueT />',
+    },
+    {
+      importSource: "import { VueT as LocalT } from '@fixture/multi/vue';",
+      name: 'a named import shadowed by an exact setup binding',
+      setupSource: "const LocalT = 'section';",
+      template: '<LocalT />',
+    },
+    {
+      importSource: "import LocalT from '@fixture/multi/vue';",
+      name: 'a default import shadowed by an exact setup binding',
+      setupSource: "const LocalT = 'section';",
+      template: '<LocalT />',
+    },
+    {
+      importSource: "import * as Mixed from '@fixture/multi/vue';",
+      name: 'a namespace import shadowed by an exact setup binding',
+      setupSource: "const Mixed = { VueT: 'section' };",
+      template: '<Mixed.VueT />',
+    },
+  ])(
+    'does not expose $name to the template',
+    ({ importSource, setupSource, template }) => {
+      const root = createConsumerFixture({
+        'src/App.vue': `<script>
+${importSource}
+export default {};
+</script>
+<script setup>${setupSource}</script>
+<template>${template}</template>`,
+      });
+
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
+
+  it('does not treat an uppercase SETUP attribute as script setup', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script SETUP>
+import { VueT } from '@fixture/multi/vue';
+export default {};
+</script>
+<template><VueT /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('does not activate Vue for a compiler-option-ambiguous props binding', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script setup>
+import { VueT } from '@fixture/multi/vue';
+const { vueT } = defineProps(['vueT']);
+</script>
+<template><vue-t /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('does not activate Vue for a version-ambiguous slots binding', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script setup>
+import { VueT as vueT } from '@fixture/multi/vue';
+const VueT = defineSlots();
+</script>
+<template><vue-t /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
   it('does not make an unrelated SFC require a Vue compiler', async () => {
     const root = createConsumerFixture({
       'src/index.d.ts': `
@@ -172,6 +289,109 @@ describe('non-runtime local Vue wrapper references', () => {
 });
 
 describe('runtime local Vue wrapper references', () => {
+  it('preserves an ordinary-script import registered as a component', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script>
+import { VueT } from '@fixture/multi/vue';
+export default { components: { VueT } };
+</script>
+<template><VueT /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves an ordinary-script import referenced from script setup', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script>
+import { VueT } from '@fixture/multi/vue';
+export default {};
+</script>
+<script setup>
+const component = VueT;
+</script>
+<template><component :is="component" /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves an ordinary namespace member referenced from script setup', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script>
+import * as Mixed from '@fixture/multi/vue';
+export default {};
+</script>
+<script setup>
+const component = Mixed.VueT;
+</script>
+<template><component :is="component" /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves an ordinary namespace member rendered from script-setup TSX', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script lang="tsx">
+import * as Mixed from '@fixture/multi/vue';
+export default {};
+</script>
+<script setup lang="tsx">
+const view = () => <Mixed.VueT />;
+</script>
+<template><component :is="view" /></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    {
+      importSource: "import { VueT } from '@fixture/multi/vue';",
+      name: 'a named ordinary import',
+      template: '<VueT />',
+    },
+    {
+      importSource: "import VueT from '@fixture/multi/vue';",
+      name: 'a default ordinary import',
+      template: '<VueT />',
+    },
+    {
+      importSource: "import * as Mixed from '@fixture/multi/vue';",
+      name: 'an ordinary namespace import',
+      template: '<Mixed.VueT />',
+    },
+  ])(
+    'preserves $name when a script-setup block exposes it',
+    ({ importSource, template }) => {
+      const root = createConsumerFixture({
+        'src/App.vue': `<script>
+${importSource}
+export default {};
+</script>
+<script setup>const ready = true;</script>
+<template>${template}</template>`,
+      });
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it.each(['setup', 'setup=""', 'setup="false"'])(
+    'recognizes the lowercase script attribute %s',
+    (setupAttribute) => {
+      const root = createConsumerFixture({
+        'src/App.vue': `<script ${setupAttribute}>
+import { VueT } from '@fixture/multi/vue';
+</script>
+<template><VueT /></template>`,
+      });
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
   it('preserves a named wrapper used in TSX', () => {
     const root = createConsumerFixture({
       'src/App.tsx': `
@@ -235,6 +455,20 @@ type Component = typeof VueT;
         `,
       },
       { main: './lib/index.js' }
+    );
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves source usage in a nested src/es directory', () => {
+    const root = createConsumerFixture(
+      {
+        'src/es/index.ts': `
+          import { VueT } from '@fixture/multi/vue';
+          export const component = VueT;
+        `,
+      },
+      { module: './src/es/index.ts' }
     );
 
     expect(detectVueProject(root)).toBe(true);

--- a/packages/vue-extractor/src/internal/__tests__/consumerNonRuntimeRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerNonRuntimeRegression.test.ts
@@ -1,0 +1,274 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('non-runtime local Vue wrapper references', () => {
+  it.each([
+    [
+      'd.ts',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export declare const component: typeof VueT;
+      `,
+    ],
+    [
+      'd.mts',
+      `
+        import VueT from '@fixture/multi/vue';
+        export declare const component: typeof VueT;
+      `,
+    ],
+    [
+      'd.cts',
+      `
+        import * as Mixed from '@fixture/multi/vue';
+        export declare const component: typeof Mixed.VueT;
+      `,
+    ],
+  ])('ignores wrapper imports in .%s declarations', (extension, source) => {
+    const root = createConsumerFixture({
+      [`src/index.${extension}`]: source,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('ignores value re-exports from declaration files', () => {
+    const root = createConsumerFixture({
+      'src/index.d.ts': "export { VueT } from '@fixture/multi/vue';\n",
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('ignores a declaration file selected as a public import entry', () => {
+    const root = createConsumerFixture(
+      {
+        'types/index.d.ts': "export { VueT } from '@fixture/multi/vue';\n",
+      },
+      {
+        exports: { '.': { import: './types/index.d.ts' } },
+      }
+    );
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    ['main', { main: './lib/index.js' }],
+    ['exports import', { exports: { '.': { import: './lib/index.js' } } }],
+  ])('ignores a stale lib entry selected through %s', (_name, manifest) => {
+    const root = createConsumerFixture(
+      {
+        'lib/index.js': "export { VueT } from '@fixture/multi/vue';\n",
+        'src/App.tsx': 'export const App = () => <main>React</main>;\n',
+      },
+      manifest
+    );
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    [
+      'a named import in a TypeScript type query',
+      'src/App.ts',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export type Component = typeof VueT;
+      `,
+    ],
+    [
+      'a default import in a TypeScript type query',
+      'src/App.ts',
+      `
+        import VueT from '@fixture/multi/vue';
+        export interface Options { component: typeof VueT }
+      `,
+    ],
+    [
+      'a named import in a satisfies type argument',
+      'src/App.ts',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export const options = {} satisfies Record<string, typeof VueT>;
+      `,
+    ],
+    [
+      'a named import in a Flow type query',
+      'src/App.js',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export type Component = typeof VueT;
+      `,
+    ],
+    [
+      'a namespace import in a TypeScript type query',
+      'src/App.ts',
+      `
+        import * as Mixed from '@fixture/multi/vue';
+        export type Component = typeof Mixed.VueT;
+      `,
+    ],
+    [
+      'an explicit type import',
+      'src/App.ts',
+      `
+        import type { VueT } from '@fixture/multi/vue';
+        export type Component = typeof VueT;
+      `,
+    ],
+    [
+      'a locally imported value in a type-only export',
+      'src/App.ts',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export type { VueT };
+      `,
+    ],
+    [
+      'a locally imported value in an inline type-only export',
+      'src/App.ts',
+      `
+        import { VueT } from '@fixture/multi/vue';
+        export { type VueT };
+      `,
+    ],
+  ])('ignores %s', (_name, file, source) => {
+    const root = createConsumerFixture({ [file]: source });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('does not make an unrelated SFC require a Vue compiler', async () => {
+    const root = createConsumerFixture({
+      'src/index.d.ts': `
+        import { VueT } from '@fixture/multi/vue';
+        export declare const component: typeof VueT;
+      `,
+      'src/Unrelated.vue': '<template>Ordinary fixture</template>',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+    await expect(extractFromVueProject({ cwd: root })).resolves.toMatchObject({
+      errors: [],
+      updates: [],
+    });
+  });
+});
+
+describe('runtime local Vue wrapper references', () => {
+  it('preserves a named wrapper used in TSX', () => {
+    const root = createConsumerFixture({
+      'src/App.tsx': `
+        import { VueT } from '@fixture/multi/vue';
+        export const App = () => <VueT>Vue</VueT>;
+      `,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves a wrapper used as a script value', () => {
+    const root = createConsumerFixture({
+      'src/App.ts': `
+        import { VueT } from '@fixture/multi/vue';
+        export const component = VueT;
+      `,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves a runtime wrapper re-export', () => {
+    const root = createConsumerFixture({
+      'src/index.ts': "export { VueT } from '@fixture/multi/vue';\n",
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves a named wrapper used only in an SFC template', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script setup lang="ts">
+import { VueT } from '@fixture/multi/vue';
+</script>
+<template><vue-t>Template wrapper</vue-t></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves template usage when script references are type-only', () => {
+    const root = createConsumerFixture({
+      'src/App.vue': `<script setup lang="ts">
+import { VueT } from '@fixture/multi/vue';
+type Component = typeof VueT;
+</script>
+<template><VueT>Template wrapper</VueT></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('preserves source usage when a stale lib entry also exists', () => {
+    const root = createConsumerFixture(
+      {
+        'lib/index.js': "export { VueT } from '@fixture/multi/vue';\n",
+        'src/App.tsx': `
+          import { VueT } from '@fixture/multi/vue';
+          export const App = () => <VueT>Source wrapper</VueT>;
+        `,
+      },
+      { main: './lib/index.js' }
+    );
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+});
+
+function createConsumerFixture(
+  sourceFiles: Record<string, string>,
+  manifest: Record<string, unknown> = {}
+): string {
+  const root = createProjectFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+      ...manifest,
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: {
+        '.': './src/react.ts',
+        './vue': './src/vue.ts',
+      },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/react.ts': "export { T as ReactT } from 'gt-react';\n",
+    'vendor/multi/src/vue.ts':
+      "export { T as VueT, T as default } from 'gt-vue';\n",
+    ...sourceFiles,
+  });
+  temporaryDirectories.push(root);
+
+  const destination = path.join(root, 'node_modules/@fixture/multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  return root;
+}

--- a/packages/vue-extractor/src/internal/__tests__/consumerTemplateLexingRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerTemplateLexingRegression.test.ts
@@ -1,0 +1,254 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('Vue wrapper use in consumer templates', () => {
+  it.each([
+    {
+      name: 'an HTML-commented script block',
+      source: `
+        <!--
+        <script setup>
+        import { VueT } from '@fixture/multi/vue';
+        </script>
+        -->
+        <template><main>React-owned application</main></template>
+      `,
+    },
+    {
+      name: 'an HTML-commented template block',
+      source: `
+        <script setup>
+        import * as Mixed from '@fixture/multi/vue';
+        </script>
+        <!-- <template><Mixed.VueT>Inactive</Mixed.VueT></template> -->
+        <template><main>React-owned application</main></template>
+      `,
+    },
+  ])('ignores $name', ({ source }) => {
+    const root = createConsumerFixture(source);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'a string literal',
+      expression: "'Mixed.VueT'",
+    },
+    {
+      name: 'template literal text',
+      expression: '`Mixed.VueT`',
+    },
+    {
+      name: 'a JavaScript comment',
+      expression: "/* Mixed.VueT */ 'ordinary'",
+    },
+    {
+      name: 'a shadowed callback parameter',
+      expression: '[1].map((Mixed) => Mixed.VueT)',
+    },
+  ])('ignores namespace spelling in $name', ({ expression }) => {
+    const root = createConsumerFixture(`
+      <script setup>
+      import * as Mixed from '@fixture/multi/vue';
+      </script>
+      <template><main :title="${expression}">Ordinary</main></template>
+    `);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'a tag-shaped string in a directive',
+      template: `<main :title="'<Mixed.VueT>'">Ordinary</main>`,
+    },
+    {
+      name: 'a tag-shaped string in an interpolation',
+      template: `<main>{{ '<Mixed.VueT>' }}</main>`,
+    },
+    {
+      name: 'directive-shaped plain text',
+      template: `<pre>Example :title="Mixed.VueT"</pre>`,
+    },
+    {
+      name: 'tag-shaped textarea text',
+      template: `<textarea><Mixed.VueT /></textarea>`,
+    },
+    {
+      name: 'a slot binding that shadows the imported name',
+      template: `<Child v-slot="{ Mixed }">Ordinary</Child>`,
+    },
+    {
+      name: 'a loop binding that shadows the imported name',
+      template: `<main v-for="Mixed in values">Ordinary</main>`,
+    },
+    {
+      name: 'a slot binding used by a descendant dynamic component',
+      template: `<Child v-slot="{ Mixed }"><component :is="Mixed.VueT" /></Child>`,
+    },
+    {
+      name: 'a loop binding used by a descendant dynamic component',
+      template: `<main v-for="Mixed in values"><component :is="Mixed.VueT" /></main>`,
+    },
+    {
+      name: 'a loop binding used by a same-element dynamic component',
+      template: `<component v-for="Mixed in values" :is="Mixed.VueT" />`,
+    },
+    {
+      name: 'a loop binding declared after a same-element dynamic component',
+      template: `<component :is="Mixed.VueT" v-for="Mixed in values" />`,
+    },
+  ])('ignores namespace spelling in $name', ({ template }) => {
+    const root = createConsumerFixture(`
+      <script setup>
+      import * as Mixed from '@fixture/multi/vue';
+      const values = [];
+      </script>
+      <template>${template}</template>
+    `);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    {
+      name: 'a direct member expression',
+      template: '<component :is="Mixed.VueT" />',
+    },
+    {
+      name: 'an optional member expression',
+      template: '<component :is="Mixed?.VueT" />',
+    },
+    {
+      name: 'a statically computed member expression',
+      template: `<component :is="Mixed['VueT']" />`,
+    },
+    {
+      name: 'a dynamic bind argument',
+      template: `<main :[Mixed.VueT]="true" />`,
+    },
+    {
+      name: 'a dynamic event argument',
+      template: `<main v-on:[Mixed.VueT]="handler" />`,
+    },
+    {
+      name: 'a namespace component tag',
+      template: '<Mixed.VueT>Active</Mixed.VueT>',
+    },
+    {
+      name: 'a namespace component tag beneath a same-named slot binding',
+      template: `<Child v-slot="{ Mixed }"><Mixed.VueT /></Child>`,
+    },
+    {
+      name: 'an outer namespace beneath an unrelated loop binding',
+      template: `<main v-for="item in values"><component :is="Mixed.VueT" /></main>`,
+    },
+    {
+      name: 'an outer namespace after a same-named loop binding closes',
+      template: `<section><main v-for="Mixed in values"></main><component :is="Mixed.VueT" /></section>`,
+    },
+    {
+      name: 'an outer namespace in same-element v-if before v-for',
+      template: `<component v-if="Mixed.VueT" v-for="Mixed in values" :is="'div'" />`,
+    },
+    {
+      name: 'an outer namespace in same-element v-if after v-for',
+      template: `<component v-for="Mixed in values" v-if="Mixed.VueT" :is="'div'" />`,
+    },
+    {
+      name: 'a member after a nested template closes',
+      template: `
+        <section>
+          <template #header><h1>Header</h1></template>
+          <Mixed.VueT>Active after nested template</Mixed.VueT>
+        </section>
+      `,
+    },
+  ])('recognizes $name', ({ template }) => {
+    const root = createConsumerFixture(`
+      <script setup>
+      import * as Mixed from '@fixture/multi/vue';
+      </script>
+      <template>${template}</template>
+    `);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    'Button',
+    'Component',
+    'LinearGradient',
+    'Math',
+    'Slot',
+    'Template',
+    'keepalive',
+    'transitiongroup',
+  ])('recognizes <%s> as a component with Vue-exact casing', (name) => {
+    const root = createConsumerFixture(`
+      <script setup>
+      import { VueT as ${name} } from '@fixture/multi/vue';
+      </script>
+      <template><${name}>Active component</${name}></template>
+    `);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    'button',
+    'linearGradient',
+    'math',
+    'BaseTransition',
+    'KeepAlive',
+    'Teleport',
+    'TransitionGroup',
+  ])('does not treat native or built-in <%s> as import usage', (name) => {
+    const root = createConsumerFixture(`
+      <script setup>
+      import { VueT as ${name} } from '@fixture/multi/vue';
+      </script>
+      <template><${name}>Platform element</${name}></template>
+    `);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+});
+
+function createConsumerFixture(source: string): string {
+  const root = createProjectFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: { './vue': './src/vue.ts' },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+    'src/App.vue': source,
+  });
+  temporaryDirectories.push(root);
+
+  const destination = path.join(root, 'node_modules', '@fixture', 'multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  return root;
+}

--- a/packages/vue-extractor/src/internal/__tests__/consumerTemplateLexingRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerTemplateLexingRegression.test.ts
@@ -151,10 +151,6 @@ describe('Vue wrapper use in consumer templates', () => {
       template: '<Mixed.VueT>Active</Mixed.VueT>',
     },
     {
-      name: 'a namespace component tag beneath a same-named slot binding',
-      template: `<Child v-slot="{ Mixed }"><Mixed.VueT /></Child>`,
-    },
-    {
       name: 'an outer namespace beneath an unrelated loop binding',
       template: `<main v-for="item in values"><component :is="Mixed.VueT" /></main>`,
     },

--- a/packages/vue-extractor/src/internal/__tests__/consumerTemplateScopeRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerTemplateScopeRegression.test.ts
@@ -1,0 +1,303 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { compileScript, parse } from '@vue/compiler-sfc';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('Vue wrapper use in lexically scoped component tags', () => {
+  it.each([
+    {
+      name: 'a namespace beneath a slot binding',
+      template: '<Child v-slot="{ Mixed }"><Mixed.VueT /></Child>',
+    },
+    {
+      name: 'a named component beneath a slot binding',
+      template: '<Child v-slot="{ VueT }"><VueT /></Child>',
+    },
+    {
+      name: 'a namespace beneath a simple v-for binding',
+      template: '<main v-for="Mixed in rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'a named component beneath a simple v-for binding',
+      template: '<main v-for="VueT in rows"><VueT /></main>',
+    },
+    {
+      name: 'a namespace on the element declaring its v-for binding',
+      template: '<Mixed.VueT v-for="Mixed in rows" />',
+    },
+    {
+      name: 'a named component on the element declaring its v-for binding',
+      template: '<VueT v-for="VueT in rows" />',
+    },
+    {
+      name: 'a parenthesized v-for binding',
+      template: '<main v-for="(Mixed, index) in rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'a parenthesized array v-for binding',
+      template: '<main v-for="([Mixed], index) in rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'a parenthesized object v-for binding',
+      template:
+        '<main v-for="({ Mixed }, index) in rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'a parenthesized v-for binding used by a dynamic component',
+      template:
+        '<main v-for="(Mixed, index) in rows"><component :is="Mixed.VueT" /></main>',
+    },
+  ])('does not attribute $name to the wrapper import', ({ template }) => {
+    const root = createConsumerFixture(template);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each(['component', 'Component'])(
+    'does not treat dynamic <%s> as an import use',
+    (component) => {
+      const root = createConsumerFixture(`<${component} :is="'div'" />`);
+
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
+
+  it.each(['component', 'Component'])(
+    'retains imported static <%s> as a runtime use',
+    (component) => {
+      const root = createConsumerFixture(`<${component} />`);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it.each(['COMPONENT', 'cOmPoNeNt'])(
+    'retains imported non-builtin casing <%s> with an is binding',
+    (component) => {
+      const root = createConsumerFixture(`<${component} :is="'div'" />`);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it.each(['component', 'Component'])(
+    'retains imported static <%s> when boolean is has no value',
+    (component) => {
+      const root = createConsumerFixture(`<${component} is />`);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it('does not attribute a dot-shorthand dynamic component to a static component import', () => {
+    const root = createConsumerFixture(
+      `<component .is="'div'" />`,
+      "import { VueT as component } from '@fixture/multi/vue';"
+    );
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('tracks a wrapper passed through the dot-shorthand dynamic component expression', () => {
+    const root = createConsumerFixture(
+      '<component .is="VueT" />',
+      "import { VueT } from '@fixture/multi/vue';"
+    );
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'an explicit template slot scope',
+      template:
+        '<Child><template #default="{ Mixed }"><Mixed.VueT /></template></Child>',
+    },
+    {
+      name: 'a three-parameter parenthesized v-for scope',
+      template:
+        '<main v-for="(Mixed, index, key) of rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'an exact Pascal binding rendered through kebab casing',
+      imports: "import { VueT } from '@fixture/multi/vue';",
+      template: '<main v-for="VueT in rows"><vue-t /></main>',
+    },
+    {
+      name: 'an exact camel binding rendered through kebab casing',
+      imports: "import { VueT as vueT } from '@fixture/multi/vue';",
+      template: '<main v-for="vueT in rows"><vue-t /></main>',
+    },
+    {
+      name: 'a self-referential slot binding default',
+      imports: "import { VueT } from '@fixture/multi/vue';",
+      template: '<Child v-slot="{ VueT = VueT }"><VueT /></Child>',
+    },
+  ])(
+    'does not attribute $name to the wrapper import',
+    ({ imports, template }) => {
+      const root = createConsumerFixture(template, imports);
+
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
+
+  it.each([
+    {
+      name: 'the component owning a same-named slot binding',
+      template: '<VueT v-slot="{ VueT }"><span /></VueT>',
+    },
+    {
+      name: 'a same-named component in the v-for source',
+      template: '<VueT v-for="VueT in [VueT]" />',
+    },
+    {
+      name: 'a same-named component in a higher-precedence v-if',
+      template: '<VueT v-for="VueT in rows" v-if="VueT" />',
+    },
+    {
+      name: 'a namespace not bound by an aliased object pattern',
+      imports: "import * as Mixed from '@fixture/multi/vue';",
+      template:
+        '<main v-for="({ Mixed: local }, index) in rows"><Mixed.VueT /></main>',
+    },
+    {
+      name: 'a Pascal import when only its camel variant is scoped',
+      template: '<main v-for="vueT in rows"><vue-t /></main>',
+    },
+    {
+      name: 'a Pascal namespace rendered through lowercase casing',
+      imports: "import * as Mixed from '@fixture/multi/vue';",
+      template: '<mixed.VueT />',
+    },
+    {
+      name: 'a Pascal namespace rendered through kebab casing',
+      imports: "import * as MyComponents from '@fixture/multi/vue';",
+      template: '<my-components.VueT />',
+    },
+    {
+      name: 'a camel namespace rendered through kebab casing',
+      imports: "import * as myComponents from '@fixture/multi/vue';",
+      template: '<my-components.VueT />',
+    },
+  ])('retains $name as a wrapper import use', ({ imports, template }) => {
+    const root = createConsumerFixture(template, imports);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('does not attribute a normalized namespace tag to its shadowed Pascal binding', () => {
+    const root = createConsumerFixture(
+      '<Child v-slot="{ Mixed }"><mixed.VueT /></Child>',
+      "import * as Mixed from '@fixture/multi/vue';"
+    );
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it.each([
+    {
+      imports: "import { VueT as component } from '@fixture/multi/vue';",
+      name: 'the Vue 3.3 static component interpretation',
+    },
+    {
+      imports: "import { VueT as is } from '@fixture/multi/vue';",
+      name: 'the Vue 3.5 same-name binding interpretation',
+    },
+  ])(
+    'conservatively retains $name of no-value :is shorthand',
+    ({ imports }) => {
+      const root = createConsumerFixture('<component :is />', imports);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it('matches Vue 3.5 lexical resolution for slot and v-for component tags', () => {
+    const slot = compileInlineTemplate(
+      '<Child v-slot="{ Mixed }"><Mixed.VueT /></Child>'
+    );
+    const loop = compileInlineTemplate(
+      '<main v-for="(Mixed, index) in rows"><Mixed.VueT /></main>'
+    );
+
+    expect(slot).toContain('default: _withCtx(({ Mixed }) => [');
+    expect(slot).toContain('_createVNode(Mixed.VueT)');
+    expect(loop).toContain('_renderList(rows, (Mixed, index) => {');
+    expect(loop).toContain('_createVNode(Mixed.VueT)');
+  });
+
+  it('matches Vue 3.5 resolution of the lowercase component builtin', () => {
+    const output = compileInlineTemplate('<component :is="\'div\'" />');
+
+    expect(output).toContain("_resolveDynamicComponent('div')");
+    expect(output).not.toContain('_unref(component)');
+  });
+});
+
+function createConsumerFixture(
+  template: string,
+  imports = defaultImports
+): string {
+  const root = createProjectFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: { './vue': './src/vue.ts' },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+    'src/App.vue': createSfc(template, imports),
+  });
+  temporaryDirectories.push(root);
+
+  const destination = path.join(root, 'node_modules', '@fixture', 'multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  return root;
+}
+
+function compileInlineTemplate(template: string): string {
+  const { descriptor, errors } = parse(createSfc(template), {
+    filename: 'Scope.vue',
+  });
+  expect(errors).toEqual([]);
+  return compileScript(descriptor, {
+    id: 'consumer-template-scope-regression',
+    inlineTemplate: true,
+  }).content;
+}
+
+function createSfc(template: string, imports = defaultImports): string {
+  return `<script setup>
+${imports}
+const rows = [];
+</script>
+<template>${template}</template>`;
+}
+
+const defaultImports = `import * as Mixed from '@fixture/multi/vue';
+import {
+  VueT,
+  VueT as component,
+  VueT as Component,
+  VueT as COMPONENT,
+  VueT as cOmPoNeNt,
+} from '@fixture/multi/vue';`;

--- a/packages/vue-extractor/src/internal/__tests__/consumerTemplateScopeRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerTemplateScopeRegression.test.ts
@@ -146,6 +146,42 @@ describe('Vue wrapper use in lexically scoped component tags', () => {
       imports: "import { VueT } from '@fixture/multi/vue';",
       template: '<Child v-slot="{ VueT = VueT }"><VueT /></Child>',
     },
+    {
+      name: 'a Pascal import when a camel setup binding has precedence',
+      imports:
+        "import { VueT } from '@fixture/multi/vue'; const vueT = 'section';",
+      template: '<vue-t />',
+    },
+    {
+      name: 'a Pascal namespace when a camel setup binding has precedence',
+      imports:
+        "import * as Mixed from '@fixture/multi/vue'; const mixed = { VueT: 'section' };",
+      template: '<mixed.VueT />',
+    },
+    {
+      name: 'an exact camel import when a Pascal literal has type precedence',
+      imports:
+        "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = 'section';",
+      template: '<vue-t />',
+    },
+    {
+      name: 'an exact camel import when a static template has type precedence',
+      imports:
+        "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = `section${1}`;",
+      template: '<vue-t />',
+    },
+    {
+      name: 'an exact camel import when an object rest binding has type precedence',
+      imports:
+        "import { VueT as vueT } from '@fixture/multi/vue'; const { ...VueT } = source;",
+      template: '<vue-t />',
+    },
+    {
+      name: 'an exact camel import when a RegExp binding has type precedence',
+      imports:
+        "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = /section/;",
+      template: '<vue-t />',
+    },
   ])(
     'does not attribute $name to the wrapper import',
     ({ imports, template }) => {
@@ -192,6 +228,18 @@ describe('Vue wrapper use in lexically scoped component tags', () => {
       name: 'a camel namespace rendered through kebab casing',
       imports: "import * as myComponents from '@fixture/multi/vue';",
       template: '<my-components.VueT />',
+    },
+    {
+      name: 'a Pascal namespace with type precedence over a camel binding',
+      imports:
+        "import * as MyComponents from '@fixture/multi/vue'; const myComponents = getComponents();",
+      template: '<my-components.VueT />',
+    },
+    {
+      name: 'a camel import ahead of a Pascal member-call binding',
+      imports:
+        "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = factory.make();",
+      template: '<vue-t />',
     },
   ])('retains $name as a wrapper import use', ({ imports, template }) => {
     const root = createConsumerFixture(template, imports);
@@ -246,6 +294,54 @@ describe('Vue wrapper use in lexically scoped component tags', () => {
     expect(output).toContain("_resolveDynamicComponent('div')");
     expect(output).not.toContain('_unref(component)');
   });
+
+  it('matches Vue component lookup precedence for camel setup bindings', () => {
+    const output = compileInlineTemplate(
+      '<vue-t />',
+      "import { VueT } from '@fixture/multi/vue'; const vueT = 'section';"
+    );
+
+    expect(output).toContain('_createBlock(vueT)');
+    expect(output).not.toContain('_unref(VueT)');
+  });
+
+  it('matches Vue binding-type precedence ahead of normalized spelling', () => {
+    const literalOutput = compileInlineTemplate(
+      '<vue-t />',
+      "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = 'section';"
+    );
+    const namespaceOutput = compileInlineTemplate(
+      '<my-components.VueT />',
+      "import * as MyComponents from '@fixture/multi/vue'; const myComponents = getComponents();"
+    );
+    const restOutput = compileInlineTemplate(
+      '<vue-t />',
+      "import { VueT as vueT } from '@fixture/multi/vue'; const { ...VueT } = source;"
+    );
+    const memberCallOutput = compileInlineTemplate(
+      '<vue-t />',
+      "import { VueT as vueT } from '@fixture/multi/vue'; const VueT = factory.make();"
+    );
+
+    expect(literalOutput).toContain('_createBlock(VueT)');
+    expect(literalOutput).not.toContain('_unref(vueT)');
+    expect(namespaceOutput).toContain('MyComponents.VueT');
+    expect(namespaceOutput).not.toContain('myComponents.VueT');
+    expect(restOutput).toContain('_createBlock(VueT)');
+    expect(restOutput).not.toContain('_unref(vueT)');
+    expect(memberCallOutput).toContain('_createBlock(_unref(vueT))');
+    expect(memberCallOutput).not.toContain('_unref(VueT)');
+  });
+
+  it('selects a setup binding before applying lexical shadowing', () => {
+    const output = compileInlineTemplate(
+      '<main v-for="vueT in rows"><vue-t /></main>',
+      "import { VueT } from '@fixture/multi/vue';"
+    );
+
+    expect(output).toContain('_unref(VueT)');
+    expect(output).not.toContain('_createVNode(vueT)');
+  });
 });
 
 function createConsumerFixture(
@@ -274,8 +370,11 @@ function createConsumerFixture(
   return root;
 }
 
-function compileInlineTemplate(template: string): string {
-  const { descriptor, errors } = parse(createSfc(template), {
+function compileInlineTemplate(
+  template: string,
+  imports = defaultImports
+): string {
+  const { descriptor, errors } = parse(createSfc(template, imports), {
     filename: 'Scope.vue',
   });
   expect(errors).toEqual([]);

--- a/packages/vue-extractor/src/internal/__tests__/consumerUsageCacheRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerUsageCacheRegression.test.ts
@@ -1,0 +1,402 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import { inspectVueProject } from '../../inspect.js';
+import {
+  createConsumerUsageCache,
+  packageConsumesPublicGT,
+} from '../project/consumerUsage.js';
+import { parseScriptAst } from '../script/parser.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+  writeProjectFiles,
+} from './projectTestUtils.js';
+
+vi.mock('../script/parser.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../script/parser.js')>();
+  return {
+    ...actual,
+    parseScriptAst: vi.fn(actual.parseScriptAst),
+  };
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('consumer wrapper usage cache', () => {
+  it('parses each shared consumer source at most once across five wrapper queries', () => {
+    const root = createWrapperWorkspace(5);
+    const consumerDirectory = fs.realpathSync(path.join(root, 'apps/docs'));
+    const consumerSourceDirectory = path.join(consumerDirectory, 'src');
+    const consumerImportsFile = path.join(
+      consumerSourceDirectory,
+      'wrappers.ts'
+    );
+    const consumerMarkers = [
+      'consumer-cache-ordinary',
+      'consumer-cache-wrapper-imports',
+    ];
+    const parseScript = vi.mocked(parseScriptAst);
+    const readDirectory = vi.spyOn(fs, 'readdirSync');
+    const readFile = vi.spyOn(fs, 'readFileSync');
+    parseScript.mockClear();
+
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: false,
+    });
+
+    for (const marker of consumerMarkers) {
+      expect(
+        countSourceParses(parseScript.mock.calls, marker),
+        marker
+      ).toBeLessThanOrEqual(1);
+    }
+    expect(
+      countSourceParses(
+        parseScript.mock.calls,
+        'consumer-cache-wrapper-imports'
+      )
+    ).toBe(1);
+    expect(
+      countPathCalls(readDirectory.mock.calls, consumerSourceDirectory)
+    ).toBe(1);
+    expect(countPathCalls(readFile.mock.calls, consumerImportsFile)).toBe(1);
+    for (let index = 0; index < 5; index += 1) {
+      expect(
+        countSourceParses(
+          parseScript.mock.calls,
+          `wrapper-cache-source-${index}`
+        )
+      ).toBe(1);
+    }
+
+    readDirectory.mockRestore();
+    readFile.mockRestore();
+  });
+
+  it('reuses one consumer scan for selection and propagation queries', () => {
+    const root = createWrapperWorkspace(1);
+    const parseScript = vi.mocked(parseScriptAst);
+    parseScript.mockClear();
+
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: false,
+    });
+
+    expect(
+      countSourceParses(
+        parseScript.mock.calls,
+        'consumer-cache-wrapper-imports'
+      )
+    ).toBe(1);
+  });
+
+  it('does not retain consumer usage across separate inspections', () => {
+    const root = createLocalWrapperApp(false);
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: false,
+      rootOwnsVue: false,
+    });
+
+    writeProjectFiles(root, {
+      'src/App.ts': `
+        import { WrapperT } from '@fixture/local-wrapper';
+        export const component = WrapperT;
+      `,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: true,
+    });
+
+    writeProjectFiles(root, {
+      'src/App.ts': "export const component = 'react-only-again';\n",
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: false,
+      rootOwnsVue: false,
+    });
+  });
+
+  it('does not retain wrapper provenance across separate inspections', () => {
+    const root = createLocalWrapperApp(true);
+
+    expect(detectVueProject(root)).toBe(true);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: true,
+    });
+
+    writeProjectFiles(root, {
+      'vendor/local-wrapper/src/index.ts':
+        "export const WrapperT = 'ordinary';\n",
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: false,
+      rootOwnsVue: false,
+    });
+
+    writeProjectFiles(root, {
+      'vendor/local-wrapper/src/index.ts':
+        "export { T as WrapperT } from 'gt-vue';\n",
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: true,
+    });
+  });
+
+  it('resumes a partially scanned consumer for a later wrapper query', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/consumer',
+        exports: './entry.ts',
+      }),
+      'entry.ts': `
+        import { WrapperA } from '@fixture/wrapper-a';
+        export const component = WrapperA;
+        export const marker = 'consumer-cache-early';
+      `,
+      'src/later.ts': `
+        import { WrapperB } from '@fixture/wrapper-b';
+        export const component = WrapperB;
+        export const marker = 'consumer-cache-later';
+      `,
+      ...createDirectWrapperFiles('a'),
+      ...createDirectWrapperFiles('b'),
+    });
+    const cache = createConsumerUsageCache();
+    const parseScript = vi.mocked(parseScriptAst);
+    parseScript.mockClear();
+
+    expect(queryDirectWrapper(root, 'a', cache)).toBe(true);
+    expect(
+      countSourceParses(parseScript.mock.calls, 'consumer-cache-early')
+    ).toBe(1);
+    expect(
+      countSourceParses(parseScript.mock.calls, 'consumer-cache-later')
+    ).toBe(0);
+
+    expect(queryDirectWrapper(root, 'b', cache)).toBe(true);
+    expect(
+      countSourceParses(parseScript.mock.calls, 'consumer-cache-early')
+    ).toBe(1);
+    expect(
+      countSourceParses(parseScript.mock.calls, 'consumer-cache-later')
+    ).toBe(1);
+  });
+
+  it('returns order-independent results for used and unused wrappers', () => {
+    const wrapperNames = ['a', 'b', 'c', 'd', 'e', 'f'];
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/consumer',
+        exports: './entry.ts',
+      }),
+      'entry.ts': createRuntimeConsumerImport('a'),
+      'src/middle.ts': createRuntimeConsumerImport('c'),
+      'src/later.ts': createRuntimeConsumerImport('f'),
+      ...Object.assign(
+        {},
+        ...wrapperNames.map((name) => createDirectWrapperFiles(name))
+      ),
+    });
+    const expected = new Map(
+      wrapperNames.map((name) => [
+        name,
+        queryDirectWrapper(root, name, createConsumerUsageCache()),
+      ])
+    );
+
+    expect(Object.fromEntries(expected)).toEqual({
+      a: true,
+      b: false,
+      c: true,
+      d: false,
+      e: false,
+      f: true,
+    });
+    for (const order of [
+      wrapperNames,
+      [...wrapperNames].reverse(),
+      ['b', 'a', 'd', 'c', 'e', 'f'],
+    ]) {
+      const cache = createConsumerUsageCache();
+      const actual = new Map(
+        order.map((name) => [name, queryDirectWrapper(root, name, cache)])
+      );
+      expect(actual).toEqual(
+        new Map(order.map((name) => [name, expected.get(name)]))
+      );
+    }
+  });
+});
+
+function createWrapperWorkspace(wrapperCount: number): string {
+  const dependencies: Record<string, string> = {};
+  const imports: string[] = [];
+  const wrappers: Record<string, string> = {};
+  for (let index = 0; index < wrapperCount; index += 1) {
+    const packageName = `@fixture/vue-wrapper-${index}`;
+    dependencies[packageName] = 'workspace:*';
+    imports.push(`import { WrapperT${index} } from '${packageName}';`);
+    wrappers[`packages/wrapper-${index}/package.json`] = JSON.stringify({
+      name: packageName,
+      version: '1.0.0',
+      exports: './src/index.ts',
+      dependencies: { 'gt-vue': '*' },
+    });
+    wrappers[`packages/wrapper-${index}/src/index.ts`] =
+      `// wrapper-cache-source-${index}\nexport { T as WrapperT${index} } from 'gt-vue';\n`;
+  }
+
+  return createFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/root',
+      private: true,
+      workspaces: ['packages/*', 'apps/*'],
+    }),
+    ...wrappers,
+    'apps/docs/package.json': JSON.stringify({
+      name: '@fixture/docs',
+      version: '1.0.0',
+      dependencies,
+    }),
+    'apps/docs/src/ordinary.ts':
+      "export const ordinary = 'consumer-cache-ordinary';\n",
+    'apps/docs/src/wrappers.ts': `${imports.join('\n')}
+export const marker = 'consumer-cache-wrapper-imports';
+export const wrappers = [${Array.from(
+      { length: wrapperCount },
+      (_, index) => `WrapperT${index}`
+    ).join(', ')}];
+`,
+  });
+}
+
+function createLocalWrapperApp(usesWrapper: boolean): string {
+  const root = createFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/app',
+      dependencies: {
+        '@fixture/local-wrapper': 'file:./vendor/local-wrapper',
+      },
+    }),
+    'vendor/local-wrapper/package.json': JSON.stringify({
+      name: '@fixture/local-wrapper',
+      version: '1.0.0',
+      exports: './src/index.ts',
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/local-wrapper/src/index.ts':
+      "export { T as WrapperT } from 'gt-vue';\n",
+    'src/App.ts': usesWrapper
+      ? `
+          import { WrapperT } from '@fixture/local-wrapper';
+          export const component = WrapperT;
+        `
+      : "export const component = 'react-only';\n",
+  });
+  linkPackage(root, '', '@fixture/local-wrapper', 'vendor/local-wrapper');
+  return root;
+}
+
+function countSourceParses(
+  calls: Parameters<typeof parseScriptAst>[][],
+  marker: string
+): number {
+  return calls.filter(([source]) => source.includes(marker)).length;
+}
+
+function countPathCalls(calls: unknown[][], expectedPath: string): number {
+  return calls.filter(
+    ([file]) =>
+      typeof file === 'string' &&
+      path.resolve(file) === path.resolve(expectedPath)
+  ).length;
+}
+
+function createDirectWrapperFiles(name: string): Record<string, string> {
+  const packageName = `@fixture/wrapper-${name}`;
+  return {
+    [`wrappers/${name}/package.json`]: JSON.stringify({
+      name: packageName,
+      version: '1.0.0',
+      exports: './src/index.ts',
+      dependencies: { 'gt-vue': '*' },
+    }),
+    [`wrappers/${name}/src/index.ts`]: `export { T as Wrapper${name.toUpperCase()} } from 'gt-vue';\n`,
+  };
+}
+
+function queryDirectWrapper(
+  root: string,
+  name: string,
+  cache: ReturnType<typeof createConsumerUsageCache>
+): boolean {
+  const packageName = `@fixture/wrapper-${name}`;
+  const manifest = {
+    name: packageName,
+    version: '1.0.0',
+    exports: './src/index.ts',
+    dependencies: { 'gt-vue': '*' },
+  };
+  return packageConsumesPublicGT(
+    root,
+    packageName,
+    path.join(root, 'wrappers', name),
+    manifest,
+    cache
+  );
+}
+
+function createRuntimeConsumerImport(name: string): string {
+  const component = `Wrapper${name.toUpperCase()}`;
+  return `
+    import { ${component} } from '@fixture/wrapper-${name}';
+    export const component = ${component};
+  `;
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function linkPackage(
+  root: string,
+  consumerDirectory: string,
+  bindingName: string,
+  targetDirectory: string
+): void {
+  const destination = path.join(
+    root,
+    consumerDirectory,
+    'node_modules',
+    ...bindingName.split('/')
+  );
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, targetDirectory), destination, 'dir');
+}

--- a/packages/vue-extractor/src/internal/__tests__/consumerVPreRegression.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerVPreRegression.test.ts
@@ -1,0 +1,221 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { compile } from '@vue/compiler-dom';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('Vue wrapper use beneath v-pre', () => {
+  it.each([
+    {
+      name: 'a namespace component tag',
+      template: '<section v-pre><Mixed.VueT /></section>',
+    },
+    {
+      name: 'a named component tag',
+      template: '<section v-pre><VueT /></section>',
+    },
+    {
+      name: 'a directive expression',
+      template: '<section v-pre :title="Mixed.VueT" />',
+    },
+    {
+      name: 'a directive before v-pre',
+      template: '<section :title="Mixed.VueT" v-pre />',
+    },
+    {
+      name: 'an interpolation',
+      template: '<section v-pre>{{ Mixed.VueT }}</section>',
+    },
+    {
+      name: 'nested elements',
+      template: `
+        <section v-pre>
+          <div><Mixed.VueT />{{ Mixed.VueT }}</div>
+        </section>
+      `,
+    },
+    {
+      name: 'v-pre on the namespace component itself',
+      template: '<Mixed.VueT v-pre />',
+    },
+    {
+      name: 'v-pre on the named component itself',
+      template: '<VueT v-pre />',
+    },
+    {
+      name: 'a v-pre modifier accepted by the Vue compiler',
+      template: '<section v-pre.foo><Mixed.VueT /></section>',
+    },
+    {
+      name: 'a v-pre argument accepted by the Vue compiler',
+      template: '<section v-pre:ignored><Mixed.VueT /></section>',
+    },
+    {
+      name: 'a void element inside v-pre',
+      template: `
+        <section v-pre>
+          <img :src="Mixed.VueT">
+          <Mixed.VueT />
+        </section>
+      `,
+    },
+    {
+      name: 'a raw-text element inside v-pre',
+      template: `
+        <section v-pre>
+          <textarea>{{ Mixed.VueT }}<Mixed.VueT /></textarea>
+          <Mixed.VueT />
+        </section>
+      `,
+    },
+    {
+      name: 'closing-tag-shaped content in a comment',
+      template: `
+        <section v-pre>
+          <!-- </section><Mixed.VueT /> -->
+          <Mixed.VueT />
+        </section>
+      `,
+    },
+    {
+      name: 'an uppercase void-name component used as a v-pre owner',
+      template: `
+        <INPUT v-pre :value="Mixed.VueT">
+          <Mixed.VueT />
+        </INPUT>
+      `,
+    },
+  ])('ignores $name', ({ template }) => {
+    const root = createConsumerFixture(template);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('resumes executable component detection after the v-pre element closes', () => {
+    const root = createConsumerFixture(`
+      <section>
+        <section v-pre>
+          <section><Mixed.VueT /></section>
+        </section>
+        <Mixed.VueT />
+      </section>
+    `);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    {
+      name: 'a case-insensitive HTML closing tag',
+      template: `
+        <SECTION v-pre><Mixed.VueT /></section>
+        <Mixed.VueT />
+      `,
+    },
+    {
+      name: 'a void v-pre owner',
+      template: `
+        <input v-pre :value="Mixed.VueT">
+        <Mixed.VueT />
+      `,
+    },
+    {
+      name: 'a raw-text v-pre owner',
+      template: `
+        <textarea v-pre>{{ Mixed.VueT }}<Mixed.VueT /></textarea>
+        <Mixed.VueT />
+      `,
+    },
+    {
+      name: 'an uppercase raw-text v-pre owner',
+      template: `
+        <TEXTAREA v-pre>{{ Mixed.VueT }}<Mixed.VueT /></textarea>
+        <Mixed.VueT />
+      `,
+    },
+  ])('resumes component detection after $name', ({ template }) => {
+    const root = createConsumerFixture(template);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each(['textarea', 'title'])(
+    'recognizes executable interpolation in <%s> without v-pre',
+    (tag) => {
+      const root = createConsumerFixture(`<${tag}>{{ Mixed.VueT }}</${tag}>`);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it.each(['INPUT', 'TEXTAREA', 'SCRIPT'])(
+    'treats case-sensitive <%s> as a component container without v-pre',
+    (tag) => {
+      const root = createConsumerFixture(`<${tag}><Mixed.VueT /></${tag}>`);
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it('matches the Vue 3.5 compiler treatment of v-pre content', () => {
+    const { code } = compile(
+      `
+        <section v-pre>
+          <Mixed.VueT />
+          <VueT />
+          <main :title="Mixed.VueT">{{ Mixed.VueT }}</main>
+        </section>
+        <Mixed.VueT />
+      `,
+      { mode: 'module', prefixIdentifiers: true }
+    );
+
+    expect(code).toContain('_createElementVNode("Mixed.VueT")');
+    expect(code).toContain('_createElementVNode("VueT")');
+    expect(code).toContain('{ ":title": "Mixed.VueT" }');
+    expect(code).toContain('"{{ Mixed.VueT }}"');
+    expect(code).toContain('_resolveComponent("Mixed.VueT")');
+    expect(code).not.toContain('_ctx.Mixed');
+  });
+});
+
+function createConsumerFixture(template: string): string {
+  const root = createProjectFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: { './vue': './src/vue.ts' },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+    'src/App.vue': `
+      <script setup>
+      import * as Mixed from '@fixture/multi/vue';
+      import { VueT } from '@fixture/multi/vue';
+      </script>
+      <template>${template}</template>
+    `,
+  });
+  temporaryDirectories.push(root);
+
+  const destination = path.join(root, 'node_modules', '@fixture', 'multi');
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, 'vendor/multi'), destination, 'dir');
+  return root;
+}

--- a/packages/vue-extractor/src/internal/__tests__/consumerWrapperUsage.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/consumerWrapperUsage.test.ts
@@ -1,0 +1,426 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import { inspectVueProject } from '../../inspect.js';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  linkInstalledVue,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('local Vue wrapper consumer usage', () => {
+  it('does not promote React through an unused public Vue subpath', () => {
+    const root = createMultiFrameworkFixture({
+      'src/App.tsx': `
+        import { ReactT } from '@fixture/multi';
+        export const App = () => <ReactT>React</ReactT>;
+      `,
+      'src/Unrelated.vue': '<template>Not a GT component</template>',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: false,
+      rootOwnsVue: false,
+    });
+  });
+
+  it('promotes a consumer that uses the exact Vue subpath export', () => {
+    const root = createMultiFrameworkFixture({
+      'src/App.tsx': `
+        import { VueT } from '@fixture/multi/vue';
+        export const App = () => <VueT>Vue</VueT>;
+      `,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+    expect(inspectVueProject(root)).toMatchObject({
+      hasVueScopes: true,
+      rootOwnsVue: true,
+    });
+  });
+
+  it('distinguishes ordinary and GT-derived named exports at one entry', () => {
+    const ordinaryRoot = createRootEntryFixture(`
+      import { ReactT } from '@fixture/mixed-root';
+      export const App = () => <ReactT>React</ReactT>;
+    `);
+    const vueRoot = createRootEntryFixture(`
+      import { VueT } from '@fixture/mixed-root';
+      export const App = () => <VueT>Vue</VueT>;
+    `);
+
+    expect(detectVueProject(ordinaryRoot)).toBe(false);
+    expect(detectVueProject(vueRoot)).toBe(true);
+  });
+
+  it('reads a wrapper import used by an SFC template without a Vue compiler', () => {
+    const root = createMultiFrameworkFixture({
+      'src/App.vue': `<script setup lang="ts">
+import { VueT } from '@fixture/multi/vue';
+</script>
+<template><vue-t>SFC wrapper</vue-t></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('ignores namespace names found only in style, comments, and text', () => {
+    const root = createMultiFrameworkFixture({
+      'src/App.vue': `<script setup lang="ts">
+import * as Mixed from '@fixture/multi/vue';
+</script>
+<template>
+  <!-- Mixed.VueT -->
+  <p>Mixed.VueT</p>
+</template>
+<style>.Mixed.VueT { color: red; }</style>`,
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('recognizes an exact namespace component used by an SFC template', () => {
+    const root = createMultiFrameworkFixture({
+      'src/App.vue': `<script setup lang="ts">
+import * as Mixed from '@fixture/multi/vue';
+</script>
+<template><Mixed.VueT>Namespace wrapper</Mixed.VueT></template>`,
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('matches the dependency binding name for an aliased local package', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/app',
+        dependencies: { 'vue-alias': 'file:./vendor/multi' },
+      }),
+      'vendor/multi/package.json': JSON.stringify({
+        name: '@fixture/multi',
+        version: '1.0.0',
+        exports: { './vue': './src/vue.ts' },
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+      'src/App.tsx': `
+        import { VueT } from 'vue-alias/vue';
+        export const App = () => <VueT>Aliased</VueT>;
+      `,
+    });
+    linkPackage(root, '', 'vue-alias', 'vendor/multi');
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('propagates through source-used transitive wrapper re-exports', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/base/package.json': JSON.stringify({
+        name: '@fixture/base',
+        version: '1.0.0',
+        exports: './src/index.ts',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/base/src/index.ts': "export { T as BaseT } from 'gt-vue';\n",
+      'packages/wrapper/package.json': JSON.stringify({
+        name: '@fixture/wrapper',
+        version: '1.0.0',
+        exports: './src/index.ts',
+        dependencies: { '@fixture/base': 'workspace:*' },
+      }),
+      'packages/wrapper/src/index.ts':
+        "export { BaseT as WrapperT } from '@fixture/base';\n",
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/wrapper': 'workspace:*' },
+      }),
+      'apps/docs/src/App.vue': `<script setup lang="ts">
+import { WrapperT } from '@fixture/wrapper';
+</script>
+<template><WrapperT>Transitive wrapper</WrapperT></template>`,
+    });
+    linkPackage(root, 'packages/wrapper', '@fixture/base', 'packages/base');
+    linkPackage(root, 'apps/docs', '@fixture/wrapper', 'packages/wrapper');
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Transitive wrapper',
+    ]);
+  });
+
+  it('does not infer namespace use from an ordinary member', () => {
+    const ordinaryRoot = createRootEntryFixture(`
+      import * as Mixed from '@fixture/mixed-root';
+      export const App = () => <Mixed.ReactT>React</Mixed.ReactT>;
+    `);
+    const vueRoot = createRootEntryFixture(`
+      import * as Mixed from '@fixture/mixed-root';
+      export const App = () => <Mixed.VueT>Vue</Mixed.VueT>;
+    `);
+
+    expect(detectVueProject(ordinaryRoot)).toBe(false);
+    expect(detectVueProject(vueRoot)).toBe(true);
+  });
+
+  it('recognizes an exact member destructured from a package namespace', () => {
+    const root = createRootEntryFixture(`
+      import * as Mixed from '@fixture/mixed-root';
+      const { VueT } = Mixed;
+      export const App = () => <VueT>Vue</VueT>;
+    `);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('recognizes an exact member used through an immutable namespace alias', () => {
+    const root = createRootEntryFixture(`
+      import * as Wrapper from '@fixture/mixed-root';
+      const Alias = Wrapper;
+      export const App = () => <Alias.VueT>Vue</Alias.VueT>;
+    `);
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('recognizes a top-level namespace alias used by an SFC template', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/react-app',
+        dependencies: {
+          '@fixture/mixed-root': 'file:./vendor/mixed-root',
+        },
+      }),
+      'vendor/mixed-root/package.json': JSON.stringify({
+        name: '@fixture/mixed-root',
+        version: '1.0.0',
+        exports: './src/index.ts',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'vendor/mixed-root/src/index.ts': `
+        export { T as VueT } from 'gt-vue';
+        export { T as ReactT } from 'gt-react';
+      `,
+      'src/App.vue': `<script setup>
+import * as Wrapper from '@fixture/mixed-root';
+const Alias = Wrapper;
+</script>
+<template><Alias.VueT>Vue</Alias.VueT></template>`,
+    });
+    linkPackage(root, '', '@fixture/mixed-root', 'vendor/mixed-root');
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it.each([
+    `
+      import * as Wrapper from '@fixture/mixed-root';
+      const Alias = Wrapper;
+      export const App = () => <Alias.ReactT>React</Alias.ReactT>;
+    `,
+    `
+      import * as Wrapper from '@fixture/mixed-root';
+      const Alias = Wrapper;
+      export function render(Alias) {
+        return <Alias.VueT>Shadowed</Alias.VueT>;
+      }
+      export const App = () => <Alias.ReactT>React</Alias.ReactT>;
+    `,
+    `
+      import * as Wrapper from '@fixture/mixed-root';
+      let Alias = Wrapper;
+      Alias = { VueT: String };
+      export const App = () => <Alias.VueT>Mutated</Alias.VueT>;
+    `,
+    `
+      import * as Wrapper from '@fixture/mixed-root';
+      const Alias = Wrapper;
+      Alias.VueT = String;
+      export const App = () => <Alias.VueT>Mutated member</Alias.VueT>;
+    `,
+  ])('rejects an unsafe or ordinary namespace alias: %s', (source) => {
+    const root = createRootEntryFixture(source);
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('fails closed when a consumer reexports a mixed namespace container', () => {
+    const root = createRootEntryFixture(
+      "export * as Components from '@fixture/mixed-root';"
+    );
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('fails closed for a mixed wrapper-created namespace export', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/react-app',
+        dependencies: { '@fixture/container': 'file:./vendor/container' },
+      }),
+      'vendor/container/package.json': JSON.stringify({
+        name: '@fixture/container',
+        version: '1.0.0',
+        exports: './src/index.ts',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'vendor/container/src/index.ts':
+        "export * as Components from './components';\n",
+      'vendor/container/src/components.ts': `
+        export { T as VueT } from 'gt-vue';
+        export { T as ReactT } from 'gt-react';
+      `,
+      'src/App.tsx': `
+        import { Components } from '@fixture/container';
+        export const App = () => <Components.ReactT>React</Components.ReactT>;
+      `,
+    });
+    linkPackage(root, '', '@fixture/container', 'vendor/container');
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('ignores wrapper imports that exist only in generated artifacts', () => {
+    const root = createMultiFrameworkFixture({
+      '.turbo/generated.ts': `
+        import { VueT } from '@fixture/multi/vue';
+        void VueT;
+      `,
+      'dist/generated.js': `
+        import { VueT } from '@fixture/multi/vue';
+        void VueT;
+      `,
+      'src/App.tsx': 'export const App = () => <main>React</main>;',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('ignores a generated public entry that imports a wrapper', () => {
+    const root = createMultiFrameworkFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/react-app',
+        main: './dist/index.js',
+        dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+      }),
+      'dist/index.js': `
+        import { VueT } from '@fixture/multi/vue';
+        export { VueT };
+      `,
+      'src/App.tsx': 'export const App = () => <main>React</main>;',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('does not follow a default source directory symlink outside the package', () => {
+    const outside = createFixture({
+      'src/App.tsx': `
+        import { VueT } from '@fixture/multi/vue';
+        export const App = () => <VueT>Outside</VueT>;
+      `,
+    });
+    const root = createMultiFrameworkFixture({});
+    fs.symlinkSync(path.join(outside, 'src'), path.join(root, 'src'), 'dir');
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('keeps direct gt-vue ownership independent of source imports', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/direct-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+});
+
+function createMultiFrameworkFixture(
+  sourceFiles: Record<string, string>
+): string {
+  const root = createFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/multi': 'file:./vendor/multi' },
+    }),
+    'vendor/multi/package.json': JSON.stringify({
+      name: '@fixture/multi',
+      version: '1.0.0',
+      exports: {
+        '.': './src/react.ts',
+        './vue': './src/vue.ts',
+      },
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/multi/src/react.ts': "export { T as ReactT } from 'gt-react';\n",
+    'vendor/multi/src/vue.ts': "export { T as VueT } from 'gt-vue';\n",
+    ...sourceFiles,
+  });
+  linkPackage(root, '', '@fixture/multi', 'vendor/multi');
+  return root;
+}
+
+function createRootEntryFixture(appSource: string): string {
+  const root = createFixture({
+    'package.json': JSON.stringify({
+      name: '@fixture/react-app',
+      dependencies: { '@fixture/mixed-root': 'file:./vendor/mixed-root' },
+    }),
+    'vendor/mixed-root/package.json': JSON.stringify({
+      name: '@fixture/mixed-root',
+      version: '1.0.0',
+      exports: './src/index.ts',
+      dependencies: { 'gt-vue': '*' },
+    }),
+    'vendor/mixed-root/src/index.ts': `
+      export { T as VueT } from 'gt-vue';
+      export { T as ReactT } from 'gt-react';
+    `,
+    'src/App.tsx': appSource,
+  });
+  linkPackage(root, '', '@fixture/mixed-root', 'vendor/mixed-root');
+  return root;
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function linkPackage(
+  root: string,
+  consumerDirectory: string,
+  bindingName: string,
+  targetDirectory: string
+): void {
+  const destination = path.join(
+    root,
+    consumerDirectory,
+    'node_modules',
+    ...bindingName.split('/')
+  );
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, targetDirectory), destination, 'dir');
+}

--- a/packages/vue-extractor/src/internal/__tests__/containerIdentitySemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/containerIdentitySemantics.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type IdentityProbe = {
+  /** Human-readable JavaScript or Vue identity rule exercised by the probe. */
+  name: string;
+  /** Statements inserted after the shared gt-vue and Vue imports. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector?: string;
+  /** Whether the runtime-selected container can still contain `<T>`. */
+  possibleT: boolean;
+};
+
+/**
+ * Runtime-verified identity cases for aliases, Vue proxies, and array copies.
+ *
+ * JavaScript aliases retain the object captured at assignment time, while a
+ * later root assignment changes only the mutable binding. Vue proxies likewise
+ * retain their original raw target. `toRaw()` returns that target, so writes
+ * through it remain visible through every proxy view. Vue also returns an
+ * existing proxy from incompatible nested wrappers: readonly proxies remain
+ * readonly, and a shallow-readonly proxy remains shallow when passed to
+ * `readonly()`. Array copy transforms capture their source values at call time.
+ *
+ * These expectations were checked against Vue 3.5 before being encoded here.
+ * A possible `<T>` selected through an unknown key must fail closed with the
+ * extractor diagnostic; an ordinary final value must remain completely silent.
+ */
+const identityProbes: IdentityProbe[] = [
+  {
+    name: 'a rebound registry is detached from its old T alias',
+    code: 'let registry = [T]; const alias = registry; registry = [String];',
+    possibleT: false,
+  },
+  {
+    name: 'an old alias retains T after its binding is rebound',
+    code: 'let registry = [T]; const alias = registry; registry = [String];',
+    selector: 'alias[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an old ordinary alias is not retargeted by a T rebind',
+    code: 'let registry = [String]; const alias = registry; registry = [T];',
+    selector: 'alias[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a rebound registry contains its new T value',
+    code: 'let registry = [String]; const alias = registry; registry = [T];',
+    possibleT: true,
+  },
+  {
+    name: 'a write to a detached alias does not taint a rebound registry',
+    code: 'let registry = [String]; const alias = registry; registry = [String]; alias[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'a write to a detached alias remains visible through that alias',
+    code: 'let registry = [String]; const alias = registry; registry = [String]; alias[0] = T;',
+    selector: 'alias[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a later root replacement detaches a previously mutated alias',
+    code: 'let registry = [String]; const alias = registry; alias[0] = T; registry = [String];',
+    possibleT: false,
+  },
+  {
+    name: 'a later root replacement leaves the old alias mutated',
+    code: 'let registry = [String]; const alias = registry; alias[0] = T; registry = [String];',
+    selector: 'alias[key]',
+    possibleT: true,
+  },
+  {
+    name: 'pop erases T from a detached alias',
+    code: 'let registry = [T]; const alias = registry; registry = [String]; alias.pop();',
+    selector: 'alias[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a detached pop does not taint the rebound registry',
+    code: 'let registry = [T]; const alias = registry; registry = [String]; alias.pop();',
+    possibleT: false,
+  },
+  {
+    name: 'an erased old alias stays ordinary beside a fresh T alias',
+    code: 'let registry = [T]; const oldAlias = registry; oldAlias[0] = String; registry = [T]; const freshAlias = registry;',
+    selector: 'oldAlias[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a fresh alias sees the new T identity',
+    code: 'let registry = [T]; const oldAlias = registry; oldAlias[0] = String; registry = [T]; const freshAlias = registry;',
+    selector: 'freshAlias[key]',
+    possibleT: true,
+  },
+  {
+    name: 'readonly captures an old T target across a raw binding rebind',
+    code: 'let raw = [T]; const registry = readonly(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'shallowReadonly captures an old T target across a raw rebind',
+    code: 'let raw = [T]; const registry = shallowReadonly(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'reactive captures an old T target across a raw binding rebind',
+    code: 'let raw = [T]; const registry = reactive(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'readonly is not retargeted when its raw binding gains T',
+    code: 'let raw = [String]; const registry = readonly(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'shallowReadonly is not retargeted when its raw binding gains T',
+    code: 'let raw = [String]; const registry = shallowReadonly(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'reactive is not retargeted when its raw binding gains T',
+    code: 'let raw = [String]; const registry = reactive(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'a raw mutation after readonly creation adds T',
+    code: 'const raw = [String]; const registry = readonly(raw); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'a raw mutation after readonly creation erases T',
+    code: 'const raw = [T]; const registry = readonly(raw); raw[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a raw alias mutation after readonly creation erases T',
+    code: 'const raw = [T]; const registry = readonly(raw); const alias = raw; alias[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a toRaw alias adds T behind readonly',
+    code: 'const registry = readonly([String]); const raw = toRaw(registry); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'an inline toRaw mutation adds T behind readonly',
+    code: 'const registry = readonly([String]); toRaw(registry)[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'a toRaw alias adds T behind shallowReadonly',
+    code: 'const registry = shallowReadonly([String]); const raw = toRaw(registry); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'a toRaw alias adds T behind reactive',
+    code: 'const registry = reactive([String]); const raw = toRaw(registry); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'a toRaw alias erases T behind readonly',
+    code: 'const registry = readonly([T]); const raw = toRaw(registry); raw[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'an inline toRaw mutation erases T behind readonly',
+    code: 'const registry = readonly([T]); toRaw(registry)[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a nested toRaw mutation adds T behind shallowReadonly',
+    code: 'const registry = shallowReadonly([[String]]); const raw = toRaw(registry); raw[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested toRaw mutation adds T behind readonly',
+    code: 'const registry = readonly([[String]]); const raw = toRaw(registry); raw[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested toRaw mutation adds T behind reactive',
+    code: 'const registry = reactive([[String]]); const raw = toRaw(registry); raw[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: true,
+  },
+  {
+    name: 'reactive of readonly stays readonly at the root',
+    code: 'const registry = reactive(readonly([String])); registry[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'shallowReadonly of readonly stays deeply readonly',
+    code: 'const registry = shallowReadonly(readonly([[String]])); registry[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: false,
+  },
+  {
+    name: 'reactive of shallowReadonly stays readonly at the root',
+    code: 'const registry = reactive(shallowReadonly([String])); registry[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'readonly of shallowReadonly stays shallow',
+    code: 'const registry = readonly(shallowReadonly([[String]])); registry[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: true,
+  },
+  {
+    name: 'readonly of reactive blocks a root write',
+    code: 'const registry = readonly(reactive([String])); registry[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'shallowReadonly of reactive permits a nested write',
+    code: 'const registry = shallowReadonly(reactive([[String]])); registry[0][0] = T;',
+    selector: 'registry[key][key]',
+    possibleT: true,
+  },
+  {
+    name: 'reactive of readonly retains T after a blocked erasure',
+    code: 'const registry = reactive(readonly([T])); registry[0] = String;',
+    possibleT: true,
+  },
+  {
+    name: 'a readonly slice excludes a later T raw mutation',
+    code: 'const raw = [String]; const registry = readonly(raw.slice()); raw[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'a readonly slice retains T after later raw erasure',
+    code: 'const raw = [T]; const registry = readonly(raw.slice()); raw[0] = String;',
+    possibleT: true,
+  },
+  {
+    name: 'a spread copy excludes a later T raw mutation',
+    code: 'const raw = [String]; const registry = [...raw]; raw[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'a spread copy retains T after later raw erasure',
+    code: 'const raw = [T]; const registry = [...raw]; raw[0] = String;',
+    possibleT: true,
+  },
+  {
+    name: 'a map copy excludes a later T raw mutation',
+    code: 'const raw = [String]; const registry = raw.map((value) => value); raw[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'a concat copy retains T after later raw erasure',
+    code: 'const raw = [T]; const registry = [].concat(raw); raw[0] = String;',
+    possibleT: true,
+  },
+  {
+    name: 'an Array.from copy excludes a later T raw mutation',
+    code: 'const raw = [String]; const registry = Array.from(raw); raw[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'a toSpliced copy retains T after later raw erasure',
+    code: 'const raw = [T]; const registry = raw.toSpliced(); raw[0] = String;',
+    possibleT: true,
+  },
+];
+
+describe('Vue container identity semantics', () => {
+  it.each(identityProbes)(
+    '$name',
+    async ({ code, selector = 'registry[key]', possibleT }) => {
+      const output = await extractFromVueSource(
+        createFixture(code, selector),
+        '/fixtures/ContainerIdentity.vue',
+        { projectRoot: '/fixtures' }
+      );
+
+      expect(output.results).toEqual([]);
+      if (possibleT) {
+        expect(output.errors.join('\n')).toContain(POSSIBLE_ALIAS_DIAGNOSTIC);
+      } else {
+        expect(output.errors).toEqual([]);
+      }
+    }
+  );
+});
+
+/** Creates a minimal SFC whose unknown key exercises container provenance. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    import { reactive, readonly, shallowReadonly, toRaw } from 'vue';
+    ${code}
+    const key = getIndex();
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/createVueInlineUpdates.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/createVueInlineUpdates.test.ts
@@ -1,0 +1,301 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { extractFromVueSource } from './testVueCompiler.js';
+import type { VueCompilerOptions, VueExtractionResult } from '../../types.js';
+
+describe('extractFromVueSource', () => {
+  it('extracts context-only strings and a runtime-compatible rich source tree', async () => {
+    const result = await extractFixtures(['rich.vue'], {
+      includeSourceCodeContext: true,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.updates).toHaveLength(10);
+
+    const expectedRichSource: JsxChildren = [
+      {
+        t: 'p',
+        i: 1,
+        d: { ti: 'Greeting' },
+        c: [' Hello ', { i: 2, k: '_gt_value_2', v: 'v' }, ' ! '],
+      },
+      {
+        t: 'Plural',
+        i: 3,
+        d: {
+          b: {
+            one: [' one ', { i: 4, k: '_gt_value_4', v: 'v' }],
+            other: [' other ', { i: 4, k: '_gt_value_4', v: 'v' }],
+          },
+          t: 'p',
+        },
+        c: [' fallback ', { i: 4, k: '_gt_value_4', v: 'v' }],
+      },
+      {
+        t: 'Branch',
+        i: 5,
+        d: {
+          b: {
+            formal: [' formal ', { i: 6, k: '_gt_value_6', v: 'v' }],
+            casual: [' casual ', { i: 6, k: '_gt_value_6', v: 'v' }],
+          },
+          t: 'b',
+        },
+        c: [' fallback ', { i: 6, k: '_gt_value_6', v: 'v' }],
+      },
+      { t: 'b', i: 7, c: 'end' },
+      { i: 8, k: '_gt_n_8', v: 'n' },
+      { i: 9, k: '_gt_date_9', v: 'd' },
+      { i: 10, k: '_gt_cost_10', v: 'c' },
+      { t: 'var', i: 11, c: 'native' },
+    ];
+    const rich = result.updates.find((update) => update.dataFormat === 'JSX');
+    expect(rich).toMatchObject({
+      dataFormat: 'JSX',
+      metadata: { context: 'hero' },
+      source: expectedRichSource,
+    });
+
+    const stringUpdates = result.updates.filter(
+      (update) => update.dataFormat === 'STRING'
+    );
+    expect(stringUpdates.map((update) => update.source)).toEqual([
+      'Normal {literal}',
+      'Hello {name}',
+      'Navigation',
+      'First',
+      'Second',
+      'Aliased call',
+      'Template call',
+      'Encoded message',
+      'Template title',
+    ]);
+    expect(
+      stringUpdates.find((update) => update.source === 'Normal {literal}')
+        ?.metadata
+    ).toMatchObject({ context: 'normal' });
+    expect(
+      stringUpdates.find((update) => update.source === 'First')?.metadata
+    ).toMatchObject({ context: 'list' });
+    expect(
+      stringUpdates.find((update) => update.source === 'Template call')
+        ?.metadata
+    ).toMatchObject({ context: 'template' });
+    expect(
+      stringUpdates.find((update) => update.source === 'Normal {literal}')
+        ?.metadata.sourceCode
+    ).toBeDefined();
+  });
+
+  it('rejects comments that make whitespace hashes build-dependent', async () => {
+    const result = await extractFixtures(['comments.vue']);
+
+    expect(result.updates).toEqual([]);
+    expect(result.errors.join('\n')).toContain(
+      'comment adjacent to translatable whitespace'
+    );
+  });
+
+  it('diagnoses dynamic content and every unsupported metadata field', async () => {
+    const result = await extractFixtures(['invalid.vue']);
+    const messages = result.errors.join('\n');
+
+    expect(result.updates).toEqual([]);
+    expect(messages).toContain('dynamic content');
+    expect(messages).toContain('$maxChars');
+    expect(messages).toContain('$format');
+    expect(messages).toContain('"name"');
+    expect(messages).toContain('$id');
+    expect(messages).toContain('dynamic context');
+    expect(messages).toContain('v-if');
+    expect(messages).toContain('dynamic translatable prop "title"');
+    expect(messages).toContain('unsupported value prop');
+    expect(messages).toMatch(/invalid\.vue.*\(6:1\)/);
+  });
+
+  it('diagnoses context bindings whose modifiers change the runtime prop', async () => {
+    const result = await extractFixtures(['context-modifier.vue']);
+
+    expect(result.updates).toEqual([]);
+    expect(result.errors.join('\n')).toContain(
+      'unsupported directive :context.prop'
+    );
+  });
+
+  it('uses Vue component-name normalization while preserving native tags', async () => {
+    const result = await extractFixtures(['normalization.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0].source).toEqual([
+      { i: 1, k: '_gt_date_1', v: 'd' },
+      { t: 'var', i: 2, c: 'native' },
+    ]);
+  });
+
+  it('ignores type-only gt-vue imports', async () => {
+    const result = await extractFixtures(['type-only.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toEqual([]);
+  });
+
+  it('resolves static Options API component registrations', async () => {
+    const result = await extractFixtures([
+      'options-api.vue',
+      'options-api-define-component.vue',
+    ]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates.map((update) => update.source)).toEqual([
+      'Options API',
+      'Defined component',
+    ]);
+  });
+
+  it('exposes statically returned setup translation functions to templates', async () => {
+    const result = await extractFixtures(['options-api-setup.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates.map((update) => update.source)).toEqual([
+      'Composition API',
+      'Setup component',
+      'Setup string',
+      'Setup message',
+      'Setup msg',
+    ]);
+    expect(result.updates.at(-1)?.metadata).toMatchObject({
+      context: 'classic',
+    });
+  });
+
+  it('propagates top-level component aliases with Branch semantics', async () => {
+    const result = await extractFixtures(['component-aliases.vue']);
+    const expectedSource: JsxChildren = {
+      t: 'Branch',
+      i: 1,
+      d: { b: { formal: 'Hello' }, t: 'b' },
+      c: 'Fallback',
+    };
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toMatchObject({
+      dataFormat: 'JSX',
+      source: expectedSource,
+    });
+  });
+
+  it('extracts branch props that match Object.prototype names', async () => {
+    const result = await extractFixtures(['branch-object-keys.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toMatchObject({
+      dataFormat: 'JSX',
+      source: {
+        t: 'Branch',
+        i: 1,
+        d: {
+          b: {
+            constructor: 'Constructor branch',
+            toString: 'String branch',
+          },
+          t: 'b',
+        },
+        c: ' Fallback ',
+      },
+    });
+  });
+
+  it('ignores listeners and diagnoses directives that alter branch props', async () => {
+    const result = await extractFixtures(['branch-directives.vue']);
+    const errors = result.errors.join('\n');
+
+    expect(errors).not.toContain('unsupported directive @click');
+    expect(errors).toContain('unsupported directive v-model');
+    expect(errors).toContain('unsupported directive :foo-bar.camel');
+  });
+
+  it('keeps component tags separate from v-for and v-slot bindings', async () => {
+    const result = await extractFixtures(['template-namespaces.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates.map((update) => update.source)).toEqual([
+      'Loop scope',
+      'Slot scope',
+    ]);
+  });
+
+  it('extracts a nested translation rendered through an opaque Var slot', async () => {
+    const result = await extractFixtures(['nested-var.vue']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates.map((update) => update.source)).toEqual([
+      [' Outer ', { i: 1, k: '_gt_value_1', v: 'v' }],
+      'Inner',
+    ]);
+  });
+
+  it('extracts rich Vue JSX alongside string calls', async () => {
+    const result = await extractFixtures(['vue-jsx.tsx']);
+
+    expect(result.errors).toEqual([]);
+    expect(result.updates).toHaveLength(2);
+    expect(result.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      source: 'TSX string',
+    });
+    expect(result.updates[1]).toMatchObject({
+      dataFormat: 'JSX',
+      source: 'Rich TSX',
+    });
+  });
+
+  it('keeps ordinary component slots opaque while diagnosing invalid T content', async () => {
+    const result = await extractFixtures(['unsupported-slots.vue']);
+    const errors = result.errors.join('\n');
+
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]?.source).toEqual({ t: 'Card', i: 1 });
+    expect(errors).toContain('bare <template>');
+    expect(errors).toContain('nested gt-vue <T>');
+  });
+});
+
+function fixturePath(name: string): string {
+  return path.join(__dirname, 'fixtures', name);
+}
+
+async function extractFixtures(
+  filenames: string[],
+  options: {
+    includeSourceCodeContext?: boolean;
+    vueCompilerOptions?: VueCompilerOptions;
+  } = {}
+) {
+  const updates: VueExtractionResult[] = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const filename of filenames) {
+    const file = fixturePath(filename);
+    const result = await extractFromVueSource(
+      fs.readFileSync(file, 'utf8'),
+      file,
+      {
+        compilerOptions: options.vueCompilerOptions,
+        includeSourceCodeContext: options.includeSourceCodeContext ?? false,
+        projectRoot: process.cwd(),
+      }
+    );
+    updates.push(...result.results);
+    errors.push(...result.errors);
+    warnings.push(...result.warnings);
+  }
+
+  return { updates, errors, warnings };
+}

--- a/packages/vue-extractor/src/internal/__tests__/cyclicContainerSafety.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/cyclicContainerSafety.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type CycleProbe = {
+  /** Human-readable cyclic provenance path exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script setup block. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector: string;
+  /** Whether the selected component is `<T>` at runtime. */
+  possibleT: boolean;
+};
+
+/**
+ * Safety cases for self-referential and mutually referential containers.
+ *
+ * Static analysis must terminate for every cycle depth. When a cycle contains
+ * an imported `<T>`, truncating recursion must conservatively preserve that
+ * possibility rather than silently treating a deeper path as ordinary. Exact
+ * resolution is optional: the existing possible-alias diagnostic is the safe
+ * minimum. Matching String-only cycles remain silent termination controls.
+ */
+const cycleProbes: CycleProbe[] = [
+  {
+    name: 'a self-object exposes T through one cycle edge',
+    code: 'const cyclic = { component: T }; cyclic.self = cyclic;',
+    selector: 'cyclic.self.component',
+    possibleT: true,
+  },
+  {
+    name: 'a self-object exposes T through two cycle edges',
+    code: 'const cyclic = { component: T }; cyclic.self = cyclic;',
+    selector: 'cyclic.self.self.component',
+    possibleT: true,
+  },
+  {
+    name: 'a self-object exposes T through four cycle edges',
+    code: 'const cyclic = { component: T }; cyclic.self = cyclic;',
+    selector: 'cyclic.self.self.self.self.component',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary self-object terminates silently at one edge',
+    code: 'const cyclic = { component: String }; cyclic.self = cyclic;',
+    selector: 'cyclic.self.component',
+    possibleT: false,
+  },
+  {
+    name: 'an ordinary self-object terminates silently at four edges',
+    code: 'const cyclic = { component: String }; cyclic.self = cyclic;',
+    selector: 'cyclic.self.self.self.self.component',
+    possibleT: false,
+  },
+  {
+    name: 'a mutual object cycle exposes T after one hop',
+    code: 'const first = {}; const second = { component: T }; first.next = second; second.next = first;',
+    selector: 'first.next.component',
+    possibleT: true,
+  },
+  {
+    name: 'a mutual object cycle exposes T after three hops',
+    code: 'const first = {}; const second = { component: T }; first.next = second; second.next = first;',
+    selector: 'first.next.next.next.component',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary mutual object cycle terminates silently',
+    code: 'const first = {}; const second = { component: String }; first.next = second; second.next = first;',
+    selector: 'first.next.next.next.component',
+    possibleT: false,
+  },
+  {
+    name: 'a self-array exposes T through one cycle edge',
+    code: 'const cyclic = [T]; cyclic.push(cyclic);',
+    selector: 'cyclic[1][0]',
+    possibleT: true,
+  },
+  {
+    name: 'a self-array exposes T through two cycle edges',
+    code: 'const cyclic = [T]; cyclic.push(cyclic);',
+    selector: 'cyclic[1][1][0]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary self-array terminates silently at one edge',
+    code: 'const cyclic = [String]; cyclic.push(cyclic);',
+    selector: 'cyclic[1][0]',
+    possibleT: false,
+  },
+  {
+    name: 'an ordinary self-array terminates silently at two edges',
+    code: 'const cyclic = [String]; cyclic.push(cyclic);',
+    selector: 'cyclic[1][1][0]',
+    possibleT: false,
+  },
+];
+
+describe('cyclic dynamic-component container safety', () => {
+  it.each(cycleProbes)('$name', async ({ code, selector, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code, selector),
+      '/fixtures/CyclicContainer.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    if (possibleT) {
+      expect(output.errors.join('\n')).toContain(POSSIBLE_ALIAS_DIAGNOSTIC);
+      expect(output.errors.join('\n')).toContain(`"${selector}"`);
+    } else {
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+/** Creates a minimal SFC whose selector follows a cyclic container path. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    ${code}
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/escapedContainerProvenance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/escapedContainerProvenance.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type EscapeProvenanceProbe = {
+  /** Human-readable escape and copy operation exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script-setup block. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector: string;
+  /** Whether the selector can resolve to `<T>` when the fixture executes. */
+  possibleT: boolean;
+};
+
+/**
+ * An unsupported branch makes a mutable value unsafe because the branch may
+ * replace an ordinary component with `<T>`. Values subsequently read or copied
+ * from that identity must retain the uncertainty; otherwise a spread, slice,
+ * destructure, or member read can silently launder a runtime `<T>` possibility.
+ */
+const escapeProvenanceProbes: EscapeProvenanceProbe[] = [
+  {
+    name: 'retains uncertainty on the escaped array itself',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through an array spread',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const copy = [...registry];
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through slice',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const copy = registry.slice();
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through Array.from',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const copy = Array.from(registry);
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through array destructuring',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const [selected] = registry;
+    `,
+    selector: 'selected',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through an array member snapshot',
+    code: `
+      const registry = [String];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const selected = registry[0];
+    `,
+    selector: 'selected',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through an object spread',
+    code: `
+      const registry = { x: String };
+      function mutate(value) { if (flag) value.x = T; }
+      mutate(registry);
+      const copy = { ...registry };
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through Object.assign',
+    code: `
+      const registry = { x: String };
+      function mutate(value) { if (flag) value.x = T; }
+      mutate(registry);
+      const copy = Object.assign({}, registry);
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through an aliased array copy',
+    code: `
+      const registry = [String];
+      const alias = registry;
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+      const copy = alias.slice();
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through a nested array spread',
+    code: `
+      const root = { box: [String] };
+      function mutate(value) { if (flag) value.box[0] = T; }
+      mutate(root);
+      const copy = [...root.box];
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through a ref value spread',
+    code: `
+      const registry = ref([String]);
+      function mutate(value) { if (flag) value.value[0] = T; }
+      mutate(registry);
+      const copy = [...registry.value];
+    `,
+    selector: 'copy[key]',
+    possibleT: true,
+  },
+  {
+    name: 'retains uncertainty through an escaped Map get',
+    code: `
+      const registry = new Map([['x', String]]);
+      function mutate(value) { if (flag) value.set('x', T); }
+      mutate(registry);
+      const selected = registry.get('x');
+    `,
+    selector: 'selected',
+    possibleT: true,
+  },
+  {
+    name: 'keeps a finite ordinary mutation precise after array spread',
+    code: `
+      const registry = [T];
+      function mutate(value) { value[0] = String; }
+      mutate(registry);
+      const copy = [...registry];
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'keeps a finite ordinary mutation precise after a member snapshot',
+    code: `
+      const registry = [T];
+      function mutate(value) { value[0] = String; }
+      mutate(registry);
+      const selected = registry[0];
+    `,
+    selector: 'selected',
+    possibleT: false,
+  },
+];
+
+describe('escaped container provenance', () => {
+  it.each(escapeProvenanceProbes)(
+    '$name',
+    async ({ code, selector, possibleT }) => {
+      const output = await extractFromVueSource(
+        createFixture(code, selector),
+        '/fixtures/EscapedContainerProvenance.vue',
+        { projectRoot: '/fixtures' }
+      );
+      const extracted = output.results.some(
+        ({ source }) => source === 'Hidden'
+      );
+      const diagnosed = output.errors.some((error) =>
+        error.includes(POSSIBLE_ALIAS_DIAGNOSTIC)
+      );
+
+      if (possibleT) {
+        expect(extracted || diagnosed).toBe(true);
+      } else {
+        expect(output.results).toEqual([]);
+        expect(output.errors).toEqual([]);
+      }
+    }
+  );
+});
+
+/** Creates an SFC containing one escaped-container selector scenario. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    import { ref } from 'vue';
+    const flag = Boolean(Date.now());
+    const key = getKey();
+    ${code}
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/exoticContainerSafety.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/exoticContainerSafety.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type SafetyProbe = {
+  /** Human-readable provenance path exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script setup block. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector: string;
+  /** Whether the expression can select `<T>` at runtime. */
+  possibleT: boolean;
+};
+
+/**
+ * Safety cases for valid JavaScript containers beyond direct arrays and objects.
+ *
+ * Precise evaluation of every JavaScript abstraction is optional, but silence
+ * is unsound when a statically imported `<T>` visibly reaches a dynamic Vue
+ * component through a Map, Set, reflection, prototype, Proxy, class accessor,
+ * or nested alias. Those paths must at minimum emit the existing possible-alias
+ * diagnostic so catalog generation fails closed. Exact ordinary final states
+ * remain silent to prevent stale false positives from blocking extraction.
+ */
+const safetyProbes: SafetyProbe[] = [
+  {
+    name: 'an object root rebind detaches its old T alias',
+    code: 'let registry = { x: T }; const alias = registry; registry = { x: String };',
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an object old alias retains T after a root rebind',
+    code: 'let registry = { x: T }; const alias = registry; registry = { x: String };',
+    selector: 'alias[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary object alias is not retargeted by a T rebind',
+    code: 'let registry = { x: String }; const alias = registry; registry = { x: T };',
+    selector: 'alias[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an object rebound registry contains its new T value',
+    code: 'let registry = { x: String }; const alias = registry; registry = { x: T };',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested property replacement detaches an old T alias',
+    code: 'const registry = { box: { x: T } }; const box = registry.box; registry.box = { x: String };',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested old alias retains T after property replacement',
+    code: 'const registry = { box: { x: T } }; const box = registry.box; registry.box = { x: String };',
+    selector: 'box[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested ordinary alias is not retargeted',
+    code: 'const registry = { box: { x: String } }; const box = registry.box; registry.box = { x: T };',
+    selector: 'box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a detached nested write does not taint its replacement',
+    code: 'const registry = { box: { x: String } }; const box = registry.box; registry.box = { x: String }; box.x = T;',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'delete erases T from a detached nested alias',
+    code: 'const registry = { box: { x: T } }; const box = registry.box; registry.box = { x: String }; delete box.x;',
+    selector: 'box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'readonly captures an old raw object containing T',
+    code: 'let raw = { x: T }; const registry = readonly(raw); raw = { x: String };',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'readonly is not retargeted by a raw object T rebind',
+    code: 'let raw = { x: String }; const registry = readonly(raw); raw = { x: T };',
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a toRaw object write introduces T behind readonly',
+    code: 'const registry = readonly({ x: String }); const raw = toRaw(registry); raw.x = T;',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a toRaw object write erases T behind readonly',
+    code: 'const registry = readonly({ x: T }); const raw = toRaw(registry); raw.x = String;',
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'readonly of shallowReadonly permits a nested object write',
+    code: 'const registry = readonly(shallowReadonly({ box: { x: String } })); registry.box.x = T;',
+    selector: 'registry.box[key]',
+    possibleT: true,
+  },
+  {
+    name: 'shallowReadonly of readonly blocks a nested object write',
+    code: 'const registry = shallowReadonly(readonly({ box: { x: String } })); registry.box.x = T;',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a Map literal may select T',
+    code: "const registry = new Map([['x', T]]);",
+    selector: 'registry.get(key)',
+    possibleT: true,
+  },
+  {
+    name: 'Map.set may introduce T',
+    code: "const registry = new Map([['x', String]]); registry.set('y', T);",
+    selector: 'registry.get(key)',
+    possibleT: true,
+  },
+  {
+    name: 'Map.set replacement erases T',
+    code: "const registry = new Map([['x', T]]); registry.set('x', String);",
+    selector: 'registry.get(key)',
+    possibleT: false,
+  },
+  {
+    name: 'Map.delete erases T',
+    code: "const registry = new Map([['x', T]]); registry.delete('x');",
+    selector: 'registry.get(key)',
+    possibleT: false,
+  },
+  {
+    name: 'a Map alias may receive T',
+    code: "const registry = new Map([['x', String]]); const alias = registry; alias.set('y', T);",
+    selector: 'registry.get(key)',
+    possibleT: true,
+  },
+  {
+    name: 'an array copied from Map values may select T',
+    code: "const source = new Map([['x', T]]); const registry = Array.from(source.values());",
+    selector: 'registry[index]',
+    possibleT: true,
+  },
+  {
+    name: 'an array copied from Set values may select T',
+    code: 'const source = new Set([T]); const registry = Array.from(source);',
+    selector: 'registry[index]',
+    possibleT: true,
+  },
+  {
+    name: 'Set.delete erases T before an array copy',
+    code: 'const source = new Set([T]); source.delete(T); const registry = Array.from(source);',
+    selector: 'registry[index]',
+    possibleT: false,
+  },
+  {
+    name: 'Reflect.get may select T',
+    code: 'const registry = { x: T };',
+    selector: 'Reflect.get(registry, key)',
+    possibleT: true,
+  },
+  {
+    name: 'Object.create may expose inherited T',
+    code: 'const registry = Object.create({ x: T });',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'Object.setPrototypeOf may expose inherited T',
+    code: 'const registry = {}; Object.setPrototypeOf(registry, { x: T });',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a transparent Proxy may expose target T',
+    code: 'const target = { x: T }; const registry = new Proxy(target, {});',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a Proxy get trap may return T',
+    code: 'const registry = new Proxy({}, { get() { return T; } });',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an object getter may return T',
+    code: 'const registry = { get x() { return T; } };',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a class getter may return T',
+    code: 'class Registry { get x() { return T; } } const registry = new Registry();',
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a symbol-keyed object may select T',
+    code: 'const token = Symbol(); const registry = { [token]: T };',
+    selector: 'registry[token]',
+    possibleT: true,
+  },
+  {
+    name: 'an optional member may select T',
+    code: 'const registry = { x: T };',
+    selector: 'registry?.[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nullish member fallback may select T',
+    code: 'const registry = { x: undefined };',
+    selector: 'registry[key] ?? T',
+    possibleT: true,
+  },
+  {
+    name: 'a logical member fallback may select T',
+    code: 'const registry = { x: null };',
+    selector: 'registry[key] || T',
+    possibleT: true,
+  },
+];
+
+describe('dynamic component container safety', () => {
+  it.each(safetyProbes)('$name', async ({ code, selector, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code, selector),
+      '/fixtures/ExoticContainerSafety.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    if (possibleT) {
+      expect(output.errors.join('\n')).toContain(POSSIBLE_ALIAS_DIAGNOSTIC);
+    } else {
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+/** Creates a minimal SFC that selects a component through the tested path. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    import { readonly, shallowReadonly, toRaw } from 'vue';
+    ${code}
+    const key = getKey();
+    const index = getIndex();
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/branch-directives.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/branch-directives.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+const tone = 'formal';
+const handler = () => undefined;
+</script>
+
+<template>
+  <T>
+    <Branch :branch="tone" formal="Hello" @click="handler">Fallback</Branch>
+    <Branch :branch="tone" formal="Hello" v-model="tone">Fallback</Branch>
+    <Branch :branch="tone" :foo-bar.camel="'Hello'">Fallback</Branch>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/branch-object-keys.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/branch-object-keys.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+import { Branch, T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Branch
+      branch="constructor"
+      constructor="Constructor branch"
+      toString="String branch"
+    >
+      Fallback
+    </Branch>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/comments.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/comments.vue
@@ -1,0 +1,11 @@
+<script setup>
+import { T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    Hello
+    <!-- retained by Vue -->
+    world
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/component-aliases.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/component-aliases.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { Branch, T } from 'gt-vue';
+
+const Tr = T;
+const B = Branch;
+</script>
+
+<template>
+  <Tr><B :branch="tone" formal="Hello">Fallback</B></Tr>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/context-modifier.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/context-modifier.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import { T } from 'gt-vue';
+</script>
+
+<template><T :context.prop="'hero'">Hello</T></template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/invalid.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/invalid.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { T, Var, msg, useGT } from 'gt-vue';
+const gt = useGT();
+const name = String(Date.now());
+const dynamic = String(Date.now());
+gt(`Dynamic ${name}`);
+gt('Too long', { $maxChars: 12 });
+gt('Formatted', { $format: 'ICU' });
+gt('Interpolated', { name });
+msg('Registered', { $id: 'custom' });
+const visible = true;
+</script>
+
+<template>
+  <T :context="dynamic">
+    <div v-if="visible" :title="dynamic">{{ name }}</div>
+    <Var :value="name">{{ name }}</Var>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/nested-var.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/nested-var.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { T, Var } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    Outer
+    <Var><T>Inner</T></Var>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/normalization.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/normalization.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { DateTime, T as Translation } from 'gt-vue';
+</script>
+
+<template>
+  <translation>
+    <date-time :value="date" />
+    <var>native</var>
+  </translation>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-api-define-component.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-api-define-component.vue
@@ -1,0 +1,13 @@
+<script lang="ts">
+import { defineComponent } from 'vue';
+import { T } from 'gt-vue';
+
+const Translation = T;
+const registeredComponents = { Translation };
+
+export default defineComponent({
+  components: registeredComponents,
+});
+</script>
+
+<template><Translation>Defined component</Translation></template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-api-setup.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-api-setup.vue
@@ -1,0 +1,20 @@
+<script>
+import { T, msg, useGT, useMessages } from 'gt-vue';
+
+export default {
+  components: { T },
+  setup() {
+    const gt = useGT();
+    const m = useMessages();
+    return { gt, LocalT: T, m, register: msg };
+  },
+};
+</script>
+
+<template>
+  <T>Composition API</T>
+  <component :is="LocalT">Setup component</component>
+  {{ gt('Setup string') }}
+  {{ m('Setup message') }}
+  {{ register('Setup msg', { $context: 'classic' }) }}
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-api.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-api.vue
@@ -1,0 +1,9 @@
+<script>
+import { T } from 'gt-vue';
+
+export default {
+  components: { T },
+};
+</script>
+
+<template><T>Options API</T></template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-concise-return.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-concise-return.vue
@@ -1,0 +1,8 @@
+<script>
+import { useGT } from 'gt-vue';
+
+const setup = () => ({ gt: useGT() });
+export default { setup };
+</script>
+
+<template>{{ gt('Concise setup return') }}</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-define-alias.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-define-alias.vue
@@ -1,0 +1,9 @@
+<script>
+import { defineComponent } from 'vue';
+import { T } from 'gt-vue';
+
+const dc = defineComponent;
+export default dc({ components: { T } });
+</script>
+
+<template><T>Aliased defineComponent</T></template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-direct-return.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-direct-return.vue
@@ -1,0 +1,11 @@
+<script>
+import { useGT } from 'gt-vue';
+
+export default {
+  setup() {
+    return { gt: useGT() };
+  },
+};
+</script>
+
+<template>{{ gt('Direct setup return') }}</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-react-parity.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-react-parity.vue
@@ -1,0 +1,26 @@
+<script lang="ts">
+import { defineComponent as define } from 'vue';
+import { T as SourceT, useGT as createGT } from 'gt-vue';
+
+const defineAlias = define;
+const LocalT = SourceT;
+
+const setup = () => {
+  const original = createGT();
+  const translate = original;
+  const exposed = { translate };
+  return { ...exposed };
+};
+
+const options = {
+  components: { LocalT },
+  setup,
+};
+
+export default defineAlias(options);
+</script>
+
+<template>
+  <LocalT>Options registered alias</LocalT>
+  {{ translate('Options returned alias') }}
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/options-spread-return.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/options-spread-return.vue
@@ -1,0 +1,13 @@
+<script>
+import { useGT } from 'gt-vue';
+
+export default {
+  setup() {
+    const gt = useGT();
+    const exposed = { gt };
+    return { ...exposed };
+  },
+};
+</script>
+
+<template>{{ gt('Spread setup return') }}</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/rich.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/rich.vue
@@ -1,0 +1,74 @@
+<script lang="ts">
+import { msg } from 'gt-vue';
+
+export const normalMessage = msg('Normal {literal}', { $context: 'normal' });
+</script>
+
+<script setup lang="ts">
+import {
+  Branch,
+  Currency,
+  DateTime as When,
+  Num,
+  Plural,
+  T as Translate,
+  Var as Value,
+  msg as defineMessage,
+  useGT as useTranslate,
+  useMessages,
+} from 'gt-vue';
+
+const gt = useTranslate();
+const m = useMessages();
+const alias = gt;
+const greeting = gt('Hello {name}', { $context: 'greeting' });
+const navigation = m('Navigation');
+const list = defineMessage(['First', 'Second'] as const, { $context: 'list' });
+const aliased = alias('Aliased call');
+function shadowed(gt: (value: string) => string) {
+  return gt('Not a GT call');
+}
+</script>
+
+<template>
+  <Translate context="hero">
+    <p title="Greeting">
+      Hello
+      <Value>{{ name }}</Value>
+      !
+    </p>
+    <Plural :n="count">
+      <template #one>
+        one
+        <Value>{{ item }}</Value>
+      </template>
+      <template #other>
+        other
+        <Value>{{ item }}</Value>
+      </template>
+      fallback
+      <Value>{{ item }}</Value>
+    </Plural>
+    <Branch :branch="tone" key="stable">
+      <template #formal>
+        formal
+        <Value>{{ name }}</Value>
+      </template>
+      <template #casual>
+        casual
+        <Value>{{ name }}</Value>
+      </template>
+      fallback
+      <Value>{{ name }}</Value>
+    </Branch>
+    <b>end</b>
+    <Num :value="count" />
+    <When :value="date" />
+    <Currency :value="cost" />
+    <var>native</var>
+  </Translate>
+  {{ gt('Template call', { $context: 'template' }) }}
+  {{ m(defineMessage('Encoded message', { $context: 'encoded' })) }}
+  <p :title="gt('Template title')" />
+  <Some v-slot="{ gt }">{{ gt('Shadowed template call') }}</Some>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-commonjs.cjs
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-commonjs.cjs
@@ -1,0 +1,5 @@
+const { msg, useGT } = require('gt-vue');
+
+msg('CommonJS message');
+const gt = useGT();
+gt('CommonJS translation');

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-commonjs.cts
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-commonjs.cts
@@ -1,0 +1,5 @@
+import GT = require('gt-vue');
+
+GT.msg('CTS namespace message');
+const gt = GT.useGT();
+gt('CTS namespace translation');

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-cross-block.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-cross-block.vue
@@ -1,0 +1,14 @@
+<script lang="ts">
+import { T, useGT } from 'gt-vue';
+</script>
+
+<script setup lang="ts">
+// oxlint-disable-next-line no-undef -- verifies imports shared from the normal script block
+const gt = useGT();
+gt('Cross-block script call');
+</script>
+
+<template>
+  <T>Cross-block component</T>
+  {{ gt('Cross-block template call') }}
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-decorators.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-decorators.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { msg } from 'gt-vue';
+
+function sealed(_value: Function) {}
+@sealed
+class Decorated {}
+
+msg('Decorated script');
+</script>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-namespace.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-namespace.vue
@@ -1,0 +1,15 @@
+<script setup>
+import * as GT from 'gt-vue';
+
+const gt = GT.useGT();
+const LocalT = GT.T;
+gt('Namespace hook');
+GT.msg('Namespace message');
+GT['useGT']()('Computed namespace hook');
+GT['msg']('Computed namespace message');
+</script>
+
+<template>
+  <LocalT>Namespace alias component</LocalT>
+  <GT.T>Namespace component</GT.T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-react-parity-dynamic.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-react-parity-dynamic.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { msg, useGT, useMessages } from 'gt-vue';
+
+const gt = useGT();
+const messages = useMessages();
+const runtimeValue = String(Date.now());
+
+gt(`Dynamic ${runtimeValue}`);
+messages(runtimeValue);
+
+const dynamicOptions = { $context: runtimeValue };
+gt('Dynamic options', dynamicOptions);
+
+msg?.('Optional direct msg');
+
+function receivesTranslator(translator: typeof gt) {
+  return translator('Passed callback');
+}
+void receivesTranslator;
+
+const conditional = Date.now() > 0 ? gt : String;
+conditional('Conditional callback');
+</script>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-react-parity.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-react-parity.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import {
+  T as ImportedT,
+  msg as importedMsg,
+  useGT as createGT,
+  useMessages as createMessages,
+} from 'gt-vue';
+
+type Translator = ReturnType<typeof createGT>;
+
+const hookAlias = createGT;
+const translate = hookAlias();
+const firstAlias = translate;
+const secondAlias = (firstAlias as Translator)!;
+
+const framework = 'Vue';
+const suffix = ' parity' as const;
+secondAlias(`Hello, ${framework}${suffix}`);
+secondAlias('Count ' + -2 + ' / ' + true + ' / ' + null);
+
+const wrappedMessage = 'Wrapped static' satisfies string as string;
+secondAlias(wrappedMessage);
+
+const stableMessage = importedMsg;
+stableMessage('Aliased msg');
+
+const messages = createMessages();
+const rawTitle = 'Raw messages identifier';
+messages(rawTitle);
+
+(hookAlias as typeof createGT)()('Wrapped direct hook call');
+createGT()?.('Optional direct hook call');
+
+// oxlint-disable-next-line prefer-const -- exercises a post-declaration object assignment flow
+let objectAssigned: Translator;
+({ translator: objectAssigned } = { translator: createGT() });
+objectAssigned('Object assignment flow');
+
+// oxlint-disable-next-line prefer-const -- exercises a post-declaration array assignment flow
+let arrayAssigned: Translator;
+[arrayAssigned] = [createGT()];
+arrayAssigned('Array assignment flow');
+
+const LocalT = (ImportedT as typeof ImportedT)!;
+
+{
+  const importedMsg = String;
+  importedMsg('Shadowed local binding');
+}
+
+function shadowParameter(importedMsg: typeof stableMessage) {
+  return importedMsg('Shadowed parameter binding');
+}
+void shadowParameter;
+
+let mutableMessage = importedMsg;
+mutableMessage = ((source: string) => source) as typeof importedMsg;
+mutableMessage('Reassigned alias');
+</script>
+
+<template>
+  <LocalT>Wrapped component alias</LocalT>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/script-static.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/script-static.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { T, T as T2, msg, useGT, useMessages } from 'gt-vue';
+
+type GTFunction = ReturnType<typeof useGT>;
+const first = 'A';
+const second = 'B' as const;
+const gt = useGT() as GTFunction;
+const m = useMessages();
+const title = 'Static message';
+const LocalT = T as typeof T;
+
+gt(first + second);
+gt(`BigInt ${1n}`);
+gt('Typed context', { $context: 'typed' } as const);
+gt('Satisfies context', {
+  $context: 'satisfies',
+} satisfies { $context: string });
+gt('Static satisfies' satisfies string);
+m(title);
+useGT()('Direct hook call');
+gt?.('Optional call');
+gt!('Non-null call');
+
+// oxlint-disable-next-line prefer-const -- exercises a post-declaration assignment flow
+let assigned;
+assigned = useGT();
+assigned('Assigned hook result');
+
+const [arrayGT] = [useGT()];
+arrayGT('Array destructured hook result');
+const { objectGT } = { objectGT: useGT() };
+objectGT('Object destructured hook result');
+
+let reassigned = msg;
+reassigned = String;
+reassigned('Not a GT message');
+</script>
+
+<template>
+  <LocalT>Typed component alias</LocalT>
+  <t-2>Digit component alias</t-2>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/template-adversarial.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/template-adversarial.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { Branch, Plural, T, T as T2, useGT } from 'gt-vue';
+
+const gt = useGT();
+const rows = [{ value: 'row' }];
+</script>
+
+<template>
+  <div v-for="gt in rows" v-if="gt('Outer v-if')" />
+  <div v-for="{ value = gt('VForDefault') } in rows" />
+  <div v-for="item in gt('VForSource')" />
+  <Card v-slot="{ value = gt('SlotDefault') }" />
+
+  <t-2>Digit-normalized component</t-2>
+  <component :is="T">Dynamic component</component>
+
+  <T>
+    <!-- ignored -->
+    <template #default>Explicit default</template>
+  </T>
+  <T>
+    <Branch branch="formal">
+      <template #formal>First</template>
+      <template #casual>Second</template>
+    </Branch>
+  </T>
+  <T>
+    <Plural :n="1">
+      <template #one>One</template>
+      <template #other>Other</template>
+    </Plural>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/template-duplicate-default.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/template-duplicate-default.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <template #default>Explicit</template>
+    Implicit
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/template-namespaces.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/template-namespaces.vue
@@ -1,0 +1,10 @@
+<script setup>
+import { T } from 'gt-vue';
+
+const items = ['one'];
+</script>
+
+<template>
+  <T v-for="T in items" :key="T">Loop scope</T>
+  <Some v-slot="{ T }"><T>Slot scope</T></Some>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/template-rich-matrix.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/template-rich-matrix.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import {
+  Branch as Choose,
+  Currency,
+  DateTime as When,
+  Num,
+  Plural,
+  T as Translate,
+  Var as Value,
+} from 'gt-vue';
+
+const cost = 12.5;
+const count = 2;
+const date = new Date('2026-01-01');
+const name = 'Ada';
+const tone = 'formal';
+</script>
+
+<template>
+  <Translate context="matrix">
+    <section title="Heading" aria-label="Greeting">
+      Hello
+      <strong>
+        <Value>{{ name }}</Value>
+      </strong>
+      !
+      <input placeholder="Your name" />
+      <img alt="Portrait" aria-describedby="hint" />
+      <Num :value="count" />
+      <When :value="date" />
+      <Currency :value="cost" />
+      <var>native</var>
+      <Choose :branch="tone" formal="Ignored because the slot wins">
+        <template #formal>
+          Formal
+          <Value>{{ name }}</Value>
+        </template>
+        <template #casual>
+          Casual
+          <Value>{{ name }}</Value>
+        </template>
+        Fallback
+        <Value>{{ name }}</Value>
+      </Choose>
+      <Plural :n="count" zero="None">
+        <template #one>
+          One
+          <Value>{{ count }}</Value>
+        </template>
+        <template #other>
+          Many
+          <Value>{{ count }}</Value>
+        </template>
+        Fallback
+        <Value>{{ count }}</Value>
+      </Plural>
+    </section>
+  </Translate>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/template-runtime-parity.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/template-runtime-parity.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Branch, Plural, T, T as T2, useGT } from 'gt-vue';
+
+const gt = useGT();
+const rows = [{ value: 'row' }];
+const value = 'attribute';
+</script>
+
+<template>
+  <div v-for="gt in rows" v-if="gt('Outer v-if')" />
+  <div v-for="{ value = gt('v-for default') } in rows" />
+  <div :[gt('Directive')]="value" />
+  <Card v-slot="{ value = gt('slot default') }" />
+
+  <t-2>Digit-normalized component</t-2>
+  <component :is="T">Dynamic component</component>
+
+  <T><!-- ignored --><template #default>Explicit default</template></T>
+  <T>
+    <Branch branch="formal"><template #formal>First</template> <template #casual>Second</template></Branch>
+  </T>
+  <T>
+    <Plural :n="1"><template #one>One</template> <template #other>Other</template></Plural>
+  </T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/type-only.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/type-only.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts">
+import type { T } from 'gt-vue';
+</script>
+
+<template><T>Type-only component</T></template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/unsupported-slots.vue
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/unsupported-slots.vue
@@ -1,0 +1,16 @@
+<script setup>
+import { T } from 'gt-vue';
+</script>
+
+<template>
+  <T>
+    <Card>
+      <template #header>Header</template>
+      <template #default>Body</template>
+    </Card>
+  </T>
+  <T>
+    <template><b>Bare template</b></template>
+  </T>
+  <T><T>Nested</T></T>
+</template>

--- a/packages/vue-extractor/src/internal/__tests__/fixtures/vue-jsx.tsx
+++ b/packages/vue-extractor/src/internal/__tests__/fixtures/vue-jsx.tsx
@@ -1,0 +1,6 @@
+import { T, useGT } from 'gt-vue';
+
+const gt = useGT();
+
+export const message = gt('TSX string');
+export const View = () => <T>Rich TSX</T>;

--- a/packages/vue-extractor/src/internal/__tests__/higherOrderMutationSemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/higherOrderMutationSemantics.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type HigherOrderMutationProbe = {
+  /** Human-readable function flow exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script-setup block. */
+  code: string;
+  /** Whether the final registry can contain `<T>`. */
+  possibleT: boolean;
+};
+
+/**
+ * JavaScript functions can retain mutable arguments in closures or invoke a
+ * callback supplied by another function. If the finite replay cannot execute
+ * one of these higher-order flows exactly, it must preserve the possibility
+ * that the captured registry was changed rather than silently treating the
+ * original snapshot as final.
+ */
+const higherOrderMutationProbes: HigherOrderMutationProbe[] = [
+  {
+    name: 'a factory returns an arrow that writes T',
+    code: `
+      const registry = [String];
+      const make = (value) => () => { value[0] = T; };
+      const mutate = make(registry);
+      mutate();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a factory returns a named closure that writes T',
+    code: `
+      const registry = [String];
+      function make(value) { return function mutate() { value[0] = T; }; }
+      const mutate = make(registry);
+      mutate();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'an immediately invoked returned closure writes T',
+    code: `
+      const registry = [String];
+      const make = (value) => () => { value[0] = T; };
+      make(registry)();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a factory object method writes T through its closure',
+    code: `
+      const registry = [String];
+      const make = (value) => ({ mutate() { value[0] = T; } });
+      const helper = make(registry);
+      helper.mutate();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a destructured factory method writes T through its closure',
+    code: `
+      const registry = [String];
+      const make = (value) => ({ mutate() { value[0] = T; } });
+      const { mutate } = make(registry);
+      mutate();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a bound function writes T through its captured argument',
+    code: `
+      const registry = [String];
+      function replace(value) { value[0] = T; }
+      const mutate = replace.bind(null, registry);
+      mutate();
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'Function call writes T through its argument',
+    code: `
+      const registry = [String];
+      function mutate(value) { value[0] = T; }
+      mutate.call(null, registry);
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'Function apply writes T through its argument',
+    code: `
+      const registry = [String];
+      function mutate(value) { value[0] = T; }
+      mutate.apply(null, [registry]);
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'Reflect apply writes T through its argument',
+    code: `
+      const registry = [String];
+      function mutate(value) { value[0] = T; }
+      Reflect.apply(mutate, null, [registry]);
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a local executor invokes a callback that captures the registry',
+    code: `
+      const registry = [String];
+      function run(callback) { callback(); }
+      run(() => { registry[0] = T; });
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a local executor supplies the registry to a callback',
+    code: `
+      const registry = [String];
+      function run(callback, value) { callback(value); }
+      run((value) => { value[0] = T; }, registry);
+    `,
+    possibleT: true,
+  },
+  {
+    name: 'a factory closure deterministically erases T',
+    code: `
+      const registry = [T];
+      const make = (value) => () => { value[0] = String; };
+      const mutate = make(registry);
+      mutate();
+    `,
+    possibleT: false,
+  },
+  {
+    name: 'Function call deterministically erases T',
+    code: `
+      const registry = [T];
+      function mutate(value) { value[0] = String; }
+      mutate.call(null, registry);
+    `,
+    possibleT: false,
+  },
+  {
+    name: 'a local executor deterministically erases T',
+    code: `
+      const registry = [T];
+      function run(callback) { callback(); }
+      run(() => { registry[0] = String; });
+    `,
+    possibleT: false,
+  },
+];
+
+describe('higher-order mutation semantics', () => {
+  it.each(higherOrderMutationProbes)('$name', async ({ code, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code),
+      '/fixtures/HigherOrderMutationSemantics.vue',
+      { projectRoot: '/fixtures' }
+    );
+    const extracted = output.results.some(({ source }) => source === 'Hidden');
+    const diagnosed = output.errors.some((error) =>
+      error.includes(POSSIBLE_ALIAS_DIAGNOSTIC)
+    );
+
+    if (possibleT) {
+      expect(extracted || diagnosed).toBe(true);
+    } else {
+      // Higher-order calls may remain outside the exact replay subset. A
+      // conservative diagnostic is acceptable, but publishing the erased T
+      // as a translation is not.
+      expect(output.results).toEqual([]);
+    }
+  });
+});
+
+/** Creates an SFC with one higher-order mutation and dynamic selector. */
+function createFixture(code: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    const key = getKey();
+    ${code}
+  </script>
+  <template><component :is="registry[key]">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/liveObjectSemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/liveObjectSemantics.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type LiveObjectProbe = {
+  /** Human-readable object-identity behavior exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script-setup block. */
+  code: string;
+  /** Dynamic component expression read after script setup completes. */
+  selector: string;
+  /** Whether the selector resolves to `<T>` in the final runtime state. */
+  possibleT: boolean;
+};
+
+/**
+ * Getters and prototype chains are live views, not construction-time copies.
+ * The extractor must use the same final identity state that Vue observes when
+ * rendering a template. Shadowing and deletion must likewise expose exactly
+ * the own or inherited member JavaScript would read at render time.
+ */
+const liveObjectProbes: LiveObjectProbe[] = [
+  {
+    name: 'an object getter reads a later T binding',
+    code: `
+      let value = String;
+      const registry = { get x() { return value; } };
+      value = T;
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an object getter reads a later ordinary binding',
+    code: `
+      let value = T;
+      const registry = { get x() { return value; } };
+      value = String;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a class getter reads a later T binding',
+    code: `
+      let value = String;
+      class Registry { get x() { return value; } }
+      const registry = new Registry();
+      value = T;
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a class getter reads a later ordinary binding',
+    code: `
+      let value = T;
+      class Registry { get x() { return value; } }
+      const registry = new Registry();
+      value = String;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a class field retains T',
+    code: `
+      class Registry { x = T; }
+      const registry = new Registry();
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary class field stays silent',
+    code: `
+      class Registry { x = String; }
+      const registry = new Registry();
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a class constructor assignment retains T',
+    code: `
+      class Registry { constructor() { this.x = T; } }
+      const registry = new Registry();
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary class constructor assignment stays silent',
+    code: `
+      class Registry { constructor() { this.x = String; } }
+      const registry = new Registry();
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'Object.create observes a later T prototype write',
+    code: `
+      const prototype = { x: String };
+      const registry = Object.create(prototype);
+      prototype.x = T;
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'Object.create observes a later ordinary prototype write',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      prototype.x = String;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'setPrototypeOf observes a later T prototype write',
+    code: `
+      const prototype = { x: String };
+      const registry = {};
+      Object.setPrototypeOf(registry, prototype);
+      prototype.x = T;
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'setPrototypeOf observes a later ordinary prototype write',
+    code: `
+      const prototype = { x: T };
+      const registry = {};
+      Object.setPrototypeOf(registry, prototype);
+      prototype.x = String;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an ordinary own property shadows an inherited T',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      registry.x = String;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'deleting an ordinary own property reveals inherited T',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      registry.x = String;
+      delete registry.x;
+    `,
+    selector: 'registry[key]',
+    possibleT: true,
+  },
+  {
+    name: 'deleting a T own property reveals an ordinary inherited value',
+    code: `
+      const prototype = { x: String };
+      const registry = Object.create(prototype);
+      registry.x = T;
+      delete registry.x;
+    `,
+    selector: 'registry[key]',
+    possibleT: false,
+  },
+  {
+    name: 'deleting through a detached nested alias removes T',
+    code: `
+      const registry = { box: { x: T } };
+      const box = registry.box;
+      registry.box = { x: String };
+      delete box.x;
+    `,
+    selector: 'box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an object getter reads T through its receiver',
+    code: `
+      const registry = { value: T, get x() { return this.value; } };
+    `,
+    selector: 'registry.x',
+    possibleT: true,
+  },
+  {
+    name: 'an object getter observes a receiver mutation',
+    code: `
+      const registry = { value: T, get x() { return this.value; } };
+      registry.value = String;
+    `,
+    selector: 'registry.x',
+    possibleT: false,
+  },
+  {
+    name: 'an object method reads T through its receiver',
+    code: `
+      const registry = { value: T, read() { return this.value; } };
+    `,
+    selector: 'registry.read()',
+    possibleT: true,
+  },
+  {
+    name: 'an object method observes a receiver mutation',
+    code: `
+      const registry = { value: T, read() { return this.value; } };
+      registry.value = String;
+    `,
+    selector: 'registry.read()',
+    possibleT: false,
+  },
+  {
+    name: 'a class getter reads T through its receiver',
+    code: `
+      class Registry {
+        value = T;
+        get x() { return this.value; }
+      }
+      const registry = new Registry();
+    `,
+    selector: 'registry.x',
+    possibleT: true,
+  },
+  {
+    name: 'a class getter observes a receiver mutation',
+    code: `
+      class Registry {
+        value = T;
+        get x() { return this.value; }
+      }
+      const registry = new Registry();
+      registry.value = String;
+    `,
+    selector: 'registry.x',
+    possibleT: false,
+  },
+  {
+    name: 'a class method reads T through its receiver',
+    code: `
+      class Registry {
+        value = T;
+        read() { return this.value; }
+      }
+      const registry = new Registry();
+    `,
+    selector: 'registry.read()',
+    possibleT: true,
+  },
+  {
+    name: 'a class method observes a receiver mutation',
+    code: `
+      class Registry {
+        value = T;
+        read() { return this.value; }
+      }
+      const registry = new Registry();
+      registry.value = String;
+    `,
+    selector: 'registry.read()',
+    possibleT: false,
+  },
+];
+
+describe('live getter and prototype identity semantics', () => {
+  it.each(liveObjectProbes)('$name', async ({ code, selector, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code, selector),
+      '/fixtures/LiveObjectSemantics.vue',
+      { projectRoot: '/fixtures' }
+    );
+    const extracted = output.results.some(({ source }) => source === 'Hidden');
+    const diagnosed = output.errors.some((error) =>
+      error.includes(POSSIBLE_ALIAS_DIAGNOSTIC)
+    );
+
+    if (possibleT) {
+      expect(extracted || diagnosed).toBe(true);
+    } else {
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+/** Creates an SFC that reads one final live-object selector. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    const key = getKey();
+    ${code}
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/localModuleResolution.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/localModuleResolution.test.ts
@@ -1,0 +1,1019 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+let fixtureRoot: string;
+
+beforeEach(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-modules-'));
+});
+
+afterEach(() => {
+  fs.rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+describe('local module identity resolution', () => {
+  it('matches direct imports through renamed and index-barrel reexports', async () => {
+    write(
+      'runtime.ts',
+      `export {
+        T as Translate,
+        Branch as Choice,
+        Currency as Money,
+        DateTime as DateValue,
+        Num as NumberValue,
+        Var as Variable,
+        msg as defineMessage,
+        useGT as createTranslator,
+        useMessages as createMessages,
+      } from 'gt-vue';`
+    );
+    write(
+      'barrels/index.ts',
+      `export {
+        Translate as T,
+        Choice as Branch,
+        Money as Currency,
+        DateValue as DateTime,
+        NumberValue as Num,
+        Variable as Var,
+        defineMessage as msg,
+        createTranslator as useGT,
+        createMessages as useMessages,
+      } from '../runtime.js';`
+    );
+    write('barrels/nested/index.ts', `export * from '..';`);
+
+    const direct = await extract(
+      'Direct.vue',
+      componentSource(`from 'gt-vue'`)
+    );
+    const barrel = await extract(
+      'Barrel.vue',
+      componentSource(`from './barrels/nested'`)
+    );
+
+    expect(direct.errors).toEqual([]);
+    expect(barrel.errors).toEqual([]);
+    expect(comparable(barrel.results)).toEqual(comparable(direct.results));
+  });
+
+  it('resolves namespace, default, and immutable local aliases', async () => {
+    write(
+      'aliases.ts',
+      `import { T, Branch, msg, useGT } from 'gt-vue';
+       const LocalT = T;
+       const LocalBranch = Branch;
+       const defineMessage = msg;
+       const createTranslator = useGT;
+       export default LocalT;
+       export { LocalBranch as Branch, defineMessage as msg, createTranslator as useGT };`
+    );
+    write(
+      'index.ts',
+      `export * from './aliases'; export { default } from './aliases';`
+    );
+    const output = await extract(
+      'Aliases.vue',
+      `<script setup lang="ts">
+        import DefaultT, { Branch, msg, useGT } from './index';
+        import * as Local from './index';
+        const gt = useGT();
+        gt('Default alias function');
+        msg('Named alias message');
+        Local.msg('Namespace alias message');
+      </script>
+      <template>
+        <DefaultT context="default"><Branch branch="one"><template #one>Default rich</template></Branch></DefaultT>
+        <Local.default context="namespace">Namespace rich</Local.default>
+      </template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Default alias function',
+      'Named alias message',
+      'Namespace alias message',
+      expect.any(Object),
+      'Namespace rich',
+    ]);
+  });
+
+  it('uses an explicit resolver for a tsconfig-style path alias', async () => {
+    const barrel = write(
+      'src/i18n/barrel.ts',
+      `export { T as Translate, msg as defineMessage } from 'gt-vue';`
+    );
+    const output = await extract(
+      'src/Alias.vue',
+      `<script setup>
+        import { Translate, defineMessage } from '@app/i18n';
+        defineMessage('Aliased package message');
+      </script>
+      <template><Translate>Aliased package rich text</Translate></template>`,
+      {
+        resolveModule(specifier) {
+          return specifier === '@app/i18n' ? barrel : undefined;
+        },
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Aliased package message',
+      'Aliased package rich text',
+    ]);
+  });
+
+  it('recognizes reexported identities in TSX', async () => {
+    write(
+      'helper.ts',
+      `export function invoke(translate) { translate('TSX forwarded'); }`
+    );
+    write(
+      'barrel.ts',
+      `export { T as Translate, msg as defineMessage, useGT as createTranslator } from 'gt-vue';
+       export * as GT from 'gt-vue';
+       export * as Vue from 'vue';
+       export { h as render } from 'vue';
+       export { invoke } from './helper';`
+    );
+    const output = await extract(
+      'consumer.tsx',
+      `import { GT, Vue, Translate, createTranslator, defineMessage, invoke, render } from './barrel';
+       const gt = createTranslator();
+       gt('TSX function');
+       defineMessage('TSX message');
+       invoke(gt);
+       export const first = <Translate><Vue.Fragment>TSX rich</Vue.Fragment></Translate>;
+       export const namespace = <GT.T>TSX namespace rich</GT.T>;
+       export const second = render(Translate, null, 'Render rich');`
+    );
+
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'TSX function',
+      'TSX message',
+      'TSX forwarded',
+      'TSX rich',
+      'TSX namespace rich',
+    ]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Vue render function'),
+    ]);
+  });
+
+  it('rejects a locally reexported renamed Fragment in TSX', async () => {
+    write(
+      'fragment-barrel.ts',
+      `export { T } from 'gt-vue';
+       export { Fragment as VueFragment } from 'vue';`
+    );
+    const output = await extract(
+      'renamed-fragment.tsx',
+      `import { T, VueFragment } from './fragment-barrel';
+       export const View = () => <T><VueFragment><b>Lost</b></VueFragment></T>;`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('renamed Vue Fragment binding');
+  });
+
+  it('resolves external namespace reexports for gt-vue and Vue', async () => {
+    write(
+      'namespaces.ts',
+      `export * as GT from 'gt-vue'; export * as Vue from 'vue';`
+    );
+    const output = await extract(
+      'namespaces.tsx',
+      `import { GT, Vue } from './namespaces';
+       GT.msg('Namespace export message');
+       GT.useGT()('Namespace export function');
+       export const fragment = Vue.Fragment;
+       export const rich = Vue.h(GT.T, null, 'Namespace render');`
+    );
+
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Namespace export message',
+      'Namespace export function',
+    ]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Vue render function'),
+    ]);
+
+    write(
+      'namespace-aliases.ts',
+      `import * as GTNamespace from 'gt-vue';
+       import * as VueNamespace from 'vue';
+       export { GTNamespace as GT, VueNamespace as Vue };`
+    );
+    const aliases = await extract(
+      'namespace-aliases.tsx',
+      `import { GT, Vue } from './namespace-aliases';
+       GT.msg('Namespace alias message');
+       export const fragment = Vue.Fragment;
+       export const rich = Vue.h(GT.T, null, 'Namespace alias render');`
+    );
+    expect(aliases.results.map(({ source }) => source)).toEqual([
+      'Namespace alias message',
+    ]);
+    expect(aliases.errors).toEqual([
+      expect.stringContaining('Vue render function'),
+    ]);
+
+    write('gt-runtime.ts', `export * from 'gt-vue';`);
+    write('vue-runtime.ts', `export * from 'vue';`);
+    write(
+      'local-namespaces.ts',
+      `export * as GT from './gt-runtime';
+       export * as Vue from './vue-runtime';`
+    );
+    const localNamespaces = await extract(
+      'local-namespaces.tsx',
+      `import { GT, Vue } from './local-namespaces';
+       GT.msg('Local namespace message');
+       export const fragment = Vue.Fragment;
+       export const rich = Vue.h(GT.T, null, 'Local namespace render');`
+    );
+    expect(localNamespaces.results.map(({ source }) => source)).toEqual([
+      'Local namespace message',
+    ]);
+    expect(localNamespaces.errors).toEqual([
+      expect.stringContaining('Vue render function'),
+    ]);
+  });
+
+  it('resolves a locally reexported Vue Suspense alias in an SFC template', async () => {
+    write(
+      'vue-builtins.ts',
+      `export { Suspense as AwaitBoundary } from 'vue';
+       export { T } from 'gt-vue';`
+    );
+    const output = await extract(
+      'SuspenseAlias.vue',
+      `<script setup>
+        import { AwaitBoundary, T } from './vue-builtins';
+      </script>
+      <template>
+        <T>
+          <AwaitBoundary>
+            <template #default><p>Loaded content</p></template>
+            <template #fallback><p>Loading content</p></template>
+          </AwaitBoundary>
+        </T>
+      </template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toHaveLength(1);
+    expect(output.results[0]?.source).toMatchObject({
+      c: expect.objectContaining({ c: 'Loaded content' }),
+      t: 'Suspense',
+    });
+  });
+
+  it('lets the supplied resolver override competing relative build output', async () => {
+    const sourceModule = write(
+      'resolved/source.ts',
+      `export { T } from 'gt-vue';`
+    );
+    write('resolved/source.js', `export const T = String;`);
+    const output = await extract(
+      'resolved/Consumer.vue',
+      `<script setup>import { T } from './source.js';</script><template><T>Resolver source</T></template>`,
+      {
+        resolveModule(specifier) {
+          return specifier === './source.js' ? sourceModule : undefined;
+        },
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Resolver source',
+    ]);
+  });
+
+  it('resolves cycles but fails closed for ambiguous and mutable exports', async () => {
+    write(
+      'cycle-a.ts',
+      `export * from './cycle-b'; export { T } from 'gt-vue';`
+    );
+    write('cycle-b.ts', `export * from './cycle-a';`);
+    const cycle = await extract(
+      'Cycle.vue',
+      `<script setup>import { T } from './cycle-b';</script><template><T>Cycle rich</T></template>`
+    );
+    expect(cycle.errors).toEqual([]);
+    expect(cycle.results.map(({ source }) => source)).toEqual(['Cycle rich']);
+
+    write('ambiguous-a.ts', `export { T as Shared } from 'gt-vue';`);
+    write('ambiguous-b.ts', `export { Branch as Shared } from 'gt-vue';`);
+    write(
+      'ambiguous.ts',
+      `export * from './ambiguous-a'; export * from './ambiguous-b';`
+    );
+    const ambiguous = await extract(
+      'Ambiguous.vue',
+      `<script setup>import { Shared } from './ambiguous';</script><template><Shared>Unsafe</Shared></template>`
+    );
+    expect(ambiguous.results).toEqual([]);
+    expect(ambiguous.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+
+    const ambiguousNamespace = await extract(
+      'AmbiguousNamespace.vue',
+      `<script setup>import * as Local from './ambiguous';</script><template><Local.Shared>Unsafe namespace</Local.Shared></template>`
+    );
+    expect(ambiguousNamespace.results).toEqual([]);
+    expect(ambiguousNamespace.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+
+    write(
+      'mutable.ts',
+      `import { T } from 'gt-vue';
+       let Mutable = T;
+       Mutable = String;
+       export { Mutable };`
+    );
+    const mutable = await extract(
+      'Mutable.vue',
+      `<script setup>import { Mutable } from './mutable';</script><template><Mutable>Unsafe</Mutable></template>`
+    );
+    expect(mutable.results).toEqual([]);
+    expect(mutable.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+  });
+
+  it('fails closed for an unresolved GT-shaped bare alias', async () => {
+    const output = await extract(
+      'Unresolved.vue',
+      `<script setup>
+        import { T as Translate, msg as defineMessage } from '@missing/gt';
+        defineMessage('Unsafe message');
+      </script>
+      <template><Translate>Unsafe rich</Translate></template>`,
+      { resolveModule: () => undefined }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+  });
+
+  it('fails closed for dynamic, CommonJS, and local Vue module identities', async () => {
+    write('barrel.ts', `export { T, msg } from 'gt-vue';`);
+    write(
+      'legacy.cjs',
+      `const { T } = require('gt-vue'); module.exports = { T };`
+    );
+    write('legacy.cts', `const { msg } = require('gt-vue'); export = { msg };`);
+    write('esm-looking.cjs', `export { T } from 'gt-vue';`);
+    write('esm-looking.cts', `export { msg } from 'gt-vue';`);
+    write('legacy-namespace.ts', `export * as Legacy from './legacy.cjs';`);
+    write(
+      'component.vue',
+      `<script>export { T } from 'gt-vue';</script><template><div /></template>`
+    );
+    const dynamic = await extract(
+      'Dynamic.vue',
+      `<script setup>
+        const GT = await import('./barrel');
+        GT.msg('Dynamic message');
+      </script><template><GT.T>Dynamic rich</GT.T></template>`
+    );
+    expect(dynamic.results).toEqual([]);
+    expect(dynamic.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+
+    const commonJs = await extract(
+      'CommonJs.vue',
+      `<script setup>import { T } from './legacy.cjs';</script><template><T>CommonJS rich</T></template>`
+    );
+    expect(commonJs.results).toEqual([]);
+    expect(commonJs.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+
+    const esmLookingCommonJs = await extract(
+      'EsmLookingCommonJs.vue',
+      `<script setup>import { T } from './esm-looking.cjs';</script><template><T>Unsafe ESM-looking CommonJS</T></template>`
+    );
+    expect(esmLookingCommonJs.results).toEqual([]);
+    expect(esmLookingCommonJs.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+
+    const commonJsNamespace = await extract(
+      'CommonJsNamespace.vue',
+      `<script setup>import { Legacy } from './legacy-namespace'; Legacy.msg('Unsafe namespace');</script><template><Legacy.T>Unsafe namespace rich</Legacy.T></template>`
+    );
+    expect(commonJsNamespace.results).toEqual([]);
+    expect(commonJsNamespace.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+
+    const commonJsTypeScript = await extract(
+      'CommonJsTypeScript.vue',
+      `<script setup>import { msg } from './legacy.cts'; msg('CommonJS TypeScript');</script><template><div /></template>`
+    );
+    expect(commonJsTypeScript.results).toEqual([]);
+    expect(commonJsTypeScript.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+
+    const esmLookingCommonJsTypeScript = await extract(
+      'EsmLookingCommonJsTypeScript.vue',
+      `<script setup>import { msg } from './esm-looking.cts'; msg('Unsafe ESM-looking CommonJS TypeScript');</script><template><div /></template>`
+    );
+    expect(esmLookingCommonJsTypeScript.results).toEqual([]);
+    expect(esmLookingCommonJsTypeScript.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+
+    const vueModule = await extract(
+      'VueModule.vue',
+      `<script setup>import { T } from './component.vue';</script><template><T>Vue module rich</T></template>`
+    );
+    expect(vueModule.results).toEqual([]);
+    expect(vueModule.errors).toEqual([
+      expect.stringContaining('Could not statically resolve'),
+    ]);
+  });
+
+  it('leaves an unrelated bare package component named T alone without a resolver', async () => {
+    const output = await extract(
+      'Ordinary.vue',
+      `<script setup>import { T } from 'ordinary-ui-library';</script><template><T>Ordinary component</T></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('leaves proven ordinary local exports and namespace members alone', async () => {
+    write(
+      'ordinary.ts',
+      `import { defineComponent } from 'vue';
+       export const Button = {};
+       export const Card = defineComponent({ name: 'Card' });
+       export const format = (value) => String(value);`
+    );
+    const output = await extract(
+      'OrdinaryLocal.vue',
+      `<script setup>
+        import { Button, Card, format } from './ordinary';
+        import * as Ordinary from './ordinary';
+        format('event');
+      </script>
+      <template>
+        <Button>Button</Button>
+        <Card>Card</Card>
+        <Ordinary.Button>Namespaced</Ordinary.Button>
+      </template>`,
+      { resolveModule: () => undefined }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('leaves ordinary local exports with GT-shaped names alone', async () => {
+    write(
+      'ordinary-gt-names.ts',
+      `export const T = String;
+       export const msg = (source) => source;
+       export const useGT = () => String;`
+    );
+    const output = await extract(
+      'OrdinaryGTNames.vue',
+      `<script setup>
+        import { T, msg, useGT } from './ordinary-gt-names';
+        import * as Ordinary from './ordinary-gt-names';
+        msg('ordinary named message');
+        useGT()('ordinary named hook');
+        Ordinary.msg('ordinary namespace message');
+        Ordinary.useGT()('ordinary namespace hook');
+      </script>
+      <template>
+        <T>Ordinary named component</T>
+        <Ordinary.T>Ordinary namespace component</Ordinary.T>
+      </template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('lets an explicit ordinary export shadow a GT star reexport', async () => {
+    write('shadowed.ts', `export * from 'gt-vue'; export const T = String;`);
+    const output = await extract(
+      'Shadowed.vue',
+      `<script setup>
+        import { T, msg } from './shadowed';
+        msg('Unshadowed message');
+      </script><template><T>Shadowed ordinary component</T></template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Unshadowed message',
+    ]);
+  });
+
+  it('does not treat a static ordinary dynamic import as gt-vue', async () => {
+    const output = await extract(
+      'OrdinaryDynamic.vue',
+      `<script setup>
+        const Ordinary = await import('ordinary-ui');
+        Ordinary.msg('analytics event');
+      </script><template><div /></template>`,
+      { resolveModule: () => undefined }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+});
+
+describe('translator forwarding through local functions', () => {
+  it('emits a captured translator callback exactly once at its lexical call', async () => {
+    const output = await extract(
+      'CapturedCallback.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        const gt = useGT();
+        function run(callback) { callback(); }
+        run(() => gt('Captured once'));
+      </script><template><div /></template>`,
+      { includeSourceCodeContext: true }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Captured once',
+    ]);
+    expect(
+      output.results[0]?.metadata.sourceCode?.['CapturedCallback.vue']?.[0]
+        ?.target
+    ).toContain(`gt('Captured once')`);
+  });
+
+  it('tracks positions, aliases, callback arrows, destructuring, rest, and cycles', async () => {
+    const output = await extract(
+      'Callbacks.vue',
+      `<script setup lang="ts">
+        import { msg, useGT, useMessages } from 'gt-vue';
+        const gt = useGT();
+        const m = useMessages();
+        function positioned(_ordinary: unknown, translate: typeof gt) { translate('Positioned'); }
+        const alias = positioned;
+        alias(null, gt);
+        function invoke(callback: (translate: typeof gt) => void, translate: typeof gt) { callback(translate); }
+        invoke((translate) => translate('Callback arrow'), m);
+        function destructured({ translate }: { translate: typeof gt }) { translate('Destructured'); }
+        destructured({ translate: gt });
+        function contextual(translate: typeof gt, context: string) { translate('Contextual', { $context: context }); }
+        contextual(gt, 'Forwarded context');
+        function rest(...values: unknown[]) { (values[1] as typeof gt)('Rest'); }
+        rest(null, msg);
+        function first(translate: typeof gt) { second(translate); }
+        function second(translate: typeof gt) { translate('Chained'); if (false) first(translate); }
+        first(gt);
+      </script><template><div /></template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Positioned',
+      'Callback arrow',
+      'Destructured',
+      'Contextual',
+      'Rest',
+      'Chained',
+    ]);
+    expect(
+      output.results.find(({ source }) => source === 'Contextual')?.metadata
+        .context
+    ).toBe('Forwarded context');
+  });
+
+  it('resolves static source and context identifiers at the consuming call', async () => {
+    write(
+      'static-helper.ts',
+      `export function invoke(translate, source, context) {
+         translate(source, { $context: context });
+       }`
+    );
+    const output = await extract(
+      'StaticArguments.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import { invoke as crossFile } from './static-helper';
+        function sameFile(translate, source, context) {
+          translate(source, { $context: context });
+        }
+        const gt = useGT();
+        const sameSource = 'Same-file source';
+        const sameContext = 'Same-file context';
+        const crossSource = 'Cross-file source';
+        const crossContext = 'Cross-file context';
+        sameFile(gt, sameSource, sameContext);
+        crossFile(gt, crossSource, crossContext);
+      </script><template><div /></template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results.map(({ metadata, source }) => [source, metadata.context])
+    ).toEqual([
+      ['Same-file source', 'Same-file context'],
+      ['Cross-file source', 'Cross-file context'],
+    ]);
+  });
+
+  it('retains callbacks that are not consumed by a local forwarding helper', async () => {
+    const output = await extract(
+      'DeferredCallbacks.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        const gt = useGT();
+        const directlyInvoked = () => gt('Direct callback');
+        const returned = () => gt('Returned callback');
+        const externallyRegistered = () => gt('External callback');
+        function keep(callback) { return callback; }
+        function ignore(_callback) {}
+        ignore(directlyInvoked);
+        directlyInvoked();
+        keep(returned)();
+        ignore(externallyRegistered);
+        setTimeout(externallyRegistered, 0);
+      </script><template><div /></template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Direct callback',
+      'Returned callback',
+      'External callback',
+    ]);
+  });
+
+  it('keeps a consumed captured callback lexical without double-emitting', async () => {
+    const output = await extract(
+      'ConsumedCallback.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        const gt = useGT();
+        const callback = () => gt('Consumed callback');
+        function invoke(callback) { callback(); }
+        invoke(callback);
+      </script><template><div /></template>`,
+      { includeSourceCodeContext: true }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Consumed callback',
+    ]);
+    expect(
+      output.results[0]?.metadata.sourceCode?.['ConsumedCallback.vue']?.[0]
+        ?.target
+    ).toContain(`gt('Consumed callback')`);
+  });
+
+  it('tracks cross-file helpers and attributes metadata to the consuming call', async () => {
+    write(
+      'helpers/impl.ts',
+      `export function invoke(translate) { translate('Cross-file function'); }
+       export const invokeArrow = (translate) => translate('Cross-file arrow');
+       export function invokeCallback(callback, translate) { callback(translate); }
+       export function invokeObject({ translate }) { translate('Cross-file destructured'); }
+       export function invokeRest(...values) { values[1]('Cross-file rest'); }
+       export function invokeChain(translate) { invoke(translate); }
+       export default invoke;`
+    );
+    write(
+      'helpers/index.ts',
+      `export {
+         default as runDefault,
+         invoke as run,
+         invokeArrow as runArrow,
+         invokeCallback,
+         invokeChain,
+         invokeObject,
+         invokeRest,
+       } from './impl';`
+    );
+    const output = await extract(
+      'Consumer.vue',
+      `<script setup>
+        import { useGT, useMessages } from 'gt-vue';
+        import { run, runArrow, runDefault, invokeCallback, invokeChain, invokeObject, invokeRest } from './helpers';
+        const gt = useGT();
+        const m = useMessages();
+        run(gt);
+        runArrow(m);
+        runDefault(gt);
+        invokeCallback((translate) => translate('Cross-file callback'), gt);
+        invokeObject({ translate: gt });
+        invokeRest(null, m);
+        invokeChain(gt);
+      </script><template><div /></template>`,
+      { includeSourceCodeContext: true }
+    );
+
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Cross-file function',
+      'Cross-file arrow',
+      'Cross-file function',
+      'Cross-file callback',
+      'Cross-file destructured',
+      'Cross-file rest',
+      'Cross-file function',
+    ]);
+    expect(output.errors).toEqual([]);
+    for (const result of output.results) {
+      expect(result.metadata.filePaths).toEqual(['Consumer.vue']);
+      expect(result.metadata.sourceCode?.['Consumer.vue']).toEqual([
+        expect.objectContaining({
+          target: expect.stringMatching(/run|invoke/),
+        }),
+      ]);
+    }
+  });
+
+  it('tracks default exported function declarations', async () => {
+    write(
+      'default-helper.ts',
+      `export default function invoke(translate) {
+         translate('Default function declaration');
+       }`
+    );
+    const output = await extract(
+      'DefaultHelper.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import invoke from './default-helper';
+        const gt = useGT();
+        invoke(gt);
+      </script><template><div /></template>`
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Default function declaration',
+    ]);
+  });
+
+  it('does not trust a mutated exported helper', async () => {
+    write(
+      'mutated-helper.ts',
+      `export let invoke = (translate) => translate('Unsafe helper');
+       invoke = () => undefined;`
+    );
+    const output = await extract(
+      'MutatedHelper.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import { invoke } from './mutated-helper';
+        const gt = useGT();
+        invoke(gt);
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('allows mutable ordinary helpers when no translator is passed', async () => {
+    write(
+      'mutable-format.ts',
+      `export let format = (value) => String(value);
+       format = (value) => value;`
+    );
+    const output = await extract(
+      'MutableFormat.vue',
+      `<script setup>
+        import { format } from './mutable-format';
+        import * as Helpers from './mutable-format';
+        format('named event');
+        Helpers.format('namespace event');
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('fails closed when unresolved imported helpers receive a translator', async () => {
+    write(
+      'unsupported-helper.vue',
+      `<script>export default function invoke(_translate) {}</script><template><div /></template>`
+    );
+    const output = await extract(
+      'UnresolvedHelpers.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import { invoke as missingInvoke } from './missing-helper';
+        import { invoke as packageInvoke } from 'unresolved-helper-package';
+        import vueInvoke from './unsupported-helper.vue';
+        import * as MissingHelpers from './missing-namespace';
+        const gt = useGT();
+        missingInvoke(gt);
+        packageInvoke(gt);
+        vueInvoke(gt);
+        MissingHelpers.invoke(gt);
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(4);
+    for (const error of output.errors) {
+      expect(error).toContain('possible gt-vue string function alias');
+    }
+  });
+
+  it('fails closed through immutable unresolved helper aliases', async () => {
+    const output = await extract(
+      'UnresolvedHelperAliases.vue',
+      `<script setup lang="ts">
+        import { useGT } from 'gt-vue';
+        import { invoke } from './missing-helper';
+        import * as Missing from './missing-namespace';
+        const gt = useGT();
+        const run = invoke;
+        const typedRun = invoke as typeof invoke;
+        const Helpers = Missing;
+        const { invoke: destructuredRun } = Missing;
+        run(gt);
+        typedRun(gt);
+        Helpers.invoke(gt);
+        destructuredRun(gt);
+        run({ translate: gt });
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(5);
+    for (const error of output.errors) {
+      expect(error).toContain('possible gt-vue string function alias');
+    }
+  });
+
+  it('does not transfer unresolved-helper provenance to shadow bindings', async () => {
+    const output = await extract(
+      'ShadowedUnresolvedHelpers.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import { invoke } from './missing-helper';
+        import * as Missing from './missing-namespace';
+        const gt = useGT();
+        function withParameter(invoke) { invoke(gt); }
+        function withNamespaceParameter(Missing) { Missing.invoke(gt); }
+        withParameter(() => undefined);
+        withNamespaceParameter({ invoke: () => undefined });
+        {
+          const invoke = () => undefined;
+          const Missing = { invoke: () => undefined };
+          invoke(gt);
+          Missing.invoke(gt);
+        }
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('treats an invalid ordinary barrel export only as a translator helper', async () => {
+    write('invalid-helper-barrel.ts', `export { invoke } from './absent';`);
+    const ordinary = await extract(
+      'InvalidHelperOrdinary.vue',
+      `<script setup>
+        import { invoke } from './invalid-helper-barrel';
+        invoke('event');
+      </script><template><div /></template>`
+    );
+    expect(ordinary.results).toEqual([]);
+    expect(ordinary.errors).toEqual([]);
+
+    const translator = await extract(
+      'InvalidHelperTranslator.vue',
+      `<script setup>
+        import { useGT } from 'gt-vue';
+        import { invoke } from './invalid-helper-barrel';
+        const gt = useGT();
+        invoke(gt);
+      </script><template><div /></template>`
+    );
+    expect(translator.results).toEqual([]);
+    expect(translator.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('ignores unresolved imported helpers called with ordinary values', async () => {
+    write(
+      'ordinary-helper.vue',
+      `<script>export default function invoke(_value) {}</script><template><div /></template>`
+    );
+    const output = await extract(
+      'OrdinaryUnresolvedHelpers.vue',
+      `<script setup>
+        import { invoke as missingInvoke } from './ordinary-missing';
+        import { invoke as packageInvoke } from 'ordinary-missing-package';
+        import vueInvoke from './ordinary-helper.vue';
+        import * as MissingHelpers from './ordinary-missing-namespace';
+        missingInvoke('event');
+        packageInvoke('event');
+        vueInvoke('event');
+        MissingHelpers.invoke('event');
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('ignores immutable unresolved helper aliases passed ordinary values', async () => {
+    const output = await extract(
+      'OrdinaryUnresolvedHelperAliases.vue',
+      `<script setup lang="ts">
+        import { invoke } from './ordinary-missing-helper';
+        import * as Missing from './ordinary-missing-namespace';
+        const run = invoke;
+        const typedRun = invoke as typeof invoke;
+        const Helpers = Missing;
+        const { invoke: destructuredRun } = Missing;
+        run('event');
+        typedRun('event');
+        Helpers.invoke('event');
+        destructuredRun('event');
+        run({ translate: 'event' });
+      </script><template><div /></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+});
+
+function componentSource(moduleClause: string): string {
+  return `<script setup lang="ts">
+    import { Branch, Currency, DateTime, Num, T, Var, msg, useGT, useMessages } ${moduleClause};
+    const gt = useGT();
+    const m = useMessages();
+    gt('Function text', { $context: 'function' });
+    m(msg('Message text', { $context: 'message' }));
+  </script>
+  <template>
+    <T context="rich">
+      <p>Welcome <Var>Ernest</Var></p>
+      <Branch branch="docs"><template #docs>Documentation</template><template #other>Other</template></Branch>
+      <Num :value="2" />
+      <Currency :value="12" currency="USD" />
+      <DateTime :value="0" />
+    </T>
+  </template>`;
+}
+
+function comparable(results: Awaited<ReturnType<typeof extract>>['results']) {
+  return results.map(({ dataFormat, metadata, source }) => ({
+    context: metadata.context,
+    dataFormat,
+    source,
+  }));
+}
+
+async function extract(
+  relativePath: string,
+  source: string,
+  options: {
+    includeSourceCodeContext?: boolean;
+    resolveModule?: (specifier: string, importer: string) => string | undefined;
+  } = {}
+) {
+  const filePath = write(relativePath, source);
+  return extractFromVueSource(source, filePath, {
+    ...options,
+    projectRoot: fixtureRoot,
+  });
+}
+
+function write(relativePath: string, source: string): string {
+  const filePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}

--- a/packages/vue-extractor/src/internal/__tests__/malformedPackageResolution.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/malformedPackageResolution.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { extractFromVueSource } from '../../index.js';
+import { createProjectModuleResolver } from '../project/moduleResolver.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('malformed nearest package boundaries', () => {
+  it('does not resolve a parent package past a malformed nearest install', () => {
+    const fixture = createNestedPackageFixture();
+    const resolveModule = createProjectModuleResolver();
+
+    expect(resolveModule('wrapper', fixture.importer)).toBeUndefined();
+  });
+
+  it('does not inherit gt-vue provenance from the shadowed parent package', async () => {
+    const fixture = createNestedPackageFixture();
+    const source = `
+      import { T } from 'wrapper';
+      export const App = () => <T>Wrong parent message</T>;
+    `;
+    fs.writeFileSync(fixture.importer, source);
+
+    const output = await extractFromVueSource(source, fixture.importer, {
+      projectRoot: fixture.root,
+      requireGTProvenance: true,
+      resolveModule: createProjectModuleResolver(),
+    });
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+});
+
+function createNestedPackageFixture(): {
+  importer: string;
+  root: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-malformed-'));
+  temporaryDirectories.push(root);
+  const localWrapper = path.join(root, 'packages/wrapper');
+  const parentLink = path.join(root, 'node_modules/wrapper');
+  const nearestWrapper = path.join(root, 'apps/client/node_modules/wrapper');
+  const importer = path.join(root, 'apps/client/src/App.tsx');
+  for (const directory of [
+    localWrapper,
+    path.dirname(parentLink),
+    nearestWrapper,
+    path.dirname(importer),
+  ]) {
+    fs.mkdirSync(directory, { recursive: true });
+  }
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ name: '@fixture/root' })
+  );
+  fs.writeFileSync(
+    path.join(localWrapper, 'package.json'),
+    JSON.stringify({
+      name: 'wrapper',
+      version: '1.0.0',
+      exports: './index.ts',
+    })
+  );
+  fs.writeFileSync(
+    path.join(localWrapper, 'index.ts'),
+    "export { T } from 'gt-vue';\n"
+  );
+  fs.symlinkSync(localWrapper, parentLink, 'dir');
+  fs.writeFileSync(path.join(nearestWrapper, 'package.json'), '{malformed');
+  fs.writeFileSync(
+    path.join(nearestWrapper, 'index.js'),
+    'export const T = String;\n'
+  );
+  fs.writeFileSync(importer, 'export {};\n');
+  return { importer, root };
+}

--- a/packages/vue-extractor/src/internal/__tests__/memberCallSourcePosition.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/memberCallSourcePosition.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+type SourcePositionProbe = {
+  /** Human-readable JavaScript data flow exercised by the probe. */
+  name: string;
+  /** Statements inserted into a TypeScript script-setup block. */
+  script: string;
+  /** Sources that execute through a GT string function at that call site. */
+  sources: string[];
+};
+
+/**
+ * Mutable string-function aliases are resolved at each call's source position.
+ * A later write must neither erase an earlier GT call nor retroactively turn an
+ * earlier ordinary call into a translation.
+ */
+const sourcePositionProbes: SourcePositionProbe[] = [
+  {
+    name: 'extracts an object-member useGT call before reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder.fn('member GT before ordinary');
+      holder.fn = String;
+      holder.fn('member ordinary after GT');
+    `,
+    sources: ['member GT before ordinary'],
+  },
+  {
+    name: 'extracts an object-member useGT call after reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: String };
+      holder.fn('member ordinary before GT');
+      holder.fn = useGT();
+      holder.fn('member GT after ordinary');
+    `,
+    sources: ['member GT after ordinary'],
+  },
+  {
+    name: 'extracts an object-member msg call before reassignment',
+    script: `
+      import { msg } from 'gt-vue';
+      const holder = { fn: msg };
+      holder.fn('member msg before ordinary');
+      holder.fn = String;
+      holder.fn('member ordinary after msg');
+    `,
+    sources: ['member msg before ordinary'],
+  },
+  {
+    name: 'extracts an object-member msg call after reassignment',
+    script: `
+      import { msg } from 'gt-vue';
+      const holder = { fn: String };
+      holder.fn('member ordinary before msg');
+      holder.fn = msg;
+      holder.fn('member msg after ordinary');
+    `,
+    sources: ['member msg after ordinary'],
+  },
+  {
+    name: 'extracts an object-member useMessages call before reassignment',
+    script: `
+      import { useMessages } from 'gt-vue';
+      const holder = { fn: useMessages() };
+      holder.fn('member messages before ordinary');
+      holder.fn = String;
+      holder.fn('member ordinary after messages');
+    `,
+    sources: ['member messages before ordinary'],
+  },
+  {
+    name: 'extracts an object-member useMessages call after reassignment',
+    script: `
+      import { useMessages } from 'gt-vue';
+      const holder = { fn: String };
+      holder.fn('member ordinary before messages');
+      holder.fn = useMessages();
+      holder.fn('member messages after ordinary');
+    `,
+    sources: ['member messages after ordinary'],
+  },
+  {
+    name: 'resolves a computed member at each call position',
+    script: `
+      import { useGT } from 'gt-vue';
+      const key = 'fn';
+      const holder = { [key]: useGT() };
+      holder[key]('computed GT before ordinary');
+      holder[key] = String;
+      holder[key]('computed ordinary after GT');
+    `,
+    sources: ['computed GT before ordinary'],
+  },
+  {
+    name: 'resolves a nested member at each call position',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { api: { fn: String } };
+      holder.api.fn('nested ordinary before GT');
+      holder.api.fn = useGT();
+      holder.api.fn('nested GT after ordinary');
+    `,
+    sources: ['nested GT after ordinary'],
+  },
+  {
+    name: 'preserves object identity through an alias when a member changes',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      const alias = holder;
+      alias.fn('aliased member GT before ordinary');
+      holder.fn = String;
+      alias.fn('aliased member ordinary after GT');
+    `,
+    sources: ['aliased member GT before ordinary'],
+  },
+  {
+    name: 'observes a GT member write through an object alias',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: String };
+      const alias = holder;
+      alias.fn('aliased member ordinary before GT');
+      holder.fn = useGT();
+      alias.fn('aliased member GT after ordinary');
+    `,
+    sources: ['aliased member GT after ordinary'],
+  },
+  {
+    name: 'keeps a detached member value after the object member changes',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      const detached = holder.fn;
+      holder.fn = String;
+      detached('detached GT snapshot');
+      holder.fn('mutated ordinary member');
+    `,
+    sources: ['detached GT snapshot'],
+  },
+  {
+    name: 'does not retroactively change an ordinary detached member',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: String };
+      const detached = holder.fn;
+      holder.fn = useGT();
+      detached('detached ordinary snapshot');
+      holder.fn('mutated GT member');
+    `,
+    sources: ['mutated GT member'],
+  },
+  {
+    name: 'keeps an aliased old object when its root binding is replaced',
+    script: `
+      import { useGT } from 'gt-vue';
+      let holder = { fn: useGT() };
+      const oldHolder = holder;
+      holder = { fn: String };
+      oldHolder.fn('old root GT member');
+      holder.fn('new root ordinary member');
+    `,
+    sources: ['old root GT member'],
+  },
+  {
+    name: 'uses the replacement object after its root binding changes',
+    script: `
+      import { useGT } from 'gt-vue';
+      let holder = { fn: String };
+      const oldHolder = holder;
+      holder = { fn: useGT() };
+      oldHolder.fn('old root ordinary member');
+      holder.fn('new root GT member');
+    `,
+    sources: ['new root GT member'],
+  },
+  {
+    name: 'extracts an optional object-member call',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder.fn?.('optional member call');
+    `,
+    sources: ['optional member call'],
+  },
+  {
+    name: 'extracts through an optional object member',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder?.fn('optional object member call');
+    `,
+    sources: ['optional object member call'],
+  },
+  {
+    name: 'extracts an optional computed-member call',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder?.['fn']?.('optional computed member call');
+    `,
+    sources: ['optional computed member call'],
+  },
+  {
+    name: 'extracts a non-null object-member call',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder.fn!('non-null member call');
+    `,
+    sources: ['non-null member call'],
+  },
+  {
+    name: 'extracts a type-wrapped object-member call',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      (holder.fn as typeof holder.fn)('type-wrapped member call');
+    `,
+    sources: ['type-wrapped member call'],
+  },
+  {
+    name: 'resolves an uninitialized translator through successive writes',
+    script: `
+      import { useGT } from 'gt-vue';
+      let translate;
+      translate = useGT();
+      translate('uninitialized binding GT phase');
+      translate = String;
+      translate('uninitialized binding ordinary phase');
+    `,
+    sources: ['uninitialized binding GT phase'],
+  },
+  {
+    name: 'resolves an uninitialized msg alias through successive writes',
+    script: `
+      import { msg } from 'gt-vue';
+      let message;
+      message = String;
+      message('uninitialized msg ordinary phase');
+      message = msg;
+      message('uninitialized msg GT phase');
+    `,
+    sources: ['uninitialized msg GT phase'],
+  },
+  {
+    name: 'preserves a detached alias from an uninitialized translator',
+    script: `
+      import { useGT } from 'gt-vue';
+      let translate;
+      translate = useGT();
+      const alias = translate;
+      translate = String;
+      alias?.('uninitialized detached translator');
+    `,
+    sources: ['uninitialized detached translator'],
+  },
+  {
+    name: 'preserves a detached alias from an initialized translator',
+    script: `
+      import { useGT } from 'gt-vue';
+      let translate = useGT();
+      const alias = translate;
+      translate = String;
+      alias('initialized detached translator');
+    `,
+    sources: ['initialized detached translator'],
+  },
+  {
+    name: 'does not retroactively change an ordinary detached alias',
+    script: `
+      import { useGT } from 'gt-vue';
+      let translate = String;
+      const alias = translate;
+      translate = useGT();
+      alias('initialized detached ordinary alias');
+      translate('initialized reassigned translator');
+    `,
+    sources: ['initialized reassigned translator'],
+  },
+  {
+    name: 'resolves an optional member call before reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder.fn?.('optional mutable member GT phase');
+      holder.fn = String;
+      holder.fn?.('optional mutable member ordinary phase');
+    `,
+    sources: ['optional mutable member GT phase'],
+  },
+  {
+    name: 'resolves an optional member call after reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: String };
+      holder.fn?.('optional mutable member ordinary phase');
+      holder.fn = useGT();
+      holder.fn?.('optional mutable member GT phase');
+    `,
+    sources: ['optional mutable member GT phase'],
+  },
+  {
+    name: 'resolves a non-null member call before reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: useGT() };
+      holder.fn!('non-null mutable member GT phase');
+      holder.fn = String;
+      holder.fn!('non-null mutable member ordinary phase');
+    `,
+    sources: ['non-null mutable member GT phase'],
+  },
+  {
+    name: 'resolves a non-null member call after reassignment',
+    script: `
+      import { useGT } from 'gt-vue';
+      const holder = { fn: String };
+      holder.fn!('non-null mutable member ordinary phase');
+      holder.fn = useGT();
+      holder.fn!('non-null mutable member GT phase');
+    `,
+    sources: ['non-null mutable member GT phase'],
+  },
+];
+
+describe('string-function member calls at each source position', () => {
+  it.each(sourcePositionProbes)('$name', async ({ script, sources }) => {
+    const output = await extractFromVueSource(
+      `<script setup lang="ts">${script}</script><template><div /></template>`,
+      '/fixtures/MemberCallSourcePosition.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(sources);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/mixedRuntimeIsolation.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/mixedRuntimeIsolation.test.ts
@@ -1,0 +1,1695 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const REACT_FAMILY_RUNTIMES = [
+  'gt-react',
+  'gt-next',
+  'gt-react-native',
+  'gt-tanstack-start',
+] as const;
+
+const OTHER_NON_VUE_GT_RUNTIMES = [
+  {
+    importNames: 'useGT, useMessages',
+    source: '@generaltranslation/react-core/hooks',
+    usage: `
+      const gt = useGT();
+      const m = useMessages();
+      gt('React core function');
+      m('React core message');
+    `,
+  },
+  { importNames: 'msg', source: 'gt-node', usage: `msg('Node message');` },
+  { importNames: 'msg', source: 'gt-i18n', usage: `msg('i18n message');` },
+] as const;
+
+let fixtureRoot: string;
+
+beforeEach(() => {
+  fixtureRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-mixed-'));
+});
+
+afterEach(() => {
+  fs.rmSync(fixtureRoot, { force: true, recursive: true });
+});
+
+describe('mixed-runtime isolation', () => {
+  it.each(REACT_FAMILY_RUNTIMES)(
+    'does not diagnose React-family APIs imported from %s',
+    async (runtime) => {
+      const output = await extractFromVueSource(
+        `
+          import { T, msg, useGT, useMessages } from '${runtime}';
+          const gt = useGT();
+          const m = useMessages();
+          gt('React-family function');
+          m(msg('React-family message'));
+          export const View = () => <T>React-family rich text</T>;
+        `,
+        path.join(fixtureRoot, 'View.tsx'),
+        {
+          projectRoot: fixtureRoot,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each(OTHER_NON_VUE_GT_RUNTIMES)(
+    'does not diagnose GT-shaped APIs from $source',
+    async ({ importNames, source, usage }) => {
+      const output = await extractFromVueSource(
+        `import { ${importNames} } from '${source}'; ${usage}`,
+        path.join(fixtureRoot, 'ordinary.ts'),
+        {
+          projectRoot: fixtureRoot,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each(REACT_FAMILY_RUNTIMES)(
+    'preserves ordinary provenance for local reexports from %s',
+    async (runtime) => {
+      const barrelPath = write(
+        'runtime.ts',
+        `export { T, msg, useGT, useMessages } from '${runtime}';`
+      );
+      const source = `
+        import { T, msg, useGT, useMessages } from '@app/runtime';
+        const gt = useGT();
+        const m = useMessages();
+        gt('Locally reexported function');
+        m(msg('Locally reexported message'));
+        export const View = () => <T>Locally reexported rich text</T>;
+      `;
+      const filePath = write('View.tsx', source);
+      const output = await extractFromVueSource(source, filePath, {
+        projectRoot: fixtureRoot,
+        resolveModule(specifier) {
+          return specifier === '@app/runtime' ? barrelPath : undefined;
+        },
+      });
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('ignores unresolved GT-shaped aliases without gt-vue ownership', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T as Translate, msg as defineMessage } from '@missing/gt';
+        defineMessage('Unresolved message');
+        export const View = () => <Translate>Unresolved rich text</Translate>;
+      `,
+      path.join(fixtureRoot, 'Unresolved.tsx'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each(['cjs', 'cts'])(
+    'ignores an ordinary helper imported from a local .%s module',
+    async (extension) => {
+      write(
+        `ordinary.${extension}`,
+        `exports.useGT = () => (source) => source;`
+      );
+      const output = await extractFromVueSource(
+        `import { useGT } from './ordinary.${extension}';
+         const gt = useGT();
+         gt('Ordinary CommonJS string');`,
+        path.join(fixtureRoot, 'ReactView.tsx'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      entry: `import { ordinary } from './mixed';
+        import { useGT } from '@missing/gt';
+        ordinary();
+        const gt = useGT();
+        gt('Ordinary named import');`,
+      filename: 'NamedConsumer.tsx',
+      module: `import { msg } from 'gt-vue';
+        void msg;
+        export function ordinary() { return 'ordinary'; }`,
+    },
+    {
+      entry: `import * as mixed from './mixed';
+        import { useGT } from '@missing/gt';
+        mixed.ordinary();
+        const gt = useGT();
+        gt('Ordinary namespace import');`,
+      filename: 'NamespaceConsumer.tsx',
+      module: `export { msg } from 'gt-vue';
+        export function ordinary() { return 'ordinary'; }`,
+    },
+    {
+      entry: `import { ordinary } from './mixed';
+        import { useGT } from '@missing/gt';
+        const label: string = ordinary();
+        const gt = useGT();
+        gt(label);`,
+      filename: 'TypedConsumer.js',
+      module: `import { msg } from 'gt-vue';
+        void msg;
+        export function ordinary() { return 'ordinary'; }`,
+    },
+  ])(
+    'does not inherit gt-vue ownership from an unrelated local export ($filename)',
+    async ({ entry, filename, module }) => {
+      write('mixed.ts', module);
+      const output = await extractFromVueSource(
+        entry,
+        path.join(fixtureRoot, filename),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      expected: 'Found conditional JSX content',
+      source: `const condition = true;
+        export const View = () => (
+          <mixed.T>{condition ? 'First' : 'Second'}</mixed.T>
+        );`,
+    },
+    {
+      expected: 'Vue render function',
+      source: `export const View = () =>
+        mixed.h(mixed.T, null, 'Render text');`,
+    },
+  ])(
+    'preserves the $expected diagnostic for a used GT member of a mixed namespace',
+    async ({ expected, source }) => {
+      write(
+        'mixed.ts',
+        `export { T } from 'gt-vue';
+         export { h } from 'vue';
+         export function ordinary() { return 'ordinary'; }`
+      );
+      const output = await extractFromVueSource(
+        `import * as mixed from './mixed'; ${source}`,
+        path.join(fixtureRoot, 'NamespaceError.tsx'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([expect.stringContaining(expected)]);
+    }
+  );
+
+  it('keeps unresolved aliases fail-closed after gt-vue ownership is proven', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { msg } from 'gt-vue';
+        import { useGT } from '@missing/gt';
+        void msg;
+        const gt = useGT();
+        gt('Unresolved message');
+      `,
+      path.join(fixtureRoot, 'OwnedUnresolved.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('does not treat a type-only gt-vue import as runtime ownership', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { type GTFunction } from 'gt-vue';
+        import { useGT } from '@theme/gt';
+        const gt: GTFunction = useGT();
+        gt('Ordinary theme string');
+      `,
+      path.join(fixtureRoot, 'TypeOnly.tsx'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('does not treat a Flow typeof gt-vue import as runtime ownership', async () => {
+    const output = await extractFromVueSource(
+      `
+        import typeof { GTFunction } from 'gt-vue';
+        import { useGT } from '@theme/gt';
+        const gt: GTFunction = useGT();
+        gt('Ordinary Flow theme string');
+      `,
+      path.join(fixtureRoot, 'TypeOnlyFlow.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('does not treat a type-only import-equals as runtime ownership', async () => {
+    const output = await extractFromVueSource(
+      `import type GT = require('gt-vue');
+       import { useGT } from '@theme/gt';
+       const gt = useGT();
+       gt('Ordinary import-equals theme string');
+       void (0 as unknown as GT.GTFunction);`,
+      path.join(fixtureRoot, 'TypeOnlyImportEquals.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('keeps mixed type and value gt-vue imports runtime-owned', async () => {
+    const output = await extractFromVueSource(
+      `import { type GTFunction, msg } from 'gt-vue';
+       const message: GTFunction | string = msg('Mixed import message');
+       void message;`,
+      path.join(fixtureRoot, 'MixedTypeValue.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Mixed import message',
+    ]);
+  });
+
+  it('keeps unresolved custom component aliases fail-closed in templates', async () => {
+    const output = await extractFromVueSource(
+      `
+        <script setup>
+          import { T as Translate } from '@missing/gt';
+        </script>
+        <template><Translate>Unresolved rich text</Translate></template>
+      `,
+      path.join(fixtureRoot, 'Unresolved.vue'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue component alias'),
+    ]);
+  });
+
+  it('extracts gt-vue while ignoring a colocated React runtime', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T as VueT, useGT as useVueGT } from 'gt-vue';
+        import { T as ReactT, useGT as useReactGT } from 'gt-react';
+        const vueGT = useVueGT();
+        const reactGT = useReactGT();
+        vueGT('Vue function');
+        reactGT('React function');
+        export const View = () => (
+          <><VueT>Vue rich text</VueT><ReactT>React rich text</ReactT></>
+        );
+      `,
+      path.join(fixtureRoot, 'Mixed.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Vue function',
+      'Vue rich text',
+    ]);
+  });
+});
+
+describe('standalone script provenance gating', () => {
+  it.each([
+    {
+      expected: ['Namespace string', 'Namespace rich'],
+      file: 'namespace.tsx',
+      source: `import * as GT from 'gt-vue';
+        GT.msg('Namespace string');
+        export const View = () => <GT.T>Namespace rich</GT.T>;`,
+    },
+    {
+      expected: ['Require string'],
+      file: 'required.cjs',
+      source: `const { msg } = require('gt-vue'); msg('Require string');`,
+    },
+  ])('retains supported gt-vue provenance in $file', async (fixture) => {
+    const output = await extractFromVueSource(
+      fixture.source,
+      path.join(fixtureRoot, fixture.file),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(
+      fixture.expected
+    );
+  });
+
+  it('does not hide unsupported dynamic gt-vue provenance', async () => {
+    const output = await extractFromVueSource(
+      `async function load() {
+        const GT = await import('gt-vue');
+        GT.msg('Dynamic string');
+      }
+      void load();`,
+      path.join(fixtureRoot, 'dynamic.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('does not hide a used gt-vue member from a dynamic local namespace', async () => {
+    write(
+      'dynamic-barrel.ts',
+      `export { msg } from 'gt-vue';
+       export function ordinary() { return 'ordinary'; }`
+    );
+    const output = await extractFromVueSource(
+      `const GT = await import('./dynamic-barrel');
+       GT.msg('Dynamic local string');`,
+      path.join(fixtureRoot, 'dynamic-local.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it.each([
+    `const key = 'msg'; GT[key]('Computed dynamic local');`,
+    `const Alias = GT; Alias.msg('Aliased dynamic local');`,
+    `const { msg } = GT; msg('Destructured dynamic local');`,
+    `const consume = (value) => value.msg('Forwarded dynamic local'); consume(GT);`,
+  ])(
+    'retains ownership through a proven dynamic namespace flow',
+    async (usage) => {
+      write(
+        'dynamic-flow.ts',
+        `export { msg } from 'gt-vue';
+         export function ordinary() { return 'ordinary'; }`
+      );
+      const output = await extractFromVueSource(
+        `const GT = await import('./dynamic-flow'); ${usage}`,
+        path.join(fixtureRoot, 'dynamic-flow-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('possible gt-vue string function alias'),
+      ]);
+    }
+  );
+
+  it('does not inherit ownership from an unused dynamic namespace member', async () => {
+    write(
+      'dynamic-mixed.ts',
+      `export { msg } from 'gt-vue';
+       export function ordinary() { return 'ordinary'; }`
+    );
+    const output = await extractFromVueSource(
+      `const mixed = await import('./dynamic-mixed');
+       mixed.ordinary();`,
+      path.join(fixtureRoot, 'dynamic-ordinary.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each([
+    {
+      expected: 'Direct require message',
+      source: `require('gt-vue').msg('Direct require message');`,
+    },
+    {
+      expected: 'Direct require function',
+      source: `require('gt-vue').useGT()('Direct require function');`,
+    },
+    {
+      expected: 'Direct require messages function',
+      source: `require('gt-vue').useMessages()('Direct require messages function');`,
+    },
+  ])(
+    'retains a supported CommonJS call chain for $expected',
+    async ({ expected, source }) => {
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'direct-require.cjs'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map(({ source: message }) => message)).toEqual([
+        expected,
+      ]);
+    }
+  );
+
+  it.each([
+    {
+      file: 'ReactView.ts',
+      source: `import { T } from 'gt-react'; export const View = () => <T>React</T>;`,
+    },
+    {
+      file: 'typed.js',
+      source: `export const label: string = 'React';`,
+    },
+  ])(
+    'ignores unowned React-valid syntax in $file',
+    async ({ file, source }) => {
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, file),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('does not make an unrelated Flow-typed React file Vue-fatal', async () => {
+    const output = await extractFromVueSource(
+      `import { msg } from 'gt-react';
+      type Props = {| name: string |};
+      msg('React Flow');`,
+      path.join(fixtureRoot, 'flow.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each(REACT_FAMILY_RUNTIMES)(
+    'does not let a %s call opt TypeScript-in-JavaScript into Vue parsing',
+    async (runtime) => {
+      const output = await extractFromVueSource(
+        `import { useGT } from '${runtime}';
+        const gt = useGT();
+        const label: string = gt('React typed JavaScript');
+        void label;`,
+        path.join(fixtureRoot, 'typed.js'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('keeps an unparseable direct gt-vue import fail-closed', async () => {
+    const output = await extractFromVueSource(
+      `import { msg } from 'gt-vue'; msg('Owned'); const broken = @;`,
+      path.join(fixtureRoot, 'broken.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it('keeps a gt-vue import after malformed syntax fail-closed', async () => {
+    const output = await extractFromVueSource(
+      `const broken = @;
+       import { msg } from 'gt-vue';
+       msg('Owned after syntax error');`,
+      path.join(fixtureRoot, 'broken-before-import.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it('keeps a gt-vue import before a multiline syntax error fail-closed', async () => {
+    const output = await extractFromVueSource(
+      `import { msg } from 'gt-vue';
+       const broken = (
+         @
+       );`,
+      path.join(fixtureRoot, 'multiline-error-after-import.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it.each([
+    `import * as GT from './multiline-barrel';
+     const broken = (\n@\n);
+     GT.msg('Static namespace after error');`,
+    `const GT = await import('./multiline-barrel');
+     const broken = (\n@\n);
+     GT.msg('Dynamic namespace after error');`,
+    `const { msg } = await import('./multiline-barrel');
+     const broken = (\n@\n);
+     msg('Dynamic binding after error');`,
+  ])(
+    'retains local-barrel ownership across a later multiline syntax error',
+    async (source) => {
+      write(
+        'multiline-barrel.ts',
+        `export { msg } from 'gt-vue';
+         export function ordinary() { return 'ordinary'; }`
+      );
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'multiline-local-error.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('Could not parse a gt-vue script block'),
+      ]);
+    }
+  );
+
+  it.each(['static import', 'local barrel'])(
+    'does not exhaust malformed ownership recovery before a later %s',
+    async (kind) => {
+      const barrelPath = write(
+        'src/many-errors-barrel.ts',
+        `export { msg as defineMessage } from 'gt-vue';`
+      );
+      const reference =
+        kind === 'static import'
+          ? `import { msg } from 'gt-vue'; msg('Owned after many errors');`
+          : `import { defineMessage } from '@app/many-errors';
+             defineMessage('Owned local after many errors');`;
+      const malformed = Array.from(
+        { length: 20 },
+        (_, index) => `const broken${index} = @;`
+      ).join('\n');
+      const output = await extractFromVueSource(
+        `${malformed}\n${reference}`,
+        path.join(fixtureRoot, 'src', `many-errors-${kind}.js`),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule(specifier) {
+            return specifier === '@app/many-errors' ? barrelPath : undefined;
+          },
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('Could not parse a gt-vue script block'),
+      ]);
+    }
+  );
+
+  it('keeps a direct CommonJS call after malformed syntax fail-closed', async () => {
+    const malformed = Array.from(
+      { length: 20 },
+      (_, index) => `const broken${index} = @;`
+    ).join('\n');
+    const output = await extractFromVueSource(
+      `${malformed}
+       require('gt-vue').msg('Owned CommonJS call');`,
+      path.join(fixtureRoot, 'broken-before-require.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it.each(['direct import', 'dynamic import', 'local barrel'])(
+    'recovers a later %s after malformed TSX',
+    async (kind) => {
+      const barrelPath = write(
+        'src/tsx-recovery-barrel.ts',
+        `export { msg as defineMessage } from 'gt-vue';`
+      );
+      const reference =
+        kind === 'direct import'
+          ? `import { msg } from 'gt-vue'; msg('Owned direct import');`
+          : kind === 'dynamic import'
+            ? `const { msg } = await import('gt-vue'); msg('Owned dynamic import');`
+            : `import { defineMessage } from '@app/tsx-recovery';
+               defineMessage('Owned local barrel');`;
+      const output = await extractFromVueSource(
+        `type Props = { label: string };
+         const View = (props: Props) => <div>{props.label}</div>;
+         const broken = @;
+         ${reference}`,
+        path.join(
+          fixtureRoot,
+          'src',
+          `broken-${kind.replaceAll(' ', '-')}.tsx`
+        ),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule(specifier) {
+            return specifier === '@app/tsx-recovery' ? barrelPath : undefined;
+          },
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('Could not parse a gt-vue script block'),
+      ]);
+    }
+  );
+
+  it('keeps a local gt-vue barrel after malformed syntax fail-closed', async () => {
+    const barrelPath = write(
+      'src/later-barrel.ts',
+      `export { msg as defineMessage } from 'gt-vue';`
+    );
+    const output = await extractFromVueSource(
+      `const broken = @;
+       import { defineMessage } from '@app/later-i18n';
+       defineMessage('Owned through later barrel');`,
+      path.join(fixtureRoot, 'src', 'broken-before-barrel.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule(specifier) {
+          return specifier === '@app/later-i18n' ? barrelPath : undefined;
+        },
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it.each([
+    `import * as GT from './later-namespace-barrel'; GT.msg('Static namespace');`,
+    `const GT = await import('./later-namespace-barrel'); GT.msg('Dynamic namespace');`,
+  ])(
+    'keeps a local namespace declared after malformed syntax fail-closed',
+    async (reference) => {
+      write(
+        'later-namespace-barrel.ts',
+        `export { msg } from 'gt-vue'; export const ordinary = 'ordinary';`
+      );
+      const output = await extractFromVueSource(
+        `const broken = @; ${reference}`,
+        path.join(fixtureRoot, 'broken-before-namespace.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('Could not parse a gt-vue script block'),
+      ]);
+    }
+  );
+
+  it('keeps a nested dynamic local namespace around malformed syntax fail-closed', async () => {
+    write(
+      'nested-dynamic-barrel.ts',
+      `export { msg } from 'gt-vue'; export const ordinary = 'ordinary';`
+    );
+    const output = await extractFromVueSource(
+      `async function load() {
+         const GT = await import('./nested-dynamic-barrel');
+         const broken = @;
+         GT.msg('Nested dynamic namespace');
+       }`,
+      path.join(fixtureRoot, 'broken-nested-dynamic.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it('bounds ownership recovery for a long malformed statement', async () => {
+    const malformedEntries = Array.from(
+      { length: 1_000 },
+      (_, index) => `${index};`
+    ).join('\n');
+    const output = await extractFromVueSource(
+      `const broken = (\n${malformedEntries}\n@\n);
+       import { msg } from 'gt-vue';`,
+      path.join(fixtureRoot, 'long-broken.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it.each([
+    `// import { msg } from 'gt-vue'\nconst broken = @;`,
+    `const text = "import { msg } from 'gt-vue'"; const broken = @;`,
+    "const pattern = /import { msg } from 'gt-vue'/; const broken = @;",
+    "const text = `import { msg } from 'gt-vue'`; const broken = @;",
+    `const text = "unterminated\nimport { msg } from 'gt-vue';`,
+    "const text = `unterminated\nimport { msg } from 'gt-vue';",
+    `/* unterminated\nimport { msg } from 'gt-vue';`,
+    `const view = <div>unterminated\nimport { msg } from 'gt-vue';`,
+  ])(
+    'ignores a malformed module with only a GT import lookalike',
+    async (source) => {
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'lookalike.js'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule: () => undefined,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('keeps an unparseable local gt-vue barrel fail-closed', async () => {
+    const barrelPath = write(
+      'src/broken-barrel.ts',
+      `export { msg as defineMessage } from 'gt-vue';`
+    );
+    const output = await extractFromVueSource(
+      `import { defineMessage } from '@app/i18n';
+      defineMessage('Owned through barrel');
+      const broken = @;`,
+      path.join(fixtureRoot, 'src', 'broken-entry.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule(specifier) {
+          return specifier === '@app/i18n' ? barrelPath : undefined;
+        },
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+
+  it.each([
+    `export { msg } from 'gt-vue';`,
+    `export * from 'gt-vue';`,
+    `export * as GT from 'gt-vue';`,
+  ])(
+    'keeps a malformed runtime re-export fail-closed: %s',
+    async (runtimeExport) => {
+      const source = `${runtimeExport} const broken = @;`;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'malformed-runtime-barrel.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('Could not parse a gt-vue script block'),
+      ]);
+    }
+  );
+
+  it.each([
+    `export type { GTFunction } from 'gt-vue';`,
+    `export { type GTFunction } from 'gt-vue';`,
+  ])(
+    'ignores a malformed TypeScript barrel with only a type re-export: %s',
+    async (typeExport) => {
+      const source = `${typeExport} const broken = @;`;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'malformed-type-barrel.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('ignores a malformed Flow barrel with only a type re-export', async () => {
+    const source = `export type { GTFunction } from 'gt-vue'; const broken = @;`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-flow-barrel.js'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('fails closed through a malformed gt-vue re-export barrel', async () => {
+    write(
+      'malformed-import-barrel.ts',
+      `export { msg } from 'gt-vue'; const broken = @;`
+    );
+    const source = `import { msg } from './malformed-import-barrel';
+      msg('Owned through a malformed barrel');`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-barrel-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('fails closed through a local malformed re-export chain', async () => {
+    write('runtime-base.ts', `export { msg } from 'gt-vue';`);
+    write(
+      'malformed-chain-barrel.ts',
+      `export { msg as defineMessage } from './runtime-base'; const broken = @;`
+    );
+    const source = `import { defineMessage } from './malformed-chain-barrel';
+      defineMessage('Owned through a malformed chain');`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-chain-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('fails closed through a malformed namespace re-export', async () => {
+    write(
+      'malformed-namespace-barrel.ts',
+      `export * as GT from 'gt-vue'; const broken = @;`
+    );
+    const source = `import { GT } from './malformed-namespace-barrel';
+      GT.msg('Owned through a malformed namespace');`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-namespace-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('possible gt-vue string function alias'),
+    ]);
+  });
+
+  it('does not inherit malformed namespace ownership from an unused GT member', async () => {
+    write(
+      'malformed-mixed-barrel.ts',
+      `export { msg } from 'gt-vue';
+       export function ordinary() { return 'ordinary'; }
+       const broken = @;`
+    );
+    const source = `import * as mixed from './malformed-mixed-barrel';
+      import { useGT } from '@ordinary/hooks';
+      mixed.ordinary();
+      const gt = useGT();
+      gt('Ordinary unresolved message');`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-mixed-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each([
+    `const alias = mixed; alias.msg('Aliased malformed namespace');`,
+    `const { msg } = mixed; msg('Destructured malformed namespace');`,
+    `function consume(value) { value.msg('Forwarded malformed namespace'); }
+     consume(mixed);`,
+  ])(
+    'fails closed when a malformed static namespace escapes direct analysis',
+    async (usage) => {
+      write(
+        'malformed-static-namespace.ts',
+        `export { msg } from 'gt-vue'; const broken = @;`
+      );
+      const source = `import * as mixed from './malformed-static-namespace';
+        ${usage}`;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'malformed-static-namespace-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('malformed local module'),
+      ]);
+    }
+  );
+
+  it('fails closed for a component renamed by a malformed barrel', async () => {
+    write(
+      'malformed-component-barrel.ts',
+      `export { T as Translate } from 'gt-vue'; const broken = @;`
+    );
+    const source = `import { Translate } from './malformed-component-barrel';
+      export const View = () => <Translate>Malformed component</Translate>;`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-component-consumer.tsx'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    `export const View = () => <mixed.T>Direct namespace JSX</mixed.T>;`,
+    `const alias = mixed;
+     export const View = () => <alias.T>Aliased namespace JSX</alias.T>;`,
+  ])(
+    'fails closed for JSX reached through a malformed static namespace',
+    async (usage) => {
+      write(
+        'malformed-jsx-namespace.ts',
+        `export { T } from 'gt-vue'; const broken = @;`
+      );
+      const source = `import * as mixed from './malformed-jsx-namespace';
+        ${usage}`;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'malformed-jsx-namespace-consumer.tsx'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.length).toBeGreaterThan(0);
+    }
+  );
+
+  it('does not inherit ownership from a malformed React re-export', async () => {
+    write(
+      'malformed-react-barrel.ts',
+      `export { msg } from 'gt-react'; const broken = @;`
+    );
+    const source = `import { msg } from './malformed-react-barrel';
+      msg('React message through malformed barrel');`;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'malformed-react-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each(
+    REACT_FAMILY_RUNTIMES.flatMap((runtime) => [
+      {
+        barrel: `export { T, msg, useGT } from '${runtime}'; const broken = @;`,
+        consumer: `import { T, msg, useGT } from './malformed-runtime';
+          msg('Malformed named React message');
+          useGT()('Malformed named React function');
+          export const View = () => <T>Malformed named React rich text</T>;`,
+        route: 'named',
+        runtime,
+      },
+      {
+        barrel: `export * from '${runtime}'; const broken = @;`,
+        consumer: `import { T, msg, useGT } from './malformed-runtime';
+          msg('Malformed star React message');
+          useGT()('Malformed star React function');
+          export const View = () => <T>Malformed star React rich text</T>;`,
+        route: 'star',
+        runtime,
+      },
+      {
+        barrel: `export * as Runtime from '${runtime}'; const broken = @;`,
+        consumer: `import { Runtime } from './malformed-runtime';
+          Runtime.msg('Malformed namespace React message');
+          Runtime.useGT()('Malformed namespace React function');
+          export const View = () => (
+            <Runtime.T>Malformed namespace React rich text</Runtime.T>
+          );`,
+        route: 'namespace',
+        runtime,
+      },
+    ])
+  )(
+    'preserves ordinary $runtime provenance through a malformed $route re-export',
+    async ({ barrel, consumer }) => {
+      write('malformed-runtime.ts', barrel);
+      const output = await extractFromVueSource(
+        `import { msg as vueMsg } from 'gt-vue';
+         void vueMsg;
+         ${consumer}`,
+        path.join(fixtureRoot, 'malformed-runtime-consumer.tsx'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      barrel: `export { msg } from './ordinary-runtime'; const broken = @;`,
+      route: 'named',
+    },
+    {
+      barrel: `export * from './ordinary-runtime'; const broken = @;`,
+      route: 'star',
+    },
+  ])(
+    'preserves a local exact identity through a malformed $route re-export',
+    async ({ barrel }) => {
+      write('ordinary-runtime.ts', `export const msg = (source) => source;`);
+      write('malformed-ordinary.ts', barrel);
+      const output = await extractFromVueSource(
+        `import { T as VueT } from 'gt-vue';
+         import { msg } from './malformed-ordinary';
+         void VueT;
+         msg('Malformed ordinary message');`,
+        path.join(fixtureRoot, 'malformed-ordinary-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it('preserves recovered identity-helper semantics for a proven translator', async () => {
+    write('identity-helper.ts', `export const pass = (value) => value;`);
+    write(
+      'malformed-identity-helper.ts',
+      `export { pass } from './identity-helper'; const broken = @;`
+    );
+    const output = await extractFromVueSource(
+      `import { useGT } from 'gt-vue';
+       import { pass } from './malformed-identity-helper';
+       const gt = useGT();
+       [gt].map(pass)[0]('Recovered identity callback');`,
+      path.join(fixtureRoot, 'malformed-identity-helper-consumer.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Recovered identity callback',
+    ]);
+  });
+
+  it.each(REACT_FAMILY_RUNTIMES)(
+    'preserves an immutable local msg alias to %s through a malformed re-export',
+    async (runtime) => {
+      write(
+        'aliased-runtime.ts',
+        `import { msg as runtimeMsg } from '${runtime}';
+         export const msg = runtimeMsg;`
+      );
+      write(
+        'malformed-aliased-runtime.ts',
+        `export { msg } from './aliased-runtime'; const broken = @;`
+      );
+      const output = await extractFromVueSource(
+        `import { T as VueT } from 'gt-vue';
+         import { msg } from './malformed-aliased-runtime';
+         void VueT;
+         msg('Malformed aliased React message');`,
+        path.join(fixtureRoot, 'malformed-aliased-runtime-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      module: `import { msg as runtimeMsg } from 'gt-vue';
+        export const msg = runtimeMsg;`,
+      title: 'gt-vue alias',
+    },
+    {
+      module: `import { msg as runtimeMsg } from '@missing/runtime';
+        export const msg = runtimeMsg;`,
+      title: 'unresolved alias',
+    },
+    {
+      module: `import { msg as runtimeMsg } from 'gt-react';
+        export let msg = runtimeMsg;
+        msg = (source) => source;`,
+      title: 'mutable React-family alias',
+    },
+    {
+      module: `import * as ReactGT from 'gt-react';
+        import { msg as vueMsg } from 'gt-vue';
+        export const msg = ReactGT[vueMsg('Hidden key')];`,
+      title: 'computed React-family namespace member',
+    },
+  ])(
+    'keeps a local $title behind a malformed barrel fail-closed',
+    async ({ module }) => {
+      write('unsafe-aliased-runtime.ts', module);
+      write(
+        'malformed-unsafe-alias.ts',
+        `export { msg } from './unsafe-aliased-runtime'; const broken = @;`
+      );
+      const output = await extractFromVueSource(
+        `import { T as VueT } from 'gt-vue';
+         import { msg } from './malformed-unsafe-alias';
+         void VueT;
+         msg('Unsafe malformed alias');`,
+        path.join(fixtureRoot, 'malformed-unsafe-alias-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([
+        expect.stringContaining('possible gt-vue string function alias'),
+      ]);
+    }
+  );
+
+  it.each([
+    {
+      expectError: false,
+      malformed: `export * from './ordinary-star-source'; const broken = @;`,
+      title: 'all-ordinary contributors',
+    },
+    {
+      expectError: true,
+      malformed: `export { msg } from 'gt-vue'; const broken = @;`,
+      title: 'an ordinary and a gt-vue contributor',
+    },
+    {
+      expectError: true,
+      malformed: `export * from '@missing/runtime'; const broken = @;`,
+      title: 'an ordinary and an unknown contributor',
+    },
+  ])(
+    'keeps a valid outer star barrel sound with $title',
+    async ({ expectError, malformed }) => {
+      write(
+        'ordinary-star-source.ts',
+        `export const msg = (source) => source;`
+      );
+      write('malformed-star-source.ts', malformed);
+      write(
+        'valid-outer-star.ts',
+        `export * from './ordinary-star-source';
+         export * from './malformed-star-source';`
+      );
+      const output = await extractFromVueSource(
+        `import { T as VueT } from 'gt-vue';
+         import { msg } from './valid-outer-star';
+         void VueT;
+         msg('Valid outer star message');`,
+        path.join(fixtureRoot, 'valid-outer-star-consumer.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+        }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual(
+        expectError
+          ? [expect.stringContaining('possible gt-vue string function alias')]
+          : []
+      );
+    }
+  );
+
+  it.each(['ts', 'mts', 'cts'])(
+    'recognizes a local barrel before an angle-bracket assertion in .%s',
+    async (extension) => {
+      const barrelPath = write(
+        'src/assertion-barrel.ts',
+        `export { msg as defineMessage } from 'gt-vue';`
+      );
+      const source = `import { defineMessage } from './barrel';
+        const count = <number>1;
+        void count;
+        defineMessage('Angle assertion message');`;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'src', `assertion.${extension}`),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule(specifier) {
+            return specifier === './barrel' ? barrelPath : undefined;
+          },
+        }
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map(({ source: message }) => message)).toEqual([
+        'Angle assertion message',
+      ]);
+    }
+  );
+
+  it('treats an installed opaque package useGT export as ordinary', async () => {
+    const packageEntry = write(
+      'node_modules/unrelated-hooks/index.cjs',
+      `exports.useGT = () => (value) => value;`
+    );
+    const source = `
+      import { useGT } from 'unrelated-hooks';
+      const ordinary = useGT();
+      ordinary('Not a translation');
+    `;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'ordinary.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule(specifier) {
+          return specifier === 'unrelated-hooks' ? packageEntry : undefined;
+        },
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('treats an installed ESM package useGT export as ordinary', async () => {
+    const packageEntry = write(
+      'node_modules/unrelated-esm/index.js',
+      `export function useGT() { return (value) => value; }`
+    );
+    const source = `
+      import { useGT } from 'unrelated-esm';
+      const ordinary = useGT();
+      ordinary('Not a translation');
+    `;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'ordinary-esm.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule(specifier) {
+          return specifier === 'unrelated-esm' ? packageEntry : undefined;
+        },
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('proves gt-vue provenance through a local barrel', async () => {
+    const barrelPath = write(
+      'src/i18n.ts',
+      `export { msg as defineMessage } from 'gt-vue';`
+    );
+    const source = `
+      import { defineMessage } from '@app/i18n';
+      defineMessage('Local wrapper message');
+    `;
+    const output = await extractFromVueSource(
+      source,
+      path.join(fixtureRoot, 'src', 'message.ts'),
+      {
+        projectRoot: fixtureRoot,
+        requireGTProvenance: true,
+        resolveModule(specifier) {
+          return specifier === '@app/i18n' ? barrelPath : undefined;
+        },
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source: message }) => message)).toEqual([
+      'Local wrapper message',
+    ]);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'recognizes a local workspace barrel through a node_modules symlink',
+    async () => {
+      const workspaceEntry = write(
+        'packages/i18n/index.ts',
+        `export { msg as defineMessage } from 'gt-vue';`
+      );
+      const linkedPackage = path.join(
+        fixtureRoot,
+        'node_modules',
+        '@app',
+        'i18n'
+      );
+      fs.mkdirSync(path.dirname(linkedPackage), { recursive: true });
+      fs.symlinkSync(path.dirname(workspaceEntry), linkedPackage, 'dir');
+      const source = `
+        import { defineMessage } from '@app/i18n';
+        defineMessage('Symlinked workspace message');
+      `;
+      const output = await extractFromVueSource(
+        source,
+        path.join(fixtureRoot, 'src', 'symlinked-message.ts'),
+        {
+          projectRoot: fixtureRoot,
+          requireGTProvenance: true,
+          resolveModule(specifier) {
+            return specifier === '@app/i18n'
+              ? path.join(linkedPackage, 'index.ts')
+              : undefined;
+          },
+        }
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map(({ source: message }) => message)).toEqual([
+        'Symlinked workspace message',
+      ]);
+    }
+  );
+
+  it.skipIf(process.platform === 'win32')(
+    'recognizes a symlinked workspace barrel outside the metadata project root',
+    async () => {
+      const outsideWorkspace = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'gt-vue-outside-workspace-')
+      );
+      try {
+        const workspaceEntry = path.join(outsideWorkspace, 'index.ts');
+        fs.writeFileSync(
+          workspaceEntry,
+          `export { msg as defineMessage } from 'gt-vue';`
+        );
+        const linkedPackage = path.join(
+          fixtureRoot,
+          'node_modules',
+          '@app',
+          'i18n'
+        );
+        fs.mkdirSync(path.dirname(linkedPackage), { recursive: true });
+        fs.symlinkSync(outsideWorkspace, linkedPackage, 'dir');
+        const source = `import { defineMessage } from '@app/i18n';
+          defineMessage('Outside workspace message');`;
+        const output = await extractFromVueSource(
+          source,
+          path.join(fixtureRoot, 'src', 'outside-workspace.ts'),
+          {
+            projectRoot: fixtureRoot,
+            requireGTProvenance: true,
+            resolveModule(specifier) {
+              return specifier === '@app/i18n'
+                ? path.join(linkedPackage, 'index.ts')
+                : undefined;
+            },
+          }
+        );
+
+        expect(output.errors).toEqual([]);
+        expect(output.results.map(({ source: message }) => message)).toEqual([
+          'Outside workspace message',
+        ]);
+      } finally {
+        fs.rmSync(outsideWorkspace, { force: true, recursive: true });
+      }
+    }
+  );
+});
+
+describe('JavaScript JSX parsing', () => {
+  it.each([
+    { extension: '.js', moduleSyntax: 'export const View = ViewNode;' },
+    { extension: '.mjs', moduleSyntax: 'export const View = ViewNode;' },
+    { extension: '.cjs', moduleSyntax: 'module.exports = ViewNode;' },
+  ])('accepts CRA-style JSX in $extension files', async (fixture) => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-react';
+        const ViewNode = () => <T>React rich text</T>;
+        ${fixture.moduleSyntax}
+      `,
+      path.join(fixtureRoot, `View${fixture.extension}`),
+      {
+        projectRoot: fixtureRoot,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it.each([
+    { language: '', name: 'implicit JavaScript' },
+    { language: ' lang="js"', name: 'explicit JavaScript' },
+  ])('accepts JSX in an SFC $name script', async ({ language }) => {
+    const output = await extractFromVueSource(
+      `
+        <script${language}>
+          import { T } from 'gt-react';
+          const View = () => <T>React rich text</T>;
+        </script>
+        <template><View /></template>
+      `,
+      path.join(fixtureRoot, 'View.vue'),
+      {
+        projectRoot: fixtureRoot,
+        resolveModule: () => undefined,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('continues to require TSX for JSX in TypeScript files', async () => {
+    const output = await extractFromVueSource(
+      `export const View = () => <div>TypeScript JSX</div>;`,
+      path.join(fixtureRoot, 'View.ts'),
+      { projectRoot: fixtureRoot }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([
+      expect.stringContaining('Could not parse a gt-vue script block'),
+    ]);
+  });
+});
+
+/** Writes one local module used by the read-only resolver tests. */
+function write(relativePath: string, source: string): string {
+  const filePath = path.join(fixtureRoot, relativePath);
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, source);
+  return filePath;
+}

--- a/packages/vue-extractor/src/internal/__tests__/nestedCopyIdentitySemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/nestedCopyIdentitySemantics.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type NestedCopyProbe = {
+  /** Human-readable shallow-copy rule exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script setup block. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector: string;
+  /** Whether the selected nested object can contain `<T>` at runtime. */
+  possibleT: boolean;
+};
+
+/**
+ * Runtime-verified nested identity cases for JavaScript copy transforms.
+ *
+ * Array `slice`, spread, `Array.from`, identity `map`, `concat`, and the
+ * non-mutating array transforms copy the outer array while retaining references
+ * to nested values. Object spread and `Object.assign` behave the same way for
+ * nested properties. A deliberate nested spread or nested slice creates a new
+ * inner container and therefore detaches subsequent writes to the source.
+ *
+ * These are plain JavaScript identity rules, independently checked at runtime.
+ * A shared nested write introducing `<T>` must fail closed; a shared erasure or
+ * a write to a detached source must not leave a stale diagnostic.
+ */
+const nestedCopyProbes: NestedCopyProbe[] = [
+  {
+    name: 'slice shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = raw.slice(); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'slice shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = raw.slice(); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'array spread shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = [...raw]; raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'array spread shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = [...raw]; raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'Array.from shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = Array.from(raw); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'Array.from shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = Array.from(raw); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'identity map shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = raw.map((value) => value); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'identity map shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = raw.map((value) => value); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'concat shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = [].concat(raw); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'concat shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = [].concat(raw); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'toSpliced shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = raw.toSpliced(); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'toSpliced shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = raw.toSpliced(); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'toReversed shares a later nested T write',
+    code: 'const raw = [[String]]; const registry = raw.toReversed(); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'toSorted shares a later nested T erasure',
+    code: 'const raw = [[T]]; const registry = raw.toSorted(); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested array spread detaches a later T write',
+    code: 'const raw = [[String]]; const registry = raw.map((value) => [...value]); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested array spread retains a pre-copy T',
+    code: 'const raw = [[T]]; const registry = raw.map((value) => [...value]); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested slice detaches a later T write',
+    code: 'const raw = [[String]]; const registry = raw.map((value) => value.slice()); raw[0][0] = T;',
+    selector: 'registry[index][nested]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested slice retains a pre-copy T',
+    code: 'const raw = [[T]]; const registry = raw.map((value) => value.slice()); raw[0][0] = String;',
+    selector: 'registry[index][nested]',
+    possibleT: true,
+  },
+  {
+    name: 'object spread shares a later nested T write',
+    code: 'const raw = { box: { value: String } }; const registry = { ...raw }; raw.box.value = T;',
+    selector: 'registry.box[key]',
+    possibleT: true,
+  },
+  {
+    name: 'object spread shares a later nested T erasure',
+    code: 'const raw = { box: { value: T } }; const registry = { ...raw }; raw.box.value = String;',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'Object.assign shares a later nested T write',
+    code: 'const raw = { box: { value: String } }; const registry = Object.assign({}, raw); raw.box.value = T;',
+    selector: 'registry.box[key]',
+    possibleT: true,
+  },
+  {
+    name: 'Object.assign shares a later nested T erasure',
+    code: 'const raw = { box: { value: T } }; const registry = Object.assign({}, raw); raw.box.value = String;',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested object spread detaches a later T write',
+    code: 'const raw = { box: { value: String } }; const registry = { ...raw, box: { ...raw.box } }; raw.box.value = T;',
+    selector: 'registry.box[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a nested object spread retains a pre-copy T',
+    code: 'const raw = { box: { value: T } }; const registry = { ...raw, box: { ...raw.box } }; raw.box.value = String;',
+    selector: 'registry.box[key]',
+    possibleT: true,
+  },
+];
+
+describe('nested JavaScript copy identity semantics', () => {
+  it.each(nestedCopyProbes)('$name', async ({ code, selector, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code, selector),
+      '/fixtures/NestedCopyIdentity.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    if (possibleT) {
+      expect(output.errors.join('\n')).toContain(POSSIBLE_ALIAS_DIAGNOSTIC);
+    } else {
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+/** Creates a minimal SFC that reads the copied container through unknown keys. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    ${code}
+    const index = getIndex();
+    const nested = getIndex();
+    const key = getKey();
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/opaqueComponentParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/opaqueComponentParity.test.ts
@@ -1,0 +1,694 @@
+import { describe, expect, it } from 'vitest';
+import { hashSource } from 'generaltranslation/id';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('opaque component runtime parity', () => {
+  it('does not inspect comment whitespace outside serialized component slots', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template>
+        <!-- outside translated content -->
+        <T><Card>Hidden <!-- opaque slot --> content</Card><b>After</b></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      { t: 'Card', i: 1 },
+      { t: 'b', i: 2, c: 'After' },
+    ]);
+  });
+
+  it('omits arbitrary component slots and extracts a nested T independently', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T, Var } from 'gt-vue';
+      </script>
+      <template>
+        <T context="outer"><Card title="Heading"><template #default="{ label }"><strong>Hidden</strong><T context="inner">Inner<Var>{{ label }}</Var></T></template><template #unused>Ignored</template></Card><span>After</span></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results
+        .filter((result) => result.dataFormat === 'JSX')
+        .map((result) => ({
+          context: result.metadata.context,
+          source: result.source,
+        }))
+    ).toEqual([
+      {
+        context: 'outer',
+        source: [
+          { t: 'Card', i: 1, d: { ti: 'Heading' } },
+          { t: 'span', i: 2, c: 'After' },
+        ],
+      },
+      {
+        context: 'inner',
+        source: ['Inner', { i: 1, k: '_gt_value_1', v: 'v' }],
+      },
+    ]);
+  });
+
+  it('serializes only Suspense default content and extracts fallback T independently', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template>
+        <T><Suspense><main>Source</main><template #fallback><T context="loading">Loading</T></template></Suspense><Transition><p>Motion</p></Transition><b>After</b></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results
+        .filter((result) => result.dataFormat === 'JSX')
+        .map((result) => ({
+          context: result.metadata.context,
+          source: result.source,
+        }))
+    ).toEqual([
+      {
+        context: undefined,
+        source: [
+          {
+            t: 'Suspense',
+            i: 1,
+            c: { t: 'main', i: 2, c: 'Source' },
+          },
+          { t: 'Transition', i: 3 },
+          { t: 'b', i: 4, c: 'After' },
+        ],
+      },
+      { context: 'loading', source: 'Loading' },
+    ]);
+  });
+
+  it.each(['#fallback', 'v-slot:fallback'])(
+    'extracts a component-level Suspense fallback independently with %s',
+    async (directive) => {
+      const output = await extract(`
+        <script setup lang="ts">
+        import { T } from 'gt-vue';
+        </script>
+        <template><T><Suspense ${directive}><T context="loading">Loading</T></Suspense><b>After</b></T></template>
+      `);
+
+      expect(output.errors).toEqual([]);
+      expect(
+        output.results.map((result) => ({
+          context: result.metadata.context,
+          source: result.source,
+        }))
+      ).toEqual([
+        {
+          context: undefined,
+          source: [
+            { t: 'Suspense', i: 1 },
+            { t: 'b', i: 2, c: 'After' },
+          ],
+        },
+        { context: 'loading', source: 'Loading' },
+      ]);
+    }
+  );
+
+  it('rejects multiple Suspense default roots that Vue normalizes to a comment', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template><T><Suspense><!-- ignored --><p>First</p><p>Second</p><template #fallback>Loading</template></Suspense></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'more than one default root inside Vue <Suspense>'
+    );
+  });
+
+  it.each(["Hello {{ 'world' }}", "{{ 'Hello' }}{{ ' world' }}"])(
+    'accepts adjacent text as one Suspense root: %s',
+    async (content) => {
+      const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template><T><Suspense>${content}</Suspense></T></template>
+    `);
+
+      expect(output.errors).toEqual([]);
+      expect(output.results[0]?.source).toEqual({
+        t: 'Suspense',
+        i: 1,
+        c: 'Hello world',
+      });
+    }
+  );
+
+  it.each([
+    'Hello<!-- compiler barrier -->world',
+    'Hello<template #fallback>Loading</template>world',
+    "{{ 'Hello' }}<!-- compiler barrier -->{{ ' world' }}",
+  ])(
+    'rejects text roots separated by a Vue compiler barrier: %s',
+    async (content) => {
+      const output = await extract(`
+        <script setup lang="ts">
+        import { T } from 'gt-vue';
+        </script>
+        <template><T><Suspense>${content}</Suspense></T></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'more than one default root inside Vue <Suspense>'
+      );
+    }
+  );
+
+  it('ignores a trailing comment when Suspense has one meaningful root', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template><T><Suspense><main>Source</main><!-- ignored --></Suspense></T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: { t: 'main', i: 2, c: 'Source' },
+    });
+  });
+
+  it.each([
+    {
+      name: 'literal builtin',
+      script: '',
+      tag: 'Suspense',
+    },
+    {
+      name: 'named import alias',
+      script: "import { Suspense as AsyncBoundary } from 'vue';",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'transitive alias',
+      script:
+        "import { Suspense } from 'vue'; const First = Suspense; const AsyncBoundary = First;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'namespace tag',
+      script: "import * as Vue from 'vue';",
+      tag: 'Vue.Suspense',
+    },
+    {
+      name: 'namespace-derived alias',
+      script: "import * as Vue from 'vue'; const AsyncBoundary = Vue.Suspense;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'nullish alias',
+      script:
+        "import * as Vue from 'vue'; const AsyncBoundary = Vue.Suspense ?? String;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'logical alias',
+      script:
+        "import * as Vue from 'vue'; const AsyncBoundary = Vue.Suspense || String;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'logical-and alias',
+      script:
+        "import * as Vue from 'vue'; const AsyncBoundary = Vue.Suspense && Vue.Suspense;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'static conditional alias',
+      script:
+        "import * as Vue from 'vue'; const AsyncBoundary = true ? Vue.Suspense : String;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'identical conditional alias',
+      script:
+        "import * as Vue from 'vue'; const runtimeFlag = Boolean(Date.now()); const AsyncBoundary = runtimeFlag ? Vue.Suspense : Vue.Suspense;",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'sequence alias',
+      script:
+        "import * as Vue from 'vue'; const AsyncBoundary = (0, Vue.Suspense);",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'markRaw identity wrapper',
+      script:
+        "import { markRaw, Suspense } from 'vue'; const AsyncBoundary = markRaw(Suspense);",
+      tag: 'AsyncBoundary',
+    },
+    {
+      name: 'kebab-case alias',
+      script: "import { Suspense as AsyncBoundary } from 'vue';",
+      tag: 'async-boundary',
+    },
+    {
+      name: 'dynamic direct binding',
+      script: "import { Suspense } from 'vue';",
+      tag: 'component :is="Suspense"',
+    },
+    {
+      name: 'dynamic namespace binding',
+      script: "import * as Vue from 'vue';",
+      tag: 'component :is="Vue.Suspense"',
+    },
+  ])('matches literal Suspense for a $name', async ({ script, tag }) => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      ${script}
+      </script>
+      <template><T><${tag}><main>Source</main><template #fallback>Loading</template></${tag.split(' ')[0]}></T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    const source = output.results.find(
+      (result) => result.dataFormat === 'JSX'
+    )?.source;
+    expect(source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: { t: 'main', i: 2, c: 'Source' },
+    });
+    expect(hashSource({ dataFormat: 'JSX', source })).toBe('bb63de9e2be66ffe');
+  });
+
+  it('resolves Options API Suspense registration through object spreads and static selectors', async () => {
+    const output = await extract(`
+      <script lang="ts">
+      import { defineComponent, Suspense } from 'vue';
+      import { T } from 'gt-vue';
+      const shared = { AsyncBoundary: Suspense };
+      export default defineComponent({
+        components: { T, ...shared },
+      });
+      </script>
+      <template><T><component :is="'AsyncBoundary'"><main>Source</main><template #fallback>Loading</template></component></T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    const source = output.results.find(
+      (result) => result.dataFormat === 'JSX'
+    )?.source;
+    expect(source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: { t: 'main', i: 2, c: 'Source' },
+    });
+    expect(hashSource({ dataFormat: 'JSX', source })).toBe('bb63de9e2be66ffe');
+  });
+
+  it.each([
+    {
+      name: 'direct overrides',
+      declaration: `{
+        ...getOptions(),
+        components: { T, AsyncBoundary: Suspense },
+        setup() { return {}; },
+      }`,
+    },
+    {
+      name: 'nested overrides',
+      declaration: `{
+        ...{
+          ...getOptions(),
+          components: { T, AsyncBoundary: Suspense },
+          setup() { return {}; },
+        },
+      }`,
+    },
+    {
+      name: 'explicit absent setup override',
+      declaration: `{
+        ...getOptions(),
+        components: { T, AsyncBoundary: Suspense },
+        setup: undefined,
+      }`,
+    },
+  ])(
+    'accepts relevant Options API properties after unknown top-level spreads: $name',
+    async ({ declaration }) => {
+      const output = await extract(`
+        <script>
+        import { Suspense } from 'vue';
+        import { T } from 'gt-vue';
+        const getOptions = () => ({ components: { Card: Suspense } });
+        export default ${declaration};
+        </script>
+        <template><T><AsyncBoundary><main>Source</main></AsyncBoundary></T></template>
+      `);
+
+      expect(output.errors).toEqual([]);
+      expect(output.results[0]?.source).toEqual({
+        t: 'Suspense',
+        i: 1,
+        c: { t: 'main', i: 2, c: 'Source' },
+      });
+    }
+  );
+
+  it.each([
+    {
+      name: 'missing explicit setup',
+      declaration:
+        '{ ...getOptions(), components: { T, AsyncBoundary: Suspense } }',
+    },
+    {
+      name: 'missing explicit components',
+      declaration: '{ ...getOptions(), setup() { return {}; } }',
+    },
+    {
+      name: 'trailing spread',
+      declaration:
+        '{ components: { T, AsyncBoundary: Suspense }, setup() { return {}; }, ...getOptions() }',
+    },
+    {
+      name: 'trailing computed key',
+      declaration:
+        '{ components: { T, AsyncBoundary: Suspense }, setup() { return {}; }, [getKey()]: true }',
+    },
+  ])(
+    'rejects unknown top-level Options API properties after $name',
+    async ({ declaration }) => {
+      const output = await extract(`
+        <script>
+        import { Suspense } from 'vue';
+        import { T } from 'gt-vue';
+        const getOptions = () => ({});
+        const getKey = () => 'components';
+        export default ${declaration};
+        </script>
+        <template><T><AsyncBoundary><main>Hidden</main></AsyncBoundary></T></template>
+      `);
+
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve the Vue Options API components or setup'
+      );
+    }
+  );
+
+  it('keeps unknown component-registry keys blocking after explicit overrides', async () => {
+    const output = await extract(`
+      <script>
+      import { Suspense } from 'vue';
+      import { T } from 'gt-vue';
+      const getComponents = () => ({ Card: Suspense });
+      export default {
+        components: { ...getComponents(), T, AsyncBoundary: Suspense },
+        setup() { return {}; },
+      };
+      </script>
+      <template><T><Card><main>Hidden</main></Card></T></template>
+    `);
+
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve the Vue Options API components registry'
+    );
+  });
+
+  it('keeps unproven Suspense-like components opaque and rejects unregistered string selectors', async () => {
+    const opaque = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      import { Suspense as AsyncBoundary } from './ui';
+      </script>
+      <template><T><AsyncBoundary><main>Hidden</main></AsyncBoundary></T></template>
+    `);
+    const mutable = await extract(`
+      <script setup lang="ts">
+      import { Suspense } from 'vue';
+      import { T } from 'gt-vue';
+      let AsyncBoundary = Suspense;
+      AsyncBoundary = String;
+      </script>
+      <template><T><AsyncBoundary><main>Hidden</main></AsyncBoundary></T></template>
+    `);
+    const stringSelector = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      </script>
+      <template><T><component :is="'Suspense'"><main>Hidden</main></component></T></template>
+    `);
+
+    expect(opaque.errors).toEqual([]);
+    expect(opaque.results[0]?.source).toEqual({ t: 'AsyncBoundary', i: 1 });
+    expect(mutable.results).toEqual([]);
+    expect(mutable.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "AsyncBoundary"'
+    );
+    expect(stringSelector.results).toEqual([]);
+    expect(stringSelector.errors.join('\n')).toContain('dynamic <component>');
+  });
+
+  it.each([
+    {
+      name: 'member assignment',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; registry.AsyncBoundary = String;',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'computed member assignment',
+      setup:
+        "const registry = { AsyncBoundary: Suspense }; registry['AsyncBoundary'] = String;",
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'Object.assign mutation',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; Object.assign(registry, { AsyncBoundary: String });',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'escaped container',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; console.log(registry);',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'deleted member',
+      setup:
+        'const registry: { AsyncBoundary?: unknown } = { AsyncBoundary: Suspense }; delete registry.AsyncBoundary;',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'object-pattern member assignment',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; ({ AsyncBoundary: registry.AsyncBoundary } = { AsyncBoundary: String });',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'array-pattern member assignment',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; [registry.AsyncBoundary] = [String];',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'for-of member assignment',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; for (registry.AsyncBoundary of [String]) {}',
+      registration: 'const { AsyncBoundary } = registry;',
+    },
+    {
+      name: 'hoisted closure member assignment',
+      setup: 'const registry = { AsyncBoundary: Suspense }; mutateRegistry();',
+      registration:
+        'const { AsyncBoundary } = registry; function mutateRegistry() { registry.AsyncBoundary = String; }',
+    },
+    {
+      name: 'unknown trailing spread',
+      setup: 'const getRegistry = () => ({ AsyncBoundary: String });',
+      registration:
+        'const { AsyncBoundary } = { AsyncBoundary: Suspense, ...getRegistry() };',
+    },
+    {
+      name: 'mutated Options API registry',
+      setup:
+        'const registry = { AsyncBoundary: Suspense }; registry.AsyncBoundary = String;',
+      registration: 'const components = registry;',
+      options: true,
+    },
+    {
+      name: 'unknown trailing Options API spread',
+      setup: 'const getRegistry = () => ({ AsyncBoundary: String });',
+      registration:
+        'const components = { AsyncBoundary: Suspense, ...getRegistry() };',
+      options: true,
+    },
+  ])(
+    'does not follow a Suspense alias through $name',
+    async ({ setup, registration, options }) => {
+      const output = await extract(`
+        <script${options ? '' : ' setup'} lang="ts">
+        import { Suspense } from 'vue';
+        import { T } from 'gt-vue';
+        ${setup}
+        ${registration}
+        ${options ? 'export default { components: { ...components, T } };' : ''}
+        </script>
+        <template><T><AsyncBoundary><main>Hidden</main></AsyncBoundary></T></template>
+      `);
+
+      expect(output.errors.join('\n')).toContain(
+        options
+          ? 'Could not statically resolve the Vue Options API components registry'
+          : 'Could not statically resolve component alias "AsyncBoundary"'
+      );
+      if (options) {
+        expect(output.results[0]?.source).toEqual({
+          t: 'AsyncBoundary',
+          i: 1,
+        });
+      } else {
+        expect(output.results).toEqual([]);
+      }
+    }
+  );
+
+  it.each([
+    'registry.AsyncBoundary = String;',
+    'Object.assign(registry, { AsyncBoundary: String });',
+  ])(
+    'keeps a component captured before later mutation: %s',
+    async (mutation) => {
+      const output = await extract(`
+      <script setup lang="ts">
+      import { Suspense } from 'vue';
+      import { T } from 'gt-vue';
+      const registry = { AsyncBoundary: Suspense };
+      const { AsyncBoundary } = registry;
+      ${mutation}
+      </script>
+      <template><T><AsyncBoundary><main>Source</main></AsyncBoundary></T></template>
+    `);
+
+      expect(output.errors).toEqual([]);
+      expect(output.results[0]?.source).toEqual({
+        t: 'Suspense',
+        i: 1,
+        c: { t: 'main', i: 2, c: 'Source' },
+      });
+    }
+  );
+
+  it.each([
+    {
+      name: 'reassigned destructured require binding',
+      script: "let { Suspense: Boundary } = require('vue'); Boundary = String;",
+      tag: 'Boundary',
+    },
+    {
+      name: 'mutated require namespace member',
+      script:
+        "const Vue = require('vue'); Vue.Suspense = String; const Boundary = Vue.Suspense;",
+      tag: 'Boundary',
+    },
+    {
+      name: 'reassigned require namespace',
+      script:
+        "let Vue = require('vue'); Vue = { Suspense: String }; const Boundary = Vue.Suspense;",
+      tag: 'Boundary',
+    },
+  ])('fails closed for a $name', async ({ script, tag }) => {
+    const output = await extract(`
+      <script setup>
+      import { T } from 'gt-vue';
+      ${script}
+      </script>
+      <template><T><${tag}><main>Hidden</main></${tag}></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      `Could not statically resolve component alias "${tag}"`
+    );
+  });
+
+  it('does not trust a mutable CommonJS namespace across SFC script blocks', async () => {
+    const output = await extract(`
+      <script>
+      const Vue = require('vue');
+      Vue.Suspense = String;
+      export default {};
+      </script>
+      <script setup>
+      import { T } from 'gt-vue';
+      </script>
+      <template><T><Vue.Suspense><main>Hidden</main></Vue.Suspense></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "Vue.Suspense"'
+    );
+  });
+
+  it.each([
+    'const Boundary = shallowRef(Suspense);',
+    'const Boundary = computed(() => Suspense);',
+    'const Boundary = computed({ get: () => Suspense, set() {} });',
+    'const Boundary = (() => Suspense)();',
+    'function makeBoundary() { return Suspense; } const Boundary = makeBoundary();',
+    'const holder = { get Boundary() { return Suspense; } }; const { Boundary } = holder;',
+  ])(
+    'fails closed when a wrapper can return Vue Suspense: %s',
+    async (script) => {
+      const output = await extract(`
+        <script setup>
+        import { computed, shallowRef, Suspense } from 'vue';
+        import { T } from 'gt-vue';
+        ${script}
+        </script>
+        <template><T><Boundary><main>Hidden</main></Boundary></T></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve component alias "Boundary"'
+      );
+    }
+  );
+
+  it('still rejects source-shaping directives and dynamic content props on opaque components', async () => {
+    const output = await extract(`
+      <script setup lang="ts">
+      import { T } from 'gt-vue';
+      const heading = String(Date.now());
+      const visible = true;
+      </script>
+      <template><T><Card v-if="visible" :title="heading">Hidden</Card></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('source-shaping directive v-if');
+    expect(output.errors.join('\n')).toContain(
+      'dynamic translatable prop "title"'
+    );
+  });
+});
+
+async function extract(source: string) {
+  return extractFromVueSource(source, '/fixtures/OpaqueComponents.vue', {
+    projectRoot: process.cwd(),
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/packageLayout.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/packageLayout.test.ts
@@ -27,6 +27,7 @@ describe('@generaltranslation/vue-extractor package declarations', () => {
     const declarations = [
       'config.d.ts',
       'detect.d.ts',
+      'inspect.d.ts',
       'index.d.ts',
       'project.d.ts',
       'types.d.ts',

--- a/packages/vue-extractor/src/internal/__tests__/packageLayout.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/packageLayout.test.ts
@@ -1,0 +1,40 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+const packageRoot = fileURLToPath(new URL('../../../', import.meta.url));
+
+describe('@generaltranslation/vue-extractor package declarations', () => {
+  beforeAll(() => {
+    // Turbo builds dependencies before tests. Standalone package tests rebuild
+    // so this assertion never inspects stale declarations from another run.
+    if (process.env.TURBO_HASH) return;
+
+    const command = process.env.npm_execpath ? process.execPath : 'pnpm';
+    const args = process.env.npm_execpath
+      ? [process.env.npm_execpath, 'run', 'build']
+      : ['run', 'build'];
+    execFileSync(command, args, {
+      cwd: packageRoot,
+      stdio: 'pipe',
+      timeout: 60_000,
+    });
+  }, 65_000);
+
+  it('keeps Vue compiler test types out of the public declaration graph', () => {
+    const declarations = [
+      'config.d.ts',
+      'detect.d.ts',
+      'index.d.ts',
+      'project.d.ts',
+      'types.d.ts',
+      'internal/extractFromVueSource.d.ts',
+    ]
+      .map((file) => readFileSync(join(packageRoot, 'dist', file), 'utf8'))
+      .join('\n');
+
+    expect(declarations).not.toMatch(/@vue\/compiler-(?:dom|sfc)/);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/performance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/performance.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { collectAnalyzerStats } from './analyzerPerformance.js';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS = 15_000;
+
+function createContainerAliasScript(aliasCount: number): string {
+  const declarations = [
+    "import { T } from 'gt-vue';",
+    'const components0 = [T];',
+  ];
+  for (let index = 1; index <= aliasCount; index += 1) {
+    declarations.push(`const components${index} = components${index - 1};`);
+  }
+  declarations.push('const selected = getIndex();');
+  return declarations.join('\n');
+}
+describe('Vue extractor performance', () => {
+  it(
+    'keeps analyzer visits linear for immutable container aliases',
+    () => {
+      const smaller = collectAnalyzerStats(createContainerAliasScript(500));
+      const larger = collectAnalyzerStats(createContainerAliasScript(1_000));
+
+      for (const key of Object.keys(larger) as Array<keyof typeof larger>) {
+        expect(larger[key], key).toBeLessThanOrEqual(smaller[key] * 2 + 10);
+      }
+
+      expect(
+        Object.values(larger).reduce((total, visits) => total + visits, 0)
+      ).toBeLessThanOrEqual(4_000);
+    },
+    ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS
+  );
+
+  it(
+    'fails closed for a thousand container aliases',
+    async () => {
+      const source = `<script setup>${createContainerAliasScript(1_000)}</script>
+        <template>
+          <component :is="components1000[selected]">Hidden</component>
+        </template>`;
+
+      const output = await extractFromVueSource(source, '/tmp/AliasChain.vue', {
+        projectRoot: '/tmp',
+      });
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    },
+    ANALYZER_PERFORMANCE_TEST_TIMEOUT_MS
+  );
+});

--- a/packages/vue-extractor/src/internal/__tests__/projectAliasProvenance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectAliasProvenance.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('project alias provenance', () => {
+  it('ignores an incomplete Vue alias config for React-owned source', async () => {
+    const root = createFixture({
+      'src/App.tsx': `
+        import { useGT } from 'gt-react';
+        export function App() {
+          const gt = useGT();
+          return <h1>{gt('React-owned message')}</h1>;
+        }
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('fails closed when a direct gt-vue source shares an incomplete alias config', async () => {
+    const root = createFixture({
+      'src/message.ts': `
+        import { msg } from 'gt-vue';
+        export const message = msg('Vue-owned message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve the Vue application module aliases'
+    );
+  });
+
+  it('does not infer gt-vue ownership from an unresolved GT-shaped alias', async () => {
+    const root = createFixture({
+      'src/App.tsx': `
+        import { useGT } from '#i18n';
+        export function App() {
+          const gt = useGT();
+          return <h1>{gt('Ordinary aliased message')}</h1>;
+        }
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('does not treat an ordinary relative useGT helper as gt-vue', async () => {
+    const root = createFixture({
+      'src/ordinary.ts': `
+        export const useGT = () => (value: string) => value;
+      `,
+      'src/view.ts': `
+        import { useGT } from './ordinary';
+        export const title = useGT()('Ordinary message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('keeps an ordinary React helper behind an incomplete alias silent', async () => {
+    const root = createFixture({
+      'vite.config.ts': `
+        import path from 'node:path';
+        const dynamicAliases = getAliases();
+        export default { resolve: { alias: {
+          '@app': path.resolve(__dirname, 'src/app.ts'),
+          ...dynamicAliases,
+        } } };
+      `,
+      'src/app.ts': `
+        export const useGT = () => (value: string) => value;
+      `,
+      'src/App.tsx': `
+        import { useGT } from '@app';
+        export function App() {
+          const gt = useGT();
+          return <h1>{gt('React-owned aliased message')}</h1>;
+        }
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('fails closed when an incomplete alias candidate proves gt-vue provenance', async () => {
+    const root = createFixture({
+      'vite.config.ts': `
+        import path from 'node:path';
+        const dynamicAliases = getAliases();
+        export default { resolve: { alias: {
+          '@i18n': path.resolve(__dirname, 'src/i18n.ts'),
+          ...dynamicAliases,
+        } } };
+      `,
+      'src/i18n.ts': "export { msg } from 'gt-vue';",
+      'src/message.ts': `
+        import { msg } from '@i18n';
+        export const message = msg('Vue-owned aliased message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve the Vue application module aliases'
+    );
+  });
+
+  it('keeps diagnostic alias candidates attached through transitive barrels', async () => {
+    const root = createFixture({
+      'vite.config.ts': `
+        import path from 'node:path';
+        export default { resolve: { alias: {
+          '#runtime': path.resolve(__dirname, 'src/runtime.ts'),
+          ...getAliases(),
+        } } };
+      `,
+      'src/runtime.ts': "export { msg } from 'gt-vue';",
+      'shared/barrel.ts': "export { msg as translate } from '#runtime';",
+      'src/message.ts': `
+        import { translate } from '../shared/barrel';
+        export const message = translate('Transitive aliased message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve the Vue application module aliases'
+    );
+  });
+});
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture({
+    'package.json': JSON.stringify({
+      name: 'alias-provenance-fixture',
+      private: true,
+      dependencies: {
+        'gt-react': '*',
+        'gt-vue': '*',
+      },
+    }),
+    'vite.config.ts': `
+      const createAliases = () => ({ '#i18n': './src/i18n' });
+      export default { resolve: { alias: createAliases() } };
+    `,
+    ...files,
+  });
+  temporaryDirectories.push(root);
+  return root;
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
@@ -383,6 +383,10 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         }),
         'packages/vue-wrapper/index.js':
           "export { T as WrapperT } from 'gt-vue';\n",
+        'src/App.ts': `
+          import { WrapperT } from '@fixture/vue-wrapper';
+          void WrapperT;
+        `,
       });
       linkWorkspaceBinding(
         root,
@@ -415,6 +419,10 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
       }),
       'packages/vue-wrapper/src/runtime.ts':
         "export { createGT } from 'gt-vue';\n",
+      'src/App.ts': `
+        import { createGT } from '@fixture/vue-wrapper/runtime';
+        void createGT;
+      `,
     });
     linkWorkspaceBinding(
       root,
@@ -491,8 +499,9 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         version: '1.0.0',
         devDependencies: { wrapper: 'workspace:*' },
       }),
-      'packages/middle/src/App.vue': translatableSfc(
-        'Development consumer message'
+      'packages/middle/src/App.vue': wrapperSfc(
+        'Development consumer message',
+        'wrapper'
       ),
     });
     linkWorkspaceBinding(root, '', 'middle', 'packages/middle');
@@ -635,16 +644,14 @@ import { WrapperT } from '@fixture/vue-wrapper';
           name: '@fixture/docs',
           dependencies: { '@fixture/vue-wrapper': specifier },
         }),
-        'apps/docs/src/App.vue': translatableSfc('Compatible wrapper version'),
+        'apps/docs/src/App.vue': wrapperSfc('Compatible wrapper version'),
       });
-      if (!specifier.startsWith('workspace:')) {
-        linkWorkspaceBinding(
-          root,
-          'apps/docs',
-          '@fixture/vue-wrapper',
-          'packages/vue-wrapper'
-        );
-      }
+      linkWorkspaceBinding(
+        root,
+        'apps/docs',
+        '@fixture/vue-wrapper',
+        'packages/vue-wrapper'
+      );
       linkInstalledVue(root);
 
       const output = await extractFromVueProject({ cwd: root });
@@ -720,9 +727,9 @@ import { WrapperT } from '@fixture/vue-wrapper';
           name: '@fixture/docs',
           dependencies: { '@fixture/vue-wrapper': specifier },
         }),
-        'apps/docs/src/App.vue': translatableSfc('Prerelease wrapper message'),
+        'apps/docs/src/App.vue': wrapperSfc('Prerelease wrapper message'),
       });
-      if (!specifier.startsWith('workspace:')) {
+      if (selected) {
         linkWorkspaceBinding(
           root,
           'apps/docs',
@@ -918,8 +925,16 @@ import { WrapperT } from '${bindingName}';
           name: '@fixture/docs',
           dependencies: { '@fixture/vue-wrapper': specifier },
         }),
-        'apps/docs/src/App.vue': translatableSfc('Path-selected wrapper'),
+        'apps/docs/src/App.vue': wrapperSfc('Path-selected wrapper'),
       });
+      if (selected) {
+        linkWorkspaceBinding(
+          root,
+          'apps/docs',
+          '@fixture/vue-wrapper',
+          'packages/vue-wrapper'
+        );
+      }
       linkInstalledVue(root);
 
       const output = await extractFromVueProject({ cwd: root });
@@ -1326,6 +1341,14 @@ function createFixture(files: Record<string, string>): string {
   const root = createProjectFixture(files);
   temporaryDirectories.push(root);
   return root;
+}
+
+function wrapperSfc(message: string, source = '@fixture/vue-wrapper'): string {
+  return `<script setup lang="ts">
+import { WrapperT } from '${source}';
+</script>
+<template><WrapperT>${message}</WrapperT></template>
+`;
 }
 
 function linkWorkspaceBinding(

--- a/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
@@ -7,7 +7,10 @@ import {
   readVueSfcExclusionPatterns,
 } from '../../inspect.js';
 import { extractFromVueProject } from '../../project.js';
-import { parseLocalDependencyPath } from '../project/manifest.js';
+import {
+  parseLocalDependencyPath,
+  resolveInstalledJavaScriptPackage,
+} from '../project/manifest.js';
 import {
   createProjectFixture,
   linkInstalledVue,
@@ -73,6 +76,128 @@ describe('detectVueProject', () => {
       expect(detectVueProject(root)).toBe(true);
     }
   );
+
+  it('honors an optional dependency that overrides the same required dependency', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'root-react-app',
+        dependencies: { 'gt-vue': '^1.0.0' },
+        optionalDependencies: { 'gt-vue': '^2.0.0' },
+      }),
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('rejects an installed optional dependency outside its declared range', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'root-react-app',
+        dependencies: { 'gt-vue': '^1.0.0' },
+        optionalDependencies: { 'gt-vue': '^2.0.0' },
+      }),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { import: './index.js' } },
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('rejects an installed required peer outside its declared range', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'root-react-library',
+        peerDependencies: { 'gt-vue': '^2.0.0' },
+      }),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { import: './index.js' } },
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it("uses an active Plug'n'Play API to locate import-only packages", () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'pnp-root',
+        dependencies: { '@fixture/vue-wrapper': '^1.0.0' },
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { import: './index.js' } },
+      }),
+      'packages/vue-wrapper/index.js': 'export const WrapperT = {}\n',
+      'node_modules/pnpapi/package.json': JSON.stringify({
+        name: 'pnpapi',
+        version: '1.0.0',
+        main: 'index.cjs',
+      }),
+      'node_modules/pnpapi/index.cjs': `
+        const path = require('node:path');
+        exports.resolveToUnqualified = (request, issuer) =>
+          request === '@fixture/vue-wrapper'
+            ? path.join(path.dirname(issuer), 'packages/vue-wrapper')
+            : null;
+      `,
+    });
+    const originalPnpDescriptor = Object.getOwnPropertyDescriptor(
+      process.versions,
+      'pnp'
+    );
+    Object.defineProperty(process.versions, 'pnp', {
+      configurable: true,
+      value: '3',
+    });
+
+    try {
+      expect(
+        resolveInstalledJavaScriptPackage(root, '@fixture/vue-wrapper')
+      ).toMatchObject({
+        directory: fs.realpathSync(path.join(root, 'packages/vue-wrapper')),
+        manifest: { name: '@fixture/vue-wrapper', version: '1.0.0' },
+      });
+    } finally {
+      if (originalPnpDescriptor) {
+        Object.defineProperty(process.versions, 'pnp', originalPnpDescriptor);
+      } else {
+        delete (process.versions as Record<string, string | undefined>).pnp;
+      }
+    }
+  });
+
+  it('does not fall through a malformed nearest installed package', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({ name: 'workspace-root' }),
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/vue-wrapper': '^1.0.0' },
+      }),
+      'apps/docs/node_modules/@fixture/vue-wrapper/package.json': '{broken',
+      'node_modules/@fixture/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+      }),
+    });
+
+    expect(
+      resolveInstalledJavaScriptPackage(
+        path.join(root, 'apps/docs'),
+        '@fixture/vue-wrapper'
+      )
+    ).toBeUndefined();
+  });
 
   it('does not let a workspace descendant select the root CLI mode', async () => {
     const root = createFixture({
@@ -177,6 +302,7 @@ ${translatableSfc('Text-prefixed workspace message')}`,
       'app.vue': translatableSfc('Aggregator root message'),
       'packages/vue-wrapper/package.json': JSON.stringify({
         name: '@fixture/vue-wrapper',
+        exports: './src/index.ts',
         dependencies: { 'gt-vue': 'workspace:*' },
       }),
       'packages/vue-wrapper/src/index.ts':
@@ -207,6 +333,7 @@ import { WrapperT } from '@fixture/vue-wrapper';
         name: '@fixture/root-vue-wrapper',
         private: true,
         workspaces: ['apps/*'],
+        exports: './src/index.ts',
         dependencies: { 'gt-vue': 'workspace:*' },
       }),
       'tsconfig.json': JSON.stringify({
@@ -251,8 +378,11 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         'packages/vue-wrapper/package.json': JSON.stringify({
           name: '@fixture/vue-wrapper',
           version: '1.0.0',
+          exports: { '.': { import: './index.js' } },
           dependencies: { 'gt-vue': 'workspace:*' },
         }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
       });
       linkWorkspaceBinding(
         root,
@@ -269,39 +399,76 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     }
   );
 
-  it('keeps a local development-only gt-vue owner scoped to itself', async () => {
+  it('detects a local wrapper whose gt-vue API is exposed by a wildcard subpath', () => {
     const root = createFixture({
       'package.json': JSON.stringify({
-        name: '@fixture/file-only-root',
+        name: '@fixture/docs',
         private: true,
         workspaces: ['packages/*'],
-        dependencies: { ordinary: 'workspace:*' },
+        dependencies: { '@fixture/vue-wrapper': 'workspace:*' },
       }),
-      'app.vue': translatableSfc('Unowned root message'),
-      'packages/ordinary/package.json': JSON.stringify({
-        name: 'ordinary',
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
         version: '1.0.0',
-        devDependencies: { 'gt-vue': '*' },
+        exports: { './*': { import: './src/*.ts' } },
+        dependencies: { 'gt-vue': 'workspace:*' },
       }),
-      'packages/ordinary/src/App.vue': translatableSfc(
-        'Development owner message'
-      ),
+      'packages/vue-wrapper/src/runtime.ts':
+        "export { createGT } from 'gt-vue';\n",
     });
-    linkWorkspaceBinding(root, '', 'ordinary', 'packages/ordinary');
-    linkInstalledVue(root);
+    linkWorkspaceBinding(
+      root,
+      '',
+      '@fixture/vue-wrapper',
+      'packages/vue-wrapper'
+    );
 
-    expect(detectVueProject(root)).toBe(false);
+    expect(detectVueProject(root)).toBe(true);
     expect(inspectVueProject(root)).toMatchObject({
-      rootOwnsVue: false,
+      rootOwnsVue: true,
       hasVueScopes: true,
     });
-    const output = await extractFromVueProject({ cwd: root });
-
-    expect(output.errors).toEqual([]);
-    expect(output.updates.map(({ source }) => source)).toEqual([
-      'Development owner message',
-    ]);
   });
+
+  it.each(['dependencies', 'devDependencies'] as const)(
+    'keeps a local gt-vue owner in %s scoped to itself when its public API is ordinary',
+    async (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: '@fixture/file-only-root',
+          private: true,
+          workspaces: ['packages/*'],
+          dependencies: { ordinary: 'workspace:*' },
+        }),
+        'app.vue': translatableSfc('Unowned root message'),
+        'packages/ordinary/package.json': JSON.stringify({
+          name: 'ordinary',
+          version: '1.0.0',
+          exports: './index.js',
+          [field]: { 'gt-vue': '*' },
+        }),
+        'packages/ordinary/index.js':
+          "export const ordinary = 'not a gt-vue reexport';\n",
+        'packages/ordinary/src/App.vue': translatableSfc(
+          'Direct owner message'
+        ),
+      });
+      linkWorkspaceBinding(root, '', 'ordinary', 'packages/ordinary');
+      linkInstalledVue(root);
+
+      expect(detectVueProject(root)).toBe(false);
+      expect(inspectVueProject(root)).toMatchObject({
+        rootOwnsVue: false,
+        hasVueScopes: true,
+      });
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual([
+        'Direct owner message',
+      ]);
+    }
+  );
 
   it('does not propagate a wrapper consumer reached only through a development edge', async () => {
     const root = createFixture({
@@ -315,8 +482,10 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
       'packages/wrapper/package.json': JSON.stringify({
         name: 'wrapper',
         version: '1.0.0',
+        exports: './index.js',
         dependencies: { 'gt-vue': '*' },
       }),
+      'packages/wrapper/index.js': "export { T as WrapperT } from 'gt-vue';\n",
       'packages/middle/package.json': JSON.stringify({
         name: 'middle',
         version: '1.0.0',
@@ -457,8 +626,11 @@ import { WrapperT } from '@fixture/vue-wrapper';
         'packages/vue-wrapper/package.json': JSON.stringify({
           name: '@fixture/vue-wrapper',
           version: '1.4.0',
+          exports: './index.js',
           dependencies: { 'gt-vue': 'workspace:*' },
         }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
         'apps/docs/package.json': JSON.stringify({
           name: '@fixture/docs',
           dependencies: { '@fixture/vue-wrapper': specifier },
@@ -539,8 +711,11 @@ import { WrapperT } from '@fixture/vue-wrapper';
         'packages/vue-wrapper/package.json': JSON.stringify({
           name: '@fixture/vue-wrapper',
           version: '1.0.0-beta.1',
+          exports: './index.js',
           dependencies: { 'gt-vue': 'workspace:*' },
         }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
         'apps/docs/package.json': JSON.stringify({
           name: '@fixture/docs',
           dependencies: { '@fixture/vue-wrapper': specifier },
@@ -730,8 +905,11 @@ import { WrapperT } from '${bindingName}';
         'packages/vue-wrapper/package.json': JSON.stringify({
           name: '@fixture/vue-wrapper',
           version: '1.0.0',
+          exports: './index.js',
           dependencies: { 'gt-vue': 'workspace:*' },
         }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
         'packages/other/package.json': JSON.stringify({
           name: '@fixture/other',
           version: '1.0.0',
@@ -820,6 +998,48 @@ import { WrapperT } from '${bindingName}';
     linkInstalledVue(root);
 
     expect(detectVueProject(root)).toBe(false);
+    await expect(extractFromVueProject({ cwd: root })).resolves.toEqual({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it('does not select workspace runtimes hidden by optional overrides or incompatible peers', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'react-workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'apps/optional/package.json': JSON.stringify({
+        name: 'optional-override-integration',
+        dependencies: { 'gt-vue': '^1.0.0' },
+        optionalDependencies: { 'gt-vue': '^2.0.0' },
+      }),
+      'apps/optional/src/App.vue': translatableSfc(
+        'Must stay optional after override'
+      ),
+      'apps/peer/package.json': JSON.stringify({
+        name: 'incompatible-peer-integration',
+        peerDependencies: { 'gt-vue': '^2.0.0' },
+      }),
+      'apps/peer/src/App.vue': translatableSfc(
+        'Must stay outside the peer range'
+      ),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': { import: './index.js' } },
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+
+    expect(inspectVueProject(root)).toMatchObject({
+      rootOwnsVue: false,
+      hasVueScopes: false,
+    });
     await expect(extractFromVueProject({ cwd: root })).resolves.toEqual({
       updates: [],
       errors: [],
@@ -1073,7 +1293,7 @@ import { WrapperT } from '${bindingName}';
     ]);
   });
 
-  it('does not load parser, compiler, or project extraction modules from /detect', () => {
+  it('does not load the Vue compiler or project extraction graph from /detect', () => {
     const detectEntry = path.resolve(__dirname, '../../detect.ts');
     const localGraph = collectLocalModuleGraph(detectEntry);
     const relativeGraph = [...localGraph].map((file) =>
@@ -1093,12 +1313,11 @@ import { WrapperT } from '${bindingName}';
     expect(relativeGraph).not.toEqual(
       expect.arrayContaining([
         expect.stringContaining('/config/'),
-        expect.stringContaining('/script/'),
         expect.stringContaining('/template/'),
       ])
     );
     expect(graphSource).not.toMatch(
-      /from ['"](?:@babel|@vue|fast-glob|yaml|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
+      /from ['"](?:@vue|fast-glob|yaml|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
     );
   });
 });

--- a/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
@@ -7,6 +7,7 @@ import {
   readVueSfcExclusionPatterns,
 } from '../../inspect.js';
 import { extractFromVueProject } from '../../project.js';
+import { parseLocalDependencyPath } from '../project/manifest.js';
 import {
   createProjectFixture,
   linkInstalledVue,
@@ -64,7 +65,7 @@ describe('detectVueProject', () => {
           name: 'gt-vue',
           version: '0.1.0',
           type: 'module',
-          main: 'index.js',
+          exports: { '.': { import: './index.js' } },
         }),
         'node_modules/gt-vue/index.js': 'export const T = {}\n',
       });
@@ -237,6 +238,181 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     ]);
   });
 
+  it.each(['dependencies', 'devDependencies'] as const)(
+    'detects a root that consumes a local gt-vue wrapper through %s',
+    (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: '@fixture/docs',
+          private: true,
+          workspaces: ['packages/*'],
+          [field]: { '@fixture/vue-wrapper': 'workspace:*' },
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.0.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+      });
+      linkWorkspaceBinding(
+        root,
+        '',
+        '@fixture/vue-wrapper',
+        'packages/vue-wrapper'
+      );
+
+      expect(detectVueProject(root)).toBe(true);
+      expect(inspectVueProject(root)).toMatchObject({
+        rootOwnsVue: true,
+        hasVueScopes: true,
+      });
+    }
+  );
+
+  it('keeps a local development-only gt-vue owner scoped to itself', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/file-only-root',
+        private: true,
+        workspaces: ['packages/*'],
+        dependencies: { ordinary: 'workspace:*' },
+      }),
+      'app.vue': translatableSfc('Unowned root message'),
+      'packages/ordinary/package.json': JSON.stringify({
+        name: 'ordinary',
+        version: '1.0.0',
+        devDependencies: { 'gt-vue': '*' },
+      }),
+      'packages/ordinary/src/App.vue': translatableSfc(
+        'Development owner message'
+      ),
+    });
+    linkWorkspaceBinding(root, '', 'ordinary', 'packages/ordinary');
+    linkInstalledVue(root);
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      rootOwnsVue: false,
+      hasVueScopes: true,
+    });
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Development owner message',
+    ]);
+  });
+
+  it('does not propagate a wrapper consumer reached only through a development edge', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/file-only-root',
+        private: true,
+        workspaces: ['packages/*'],
+        dependencies: { middle: 'workspace:*' },
+      }),
+      'app.vue': translatableSfc('Unowned root message'),
+      'packages/wrapper/package.json': JSON.stringify({
+        name: 'wrapper',
+        version: '1.0.0',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/middle/package.json': JSON.stringify({
+        name: 'middle',
+        version: '1.0.0',
+        devDependencies: { wrapper: 'workspace:*' },
+      }),
+      'packages/middle/src/App.vue': translatableSfc(
+        'Development consumer message'
+      ),
+    });
+    linkWorkspaceBinding(root, '', 'middle', 'packages/middle');
+    linkWorkspaceBinding(
+      root,
+      'packages/middle',
+      'wrapper',
+      'packages/wrapper'
+    );
+    linkInstalledVue(root);
+
+    expect(detectVueProject(root)).toBe(false);
+    expect(inspectVueProject(root)).toMatchObject({
+      rootOwnsVue: false,
+      hasVueScopes: true,
+    });
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Development consumer message',
+    ]);
+  });
+
+  it.each(['file:', 'link:', 'portal:'])(
+    'extracts a root that consumes an explicit %s wrapper outside workspaces',
+    async (protocol) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: '@fixture/docs',
+          private: true,
+          dependencies: {
+            '@fixture/vue-wrapper': `${protocol}./vendor/vue-wrapper`,
+          },
+        }),
+        'vendor/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.0.0',
+          dependencies: { 'gt-vue': '*' },
+        }),
+        'vendor/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
+        'src/App.vue': `<script setup>
+import { WrapperT } from '@fixture/vue-wrapper';
+</script>
+<template><WrapperT>Local wrapper root message</WrapperT></template>`,
+      });
+      linkWorkspaceBinding(
+        root,
+        '',
+        '@fixture/vue-wrapper',
+        'vendor/vue-wrapper'
+      );
+      linkInstalledVue(root);
+
+      expect(detectVueProject(root)).toBe(true);
+      expect(inspectVueProject(root)).toMatchObject({
+        rootOwnsVue: true,
+        hasVueScopes: true,
+      });
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual([
+        'Local wrapper root message',
+      ]);
+    }
+  );
+
+  it.each(['dependencies', 'devDependencies'] as const)(
+    'does not classify a root from an external package %s on gt-vue',
+    (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'file-only-root',
+          dependencies: { ordinary: '1.0.0' },
+        }),
+        'node_modules/ordinary/package.json': JSON.stringify({
+          name: 'ordinary',
+          version: '1.0.0',
+          [field]: { 'gt-vue': '1.0.0' },
+        }),
+        'node_modules/ordinary/index.js': 'export const ordinary = true;\n',
+      });
+
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
+
   it('does not select consumers whose range excludes the local wrapper', async () => {
     const root = createFixture({
       'package.json': JSON.stringify({
@@ -262,7 +438,14 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     expect(output).toEqual({ updates: [], errors: [], warnings: [] });
   });
 
-  it.each(['^1.0.0', 'workspace:^', 'workspace:*'])(
+  it.each([
+    '^1.0.0',
+    'latest',
+    'workspace:^',
+    'workspace:*',
+    'workspace:',
+    'workspace:latest',
+  ])(
     'selects a consumer whose %s range includes the local wrapper',
     async (specifier) => {
       const root = createFixture({
@@ -282,6 +465,14 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         }),
         'apps/docs/src/App.vue': translatableSfc('Compatible wrapper version'),
       });
+      if (!specifier.startsWith('workspace:')) {
+        linkWorkspaceBinding(
+          root,
+          'apps/docs',
+          '@fixture/vue-wrapper',
+          'packages/vue-wrapper'
+        );
+      }
       linkInstalledVue(root);
 
       const output = await extractFromVueProject({ cwd: root });
@@ -293,8 +484,47 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     }
   );
 
+  it('does not select a compatible bare range without an installed local binding', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.4.0',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/vue-wrapper': '^1.0.0' },
+      }),
+      'apps/docs/src/App.vue': translatableSfc(
+        'Registry-selected wrapper version'
+      ),
+      'apps/docs/node_modules/@fixture/vue-wrapper/package.json':
+        JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.4.0',
+          type: 'module',
+          exports: './index.js',
+        }),
+      'apps/docs/node_modules/@fixture/vue-wrapper/index.js':
+        "export { T as WrapperT } from 'gt-vue';\n",
+    });
+    linkInstalledVue(root);
+
+    await expect(extractFromVueProject({ cwd: root })).resolves.toEqual({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+  });
+
   it.each([
     ['*', false],
+    ['>=0.0.0', false],
     ['^1.0.0-beta.1', true],
     ['workspace:*', true],
   ])(
@@ -317,6 +547,14 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         }),
         'apps/docs/src/App.vue': translatableSfc('Prerelease wrapper message'),
       });
+      if (!specifier.startsWith('workspace:')) {
+        linkWorkspaceBinding(
+          root,
+          'apps/docs',
+          '@fixture/vue-wrapper',
+          'packages/vue-wrapper'
+        );
+      }
       linkInstalledVue(root);
 
       const output = await extractFromVueProject({ cwd: root });
@@ -325,6 +563,152 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
       expect(output.updates.map(({ source }) => source)).toEqual(
         selected ? ['Prerelease wrapper message'] : []
       );
+    }
+  );
+
+  it.each([
+    ['vue-alias', 'workspace:@fixture/vue-wrapper@*', true],
+    ['@fixture/vue-alias', 'workspace:@fixture/vue-wrapper@^1.0.0', true],
+    ['relative-alias', 'workspace:../../packages/vue-wrapper', true],
+    ['tagged-alias', 'workspace:@fixture/vue-wrapper@latest', true],
+    ['stale-alias', 'workspace:@fixture/vue-wrapper@^2.0.0', false],
+  ])(
+    'selects a consumer of workspace alias %s',
+    async (bindingName, specifier, selected) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+          workspaces: ['packages/*', 'apps/*'],
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.4.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { [bindingName]: specifier },
+        }),
+        'apps/docs/src/App.vue': `<script setup>
+import { WrapperT } from '${bindingName}';
+</script>
+<template><WrapperT>Workspace alias message</WrapperT></template>`,
+      });
+      linkWorkspaceBinding(
+        root,
+        'apps/docs',
+        bindingName,
+        'packages/vue-wrapper'
+      );
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual(
+        selected ? ['Workspace alias message'] : []
+      );
+    }
+  );
+
+  it.each([
+    ['npm:@fixture/vue-wrapper@^1.0.0', true],
+    ['npm:@fixture/vue-wrapper', true],
+    ['npm:@fixture/vue-wrapper@latest', true],
+    ['npm:@fixture/vue-wrapper@^2.0.0', false],
+  ])(
+    'validates the installed npm alias range %s',
+    async (specifier, selected) => {
+      const bindingName = 'vue-alias';
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+          workspaces: ['packages/*', 'apps/*'],
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.4.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { [bindingName]: specifier },
+        }),
+        'apps/docs/src/App.vue': `<script setup>
+import { WrapperT } from '${bindingName}';
+</script>
+<template><WrapperT>Npm alias message</WrapperT></template>`,
+      });
+      linkWorkspaceBinding(
+        root,
+        'apps/docs',
+        bindingName,
+        'packages/vue-wrapper'
+      );
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual(
+        selected ? ['Npm alias message'] : []
+      );
+    }
+  );
+
+  it.each([
+    ['@fixture/vue-wrapper', "'@fixture/vue-wrapper': ^1.0.0"],
+    ['vue-alias', 'vue-alias: npm:@fixture/vue-wrapper@^1.0.0'],
+  ])(
+    'selects the local catalog binding %s',
+    async (bindingName, catalogEntry) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+        }),
+        'pnpm-workspace.yaml': `packages:
+  - 'packages/*'
+  - 'apps/*'
+catalog:
+  ${catalogEntry}
+`,
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.4.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'packages/vue-wrapper/index.js':
+          "export { T as WrapperT } from 'gt-vue';\n",
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { [bindingName]: 'catalog:' },
+        }),
+        'apps/docs/src/App.vue': `<script setup>
+import { WrapperT } from '${bindingName}';
+</script>
+<template><WrapperT>Catalog-selected wrapper</WrapperT></template>`,
+      });
+      linkWorkspaceBinding(
+        root,
+        'apps/docs',
+        bindingName,
+        'packages/vue-wrapper'
+      );
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual([
+        'Catalog-selected wrapper',
+      ]);
     }
   );
 
@@ -384,11 +768,26 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         dependencies: { 'gt-vue': 'workspace:*' },
       }),
     });
+    linkWorkspaceBinding(
+      root,
+      '',
+      '@fixture/vue-wrapper',
+      'packages/vue-wrapper'
+    );
     linkInstalledVue(root);
 
+    expect(detectVueProject(root)).toBe(false);
     const output = await extractFromVueProject({ cwd: root });
 
     expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it.each([
+    ['workspace:.', '.'],
+    ['workspace:..', '..'],
+    ['workspace:../wrapper', '../wrapper'],
+  ])('parses the local workspace path %s', (specifier, localPath) => {
+    expect(parseLocalDependencyPath(specifier)).toBe(localPath);
   });
 
   it('does not select installed optional Vue workspace integrations', async () => {
@@ -414,7 +813,7 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
         name: 'gt-vue',
         version: '0.1.0',
         type: 'module',
-        main: 'index.js',
+        exports: { '.': { import: './index.js' } },
       }),
       'node_modules/gt-vue/index.js': 'export const T = {}\n',
     });
@@ -470,7 +869,8 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
       'packages/vue-wrapper/package.json': JSON.stringify({
         name: '@fixture/vue-wrapper',
         version: '1.0.0',
-        main: 'index.js',
+        type: 'module',
+        exports: { '.': { import: './index.js' } },
         dependencies: { 'gt-vue': '*' },
       }),
       'packages/vue-wrapper/index.js':
@@ -494,6 +894,78 @@ import { WrapperT } from '@fixture/vue-wrapper';
     expect(output.errors).toEqual([]);
     expect(output.updates.map(({ source }) => source)).toEqual([
       'Required wrapper peer message',
+    ]);
+  });
+
+  it('rejects an installed local wrapper outside a required peer range', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        peerDependencies: { '@fixture/vue-wrapper': '^2.0.0' },
+      }),
+      'apps/docs/src/App.vue': translatableSfc(
+        'Incompatible required wrapper peer'
+      ),
+    });
+    linkWorkspaceBinding(
+      root,
+      '',
+      '@fixture/vue-wrapper',
+      'packages/vue-wrapper'
+    );
+    linkInstalledVue(root);
+
+    await expect(extractFromVueProject({ cwd: root })).resolves.toEqual({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it('selects an installed required peer through a workspace alias', async () => {
+    const bindingName = 'vue-peer-alias';
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/vue-wrapper/index.js':
+        "export { T as WrapperT } from 'gt-vue';\n",
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        peerDependencies: {
+          [bindingName]: 'workspace:@fixture/vue-wrapper@*',
+        },
+      }),
+      'apps/docs/src/App.vue': `<script setup>
+import { WrapperT } from '${bindingName}';
+</script>
+<template><WrapperT>Required peer alias message</WrapperT></template>`,
+    });
+    linkWorkspaceBinding(root, '', bindingName, 'packages/vue-wrapper');
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Required peer alias message',
     ]);
   });
 
@@ -626,7 +1098,7 @@ import { WrapperT } from '@fixture/vue-wrapper';
       ])
     );
     expect(graphSource).not.toMatch(
-      /from ['"](?:@babel|@vue|fast-glob|semver|yaml|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
+      /from ['"](?:@babel|@vue|fast-glob|yaml|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
     );
   });
 });
@@ -635,6 +1107,22 @@ function createFixture(files: Record<string, string>): string {
   const root = createProjectFixture(files);
   temporaryDirectories.push(root);
   return root;
+}
+
+function linkWorkspaceBinding(
+  root: string,
+  consumerDirectory: string,
+  bindingName: string,
+  targetDirectory: string
+): void {
+  const destination = path.join(
+    root,
+    consumerDirectory,
+    'node_modules',
+    ...bindingName.split('/')
+  );
+  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  fs.symlinkSync(path.join(root, targetDirectory), destination, 'dir');
 }
 
 function collectLocalModuleGraph(entry: string): Set<string> {

--- a/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
@@ -2,6 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { detectVueProject } from '../../detect.js';
+import {
+  inspectVueProject,
+  readVueSfcExclusionPatterns,
+} from '../../inspect.js';
 import { extractFromVueProject } from '../../project.js';
 import {
   createProjectFixture,
@@ -20,32 +24,56 @@ afterEach(() => {
 });
 
 describe('detectVueProject', () => {
-  it.each([
-    'dependencies',
-    'devDependencies',
-    'optionalDependencies',
-    'peerDependencies',
-  ] as const)('detects a root declaration in %s', (field) => {
-    const root = createFixture({
-      'package.json': JSON.stringify({
-        name: 'root-vue-app',
-        [field]: { 'gt-vue': 'workspace:*' },
-      }),
-    });
+  it.each(['dependencies', 'devDependencies'] as const)(
+    'detects an installed root declaration in %s',
+    (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'root-vue-app',
+          [field]: { 'gt-vue': 'workspace:*' },
+        }),
+      });
 
-    expect(detectVueProject(root)).toBe(true);
-  });
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
 
-  it('fails safely for missing and malformed project manifests', () => {
-    const missing = createFixture({});
-    const malformed = createFixture({ 'package.json': '{not-json' });
+  it.each(['optionalDependencies', 'peerDependencies'] as const)(
+    'does not treat an unresolved %s declaration as an installed Vue application',
+    (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'root-vue-library',
+          [field]: { 'gt-vue': 'workspace:*' },
+        }),
+      });
 
-    expect(detectVueProject(missing)).toBe(false);
-    expect(detectVueProject(malformed)).toBe(false);
-    expect(detectVueProject(path.join(missing, 'does-not-exist'))).toBe(false);
-  });
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
 
-  it('detects a workspace-only Vue app without selecting the aggregator root', async () => {
+  it.each(['optionalDependencies', 'peerDependencies'] as const)(
+    'detects a resolvable root declaration in %s',
+    (field) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'root-vue-library',
+          [field]: { 'gt-vue': '*' },
+        }),
+        'node_modules/gt-vue/package.json': JSON.stringify({
+          name: 'gt-vue',
+          version: '0.1.0',
+          type: 'module',
+          main: 'index.js',
+        }),
+        'node_modules/gt-vue/index.js': 'export const T = {}\n',
+      });
+
+      expect(detectVueProject(root)).toBe(true);
+    }
+  );
+
+  it('does not let a workspace descendant select the root CLI mode', async () => {
     const root = createFixture({
       'package.json': JSON.stringify({
         name: 'workspace-root',
@@ -61,13 +89,73 @@ describe('detectVueProject', () => {
     });
     linkInstalledVue(root);
 
-    expect(detectVueProject(root)).toBe(true);
-    const output = await extractFromVueProject({ cwd: root });
+    expect(detectVueProject(root)).toBe(false);
+    const inspection = inspectVueProject(root);
+    expect(inspection).toMatchObject({
+      projectRoot: fs.realpathSync(root),
+      rootOwnsVue: false,
+      hasVueScopes: true,
+    });
+    fs.writeFileSync(path.join(root, 'package.json'), '{changed-after-plan');
+    const output = await extractFromVueProject({ cwd: root, inspection });
 
     expect(output.errors).toEqual([]);
     expect(output.updates.map(({ source }) => source)).toEqual([
       'Workspace message',
     ]);
+  });
+
+  it('partitions real child SFCs without hiding legacy JSX .vue modules', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'src/Legacy.vue': `
+        import { T } from 'gt-react';
+        export const legacy = <T>Legacy React module</T>;
+      `,
+      'apps/vue/package.json': JSON.stringify({
+        name: 'workspace-vue-app',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'apps/vue/src/App.vue': translatableSfc('Workspace message'),
+      'apps/vue/src/Localized.vue': `<i18n lang="json">
+{"en":{"title":"Localized"}}
+</i18n>
+${translatableSfc('Custom-block workspace message')}`,
+      'apps/vue/src/TextPrefixed.vue': `Copyright Fixture
+${translatableSfc('Text-prefixed workspace message')}`,
+    });
+
+    const inspection = inspectVueProject(root);
+
+    const exclusions = readVueSfcExclusionPatterns(inspection, [
+      'src/Legacy.vue',
+      'apps/vue/src/App.vue',
+      'apps/vue/src/Localized.vue',
+      'apps/vue/src/TextPrefixed.vue',
+    ]).map((pattern) => pattern.split(path.sep).join(path.posix.sep));
+    const normalizedRoot = fs
+      .realpathSync(root)
+      .split(path.sep)
+      .join(path.posix.sep);
+
+    expect(exclusions).toEqual([
+      `!${normalizedRoot}/apps/vue/src/App.vue`,
+      `!${normalizedRoot}/apps/vue/src/Localized.vue`,
+      `!${normalizedRoot}/apps/vue/src/TextPrefixed.vue`,
+    ]);
+  });
+
+  it('fails safely for missing and malformed project manifests', () => {
+    const missing = createFixture({});
+    const malformed = createFixture({ 'package.json': '{not-json' });
+
+    expect(detectVueProject(missing)).toBe(false);
+    expect(detectVueProject(malformed)).toBe(false);
+    expect(detectVueProject(path.join(missing, 'does-not-exist'))).toBe(false);
   });
 
   it('selects reverse consumers of a local wrapper while excluding the root', async () => {
@@ -146,6 +234,266 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     expect(output.errors).toEqual([]);
     expect(output.updates.map(({ source }) => source)).toEqual([
       'Root wrapper consumer',
+    ]);
+  });
+
+  it('does not select consumers whose range excludes the local wrapper', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/vue-wrapper': '^2.0.0' },
+      }),
+      'apps/docs/src/App.vue': translatableSfc('Wrong wrapper version'),
+    });
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it.each(['^1.0.0', 'workspace:^', 'workspace:*'])(
+    'selects a consumer whose %s range includes the local wrapper',
+    async (specifier) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+          workspaces: ['packages/*', 'apps/*'],
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.4.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { '@fixture/vue-wrapper': specifier },
+        }),
+        'apps/docs/src/App.vue': translatableSfc('Compatible wrapper version'),
+      });
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual([
+        'Compatible wrapper version',
+      ]);
+    }
+  );
+
+  it.each([
+    ['*', false],
+    ['^1.0.0-beta.1', true],
+    ['workspace:*', true],
+  ])(
+    'matches prerelease wrappers against %s like the workspace resolver',
+    async (specifier, selected) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+          workspaces: ['packages/*', 'apps/*'],
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.0.0-beta.1',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { '@fixture/vue-wrapper': specifier },
+        }),
+        'apps/docs/src/App.vue': translatableSfc('Prerelease wrapper message'),
+      });
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual(
+        selected ? ['Prerelease wrapper message'] : []
+      );
+    }
+  );
+
+  it.each([
+    ['file:../../packages/vue-wrapper', true],
+    ['link:../../packages/vue-wrapper', true],
+    ['portal:../../packages/vue-wrapper', true],
+    ['workspace:../../packages/vue-wrapper', true],
+    ['file:../../packages/other', false],
+  ])(
+    'resolves a %s wrapper path to its exact workspace',
+    async (specifier, selected) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          name: 'workspace-root',
+          private: true,
+          workspaces: ['packages/*', 'apps/*'],
+        }),
+        'packages/vue-wrapper/package.json': JSON.stringify({
+          name: '@fixture/vue-wrapper',
+          version: '1.0.0',
+          dependencies: { 'gt-vue': 'workspace:*' },
+        }),
+        'packages/other/package.json': JSON.stringify({
+          name: '@fixture/other',
+          version: '1.0.0',
+        }),
+        'apps/docs/package.json': JSON.stringify({
+          name: '@fixture/docs',
+          dependencies: { '@fixture/vue-wrapper': specifier },
+        }),
+        'apps/docs/src/App.vue': translatableSfc('Path-selected wrapper'),
+      });
+      linkInstalledVue(root);
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.errors).toEqual([]);
+      expect(output.updates.map(({ source }) => source)).toEqual(
+        selected ? ['Path-selected wrapper'] : []
+      );
+    }
+  );
+
+  it('does not select a root consumer whose range excludes the local wrapper', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*'],
+        dependencies: { '@fixture/vue-wrapper': '^2.0.0' },
+      }),
+      'app.vue': translatableSfc('Incompatible root consumer'),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+    });
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('does not select installed optional Vue workspace integrations', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'react-workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'apps/optional/package.json': JSON.stringify({
+        name: 'optional-vue-integration',
+        optionalDependencies: { 'gt-vue': '*' },
+        peerDependencies: { vue: '^3.5.0' },
+      }),
+      'apps/optional/src/App.vue': translatableSfc('Must stay optional'),
+      'apps/peer/package.json': JSON.stringify({
+        name: 'peer-vue-integration',
+        peerDependencies: { 'gt-vue': '*', vue: '^3.5.0' },
+        peerDependenciesMeta: { 'gt-vue': { optional: true } },
+      }),
+      'apps/peer/src/App.vue': translatableSfc('Must stay a peer'),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '0.1.0',
+        type: 'module',
+        main: 'index.js',
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+    linkInstalledVue(root);
+
+    expect(detectVueProject(root)).toBe(false);
+    await expect(extractFromVueProject({ cwd: root })).resolves.toEqual({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+  });
+
+  it('selects a workspace with an installed required gt-vue peer', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'react-workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'apps/vue-peer/package.json': JSON.stringify({
+        name: 'required-vue-peer',
+        peerDependencies: { 'gt-vue': '*', vue: '^3.5.0' },
+      }),
+      'apps/vue-peer/src/App.vue': translatableSfc(
+        'Installed required peer message'
+      ),
+      'node_modules/gt-vue/package.json': JSON.stringify({
+        name: 'gt-vue',
+        version: '0.1.0',
+        type: 'module',
+        main: 'index.js',
+      }),
+      'node_modules/gt-vue/index.js': 'export const T = {}\n',
+    });
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Installed required peer message',
+    ]);
+  });
+
+  it('selects a workspace with an installed required wrapper peer', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        version: '1.0.0',
+        main: 'index.js',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/vue-wrapper/index.js':
+        "export { T as WrapperT } from 'gt-vue';\n",
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        peerDependencies: { '@fixture/vue-wrapper': '^1.0.0' },
+      }),
+      'apps/docs/src/App.vue': `<script setup>
+import { WrapperT } from '@fixture/vue-wrapper';
+</script>
+<template><WrapperT>Required wrapper peer message</WrapperT></template>`,
+    });
+    const wrapperLink = path.join(root, 'node_modules/@fixture/vue-wrapper');
+    fs.mkdirSync(path.dirname(wrapperLink), { recursive: true });
+    fs.symlinkSync(path.join(root, 'packages/vue-wrapper'), wrapperLink, 'dir');
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Required wrapper peer message',
     ]);
   });
 
@@ -244,7 +592,7 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     });
     linkInstalledVue(root);
 
-    expect(detectVueProject(root)).toBe(true);
+    expect(detectVueProject(root)).toBe(false);
     const output = await extractFromVueProject({ cwd: root });
 
     expect(output.errors).toEqual([]);
@@ -266,13 +614,19 @@ import { WrapperT } from '@fixture/root-vue-wrapper';
     expect(relativeGraph).not.toContain('project.ts');
     expect(relativeGraph).not.toEqual(
       expect.arrayContaining([
+        expect.stringContaining('/scopes.ts'),
+        expect.stringContaining('/workspaces.ts'),
+      ])
+    );
+    expect(relativeGraph).not.toEqual(
+      expect.arrayContaining([
         expect.stringContaining('/config/'),
         expect.stringContaining('/script/'),
         expect.stringContaining('/template/'),
       ])
     );
     expect(graphSource).not.toMatch(
-      /from ['"](?:@babel|@vue|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
+      /from ['"](?:@babel|@vue|fast-glob|semver|yaml|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
     );
   });
 });

--- a/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectDetection.test.ts
@@ -1,0 +1,305 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { detectVueProject } from '../../detect.js';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  linkInstalledVue,
+  removeProjectFixture,
+  translatableSfc,
+  writePackageJson,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('detectVueProject', () => {
+  it.each([
+    'dependencies',
+    'devDependencies',
+    'optionalDependencies',
+    'peerDependencies',
+  ] as const)('detects a root declaration in %s', (field) => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'root-vue-app',
+        [field]: { 'gt-vue': 'workspace:*' },
+      }),
+    });
+
+    expect(detectVueProject(root)).toBe(true);
+  });
+
+  it('fails safely for missing and malformed project manifests', () => {
+    const missing = createFixture({});
+    const malformed = createFixture({ 'package.json': '{not-json' });
+
+    expect(detectVueProject(missing)).toBe(false);
+    expect(detectVueProject(malformed)).toBe(false);
+    expect(detectVueProject(path.join(missing, 'does-not-exist'))).toBe(false);
+  });
+
+  it('detects a workspace-only Vue app without selecting the aggregator root', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'app.vue': translatableSfc('Root must stay out'),
+      'apps/vue/package.json': JSON.stringify({
+        name: 'workspace-vue-app',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'apps/vue/src/App.vue': translatableSfc('Workspace message'),
+    });
+    linkInstalledVue(root);
+
+    expect(detectVueProject(root)).toBe(true);
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Workspace message',
+    ]);
+  });
+
+  it('selects reverse consumers of a local wrapper while excluding the root', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*', 'apps/*'],
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@fixture/vue-wrapper': ['packages/vue-wrapper/src/index.ts'],
+          },
+        },
+      }),
+      'app.vue': translatableSfc('Aggregator root message'),
+      'packages/vue-wrapper/package.json': JSON.stringify({
+        name: '@fixture/vue-wrapper',
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'packages/vue-wrapper/src/index.ts':
+        "export { T as WrapperT } from 'gt-vue';\n",
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/vue-wrapper': 'workspace:*' },
+      }),
+      'apps/docs/src/App.vue': `<script setup lang="ts">
+import { WrapperT } from '@fixture/vue-wrapper';
+</script>
+<template><WrapperT>Wrapper consumer</WrapperT></template>
+`,
+    });
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Wrapper consumer',
+    ]);
+  });
+
+  it('selects workspace consumers when the root package is the gt-vue wrapper', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/root-vue-wrapper',
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-vue': 'workspace:*' },
+      }),
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: {
+            '@fixture/root-vue-wrapper': ['src/index.ts'],
+          },
+        },
+      }),
+      'src/index.ts': "export { T as WrapperT } from 'gt-vue';\n",
+      'apps/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        dependencies: { '@fixture/root-vue-wrapper': 'workspace:*' },
+      }),
+      'apps/docs/src/App.vue': `<script setup lang="ts">
+import { WrapperT } from '@fixture/root-vue-wrapper';
+</script>
+<template><WrapperT>Root wrapper consumer</WrapperT></template>
+`,
+    });
+    linkInstalledVue(root);
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Root wrapper consumer',
+    ]);
+  });
+
+  it('treats a valid pnpm workspace file as authoritative', () => {
+    const emptyPnpmRoot = createFixture({
+      'package.json': JSON.stringify({
+        private: true,
+        workspaces: ['stale'],
+      }),
+      'pnpm-workspace.yaml': 'packages: []\n',
+      'stale/package.json': JSON.stringify({
+        name: 'stale-vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    const excludedPnpmRoot = createFixture({
+      'package.json': JSON.stringify({
+        private: true,
+        workspaces: ['packages/*'],
+      }),
+      'pnpm-workspace.yaml':
+        "packages:\n  - 'packages/*'\n  - '!packages/excluded'\n",
+      'packages/excluded/package.json': JSON.stringify({
+        name: 'excluded-vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/ordinary/package.json': JSON.stringify({
+        name: 'ordinary-package',
+      }),
+    });
+
+    expect(detectVueProject(emptyPnpmRoot)).toBe(false);
+    expect(detectVueProject(excludedPnpmRoot)).toBe(false);
+  });
+
+  it.each([
+    ['malformed YAML', 'packages: [\n'],
+    ['invalid packages shape', 'packages: stale\n'],
+  ])(
+    'does not fall back to package.json workspaces for %s in pnpm-workspace.yaml',
+    (_name, workspaceFile) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          private: true,
+          workspaces: ['stale'],
+        }),
+        'pnpm-workspace.yaml': workspaceFile,
+        'stale/package.json': JSON.stringify({
+          name: 'stale-vue-app',
+          dependencies: { 'gt-vue': '*' },
+        }),
+      });
+
+      expect(detectVueProject(root)).toBe(false);
+    }
+  );
+
+  it('rejects workspace patterns that could escape the project root', () => {
+    const outside = createFixture({
+      'package.json': JSON.stringify({
+        name: 'outside-vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    const root = createFixture({});
+    const outsideName = path.basename(outside);
+    writePackageJson(root, '', {
+      name: 'workspace-root',
+      private: true,
+      workspaces: [
+        `../${outsideName}`,
+        `{packages/safe,../${outsideName}}`,
+        '/tmp/**',
+        'C:\\outside\\*',
+        42,
+      ],
+    });
+
+    expect(detectVueProject(root)).toBe(false);
+  });
+
+  it('escapes glob metacharacters in discovered package directories', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*'],
+      }),
+      'packages/vue[docs]/package.json': JSON.stringify({
+        name: '@fixture/vue-docs',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'packages/vue[docs]/app.vue': translatableSfc(
+        'Literal bracket directory'
+      ),
+    });
+    linkInstalledVue(root);
+
+    expect(detectVueProject(root)).toBe(true);
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Literal bracket directory',
+    ]);
+  });
+
+  it('does not load parser, compiler, or project extraction modules from /detect', () => {
+    const detectEntry = path.resolve(__dirname, '../../detect.ts');
+    const localGraph = collectLocalModuleGraph(detectEntry);
+    const relativeGraph = [...localGraph].map((file) =>
+      path.relative(path.resolve(__dirname, '../..'), file)
+    );
+    const graphSource = [...localGraph]
+      .map((file) => fs.readFileSync(file, 'utf8'))
+      .join('\n');
+
+    expect(relativeGraph).not.toContain('project.ts');
+    expect(relativeGraph).not.toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('/config/'),
+        expect.stringContaining('/script/'),
+        expect.stringContaining('/template/'),
+      ])
+    );
+    expect(graphSource).not.toMatch(
+      /from ['"](?:@babel|@vue|#vue-compiler-sfc|\.\/internal\/extractFromVueSource)/
+    );
+  });
+});
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function collectLocalModuleGraph(entry: string): Set<string> {
+  const visited = new Set<string>();
+  const pending = [entry];
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (!file || visited.has(file)) continue;
+    visited.add(file);
+    const source = fs.readFileSync(file, 'utf8');
+    for (const match of source.matchAll(/from\s+['"](\.[^'"]+)['"]/g)) {
+      const specifier = match[1];
+      if (!specifier) continue;
+      const resolved = path.resolve(
+        path.dirname(file),
+        specifier.replace(/\.js$/, '.ts')
+      );
+      if (fs.existsSync(resolved)) pending.push(resolved);
+    }
+  }
+  return visited;
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
@@ -615,6 +615,29 @@ import { LocalT } from '@local/gt';
     ]);
   });
 
+  it('follows a package self-reference whose emitted export has only TypeScript source', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/self-vue-app',
+        private: true,
+        dependencies: { 'gt-vue': 'workspace:*', vue: '^3.5.0' },
+        exports: { './runtime': './dist/runtime.js' },
+      }),
+      'dist/runtime.ts': "export { T as LocalT } from 'gt-vue';\n",
+      'src/App.tsx': `
+        import { LocalT } from '@fixture/self-vue-app/runtime';
+        export const App = () => <LocalT>Self-reference message</LocalT>;
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Self-reference message',
+    ]);
+  });
+
   it('establishes provenance through a static Vite alias before extraction', async () => {
     const root = createVueFixture({
       'vite.config.ts': `

--- a/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
@@ -61,6 +61,71 @@ describe('extractFromVueProject', () => {
     ]);
   });
 
+  it('ignores a script module explicitly selected with a .vue filename', async () => {
+    const root = createVueFixture({
+      'src/Legacy.vue': `
+        import { T } from 'gt-react';
+        export const legacy = <T>Legacy React module</T>;
+      `,
+    });
+
+    await expect(
+      extractFromVueProject({
+        cwd: root,
+        filePatterns: ['src/Legacy.vue'],
+      })
+    ).resolves.toEqual({ updates: [], errors: [], warnings: [] });
+  });
+
+  it('extracts an SFC whose standard blocks follow a custom block', async () => {
+    const root = createVueFixture({
+      'src/Localized.vue': `<i18n lang="json">
+{"en":{"title":"Localized"}}
+</i18n>
+${translatableSfc('Message after custom block')}`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Message after custom block',
+    ]);
+  });
+
+  it.each([
+    ['block comment', '/* Copyright Fixture */'],
+    ['line comment', '// Copyright Fixture'],
+    ['doctype', '<!DOCTYPE html>'],
+    ['plain text', 'Copyright Fixture'],
+    ['markdown frontmatter', '---\ntitle: Fixture\n---'],
+    ['shebang', '#!/usr/bin/env vue'],
+  ])('extracts an SFC after a leading %s', async (_name, prelude) => {
+    const root = createVueFixture({
+      'src/App.vue': `${prelude}\n${translatableSfc('Message after prelude')}`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Message after prelude',
+    ]);
+  });
+
+  it('extracts an SFC after a same-line text prefix', async () => {
+    const root = createVueFixture({
+      'src/App.vue': `Copyright Fixture ${translatableSfc('Same-line prefix')}`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Same-line prefix',
+    ]);
+  });
+
   it('uses the nearest nested package config for explicitly matched sources', async () => {
     const root = createVueFixture({
       'packages/docs/package.json': JSON.stringify({
@@ -367,6 +432,26 @@ const gt = useGT();
     expect(output.updates.map(({ source }) => source)).toEqual([
       'Selected central config',
     ]);
+  });
+
+  it('does not validate Vue config when explicit patterns match no Vue-owned files', async () => {
+    const root = createWorkspaceFixture({
+      'src/App.tsx': `
+        import { T } from 'gt-react';
+        export const App = () => <T>React only</T>;
+      `,
+      'vite.config.ts': `export default ({ mode }) => mode === 'test' ? {} : {};`,
+      'apps/vue/package.json': vuePackage('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Unselected Vue app'),
+    });
+
+    await expect(
+      extractFromVueProject({
+        cwd: root,
+        filePatterns: ['src/App.tsx'],
+        viteConfigPath: 'vite.config.ts',
+      })
+    ).resolves.toEqual({ updates: [], errors: [], warnings: [] });
   });
 
   it('rejects a central explicit config that is ambiguous across matched apps', async () => {

--- a/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectExtraction.test.ts
@@ -1,0 +1,703 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { hashSource } from 'generaltranslation/id';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  linkInstalledVue,
+  removeProjectFixture,
+  translatableSfc,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('extractFromVueProject', () => {
+  it('discovers root app.vue and conventional Nuxt source directories', async () => {
+    const root = createVueFixture({
+      'app.vue': translatableSfc('Root app'),
+      'layouts/default.vue': translatableSfc('Default layout'),
+      'pages/index.vue': translatableSfc('Index page'),
+      'components/AppNav.vue': translatableSfc('App navigation'),
+      'composables/useTitle.ts': `
+        import { msg } from 'gt-vue';
+        export const title = msg('Composable title');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.warnings).toEqual([]);
+    expect(output.updates.map(({ source }) => source).sort()).toEqual([
+      'App navigation',
+      'Composable title',
+      'Default layout',
+      'Index page',
+      'Root app',
+    ]);
+  });
+
+  it('uses explicit source patterns as a replacement for defaults', async () => {
+    const root = createVueFixture({
+      'src/Ignored.vue': translatableSfc('Ignored default source'),
+      'custom/Selected.vue': translatableSfc('Selected explicit source'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['custom/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Selected explicit source',
+    ]);
+  });
+
+  it('uses the nearest nested package config for explicitly matched sources', async () => {
+    const root = createVueFixture({
+      'packages/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        private: true,
+      }),
+      'packages/docs/vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({
+          template: { compilerOptions: { delimiters: ['[[', ']]'] } },
+        })] };
+      `,
+      'packages/docs/src/App.vue': `<script setup>
+import { useGT } from 'gt-vue';
+const gt = useGT();
+</script>
+<template><p>[[ gt('Nested package message') ]]</p></template>
+`,
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['packages/docs/src/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Nested package message',
+    ]);
+  });
+
+  it('inherits root compiler options across a nested package boundary without Vue ownership', async () => {
+    const root = createVueFixture({
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({
+          template: { compilerOptions: { delimiters: ['[[', ']]'] } },
+        })] };
+      `,
+      'packages/docs/package.json': JSON.stringify({
+        name: '@fixture/docs',
+        private: true,
+      }),
+      'packages/docs/src/App.vue': `<script setup>
+import { useGT } from 'gt-vue';
+const gt = useGT();
+</script>
+<template><p>[[ gt('Inherited root compiler options') ]]</p></template>
+`,
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['packages/docs/src/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Inherited root compiler options',
+    ]);
+  });
+
+  it('gives an explicitly matched package that owns gt-vue an independent compiler scope', async () => {
+    const root = createVueFixture({
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({
+          template: { compilerOptions: { delimiters: ['[[', ']]'] } },
+        })] };
+      `,
+      'packages/docs/package.json': vuePackage('@fixture/docs'),
+      'packages/docs/src/App.vue': `<script setup>
+import { useGT } from 'gt-vue';
+const gt = useGT();
+</script>
+<template><p>{{ gt('Independent nested compiler options') }}</p></template>
+`,
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['packages/docs/src/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Independent nested compiler options',
+    ]);
+  });
+
+  it('calculates exact context-aware catalog hashes with generaltranslation/id', async () => {
+    const root = createVueFixture({
+      'src/messages.ts': `
+        import { useGT } from 'gt-vue';
+        const gt = useGT();
+        export const title = gt('Welcome to San Francisco', {
+          $context: 'homepage hero',
+        });
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]).toMatchObject({
+      dataFormat: 'STRING',
+      metadata: {
+        context: 'homepage hero',
+        hash: hashSource({
+          source: 'Welcome to San Francisco',
+          context: 'homepage hero',
+          dataFormat: 'STRING',
+        }),
+      },
+      source: 'Welcome to San Francisco',
+    });
+  });
+
+  it('deduplicates hashes while merging unique file and source metadata', async () => {
+    const root = createVueFixture({
+      'src/first.ts': `
+        import { msg } from 'gt-vue';
+        export const first = msg('Repeated message');
+      `,
+      'src/second.ts': `
+        import { msg } from 'gt-vue';
+        export const second = msg('Repeated message');
+      `,
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      includeSourceCodeContext: true,
+      surroundingLineCount: 1,
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates).toHaveLength(1);
+    expect(output.updates[0]?.metadata.filePaths?.sort()).toEqual([
+      'src/first.ts',
+      'src/second.ts',
+    ]);
+    expect(
+      Object.keys(output.updates[0]?.metadata.sourceCode ?? {}).sort()
+    ).toEqual(['src/first.ts', 'src/second.ts']);
+    expect(
+      output.updates[0]?.metadata.sourceCode?.['src/first.ts']
+    ).toHaveLength(1);
+    expect(
+      output.updates[0]?.metadata.sourceCode?.['src/second.ts']
+    ).toHaveLength(1);
+  });
+
+  it('isolates React-family and unrelated useGT sources in a mixed project', async () => {
+    const root = createVueFixture(
+      {
+        'src/App.js': `
+          import React from 'react';
+          import { T, msg, useGT } from 'gt-react';
+          export function App() {
+            const gt = useGT();
+            return <T>{gt('React call')} {msg('React message')}</T>;
+          }
+        `,
+        'src/Next.tsx': `
+          import { useGT } from 'gt-next';
+          export const NextView = () => <div>{useGT()('Next call')}</div>;
+        `,
+        'src/ordinary.cjs': `
+          module.exports.useGT = () => (value) => value;
+        `,
+        'src/Ordinary.js': `
+          import { useGT } from './ordinary.cjs';
+          export const View = () => <span>{useGT()('Ordinary call')}</span>;
+        `,
+        'src/vueMessage.ts': `
+          import { msg } from 'gt-vue';
+          export const vueMessage = msg('Vue-owned message');
+        `,
+      },
+      {
+        'gt-react': '*',
+        'gt-next': '*',
+      }
+    );
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.warnings).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Vue-owned message',
+    ]);
+  });
+
+  it('fails closed when a T context is dynamic', async () => {
+    const root = createVueFixture({
+      'src/App.vue': `<script setup lang="ts">
+import { ref } from 'vue';
+import { T } from 'gt-vue';
+const context = ref('one');
+</script>
+<template><T :context="context">Dynamic context</T></template>
+`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic context');
+  });
+
+  it('returns no partial catalog when any selected app has invalid compiler config', async () => {
+    const root = createWorkspaceFixture({
+      'apps/good/package.json': vuePackage('good-app'),
+      'apps/good/src/App.vue': translatableSfc('Good app message'),
+      'apps/bad/package.json': vuePackage('bad-app'),
+      'apps/bad/src/App.vue': translatableSfc('Bad app message'),
+      'apps/bad/vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        const readWhitespace = () => 'preserve';
+        export default {
+          plugins: [vue({
+            template: {
+              compilerOptions: { whitespace: readWhitespace() },
+            },
+          })],
+        };
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it('returns no partial catalog when one selected source has an extraction error', async () => {
+    const root = createVueFixture({
+      'src/Good.vue': translatableSfc('Valid message'),
+      'src/Bad.vue': `<script setup lang="ts">
+import { ref } from 'vue';
+import { T } from 'gt-vue';
+const context = ref('dynamic');
+</script>
+<template><T :context="context">Invalid message</T></template>
+`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic context');
+  });
+
+  it('allows one child Vue app to use a centrally located explicit Vite config', async () => {
+    const root = createWorkspaceFixture({
+      'config/vue.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+      'apps/docs/package.json': vuePackage('docs-app'),
+      'apps/docs/src/App.vue': translatableSfc('Central config message'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      viteConfigPath: 'config/vue.ts',
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Central config message',
+    ]);
+  });
+
+  it('applies a central explicit config when explicit patterns select one of several apps', async () => {
+    const root = createWorkspaceFixture({
+      'config/vue.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { delimiters: ['[[', ']]'] } } })] };
+      `,
+      'apps/selected/package.json': vuePackage('selected-app'),
+      'apps/selected/src/App.vue': `<script setup>
+import { useGT } from 'gt-vue';
+const gt = useGT();
+</script>
+<template>[[ gt('Selected central config') ]]</template>
+`,
+      'apps/other/package.json': vuePackage('other-app'),
+      'apps/other/src/App.vue': translatableSfc('Unselected app'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['apps/selected/src/**/*.vue'],
+      viteConfigPath: 'config/vue.ts',
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Selected central config',
+    ]);
+  });
+
+  it('rejects a central explicit config that is ambiguous across matched apps', async () => {
+    const root = createWorkspaceFixture({
+      'config/vue.ts': `export default {}`,
+      'apps/first/package.json': vuePackage('first-app'),
+      'apps/first/src/messages.ts': `
+        import { msg } from 'gt-vue';
+        export const first = msg('First app');
+      `,
+      'apps/second/package.json': vuePackage('second-app'),
+      'apps/second/src/messages.ts': `
+        import { msg } from 'gt-vue';
+        export const second = msg('Second app');
+      `,
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      viteConfigPath: 'config/vue.ts',
+    });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'does not own any matched Vue sources'
+    );
+  });
+
+  it.each(['missing.config.ts', '../outside.config.ts', 'vite.config.json'])(
+    'validates explicit config %s for STRING-only sources',
+    async (viteConfigPath) => {
+      const root = createVueFixture({
+        'src/messages.ts': `
+          import { msg } from 'gt-vue';
+          export const title = msg('String-only source');
+        `,
+      });
+
+      const output = await extractFromVueProject({
+        cwd: root,
+        viteConfigPath,
+      });
+
+      expect(output.updates).toEqual([]);
+      expect(output.errors).not.toEqual([]);
+    }
+  );
+
+  it('fails closed when a custom Nuxt source directory hides every default match', async () => {
+    const root = createVueFixture({
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'client/' });`,
+      'client/app.vue': translatableSfc('Hidden Nuxt message'),
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'custom Nuxt source directories'
+    );
+  });
+
+  it('allows explicit patterns to cover a custom Nuxt source directory', async () => {
+    const root = createVueFixture({
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'client/' });`,
+      'client/app.vue': translatableSfc('Explicit Nuxt source'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['client/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Explicit Nuxt source',
+    ]);
+  });
+
+  it('rejects a hidden Nuxt workspace instead of returning another app as a partial catalog', async () => {
+    const root = createWorkspaceFixture({
+      'apps/good/package.json': vuePackage('good-app'),
+      'apps/good/src/App.vue': translatableSfc('Visible app message'),
+      'apps/custom/package.json': vuePackage('custom-app'),
+      'apps/custom/nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'client/' });`,
+      'apps/custom/client/app.vue': translatableSfc('Hidden app message'),
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'custom Nuxt source directories'
+    );
+  });
+
+  it('validates hidden Nuxt workspaces when another app supplies an explicit Vite config', async () => {
+    const root = createWorkspaceFixture({
+      'apps/vite/package.json': vuePackage('vite-app'),
+      'apps/vite/vite.config.ts': `export default {}`,
+      'apps/vite/src/App.vue': translatableSfc('Visible Vite message'),
+      'apps/nuxt/package.json': vuePackage('nuxt-app'),
+      'apps/nuxt/nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'client/' });`,
+      'apps/nuxt/client/app.vue': translatableSfc('Hidden Nuxt message'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      viteConfigPath: 'apps/vite/vite.config.ts',
+    });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'custom Nuxt source directories'
+    );
+  });
+
+  it.each(['js', 'mjs', 'cjs'])(
+    'validates Vue JSX config for rich content in .%s files',
+    async (extension) => {
+      const root = createVueFixture({
+        'vite.config.ts': `
+          import vueJsx from '@vitejs/plugin-vue-jsx';
+          const customPlugin = () => ({});
+          export default { plugins: [vueJsx({ babelPlugins: [customPlugin] })] };
+        `,
+        [`src/View.${extension}`]: `
+          import { T } from 'gt-vue';
+          export const View = () => <T>Configured JSX</T>;
+        `,
+      });
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.updates).toEqual([]);
+      expect(output.errors.join('\n')).toContain('option "babelPlugins"');
+    }
+  );
+
+  it('follows TypeScript path aliases through local gt-vue reexports', async () => {
+    const root = createVueFixture({
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@local/gt': ['src/gt.ts'] },
+        },
+      }),
+      'src/gt.ts': "export { T as LocalT } from 'gt-vue';\n",
+      'src/App.vue': `<script setup lang="ts">
+import { LocalT } from '@local/gt';
+</script>
+<template><LocalT>Aliased reexport message</LocalT></template>
+`,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Aliased reexport message',
+    ]);
+  });
+
+  it('establishes provenance through a static Vite alias before extraction', async () => {
+    const root = createVueFixture({
+      'vite.config.ts': `
+        import path from 'node:path';
+        import { defineConfig } from 'vite';
+        export default defineConfig({
+          resolve: { alias: { '@i18n': path.resolve(__dirname, 'src/i18n.ts') } },
+        });
+      `,
+      'src/i18n.ts': "export { msg } from 'gt-vue';\n",
+      'src/messages.ts': `
+        import { msg } from '@i18n';
+        export const title = msg('Vite alias message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Vite alias message',
+    ]);
+  });
+
+  it.each([
+    `
+      const chooseAlias = () => '/dynamic';
+      export default { resolve: { alias: { '@i18n': chooseAlias() } } };
+    `,
+    `
+      export default { resolve: { alias: [
+        { find: '@i18n', replacement: '/static', customResolver() {} },
+      ] } };
+    `,
+    `export default ({ command }) => command === 'serve' ? {} : {};`,
+  ])(
+    'fails atomically when application aliases are not static',
+    async (config) => {
+      const root = createVueFixture({
+        'vite.config.ts': config,
+        'src/messages.ts': `
+        import { msg } from 'gt-vue';
+        export const title = msg('Direct message must not mask alias risk');
+      `,
+      });
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output.updates).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve the Vue application module aliases'
+      );
+    }
+  );
+
+  it('keeps transitive workspace aliases scoped to their originating app', async () => {
+    const root = createWorkspaceFixture({
+      'apps/first/package.json': vuePackage('first-app'),
+      'apps/first/vite.config.ts': `
+        import path from 'node:path';
+        export default { resolve: { alias: {
+          '#runtime': path.resolve(__dirname, 'src/runtime.ts'),
+        } } };
+      `,
+      'apps/first/src/runtime.ts': "export { msg } from 'gt-vue';",
+      'apps/first/src/messages.ts': `
+        import { translate } from '@fixture/shared';
+        export const title = translate('First app message');
+      `,
+      'apps/second/package.json': vuePackage('second-app'),
+      'apps/second/vite.config.ts': `
+        import path from 'node:path';
+        export default { resolve: { alias: {
+          '#runtime': path.resolve(__dirname, 'src/runtime.ts'),
+        } } };
+      `,
+      'apps/second/src/runtime.ts':
+        'export const msg = (value: string) => value;',
+      'apps/second/src/messages.ts': `
+        import { translate } from '@fixture/shared';
+        export const title = translate('Second app ordinary message');
+      `,
+      'packages/shared/package.json': JSON.stringify({
+        name: '@fixture/shared',
+        exports: { '.': './src/barrel.js' },
+      }),
+      'packages/shared/src/barrel.ts':
+        "export { msg as translate } from '#runtime';",
+    });
+    const sharedLink = path.join(root, 'node_modules/@fixture/shared');
+    fs.mkdirSync(path.dirname(sharedLink), { recursive: true });
+    fs.symlinkSync(path.join(root, 'packages/shared'), sharedLink, 'dir');
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'First app message',
+    ]);
+  });
+
+  it('is deterministic across 80 concurrent project extractions', async () => {
+    const root = createVueFixture({
+      'src/App.vue': `<script setup lang="ts">
+import { T, msg } from 'gt-vue';
+export const subtitle = msg('Concurrent subtitle');
+</script>
+<template><T context="concurrency">Concurrent heading</T></template>
+`,
+    });
+
+    const outputs = await Promise.all(
+      Array.from({ length: 80 }, () =>
+        extractFromVueProject({
+          cwd: root,
+          includeSourceCodeContext: true,
+        })
+      )
+    );
+
+    expect(outputs[0]?.errors).toEqual([]);
+    expect(outputs[0]?.updates).toHaveLength(2);
+    const expected = JSON.stringify(outputs[0]);
+    expect(outputs.every((output) => JSON.stringify(output) === expected)).toBe(
+      true
+    );
+  });
+});
+
+function createVueFixture(
+  files: Record<string, string>,
+  additionalDependencies: Record<string, string> = {}
+): string {
+  return createFixture({
+    'package.json': JSON.stringify({
+      name: 'vue-project',
+      private: true,
+      dependencies: {
+        ...additionalDependencies,
+        'gt-vue': 'workspace:*',
+        vue: '^3.5.0',
+      },
+    }),
+    ...files,
+  });
+}
+
+function createWorkspaceFixture(files: Record<string, string>): string {
+  return createFixture({
+    'package.json': JSON.stringify({
+      name: 'vue-workspace',
+      private: true,
+      workspaces: ['apps/*'],
+    }),
+    ...files,
+  });
+}
+
+function vuePackage(name: string): string {
+  return JSON.stringify({
+    name,
+    dependencies: { 'gt-vue': 'workspace:*', vue: '^3.5.0' },
+  });
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  linkInstalledVue(root);
+  return root;
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectMerge.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectMerge.test.ts
@@ -1,0 +1,88 @@
+import type { VueProjectExtractionResult } from '../../types.js';
+import { describe, expect, it } from 'vitest';
+import { mergeVueProjectExtraction } from '../../project.js';
+
+describe('mergeVueProjectExtraction', () => {
+  it('preserves primary ordering and combines diagnostics', () => {
+    const primaryUpdate = update('Primary', 'primary-hash', ['primary.tsx']);
+    const vueUpdate = update('Vue', 'vue-hash', ['component.vue']);
+
+    const result = mergeVueProjectExtraction(
+      {
+        updates: [primaryUpdate],
+        errors: ['primary error'],
+        warnings: ['shared warning', 'primary warning'],
+      },
+      {
+        updates: [vueUpdate],
+        errors: ['vue error'],
+        warnings: ['shared warning', 'vue warning'],
+      }
+    );
+
+    expect(result.updates).toEqual([primaryUpdate, vueUpdate]);
+    expect(result.errors).toEqual(['primary error', 'vue error']);
+    expect(result.warnings).toEqual([
+      'shared warning',
+      'primary warning',
+      'vue warning',
+    ]);
+  });
+
+  it('deduplicates hash collisions and merges their file paths', () => {
+    const primaryUpdate = update('Shared', 'shared-hash', ['primary.tsx']);
+
+    const result = mergeVueProjectExtraction(
+      { updates: [primaryUpdate], errors: [], warnings: [] },
+      {
+        updates: [
+          update('Shared', 'shared-hash', ['component.vue', 'primary.tsx']),
+        ],
+        errors: [],
+        warnings: [],
+      }
+    );
+
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]).toBe(primaryUpdate);
+    expect(result.updates[0]?.metadata.filePaths).toEqual([
+      'primary.tsx',
+      'component.vue',
+    ]);
+  });
+
+  it('deduplicates identical source context and preserves distinct locations', () => {
+    const duplicate = { before: 'before', target: 'target', after: 'after' };
+    const distinct = { before: 'other', target: 'target', after: 'after' };
+    const primaryUpdate = update('Shared', 'shared-hash', ['src/shared.tsx']);
+    primaryUpdate.metadata.sourceCode = {
+      'src/shared.tsx': [structuredClone(duplicate)],
+    };
+    const vueUpdate = update('Shared', 'shared-hash', ['src/shared.tsx']);
+    vueUpdate.metadata.sourceCode = {
+      'src/shared.tsx': [structuredClone(duplicate), distinct],
+    };
+
+    const result = mergeVueProjectExtraction(
+      { updates: [primaryUpdate], errors: [], warnings: [] },
+      { updates: [vueUpdate], errors: [], warnings: [] }
+    );
+
+    expect(result.updates).toHaveLength(1);
+    expect(result.updates[0]?.metadata.sourceCode).toEqual({
+      'src/shared.tsx': [duplicate, distinct],
+    });
+  });
+});
+
+function update(
+  source: string,
+  hash: string,
+  filePaths: string[]
+): VueProjectExtractionResult {
+  return {
+    dataFormat: 'STRING',
+    source,
+    metadata: { hash, filePaths },
+  };
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectModuleResolver.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectModuleResolver.test.ts
@@ -1,0 +1,411 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createServer, type ViteDevServer } from 'vite';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createProjectModuleResolver } from '../project/moduleResolver.js';
+import {
+  createProjectFixture,
+  removeProjectFixture,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('project module resolution', () => {
+  it('matches Vite default extension precedence', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'src/message.js': '',
+      'src/message.ts': '',
+      'src/component.vue': '',
+      'src/component.ts': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+    const importer = path.join(root, 'src/importer.ts');
+
+    expectResolved(
+      resolveModule('./message', importer),
+      path.join(root, 'src/message.js')
+    );
+    expectResolved(
+      resolveModule('./component', importer),
+      path.join(root, 'src/component.ts')
+    );
+  });
+
+  it('does not add the Vue SFC extension implicitly', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'src/OnlyVue.vue': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expect(
+      resolveModule('./OnlyVue', path.join(root, 'src/importer.ts'))
+    ).toBeUndefined();
+    expectResolved(
+      resolveModule('./OnlyVue.vue', path.join(root, 'src/importer.ts')),
+      path.join(root, 'src/OnlyVue.vue')
+    );
+  });
+
+  it('resolves TypeScript source for an explicit JavaScript import', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'src/message.ts': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule('./message.js', path.join(root, 'src/importer.ts')),
+      path.join(root, 'src/message.ts')
+    );
+  });
+
+  it('selects import exports instead of CommonJS exports', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        exports: {
+          '.': {
+            require: './require.cjs',
+            import: './import.js',
+            default: './default.js',
+          },
+        },
+      }),
+      'node_modules/example/require.cjs': '',
+      'node_modules/example/import.js': '',
+      'node_modules/example/default.js': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/import.js')
+    );
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.cts')),
+      path.join(root, 'node_modules/example/require.cjs')
+    );
+  });
+
+  it('uses Vite module precedence for a CommonJS browser entry', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        browser: './browser.js',
+        module: './module.js',
+        main: './main.js',
+      }),
+      'node_modules/example/browser.js': '',
+      'node_modules/example/module.js': '',
+      'node_modules/example/main.js': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/module.js')
+    );
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.cts')),
+      path.join(root, 'node_modules/example/browser.js')
+    );
+  });
+
+  it('uses a browser entry when it contains ESM syntax', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        browser: './browser.js',
+        module: './module.js',
+        main: './main.js',
+      }),
+      'node_modules/example/browser.js': 'export const target = "browser";',
+      'node_modules/example/module.js': 'export const target = "module";',
+      'node_modules/example/main.js': 'module.exports = "main";',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/browser.js')
+    );
+  });
+
+  it('applies browser object remaps to package-internal imports', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        browser: {
+          './server.js': './browser.js',
+        },
+      }),
+      'node_modules/example/index.js': '',
+      'node_modules/example/server.js': '',
+      'node_modules/example/browser.js': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule(
+        './server.js',
+        path.join(root, 'node_modules/example/index.js')
+      ),
+      path.join(root, 'node_modules/example/browser.js')
+    );
+    expectResolved(
+      resolveModule('example/server.js', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/browser.js')
+    );
+  });
+
+  it('maps JavaScript package export targets back to TypeScript source', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        exports: {
+          '.': './src/index.js',
+          './jsx': './src/view.jsx',
+        },
+      }),
+      'node_modules/example/src/index.ts': '',
+      'node_modules/example/src/view.tsx': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/src/index.ts')
+    );
+    expectResolved(
+      resolveModule('example/jsx', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/src/view.tsx')
+    );
+  });
+
+  it('expands Vite mode conditions deterministically', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        exports: {
+          '.': {
+            development: './development.js',
+            production: './production.js',
+            default: './default.js',
+          },
+        },
+      }),
+      'node_modules/example/development.js': '',
+      'node_modules/example/production.js': '',
+      'node_modules/example/default.js': '',
+    });
+    const importer = path.join(root, 'src/importer.ts');
+
+    expectResolved(
+      createProjectModuleResolver(['development|production'])(
+        'example',
+        importer
+      ),
+      path.join(root, 'node_modules/example/development.js')
+    );
+    expectResolved(
+      createProjectModuleResolver(['development|production', 'production'])(
+        'example',
+        importer
+      ),
+      path.join(root, 'node_modules/example/production.js')
+    );
+  });
+
+  it('does not bypass package exports encapsulation', () => {
+    const root = createFixture({
+      'src/importer.ts': '',
+      'node_modules/example/package.json': JSON.stringify({
+        name: 'example',
+        browser: { './private.js': './index.js' },
+        exports: {
+          '.': './index.js',
+        },
+      }),
+      'node_modules/example/index.js': '',
+      'node_modules/example/private.js': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expect(
+      resolveModule('example/private.js', path.join(root, 'src/importer.ts'))
+    ).toBeUndefined();
+    expectResolved(
+      resolveModule('example', path.join(root, 'src/importer.ts')),
+      path.join(root, 'node_modules/example/index.js')
+    );
+  });
+
+  it('matches Vite for package conditions, browser remaps, and source recovery', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({ name: 'vite-resolution-fixture' }),
+      'src/importer.ts': '',
+      'src/importer.cts': '',
+      'node_modules/conditional/package.json': JSON.stringify({
+        name: 'conditional',
+        exports: {
+          '.': {
+            require: './require.cjs',
+            import: './import.js',
+          },
+        },
+      }),
+      'node_modules/conditional/require.cts': '',
+      'node_modules/conditional/import.js': '',
+      'node_modules/browser-map/package.json': JSON.stringify({
+        name: 'browser-map',
+        browser: { './server.js': './browser.js' },
+      }),
+      'node_modules/browser-map/index.js': '',
+      'node_modules/browser-map/server.js': '',
+      'node_modules/browser-map/browser.js': '',
+      'node_modules/browser-entry/package.json': JSON.stringify({
+        name: 'browser-entry',
+        browser: './browser.js',
+        module: './module.js',
+        main: './main.js',
+      }),
+      'node_modules/browser-entry/browser.js': 'module.exports = "browser";',
+      'node_modules/browser-entry/module.js': 'export const target = "module";',
+      'node_modules/browser-entry/main.js': 'module.exports = "main";',
+      'node_modules/typed-export/package.json': JSON.stringify({
+        name: 'typed-export',
+        exports: {
+          '.': './src/index.js',
+          './public': './src/public.js',
+        },
+      }),
+      'node_modules/typed-export/src/index.ts': '',
+      'node_modules/typed-export/src/public.ts': '',
+      'node_modules/typed-export/src/private.ts': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+    const esmImporter = path.join(root, 'src/importer.ts');
+    const cjsImporter = path.join(root, 'src/importer.cts');
+    const packageImporter = path.join(
+      root,
+      'node_modules/browser-map/index.js'
+    );
+
+    await withViteResolver(root, async (resolveWithVite) => {
+      await expectViteParity(
+        resolveModule('conditional', esmImporter),
+        await resolveWithVite('conditional', esmImporter)
+      );
+      await expectViteParity(
+        resolveModule('conditional', cjsImporter),
+        await resolveWithVite('conditional', cjsImporter, true)
+      );
+      await expectViteParity(
+        resolveModule('./server.js', packageImporter),
+        await resolveWithVite('./server.js', packageImporter)
+      );
+      await expectViteParity(
+        resolveModule('browser-entry', esmImporter),
+        await resolveWithVite('browser-entry', esmImporter)
+      );
+      await expectViteParity(
+        resolveModule('browser-entry', cjsImporter),
+        await resolveWithVite('browser-entry', cjsImporter, true)
+      );
+      await expectViteParity(
+        resolveModule('typed-export', esmImporter),
+        await resolveWithVite('typed-export', esmImporter)
+      );
+      await expectViteParity(
+        resolveModule('typed-export/public', esmImporter),
+        await resolveWithVite('typed-export/public', esmImporter)
+      );
+      expect(
+        resolveModule('typed-export/private', esmImporter)
+      ).toBeUndefined();
+      expect(
+        await resolveWithVite('typed-export/private', esmImporter)
+      ).toBeUndefined();
+    });
+  });
+});
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function expectResolved(actual: string | undefined, expected: string): void {
+  expect(actual).toBeDefined();
+  expect(fs.realpathSync(actual!)).toBe(fs.realpathSync(expected));
+}
+
+async function withViteResolver(
+  root: string,
+  run: (
+    resolve: (
+      specifier: string,
+      importer: string,
+      isRequire?: boolean
+    ) => Promise<string | undefined>
+  ) => Promise<void>
+): Promise<void> {
+  const server = await createServer({
+    configFile: false,
+    logLevel: 'silent',
+    optimizeDeps: { noDiscovery: true },
+    root,
+    server: { middlewareMode: true },
+  });
+  try {
+    await run((specifier, importer, isRequire = false) =>
+      resolveWithVite(server, specifier, importer, isRequire)
+    );
+  } finally {
+    await server.close();
+  }
+}
+
+async function resolveWithVite(
+  server: ViteDevServer,
+  specifier: string,
+  importer: string,
+  isRequire: boolean
+): Promise<string | undefined> {
+  try {
+    const resolved = await server.pluginContainer.resolveId(
+      specifier,
+      importer,
+      isRequire
+        ? { custom: { 'node-resolve': { isRequire: true } } }
+        : undefined
+    );
+    return resolved?.id.split(/[?#]/, 1)[0];
+  } catch {
+    return undefined;
+  }
+}
+
+async function expectViteParity(
+  actual: string | undefined,
+  vite: string | undefined
+): Promise<void> {
+  expect(actual).toBeDefined();
+  expect(vite).toBeDefined();
+  expect(fs.realpathSync(actual!)).toBe(fs.realpathSync(vite!));
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectModuleResolver.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectModuleResolver.test.ts
@@ -195,6 +195,46 @@ describe('project module resolution', () => {
     );
   });
 
+  it('maps emitted self-reference exports back to package TypeScript source', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/self-package',
+        exports: { './runtime': './dist/runtime.js' },
+      }),
+      'src/importer.ts': '',
+      'dist/runtime.ts': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expectResolved(
+      resolveModule(
+        '@fixture/self-package/runtime',
+        path.join(root, 'src/importer.ts')
+      ),
+      path.join(root, 'dist/runtime.ts')
+    );
+  });
+
+  it('does not treat an ancestor beyond a malformed package boundary as self', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: '@fixture/outer-package',
+        exports: { './runtime': './dist/runtime.js' },
+      }),
+      'dist/runtime.ts': '',
+      'nested/package.json': '{ malformed',
+      'nested/src/importer.ts': '',
+    });
+    const resolveModule = createProjectModuleResolver();
+
+    expect(
+      resolveModule(
+        '@fixture/outer-package/runtime',
+        path.join(root, 'nested/src/importer.ts')
+      )
+    ).toBeUndefined();
+  });
+
   it('expands Vite mode conditions deterministically', () => {
     const root = createFixture({
       'src/importer.ts': '',

--- a/packages/vue-extractor/src/internal/__tests__/projectOrchestrationParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectOrchestrationParity.test.ts
@@ -1,0 +1,343 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { extractFromVueProject } from '../../project.js';
+import {
+  createProjectFixture,
+  linkInstalledVue,
+  removeProjectFixture,
+  translatableSfc,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('project extraction orchestration parity', () => {
+  it('does not resolve an unowned React root Vite config', async () => {
+    const root = createWorkspace({
+      'package.json': JSON.stringify({
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: {
+          '@vitejs/plugin-react': '*',
+          'gt-react': '*',
+          react: '*',
+          vite: '*',
+        },
+      }),
+      'vite.config.ts': `
+        import react from '@vitejs/plugin-react';
+        export default ({ command }) => command === 'serve'
+          ? { plugins: [react()] }
+          : { plugins: [react()], build: { sourcemap: true } };
+      `,
+      'src/App.tsx': `
+        import { T } from 'gt-react';
+        export const App = () => <T>React root</T>;
+      `,
+      'apps/vue/package.json': vuePackage('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Vue workspace survives'),
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Vue workspace survives',
+    ]);
+  });
+
+  it('does not scan an unrelated root SFC for a child Vue workspace', async () => {
+    const root = createWorkspace({
+      'src/Legacy.vue': `<script setup>const broken = ;</script>`,
+      'apps/vue/package.json': vuePackage('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Owned child message'),
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Owned child message',
+    ]);
+  });
+
+  it('does not promote explicitly matched sources outside owned Vue scopes', async () => {
+    const root = createWorkspace({
+      'package.json': JSON.stringify({
+        name: 'react-workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+        dependencies: { 'gt-react': '*' },
+      }),
+      'src/Legacy.vue': `<script setup>const broken = ;</script>`,
+      'apps/vue/package.json': vuePackage('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Owned child message'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['src/**/*'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates).toEqual([]);
+  });
+
+  it('honors explicit patterns inside an owned Vue workspace scope', async () => {
+    const root = createWorkspace({
+      'src/Legacy.vue': `<script setup>const broken = ;</script>`,
+      'apps/vue/package.json': vuePackage('vue-app'),
+      'apps/vue/src/App.vue': translatableSfc('Explicit owned message'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: ['apps/vue/src/**/*.vue'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Explicit owned message',
+    ]);
+  });
+
+  it('keeps compiler options isolated across Vue workspaces', async () => {
+    const root = createWorkspace({
+      'apps/custom/package.json': vuePackage('custom-app'),
+      'apps/custom/vite.config.ts': customDelimiterConfig(),
+      'apps/custom/src/App.vue': vueCall(
+        '[[',
+        ']]',
+        'Custom workspace message'
+      ),
+      'apps/standard/package.json': vuePackage('standard-app'),
+      'apps/standard/src/App.vue': vueCall(
+        '{{',
+        '}}',
+        'Standard workspace message'
+      ),
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source).sort()).toEqual([
+      'Custom workspace message',
+      'Standard workspace message',
+    ]);
+  });
+
+  it('applies an explicit config only to its owning workspace', async () => {
+    const root = createWorkspace({
+      'apps/selected/package.json': vuePackage('selected-app'),
+      'apps/selected/vite.config.ts': customDelimiterConfig(),
+      'apps/selected/src/App.vue': vueCall(
+        '[[',
+        ']]',
+        'Selected workspace config'
+      ),
+      'apps/default/package.json': vuePackage('default-app'),
+      'apps/default/src/App.vue': vueCall(
+        '{{',
+        '}}',
+        'Default workspace config'
+      ),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      viteConfigPath: 'apps/selected/vite.config.ts',
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source).sort()).toEqual([
+      'Default workspace config',
+      'Selected workspace config',
+    ]);
+  });
+
+  it('accepts supported Vue JSX plugin options', async () => {
+    const root = createVueProject({
+      'vite.config.ts': `
+        import vueJsx from '@vitejs/plugin-vue-jsx';
+        export default { plugins: [vueJsx({ babelPlugins: [], optimize: true })] };
+      `,
+      'src/View.tsx': `
+        import { T } from 'gt-vue';
+        export const View = () => <T context="card">Supported TSX</T>;
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates).toEqual([
+      expect.objectContaining({
+        dataFormat: 'JSX',
+        source: 'Supported TSX',
+        metadata: expect.objectContaining({ context: 'card' }),
+      }),
+    ]);
+  });
+
+  it('resolves Nuxt source aliases through a static srcDir', async () => {
+    const root = createVueProject({
+      'nuxt.config.ts': `
+        export default defineNuxtConfig({ srcDir: 'src/' });
+      `,
+      'src/i18n.ts': `export { msg as defineMessage } from 'gt-vue';`,
+      'src/messages.ts': `
+        import { defineMessage } from '~/i18n';
+        export const title = defineMessage('Nuxt alias message');
+      `,
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Nuxt alias message',
+    ]);
+  });
+
+  it.skipIf(process.platform === 'win32')(
+    'does not follow source globs through a symlink outside the project',
+    async () => {
+      const outside = createTemporaryDirectory();
+      fs.writeFileSync(
+        path.join(outside, 'Outside.vue'),
+        translatableSfc('Outside symlink message')
+      );
+      const root = createVueProject({});
+      fs.symlinkSync(outside, path.join(root, 'src'), 'dir');
+
+      const output = await extractFromVueProject({ cwd: root });
+
+      expect(output).toEqual({ updates: [], errors: [], warnings: [] });
+    }
+  );
+
+  it('reports invalid source patterns instead of returning an empty catalog', async () => {
+    const root = createVueProject({
+      'src/App.vue': translatableSfc('Pattern failure must be atomic'),
+    });
+
+    const output = await extractFromVueProject({
+      cwd: root,
+      filePatterns: [null as unknown as string],
+    });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not match the configured Vue source patterns'
+    );
+  });
+
+  it('reports an inaccessible project root during source matching', async () => {
+    const root = createVueProject({
+      'src/App.vue': translatableSfc('Root failure must be atomic'),
+    });
+    const realpathSync = fs.realpathSync;
+    vi.spyOn(fs, 'realpathSync').mockImplementation((target) => {
+      if (path.resolve(String(target)) === root) {
+        throw new Error('root disappeared');
+      }
+      return realpathSync(target);
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not resolve the Vue project root'
+    );
+    expect(output.errors.join('\n')).toContain('root disappeared');
+  });
+
+  it('reports a matched-file realpath race without returning partial updates', async () => {
+    const root = createVueProject({
+      'src/Good.vue': translatableSfc('Good message'),
+      'src/Lost.vue': translatableSfc('Lost message'),
+    });
+    const lostFile = path.join(root, 'src/Lost.vue');
+    const realpathSync = fs.realpathSync;
+    vi.spyOn(fs, 'realpathSync').mockImplementation((target) => {
+      if (path.resolve(String(target)) === lostFile) {
+        throw new Error('matched file disappeared');
+      }
+      return realpathSync(target);
+    });
+
+    const output = await extractFromVueProject({ cwd: root });
+
+    expect(output.updates).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not resolve a matched Vue source file'
+    );
+    expect(output.errors.join('\n')).toContain('src/Lost.vue');
+    expect(output.errors.join('\n')).toContain('matched file disappeared');
+  });
+});
+
+function createWorkspace(files: Record<string, string>): string {
+  return createFixture({
+    'package.json': JSON.stringify({
+      name: 'workspace-root',
+      private: true,
+      workspaces: ['apps/*'],
+    }),
+    ...files,
+  });
+}
+
+function createVueProject(files: Record<string, string>): string {
+  return createFixture({
+    'package.json': vuePackage('vue-project'),
+    ...files,
+  });
+}
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  linkInstalledVue(root);
+  return root;
+}
+
+function createTemporaryDirectory(): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-outside-'));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function vuePackage(name: string): string {
+  return JSON.stringify({
+    name,
+    dependencies: { 'gt-vue': 'workspace:*', vue: '^3.5.0' },
+  });
+}
+
+function customDelimiterConfig(): string {
+  return `
+    import vue from '@vitejs/plugin-vue';
+    export default { plugins: [vue({
+      template: { compilerOptions: { delimiters: ['[[', ']]'] } },
+    })] };
+  `;
+}
+
+function vueCall(open: string, close: string, source: string): string {
+  return `<script setup>
+import { useGT } from 'gt-vue';
+const gt = useGT();
+</script>
+<template>${open} gt(${JSON.stringify(source)}) ${close}</template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectOrchestrationParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectOrchestrationParity.test.ts
@@ -267,8 +267,8 @@ describe('project extraction orchestration parity', () => {
       'src/Good.vue': translatableSfc('Good message'),
       'src/Lost.vue': translatableSfc('Lost message'),
     });
-    const lostFile = path.join(root, 'src/Lost.vue');
     const realpathSync = fs.realpathSync;
+    const lostFile = realpathSync(path.join(root, 'src/Lost.vue'));
     vi.spyOn(fs, 'realpathSync').mockImplementation((target) => {
       if (path.resolve(String(target)) === lostFile) {
         throw new Error('matched file disappeared');

--- a/packages/vue-extractor/src/internal/__tests__/projectTestUtils.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectTestUtils.ts
@@ -1,0 +1,71 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const requireFromVuePackage = createRequire(import.meta.url);
+const installedVueDirectory = path.dirname(
+  requireFromVuePackage.resolve('vue/package.json')
+);
+
+/** Creates a disposable JavaScript project from project-relative file names. */
+export function createProjectFixture(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-project-'));
+  writeProjectFiles(root, files);
+  return root;
+}
+
+/** Writes project-relative files, creating their parent directories. */
+export function writeProjectFiles(
+  root: string,
+  files: Record<string, string>
+): void {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+}
+
+/** Writes a package manifest without repeating JSON formatting in fixtures. */
+export function writePackageJson(
+  root: string,
+  relativeDirectory: string,
+  manifest: Record<string, unknown>
+): void {
+  writeProjectFiles(root, {
+    [path.posix.join(relativeDirectory, 'package.json')]: JSON.stringify(
+      manifest,
+      null,
+      2
+    ),
+  });
+}
+
+/**
+ * Links the repository's installed Vue package into a fixture.
+ *
+ * Project extraction deliberately resolves the consumer's exact compiler, so
+ * tests use the real installed Vue package instead of injecting a compiler.
+ */
+export function linkInstalledVue(root: string): void {
+  const nodeModules = path.join(root, 'node_modules');
+  const destination = path.join(nodeModules, 'vue');
+  fs.mkdirSync(nodeModules, { recursive: true });
+  if (fs.existsSync(destination)) return;
+  fs.symlinkSync(installedVueDirectory, destination, 'dir');
+}
+
+/** Removes a disposable fixture without following links outside of it. */
+export function removeProjectFixture(root: string): void {
+  fs.rmSync(root, { force: true, recursive: true });
+}
+
+/** A minimal SFC that proves the imported component comes from gt-vue. */
+export function translatableSfc(message: string, component = 'T'): string {
+  return `<script setup lang="ts">
+import { T${component === 'T' ? '' : ` as ${component}`} } from 'gt-vue';
+</script>
+<template><${component}>${message}</${component}></template>
+`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/projectViteAliases.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/projectViteAliases.test.ts
@@ -1,0 +1,653 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  resolveVueProjectAliasConfiguration,
+  resolveVueProjectAliases,
+} from '../project/viteAliases.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('resolveVueProjectAliases', () => {
+  it('distinguishes definitely absent aliases from incomplete analysis', () => {
+    const withoutConfig = createProject({});
+    const withoutAliases = createProject({
+      'vite.config.ts': `export default defineConfig({ server: { port: 3000 } });`,
+    });
+    const explicitlyAbsent = createProject({
+      'vite.config.ts': `export default defineConfig({ resolve: { alias: undefined } });`,
+    });
+    const absentResolve = createProject({
+      'vite.config.ts': `export default defineConfig({ resolve: null });`,
+    });
+    const malformed = createProject({
+      'vite.config.ts': `export default defineConfig({ resolve: { alias:`,
+    });
+    const dynamicRoot = createProject({
+      'vite.config.ts': `export default defineConfig(getConfig());`,
+    });
+    const knownAliases = createProject({
+      'vite.config.ts': `export default { resolve: { alias: { '@': './src' } } };`,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(withoutConfig)).toEqual({
+      aliases: new Map(),
+      complete: true,
+    });
+    expect(resolveVueProjectAliasConfiguration(withoutAliases)).toEqual({
+      aliases: new Map(),
+      complete: true,
+    });
+    expect(resolveVueProjectAliasConfiguration(explicitlyAbsent)).toEqual({
+      aliases: new Map(),
+      complete: true,
+    });
+    expect(resolveVueProjectAliasConfiguration(absentResolve)).toEqual({
+      aliases: new Map(),
+      complete: true,
+    });
+    expect(resolveVueProjectAliasConfiguration(malformed)).toEqual({
+      aliases: new Map(),
+      complete: false,
+    });
+    expect(resolveVueProjectAliasConfiguration(dynamicRoot)).toEqual({
+      aliases: new Map(),
+      complete: false,
+    });
+    expect(resolveVueProjectAliasConfiguration(knownAliases)).toEqual({
+      aliases: new Map([['@', './src']]),
+      complete: true,
+    });
+  });
+
+  it('marks unreadable-shaped and escaping active config incomplete', () => {
+    const directoryConfig = createProject({});
+    fs.mkdirSync(path.join(directoryConfig, 'vite.config.js'));
+    const dynamicSpread = createProject({
+      'vite.config.ts': `
+        const shared = getConfig();
+        export default { ...shared, resolve: { alias: { '@': './src' } } };
+      `,
+    });
+    const escapedRoot = createProject({
+      'vite.config.ts': `
+        const config = { resolve: { alias: { '@': './src' } } };
+        consume(config);
+        export default config;
+      `,
+    });
+
+    for (const root of [directoryConfig, dynamicSpread, escapedRoot]) {
+      expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+        aliases: new Map(),
+        complete: false,
+      });
+    }
+  });
+
+  it('preserves relative replacements while evaluating explicit path expressions', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import path from 'node:path';
+        import { defineConfig } from 'vite';
+        const source = path.resolve(__dirname, 'src');
+        const shared = {
+          '@': source,
+          '#literal': './literal',
+        } as const;
+        const aliases = {
+          ...shared,
+          '@feature': path.resolve(__dirname, 'features'),
+        } satisfies Record<string, string>;
+        const resolve = { alias: aliases };
+        const config = { resolve };
+        export default defineConfig(config);
+      `,
+    });
+
+    expect(Object.fromEntries(resolveVueProjectAliases(root))).toEqual({
+      '#literal': './literal',
+      '@': path.join(root, 'src'),
+      '@feature': path.join(root, 'features'),
+    });
+  });
+
+  it('retains callback-local scope for aliases and URL expressions', () => {
+    const root = createProject({
+      'vite.config.mts': `
+        import { defineConfig } from 'vite';
+        import { fileURLToPath as toPath } from 'node:url';
+        export default defineConfig(() => {
+          const source = toPath(new URL('./src', import.meta.url));
+          const shared = [{ find: '@first', replacement: './first' }] as const;
+          const aliases = [
+            ...shared,
+            { find: '@', replacement: source },
+          ];
+          return { resolve: { alias: aliases } };
+        });
+      `,
+    });
+
+    expect([...resolveVueProjectAliases(root)]).toEqual([
+      ['@first', './first'],
+      ['@', path.join(root, 'src')],
+    ]);
+  });
+
+  it('resolves the URL constructor imported by the standard Vite scaffold', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import { fileURLToPath, URL } from 'node:url';
+        import { defineConfig } from 'vite';
+        export default defineConfig({
+          resolve: {
+            alias: {
+              '@': fileURLToPath(new URL('./src', import.meta.url)),
+            },
+          },
+        });
+      `,
+    });
+
+    expect([...resolveVueProjectAliases(root)]).toEqual([
+      ['@', path.join(root, 'src')],
+    ]);
+  });
+
+  it('does not resolve a helper shadowed by a callback parameter', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import path from 'node:path';
+        import { defineConfig } from 'vite';
+        export default defineConfig((path) => ({
+          resolve: { alias: { '@': path.resolve(__dirname, 'wrong') } },
+        }));
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@']),
+    });
+  });
+
+  it('does not trust a mutated path helper', () => {
+    const root = createProject({
+      'vite.config.cjs': `
+        const nodePath = require('node:path');
+        nodePath.resolve = () => '/wrong';
+        module.exports = {
+          resolve: { alias: { '@': nodePath.resolve(__dirname, 'src') } },
+        };
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@']),
+    });
+  });
+
+  it('reads only resolve.alias from a Vite config', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        export default defineConfig({
+          alias: { '@top-level': './ignored-top-level' },
+          resolve: { alias: { '@vite': './vite' } },
+          vite: { resolve: { alias: { '@nested': './ignored-nested' } } },
+        });
+      `,
+    });
+
+    expect([...resolveVueProjectAliases(root)]).toEqual([['@vite', './vite']]);
+  });
+
+  it('preserves configured array order and the first duplicate', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        export default {
+          resolve: {
+            alias: [
+              { find: '@wide/specific', replacement: './specific' },
+              { find: '@wide', replacement: './wide-first' },
+              { find: '@wide', replacement: './wide-second' },
+            ],
+          },
+        };
+      `,
+    });
+
+    expect([...resolveVueProjectAliases(root)]).toEqual([
+      ['@wide/specific', './specific'],
+      ['@wide', './wide-first'],
+    ]);
+  });
+
+  it('synthesizes Nuxt aliases and applies object-form override precedence', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        import { fileURLToPath } from 'node:url';
+        import { defineNuxtConfig as define } from 'nuxt';
+        const src = fileURLToPath(new URL('./src', import.meta.url));
+        export default define({
+          alias: {
+            '#shared': './shared',
+            '@': './nuxt-source',
+          },
+          vite: {
+            resolve: {
+              alias: {
+                '@': src,
+                '@client': './client',
+              },
+            },
+          },
+        });
+      `,
+    });
+
+    expect([
+      ...resolveVueProjectAliases(root, { nuxtMajorVersion: 3 }),
+    ]).toEqual([
+      ['~', trailingSlash(root)],
+      ['@', path.join(root, 'src')],
+      ['~~', trailingSlash(root)],
+      ['@@', trailingSlash(root)],
+      ['#shared', './shared'],
+      ['@client', './client'],
+    ]);
+  });
+
+  it('prepends nested Vite arrays when Nuxt merges unlike alias forms', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        export default defineNuxtConfig({
+          alias: {
+            '@wide': './nuxt-wide',
+            '#shared': './shared',
+          },
+          vite: {
+            resolve: {
+              alias: [
+                { find: '@wide/specific', replacement: './specific' },
+                { find: '@wide', replacement: './vite-wide' },
+              ],
+            },
+          },
+        });
+      `,
+    });
+
+    expect([
+      ...resolveVueProjectAliases(root, { nuxtMajorVersion: 3 }),
+    ]).toEqual([
+      ['@wide/specific', './specific'],
+      ['@wide', './vite-wide'],
+      ['~', trailingSlash(root)],
+      ['@', trailingSlash(root)],
+      ['~~', trailingSlash(root)],
+      ['@@', trailingSlash(root)],
+      ['#shared', './shared'],
+    ]);
+  });
+
+  it('uses Nuxt 3, Nuxt 4, compatibility, and explicit srcDir semantics', () => {
+    const nuxt3 = createProject({
+      'app/App.vue': '<template />',
+      'nuxt.config.ts': 'export default defineNuxtConfig({});',
+    });
+    const nuxt4 = createProject({
+      'app/App.vue': '<template />',
+      'nuxt.config.ts': 'export default defineNuxtConfig({});',
+    });
+    const compatibility = createProject({
+      'app/App.vue': '<template />',
+      'nuxt.config.ts': `export default defineNuxtConfig({ future: { compatibilityVersion: 4 } });`,
+    });
+    const explicit = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'src' });`,
+    });
+    const emptySource = createProject({
+      'app/App.vue': '<template />',
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: '' });`,
+    });
+
+    expect(
+      resolveVueProjectAliases(nuxt3, { nuxtMajorVersion: 3 }).get('@')
+    ).toBe(trailingSlash(nuxt3));
+    expect(
+      resolveVueProjectAliases(nuxt4, { nuxtMajorVersion: 4 }).get('@')
+    ).toBe(trailingSlash(path.join(nuxt4, 'app')));
+    expect(
+      resolveVueProjectAliases(compatibility, { nuxtMajorVersion: 3 }).get('@')
+    ).toBe(trailingSlash(path.join(compatibility, 'app')));
+    expect(
+      resolveVueProjectAliases(explicit, { nuxtMajorVersion: 3 }).get('@')
+    ).toBe(trailingSlash(path.join(explicit, 'src')));
+    expect(
+      resolveVueProjectAliases(emptySource, { nuxtMajorVersion: 4 }).get('@')
+    ).toBe(trailingSlash(path.join(emptySource, 'app')));
+  });
+
+  it('requires a known Nuxt generation when srcDir uses versioned defaults', () => {
+    const unknownDefault = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({});`,
+    });
+    const explicitSource = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'src' });`,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(unknownDefault)).toEqual({
+      aliases: new Map(),
+      complete: false,
+    });
+    expect(resolveVueProjectAliasConfiguration(explicitSource).complete).toBe(
+      true
+    );
+  });
+
+  it('uses the Nuxt 4 legacy-layout fallback when app is effectively empty', () => {
+    const root = createProject({
+      'app/router.options.ts': 'export default {}',
+      'nuxt.config.ts': 'export default defineNuxtConfig({});',
+      'pages/index.vue': '<template />',
+    });
+
+    expect(
+      resolveVueProjectAliases(root, { nuxtMajorVersion: 4 }).get('@')
+    ).toBe(trailingSlash(root));
+  });
+
+  it.each([
+    `srcDir: '../outside'`,
+    `rootDir: '../outside'`,
+    `srcDir: getSourceDirectory()`,
+    `future: getFutureOptions()`,
+  ])('fails closed for an unsafe Nuxt directory configuration: %s', (entry) => {
+    const root = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ ${entry}, alias: { '@safe': './safe' } });`,
+    });
+
+    expect(resolveVueProjectAliases(root, { nuxtMajorVersion: 4 })).toEqual(
+      new Map()
+    );
+  });
+
+  it('rejects a Nuxt srcDir beneath a symlink that escapes the package', () => {
+    const outside = createProject({});
+    const root = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: 'linked/src' });`,
+    });
+    fs.symlinkSync(outside, path.join(root, 'linked'), 'dir');
+
+    expect(resolveVueProjectAliases(root, { nuxtMajorVersion: 4 })).toEqual(
+      new Map()
+    );
+  });
+
+  it('uses the same filename precedence and ambiguity policy as compiler config', () => {
+    const vite = createProject({
+      'vite.config.js': `export default { resolve: { alias: { '@': './js' } } };`,
+      'vite.config.mjs': `export default { resolve: { alias: { '@': './mjs' } } };`,
+      'vite.config.ts': `export default { resolve: { alias: { '@': './ts' } } };`,
+    });
+    const nuxt = createProject({
+      'nuxt.config.mjs': `export default defineNuxtConfig({ alias: { '#which': './mjs' } });`,
+      'nuxt.config.ts': `export default defineNuxtConfig({ alias: { '#which': './ts' } });`,
+    });
+    const ambiguous = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ alias: { '@': './nuxt' } });`,
+      'vite.config.ts': `export default { resolve: { alias: { '@': './vite' } } };`,
+    });
+
+    expect(resolveVueProjectAliases(vite).get('@')).toBe('./js');
+    expect(
+      resolveVueProjectAliases(nuxt, { nuxtMajorVersion: 3 }).get('#which')
+    ).toBe('./ts');
+    expect(resolveVueProjectAliasConfiguration(ambiguous)).toEqual({
+      aliases: new Map(),
+      complete: false,
+    });
+  });
+
+  it('supports CommonJS helper aliases and config exports', () => {
+    const root = createProject({
+      'vite.config.cjs': `
+        const vite = require('vite');
+        const nodePath = require('node:path');
+        const { resolve: resolvePath } = require('path');
+        const aliases = {
+          '@': nodePath.resolve(__dirname, 'src'),
+          '@server': resolvePath(__dirname, 'server'),
+        };
+        module.exports = vite.defineConfig({ resolve: { alias: aliases } });
+      `,
+    });
+
+    expect(Object.fromEntries(resolveVueProjectAliases(root))).toEqual({
+      '@': path.join(root, 'src'),
+      '@server': path.join(root, 'server'),
+    });
+  });
+
+  it('never executes config code', () => {
+    const root = createProject({});
+    const marker = path.join(root, 'executed.txt');
+    writeFiles(root, {
+      'vite.config.js': `
+        import fs from 'node:fs';
+        fs.writeFileSync(${JSON.stringify(marker)}, 'executed');
+        throw new Error('config execution is forbidden');
+        export default defineConfig({
+          resolve: { alias: { '@': './src' } },
+        });
+      `,
+    });
+
+    expect(resolveVueProjectAliases(root).get('@')).toBe('./src');
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  it('marks a dynamic replacement incomplete without returning partial aliases', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        export default {
+          resolve: {
+            alias: {
+              '@static': './static',
+              '@dynamic': getReplacement(),
+            },
+          },
+        };
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@static', '@dynamic']),
+      potentialAliases: new Map([['@static', new Set(['./static'])]]),
+    });
+    expect(resolveVueProjectAliases(root)).toEqual(new Map());
+  });
+
+  it.each([
+    [`aliases['@'] = './after';`, false],
+    [`aliases.extra = './extra';`, false],
+    [`delete aliases['@'];`, false],
+    [`Object.assign(aliases, { '@': './after' });`, true],
+    [`consume(aliases);`, true],
+    [`const escaped = aliases; consume(escaped);`, true],
+    [`consume({ alias: aliases });`, true],
+    [`const holder = { alias: aliases }; consume(holder);`, true],
+    [`const registry = [aliases]; consume(registry);`, true],
+  ])(
+    'fails closed when an alias binding mutates or escapes: %s',
+    (escape, hasKey) => {
+      const root = createProject({
+        'vite.config.ts': `
+        const aliases = { '@': './before' };
+        ${escape}
+        export default { resolve: { alias: aliases } };
+      `,
+      });
+
+      expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+        aliases: new Map(),
+        complete: false,
+        ...(hasKey && {
+          potentialAliases: new Map([['@', new Set(['./before'])]]),
+        }),
+        ...(hasKey && { potentialAliasKeys: new Set(['@']) }),
+      });
+    }
+  );
+
+  it.each([
+    [
+      'before a dynamic override',
+      `{ '@i18n': './base', ...getAliases() }`,
+      './base',
+    ],
+    [
+      'after a dynamic spread',
+      `{ ...getAliases(), '@i18n': './fixed' }`,
+      './fixed',
+    ],
+    [
+      'beside a dynamic array spread',
+      `[{ find: '@i18n', replacement: './fixed' }, ...getAliases()]`,
+      './fixed',
+    ],
+  ])('retains a static alias key %s', (_label, aliases, replacement) => {
+    const root = createProject({
+      'vite.config.ts': `
+        export default { resolve: { alias: ${aliases} } };
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@i18n']),
+      potentialAliases: new Map([['@i18n', new Set([replacement])]]),
+    });
+    expect(resolveVueProjectAliases(root)).toEqual(new Map());
+  });
+
+  it('fails closed when a dynamic spread can change alias precedence', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        const dynamic = getAliases();
+        const aliases = { '@static': './static', ...dynamic };
+        export default { resolve: { alias: aliases } };
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@static']),
+      potentialAliases: new Map([['@static', new Set(['./static'])]]),
+    });
+  });
+
+  it('preserves every static candidate for a duplicated incomplete alias', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        export default {
+          resolve: {
+            alias: [
+              { find: '@i18n', replacement: './first' },
+              ...getAliases(),
+              { find: '@i18n', replacement: './second' },
+            ],
+          },
+        };
+      `,
+    });
+
+    expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+      aliases: new Map(),
+      complete: false,
+      potentialAliasKeys: new Set(['@i18n']),
+      potentialAliases: new Map([['@i18n', new Set(['./first', './second'])]]),
+    });
+    expect(resolveVueProjectAliases(root)).toEqual(new Map());
+  });
+
+  it.each([
+    [`{ find: '@', replacement: './src', customResolver() {} }`, true],
+    [`{ find: '@', replacement: './src', customResolver: undefined }`, true],
+    [`{ find: /^@/, replacement: './src' }`, false],
+  ])(
+    'fails closed for alias behavior that string mappings cannot model: %s',
+    (alias, hasKey) => {
+      const root = createProject({
+        'vite.config.ts': `export default { resolve: { alias: [${alias}] } };`,
+      });
+
+      expect(resolveVueProjectAliasConfiguration(root)).toEqual({
+        aliases: new Map(),
+        complete: false,
+        ...(hasKey && {
+          potentialAliases: new Map([['@', new Set(['./src'])]]),
+        }),
+        ...(hasKey && { potentialAliasKeys: new Set(['@']) }),
+      });
+    }
+  );
+
+  it('uses only an explicit in-package Vite config when supplied', () => {
+    const root = createProject({
+      'vite.config.ts': `export default { resolve: { alias: { '@': './default' } } };`,
+      'config/preview.config.ts': `export default { resolve: { alias: { '@': '../preview' } } };`,
+    });
+    const outside = createProject({
+      'vite.config.ts': `export default { resolve: { alias: { '@': './outside' } } };`,
+    });
+
+    expect(
+      resolveVueProjectAliases(root, {
+        viteConfigPath: 'config/preview.config.ts',
+      }).get('@')
+    ).toBe('../preview');
+    expect(
+      resolveVueProjectAliasConfiguration(root, {
+        viteConfigPath: path.join(outside, 'vite.config.ts'),
+      })
+    ).toEqual({ aliases: new Map(), complete: false });
+    expect(
+      resolveVueProjectAliasConfiguration(root, { viteConfigPath: '' })
+    ).toEqual({ aliases: new Map(), complete: false });
+  });
+});
+
+function createProject(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-aliases-'));
+  temporaryDirectories.push(root);
+  writeFiles(root, files);
+  return root;
+}
+
+function writeFiles(root: string, files: Record<string, string>): void {
+  for (const [relativePath, contents] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, contents);
+  }
+}
+
+function trailingSlash(directory: string): string {
+  return `${directory.replaceAll(path.sep, '/')}/`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/reactCliParityAudit.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/reactCliParityAudit.test.ts
@@ -1,0 +1,392 @@
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('React CLI parity audit: rich Vue content', () => {
+  it('serializes nested branches and public formatter value props', async () => {
+    const source = createSfc(
+      `
+        import {
+          Branch,
+          Currency,
+          DateTime,
+          Num,
+          Plural,
+          T,
+          Var,
+        } from 'gt-vue';
+        const count = 2;
+        const name = 'Ada';
+        const price = 12;
+        const createdAt = new Date();
+      `,
+      `<T><Branch branch="formal"><template #formal><section><Plural :n="count"><template #one>One <Var>{{ name }}</Var><Num :value="count" /></template><template #other><Currency :value="price" /> on <DateTime :value="createdAt" /></template>Plural fallback</Plural></section></template><template #casual>Casual</template>Branch fallback</Branch><hr /><br /></T>`
+    );
+    assertVueCompiles(source, 'nested-formatters');
+
+    const output = await extract(source, 'nested-formatters');
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      [
+        {
+          t: 'Branch',
+          i: 1,
+          d: {
+            b: {
+              formal: {
+                t: 'section',
+                i: 2,
+                c: {
+                  t: 'Plural',
+                  i: 3,
+                  d: {
+                    b: {
+                      one: [
+                        'One ',
+                        { i: 4, k: '_gt_value_4', v: 'v' },
+                        { i: 5, k: '_gt_n_5', v: 'n' },
+                      ],
+                      other: [
+                        { i: 4, k: '_gt_cost_4', v: 'c' },
+                        ' on ',
+                        { i: 5, k: '_gt_date_5', v: 'd' },
+                      ],
+                    },
+                    t: 'p',
+                  },
+                  c: 'Plural fallback',
+                },
+              },
+              casual: 'Casual',
+            },
+            t: 'b',
+          },
+          c: 'Branch fallback',
+        },
+        { t: 'hr', i: 2 },
+        { t: 'br', i: 3 },
+      ],
+    ]);
+  });
+
+  it('keeps numeric, empty, Unicode, and control branch values static', async () => {
+    const source = createSfc(
+      `import { Branch, T } from 'gt-vue';`,
+      `<T><Branch branch="hex" :hex="0x10" :octal="0o10" :binary="0b10" :scientific="1e2" :negative="-3.5" :smallest="5e-324" :underflow="1e-324" :largest="1.7976931348623157e308" :negativeZero="-0" :epsilon="2.220446049250313e-16" empty="" :disabled="false" :nothing="null" unicode="你好" :control="'\\n\\t'">Fallback</Branch></T>`
+    );
+    assertVueCompiles(source, 'primitive-branches');
+
+    const output = await extract(source, 'primitive-branches');
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      {
+        t: 'Branch',
+        i: 1,
+        d: {
+          b: {
+            hex: '16',
+            octal: '8',
+            binary: '2',
+            scientific: '100',
+            negative: '-3.5',
+            smallest: '5e-324',
+            underflow: '0',
+            largest: '1.7976931348623157e+308',
+            negativeZero: '0',
+            epsilon: '2.220446049250313e-16',
+            empty: '',
+            disabled: [],
+            nothing: [],
+            unicode: '你好',
+            control: '\n\t',
+          },
+          t: 'b',
+        },
+        c: 'Fallback',
+      },
+    ]);
+  });
+
+  it('extracts legacy and CLDR plural forms together', async () => {
+    const source = createSfc(
+      `import { Plural, T } from 'gt-vue';`,
+      `<T><Plural :n="2" singular="Single" dual="Double" plural="Plural" zero="Zero" one="One" two="Two" few="Few" many="Many" other="Other">Fallback</Plural></T>`
+    );
+    assertVueCompiles(source, 'plural-forms');
+
+    const output = await extract(source, 'plural-forms');
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      {
+        t: 'Plural',
+        i: 1,
+        d: {
+          b: {
+            singular: 'Single',
+            dual: 'Double',
+            plural: 'Plural',
+            zero: 'Zero',
+            one: 'One',
+            two: 'Two',
+            few: 'Few',
+            many: 'Many',
+            other: 'Other',
+          },
+          t: 'p',
+        },
+        c: 'Fallback',
+      },
+    ]);
+  });
+
+  it('preserves entities, built-ins, custom components, and void elements', async () => {
+    const source = createSfc(
+      `import { T } from 'gt-vue'; import Card from './Card.vue';`,
+      `<T>Hello&nbsp;<Suspense><Card title="Heading">Custom &amp; deep</Card></Suspense><Transition><p>Motion</p></Transition><img alt="Portrait" /><br /></T>`
+    );
+    assertVueCompiles(source, 'elements');
+
+    const output = await extract(source, 'elements');
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      [
+        'Hello\u00a0',
+        {
+          t: 'Suspense',
+          i: 1,
+          c: {
+            t: 'Card',
+            i: 2,
+            d: { ti: 'Heading' },
+          },
+        },
+        { t: 'Transition', i: 3 },
+        { t: 'img', i: 4, d: { alt: 'Portrait' } },
+        { t: 'br', i: 5 },
+      ],
+    ]);
+  });
+
+  it('preserves empty translations and empty named branches', async () => {
+    const source = createSfc(
+      `import { Branch, T } from 'gt-vue';`,
+      `<T></T><T><Branch branch="formal"><template #formal></template><template #casual>Casual</template></Branch></T>`
+    );
+    assertVueCompiles(source, 'empty-content');
+
+    const output = await extract(source, 'empty-content');
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      [],
+      {
+        t: 'Branch',
+        i: 1,
+        d: { b: { formal: [], casual: 'Casual' }, t: 'b' },
+      },
+    ]);
+  });
+
+  it('continues to reject value props on Var', async () => {
+    const source = createSfc(
+      `import { T, Var } from 'gt-vue'; const name = 'Ada';`,
+      `<T><Var :value="name">{{ name }}</Var></T>`
+    );
+    assertVueCompiles(source, 'var-value');
+
+    const output = await extract(source, 'var-value');
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('unsupported value prop');
+  });
+
+  it('diagnoses special global interpolations instead of hashing them incorrectly', async () => {
+    const source = createSfc(
+      `import { T } from 'gt-vue';`,
+      `<T>{{ undefined }}{{ NaN }}{{ Infinity }}</T>`
+    );
+    assertVueCompiles(source, 'special-globals');
+
+    const output = await extract(source, 'special-globals');
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(3);
+    expect(
+      output.errors.every((error) => error.includes('dynamic template content'))
+    ).toBe(true);
+  });
+});
+
+describe('React CLI parity audit: string calls', () => {
+  it('handles encoded nesting, decode exclusions, arrays, and Unicode', async () => {
+    const source = createSfc(
+      `
+        import { msg, useMessages } from 'gt-vue';
+        const m = useMessages();
+        const raw = 'Raw identifier';
+        const encoded = msg('Encoded', { $context: 'encoded' });
+        m(raw);
+        m(encoded);
+        m(msg('Nested', { $context: 'nested' }));
+        msg.decode(encoded);
+        msg['decode'](encoded);
+        msg(['First', \`Second\`], { $context: 'list' });
+        msg([]);
+        msg(['Only']);
+        msg('こんにちは\\n世界', { $context: 'unicode' });
+      `,
+      `<div />`
+    );
+    assertVueCompiles(source, 'string-parity');
+
+    const output = await extract(source, 'string-parity');
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results.map((result) => ({
+        source: result.source,
+        context: result.metadata.context,
+      }))
+    ).toEqual([
+      { source: 'Encoded', context: 'encoded' },
+      { source: 'Raw identifier', context: undefined },
+      { source: 'Nested', context: 'nested' },
+      { source: 'First', context: 'list' },
+      { source: 'Second', context: 'list' },
+      { source: 'Only', context: undefined },
+      { source: 'こんにちは\n世界', context: 'unicode' },
+    ]);
+  });
+});
+
+describe('Vue catalog safety', () => {
+  it.each([
+    {
+      name: 'unclosed translation element',
+      source: `<script setup>import { msg, T } from 'gt-vue'; msg('Script');</script><template><T>Broken`,
+    },
+    {
+      name: 'invalid closing element',
+      source: `<script setup>import { msg, T } from 'gt-vue'; msg('Script');</script><template><T>First</T></Wrong></template>`,
+    },
+    {
+      name: 'duplicate template blocks',
+      source: `<script setup>import { msg, T } from 'gt-vue'; msg('Script');</script><template><T>First</T></template><template><T>Second</T></template>`,
+    },
+  ])('emits no partial catalog for $name', async ({ name, source }) => {
+    const output = await extract(source, `malformed-${slug(name)}`);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not parse a gt-vue single-file component'
+    );
+  });
+
+  it.each([
+    {
+      name: 'malformed normal script with valid setup',
+      source: `<script>import { msg } from 'gt-vue'; msg(</script><script setup>import { T } from 'gt-vue';</script><template><T>Template</T></template>`,
+      diagnostic: 'Could not parse a gt-vue script block',
+    },
+    {
+      name: 'valid normal script with malformed setup',
+      source: `<script>import { msg } from 'gt-vue'; msg('Normal');</script><script setup>import { T } from 'gt-vue'; const broken = ;</script><template><T>Template</T></template>`,
+      diagnostic: 'Could not parse a gt-vue script block',
+    },
+    {
+      name: 'external script block',
+      source: `<script src="./logic.ts"></script><template><div /></template>`,
+      diagnostic: 'externally sourced Vue script block',
+    },
+    {
+      name: 'unsupported script language',
+      source: `<script lang="coffee">msg 'Script'</script><template><div /></template>`,
+      diagnostic: 'unsupported Vue script language "coffee"',
+    },
+    {
+      name: 'external template block',
+      source: `<script setup>import { msg } from 'gt-vue'; msg('Script');</script><template src="./view.html"></template>`,
+      diagnostic: 'externally sourced Vue template',
+    },
+    {
+      name: 'unsupported template language',
+      source: `<script setup>import { msg } from 'gt-vue'; msg('Script');</script><template lang="pug">p Template</template>`,
+      diagnostic: 'unsupported Vue template language "pug"',
+    },
+  ])('fails closed for $name', async ({ diagnostic, name, source }) => {
+    const output = await extract(source, `unsupported-${slug(name)}`);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(diagnostic);
+  });
+
+  it('keeps valid entries alongside a per-entry semantic diagnostic', async () => {
+    const source = createSfc(
+      `
+        import { msg, T } from 'gt-vue';
+        const runtime = String(Date.now());
+        msg('Script valid');
+      `,
+      `<T>Template valid</T><T>{{ runtime }}</T>`
+    );
+    assertVueCompiles(source, 'semantic-partial');
+
+    const output = await extract(source, 'semantic-partial');
+
+    expect(output.results.map((result) => result.source)).toEqual([
+      'Script valid',
+      'Template valid',
+    ]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('dynamic template content');
+  });
+});
+
+function createSfc(script: string, template: string): string {
+  return `<script setup lang="ts">${script}</script><template>${template}</template>`;
+}
+
+function extract(source: string, name: string) {
+  return extractFromVueSource(source, `/project/src/${name}.vue`, {
+    projectRoot: '/project',
+  });
+}
+
+function richSources(
+  results: Awaited<ReturnType<typeof extractFromVueSource>>['results']
+): JsxChildren[] {
+  return results
+    .filter((result) => result.dataFormat === 'JSX')
+    .map((result) => result.source);
+}
+
+function assertVueCompiles(source: string, name: string): void {
+  const filename = `/project/src/${name}.vue`;
+  const parsed = parse(source, { filename });
+  expect(parsed.errors, `${name}: SFC parse`).toEqual([]);
+  const script = compileScript(parsed.descriptor, {
+    babelParserPlugins: ['typescript'],
+    id: `audit-${name}`,
+  });
+  const template = parsed.descriptor.template;
+  if (!template) return;
+  const compiled = compileTemplate({
+    compilerOptions: {
+      bindingMetadata: script.bindings,
+      expressionPlugins: ['typescript'],
+    },
+    filename,
+    id: `audit-${name}`,
+    source: template.content,
+  });
+  expect(compiled.errors, `${name}: template compile`).toEqual([]);
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+}

--- a/packages/vue-extractor/src/internal/__tests__/refComputedIdentitySemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/refComputedIdentitySemantics.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type RefComputedProbe = {
+  /** Human-readable Vue identity rule exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script setup block. */
+  code: string;
+  /** Whether Vue's top-level unwrapped value can contain `<T>`. */
+  possibleT: boolean;
+};
+
+/**
+ * Runtime-verified identity cases for Vue refs, computed refs, and identity APIs.
+ *
+ * A ref, shallowRef, unref result, markRaw result, or ordinary function result
+ * captures its value object at the call or assignment point. Rebinding the
+ * source variable does not retarget that object, although later writes through
+ * a shared object remain visible. A computed getter instead closes over a live
+ * binding and evaluates lazily, so it observes the final binding at render time.
+ * Vue templates top-level-unwrap these values. `readonly(ref(...))` deeply
+ * blocks nested writes, while `shallowReadonly(ref(...))` blocks `.value`
+ * replacement but permits writes inside the returned reactive value.
+ *
+ * These expectations were checked with Vue 3.5.40. A possible `<T>` must fail
+ * closed with the standard alias diagnostic; an ordinary final value is silent.
+ */
+const refComputedProbes: RefComputedProbe[] = [
+  {
+    name: 'a nested ref write adds T',
+    code: 'const registry = ref([String]); registry.value[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'a nested ref write erases T',
+    code: 'const registry = ref([T]); registry.value[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a ref value replacement adds T',
+    code: 'const registry = ref([String]); registry.value = [T];',
+    possibleT: true,
+  },
+  {
+    name: 'a ref value replacement erases T',
+    code: 'const registry = ref([T]); registry.value = [String];',
+    possibleT: false,
+  },
+  {
+    name: 'ref captures an old raw T object across a source rebind',
+    code: 'let raw = [T]; const registry = ref(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'ref is not retargeted by a later raw T rebind',
+    code: 'let raw = [String]; const registry = ref(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'shallowRef captures an old T object across a source rebind',
+    code: 'let raw = [T]; const registry = shallowRef(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'shallowRef is not retargeted by a later raw T rebind',
+    code: 'let raw = [String]; const registry = shallowRef(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'ref observes a later nested raw T write',
+    code: 'const raw = [String]; const registry = ref(raw); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'ref observes a later nested raw T erasure',
+    code: 'const raw = [T]; const registry = ref(raw); raw[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'computed reads the final ordinary source binding',
+    code: 'let raw = [T]; const registry = computed(() => raw); raw = [String];',
+    possibleT: false,
+  },
+  {
+    name: 'computed reads the final T source binding',
+    code: 'let raw = [String]; const registry = computed(() => raw); raw = [T];',
+    possibleT: true,
+  },
+  {
+    name: 'computed observes a later nested T write',
+    code: 'const raw = [String]; const registry = computed(() => raw); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'computed observes a later nested T erasure',
+    code: 'const raw = [T]; const registry = computed(() => raw); raw[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a writable computed getter reads the final T binding',
+    code: 'let raw = [String]; const registry = computed({ get: () => raw, set() {} }); raw = [T];',
+    possibleT: true,
+  },
+  {
+    name: 'a writable computed getter reads the final ordinary binding',
+    code: 'let raw = [T]; const registry = computed({ get: () => raw, set() {} }); raw = [String];',
+    possibleT: false,
+  },
+  {
+    name: 'an unref result captures its old T value object',
+    code: 'const holder = ref([T]); const registry = unref(holder); holder.value = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'an unref result is not retargeted to a later T value',
+    code: 'const holder = ref([String]); const registry = unref(holder); holder.value = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'an unref result shares a nested T write through its old value',
+    code: 'const holder = ref([String]); const registry = unref(holder); holder.value[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'an unref result shares a nested erasure through its old value',
+    code: 'const holder = ref([T]); const registry = unref(holder); holder.value[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'markRaw captures its old T object across a source rebind',
+    code: 'let raw = [T]; const registry = markRaw(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'markRaw is not retargeted by a later raw T rebind',
+    code: 'let raw = [String]; const registry = markRaw(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'markRaw shares a later nested T write',
+    code: 'const raw = [String]; const registry = markRaw(raw); raw[0] = T;',
+    possibleT: true,
+  },
+  {
+    name: 'markRaw shares a later nested T erasure',
+    code: 'const raw = [T]; const registry = markRaw(raw); raw[0] = String;',
+    possibleT: false,
+  },
+  {
+    name: 'a local identity call captures its old T argument object',
+    code: 'let raw = [T]; const identity = (value) => value; const registry = identity(raw); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'a local identity call is not retargeted by a later T rebind',
+    code: 'let raw = [String]; const identity = (value) => value; const registry = identity(raw); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'a zero-argument local call captures the old T object',
+    code: 'let raw = [T]; const read = () => raw; const registry = read(); raw = [String];',
+    possibleT: true,
+  },
+  {
+    name: 'a zero-argument local call is not retargeted by a later T rebind',
+    code: 'let raw = [String]; const read = () => raw; const registry = read(); raw = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'readonly ref blocks a T value replacement',
+    code: 'const registry = readonly(ref([String])); registry.value = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'readonly ref deeply blocks a nested T write',
+    code: 'const registry = readonly(ref([String])); registry.value[0] = T;',
+    possibleT: false,
+  },
+  {
+    name: 'shallowReadonly ref blocks a T value replacement',
+    code: 'const registry = shallowReadonly(ref([String])); registry.value = [T];',
+    possibleT: false,
+  },
+  {
+    name: 'shallowReadonly ref permits a nested T write',
+    code: 'const registry = shallowReadonly(ref([String])); registry.value[0] = T;',
+    possibleT: true,
+  },
+];
+
+describe('Vue ref and computed identity semantics', () => {
+  it.each(refComputedProbes)('$name', async ({ code, possibleT }) => {
+    const output = await extractFromVueSource(
+      createFixture(code),
+      '/fixtures/RefComputedIdentity.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    if (possibleT) {
+      expect(output.errors.join('\n')).toContain(POSSIBLE_ALIAS_DIAGNOSTIC);
+    } else {
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+/** Creates an SFC that relies on Vue's top-level template ref unwrapping. */
+function createFixture(code: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    import {
+      computed,
+      markRaw,
+      readonly,
+      ref,
+      shallowReadonly,
+      shallowRef,
+      unref,
+    } from 'vue';
+    ${code}
+    const key = getIndex();
+  </script>
+  <template><component :is="registry[key]">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/renderFunctionSafety.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/renderFunctionSafety.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+type RenderSafetyProbe = {
+  /** Human-readable unsupported rich-render path exercised by the probe. */
+  name: string;
+  /** Complete SFC source for the render path. */
+  source: string;
+  /** Diagnostic fragment proving that extraction failed closed. */
+  diagnostic: string;
+};
+
+/**
+ * Safety cases for programmatic rich `<T>` rendering.
+ *
+ * Rich translation extraction supports declarative SFC templates and Vue
+ * JSX/TSX. Programmatic `h()` and `createVNode()` calls, plus async component
+ * wrappers that visibly receive imported `<T>`, must still fail closed instead
+ * of silently producing an empty catalog.
+ */
+const renderSafetyProbes: RenderSafetyProbe[] = [
+  {
+    name: 'an Options API render function calls h with T',
+    source: `<script>
+      import { h } from 'vue';
+      import { T } from 'gt-vue';
+      export default { render() { return h(T, null, 'Hello'); } };
+    </script>`,
+    diagnostic: 'gt-vue',
+  },
+  {
+    name: 'an Options API render function calls createVNode with T',
+    source: `<script>
+      import { createVNode } from 'vue';
+      import { T } from 'gt-vue';
+      export default { render() { return createVNode(T, null, 'Hello'); } };
+    </script>`,
+    diagnostic: 'gt-vue',
+  },
+  {
+    name: 'an Options API setup function returns a render function with T',
+    source: `<script>
+      import { h } from 'vue';
+      import { T } from 'gt-vue';
+      export default { setup() { return () => h(T, null, 'Hello'); } };
+    </script>`,
+    diagnostic: 'gt-vue',
+  },
+  {
+    name: 'a defineComponent render function calls h with T',
+    source: `<script>
+      import { defineComponent, h } from 'vue';
+      import { T } from 'gt-vue';
+      export default defineComponent({
+        render() { return h(T, null, 'Hello'); },
+      });
+    </script>`,
+    diagnostic: 'gt-vue',
+  },
+  {
+    name: 'script setup passes T to createVNode used as a component',
+    source: `<script setup>
+      import { createVNode } from 'vue';
+      import { T } from 'gt-vue';
+      const vnode = createVNode(T, null, 'Hello');
+    </script>
+    <template><component :is="vnode" /></template>`,
+    diagnostic: 'possible gt-vue component alias',
+  },
+  {
+    name: 'resolveDynamicComponent receives T',
+    source: `<script setup>
+      import { resolveDynamicComponent } from 'vue';
+      import { T } from 'gt-vue';
+      const selected = resolveDynamicComponent(T);
+    </script>
+    <template><component :is="selected">Hello</component></template>`,
+    diagnostic: 'possible gt-vue component alias',
+  },
+  {
+    name: 'defineAsyncComponent resolves to T',
+    source: `<script setup>
+      import { defineAsyncComponent } from 'vue';
+      import { T } from 'gt-vue';
+      const selected = defineAsyncComponent(() => Promise.resolve(T));
+    </script>
+    <template><component :is="selected">Hello</component></template>`,
+    diagnostic: 'gt-vue',
+  },
+];
+
+describe('programmatic rich translation safety', () => {
+  it.each(renderSafetyProbes)('$name', async ({ source, diagnostic }) => {
+    const output = await extractFromVueSource(
+      source,
+      '/fixtures/RenderFunctionSafety.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(diagnostic);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/resolveVueCompilerOptions.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/resolveVueCompilerOptions.test.ts
@@ -1,0 +1,1110 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveVueCompilerOptions } from '../../config.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('resolveVueCompilerOptions', () => {
+  it('uses explicit options when no framework config exists', () => {
+    const root = createProject({});
+
+    expect(
+      resolveVueCompilerOptions(root, {
+        delimiters: ['[[', ']]'],
+        whitespace: 'condense',
+      })
+    ).toEqual({
+      compilerOptions: {
+        delimiters: ['[[', ']]'],
+        whitespace: 'condense',
+      },
+      errors: [],
+    });
+  });
+
+  it('resolves static Vite options through aliases, spreads, and TypeScript wrappers', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        const delimiters = ['[[', ']]'] as const;
+        const compilerOptions = {
+          whitespace: 'preserve',
+          delimiters,
+        } satisfies Record<string, unknown>;
+        const template = { compilerOptions: { ...compilerOptions } };
+        export default { plugins: [vue({ template })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {
+        delimiters: ['[[', ']]'],
+        whitespace: 'preserve',
+      },
+      errors: [],
+    });
+  });
+
+  it('accepts Vue JSX options that do not affect supported source hashes', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import vueJsx from '@vitejs/plugin-vue-jsx';
+        const plugin = vueJsx;
+        export default { plugins: [plugin({
+          babelPlugins: [],
+          defineComponentName: ['defineComponent'],
+          enableObjectSlots: true,
+          mergeProps: true,
+          optimize: true,
+          pragma: '',
+          resolveType: false,
+          transformOn: false,
+          tsPluginOptions: {},
+        })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it.each([
+    {
+      name: 'a replacement VNode pragma',
+      options: `pragma: 'customVNode'`,
+      diagnostic: 'option "pragma"',
+    },
+    {
+      name: 'custom Babel transforms',
+      options: `babelPlugins: [customPlugin]`,
+      diagnostic: 'option "babelPlugins"',
+    },
+    {
+      name: 'a custom include filter',
+      options: `include: /src/`,
+      diagnostic: 'option "include"',
+    },
+    {
+      name: 'a custom exclude filter',
+      options: `exclude: /generated/`,
+      diagnostic: 'option "exclude"',
+    },
+    {
+      name: 'custom TypeScript transforms',
+      options: `tsPluginOptions: { optimizeConstEnums: true }`,
+      diagnostic: 'option "tsPluginOptions"',
+    },
+    {
+      name: 'custom-element classification',
+      options: `isCustomElement: (tag) => tag.startsWith('x-')`,
+      diagnostic: 'option "isCustomElement"',
+    },
+    {
+      name: 'disabled object-slot normalization',
+      options: `enableObjectSlots: false`,
+      diagnostic: 'option "enableObjectSlots"',
+    },
+    {
+      name: 'disabled prop merging',
+      options: `mergeProps: false`,
+      diagnostic: 'option "mergeProps"',
+    },
+    {
+      name: 'listener-object transformation',
+      options: `transformOn: true`,
+      diagnostic: 'option "transformOn"',
+    },
+    {
+      name: 'runtime type inference',
+      options: `resolveType: true`,
+      diagnostic: 'option "resolveType"',
+    },
+    {
+      name: 'custom component factory names',
+      options: `defineComponentName: ['component']`,
+      diagnostic: 'option "defineComponentName"',
+    },
+    {
+      name: 'a future unknown option',
+      options: `futureVNodeMode: true`,
+      diagnostic: 'option "futureVNodeMode"',
+    },
+    {
+      name: 'a dynamic optimization option',
+      options: `optimize: process.env.OPTIMIZE === '1'`,
+      diagnostic: 'option "optimize"',
+    },
+  ])(
+    'fails closed for $name in the Vue JSX plugin',
+    ({ options, diagnostic }) => {
+      const root = createProject({
+        'vite.config.ts': `
+        import * as pluginVueJsx from '@vitejs/plugin-vue-jsx';
+        const customPlugin = () => ({ visitor: {} });
+        const jsx = pluginVueJsx.default;
+        export default { plugins: [jsx({ ${options} })] };
+      `,
+      });
+
+      const result = resolveVueCompilerOptions(root, undefined);
+
+      expect(result.compilerOptions).toEqual({});
+      expect(result.errors.join('\n')).toContain(diagnostic);
+    }
+  );
+
+  it('fails closed when active Vue JSX plugin options are dynamic', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import vueJsx from '@vitejs/plugin-vue-jsx';
+        const options = getOptions();
+        export default { plugins: [vueJsx(options)] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve @vitejs/plugin-vue-jsx options'
+    );
+  });
+
+  it('tracks CommonJS Vue JSX plugin imports before auditing options', () => {
+    const root = createProject({
+      'vite.config.cjs': `
+        const vueJsx = require('@vitejs/plugin-vue-jsx').default;
+        module.exports = { plugins: [vueJsx({ mergeProps: false })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain('option "mergeProps"');
+  });
+
+  it('resolves static Nuxt compiler options', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        const whitespace = \`preserve\`;
+        const delimiters = ['<%', '%>'] as const;
+        export default defineNuxtConfig({
+          vue: { compilerOptions: { whitespace, delimiters } },
+        });
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {
+        delimiters: ['<%', '%>'],
+        whitespace: 'preserve',
+      },
+      errors: [],
+    });
+  });
+
+  it('fails closed when Nuxt layers can contribute compiler options', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        export default defineNuxtConfig({ extends: ['./layers/base'] });
+      `,
+      'layers/base/nuxt.config.ts': `
+        export default defineNuxtConfig({
+          vue: { compilerOptions: { delimiters: ['[[', ']]'] } },
+        });
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain('Nuxt layer inheritance');
+  });
+
+  it.each([
+    {
+      name: 'a custom srcDir',
+      config: `export default defineNuxtConfig({ srcDir: 'client/' });`,
+    },
+    {
+      name: 'custom directory overrides',
+      config: `export default defineNuxtConfig({ dir: { pages: 'screens' } });`,
+    },
+  ])(
+    'fails closed for $name that default discovery cannot scan',
+    ({ config }) => {
+      const root = createProject({ 'nuxt.config.ts': config });
+
+      const result = resolveVueCompilerOptions(root, undefined);
+
+      expect(result.compilerOptions).toEqual({});
+      expect(result.errors.join('\n')).toContain(
+        'custom Nuxt source directories'
+      );
+    }
+  );
+
+  it.each(['.', './', 'app/', 'src/'])(
+    'accepts the covered Nuxt srcDir %s',
+    (srcDir) => {
+      const root = createProject({
+        'nuxt.config.ts': `export default defineNuxtConfig({ srcDir: ${JSON.stringify(srcDir)} });`,
+      });
+
+      expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+        compilerOptions: {},
+        errors: [],
+      });
+    }
+  );
+
+  it('resolves a Vue plugin namespace import', () => {
+    const root = createProject({
+      'vite.config.mjs': `
+        import * as pluginVue from '@vitejs/plugin-vue';
+        export default { plugins: [pluginVue.default({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { whitespace: 'preserve' },
+      errors: [],
+    });
+  });
+
+  it('resolves a CommonJS Vue plugin default import', () => {
+    const root = createProject({
+      'vite.config.cjs': `
+        const vue = require('@vitejs/plugin-vue').default;
+        module.exports = { plugins: [vue({
+          template: { compilerOptions: { delimiters: ['[[', ']]'] } },
+        })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { delimiters: ['[[', ']]'] },
+      errors: [],
+    });
+  });
+
+  it('resolves a plain Nuxt default-exported object', () => {
+    const root = createProject({
+      'nuxt.config.js': `
+        export default {
+          vue: { compilerOptions: { whitespace: 'preserve' } },
+        };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { whitespace: 'preserve' },
+      errors: [],
+    });
+  });
+
+  it('combines matching explicit and project options', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        })] };
+      `,
+    });
+
+    expect(
+      resolveVueCompilerOptions(root, {
+        delimiters: ['[[', ']]'],
+        whitespace: 'preserve',
+      })
+    ).toEqual({
+      compilerOptions: {
+        delimiters: ['[[', ']]'],
+        whitespace: 'preserve',
+      },
+      errors: [],
+    });
+  });
+
+  it('fails closed when explicit and project options conflict', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({
+          template: { compilerOptions: { whitespace: 'condense' } },
+        })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, {
+      whitespace: 'preserve',
+    });
+
+    expect(result.compilerOptions).toEqual({ whitespace: 'preserve' });
+    expect(result.errors.join('\n')).toContain(
+      'conflicting Vue whitespace compiler options'
+    );
+  });
+
+  it('fails closed for dynamic hash-affecting options', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        const compilerOptions = getCompilerOptions();
+        export default { plugins: [vue({ template: { compilerOptions } })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it('fails closed for a dynamic compiler-options parent', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        const vue = getVueOptions();
+        export default defineNuxtConfig({ vue });
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it.each([
+    'nodeTransforms',
+    'directiveTransforms',
+    'isCustomElement',
+    'getNamespace',
+    'getTextMode',
+    'decodeEntities',
+    'comments',
+    'prefixIdentifiers',
+    'hoistStatic',
+    'cacheHandlers',
+    'scopeId',
+  ])('fails closed for the Vite compiler option %s', (option) => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: {
+          whitespace: 'preserve',
+          ${option}: true,
+        } } })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({ whitespace: 'preserve' });
+    expect(result.errors.join('\n')).toContain(
+      `unsupported Vue compiler option "${option}"`
+    );
+  });
+
+  it.each(['nodeTransforms', 'directiveTransforms', 'isCustomElement'])(
+    'fails closed for the Nuxt compiler option %s',
+    (option) => {
+      const root = createProject({
+        'nuxt.config.ts': `
+          export default defineNuxtConfig({ vue: { compilerOptions: {
+            delimiters: ['[[', ']]'],
+            ${option}: true,
+          } } });
+        `,
+      });
+
+      const result = resolveVueCompilerOptions(root, undefined);
+
+      expect(result.compilerOptions).toEqual({ delimiters: ['[[', ']]'] });
+      expect(result.errors.join('\n')).toContain(
+        `unsupported Vue compiler option "${option}"`
+      );
+    }
+  );
+
+  it('fails closed for a custom Vite compiler-sfc instance', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        import * as compiler from './custom-compiler';
+        export default { plugins: [vue({ compiler })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain('custom Vue compiler instance');
+  });
+
+  it('reports syntax errors only when a config references compiler options', () => {
+    const relevantRoot = createProject({
+      'vite.config.ts': `const compilerOptions = { whitespace: ;`,
+    });
+    const unrelatedRoot = createProject({
+      'vite.config.ts': `const unrelated = { broken: ;`,
+    });
+
+    expect(
+      resolveVueCompilerOptions(relevantRoot, undefined).errors.join('\n')
+    ).toContain('Could not parse a project configuration');
+    expect(resolveVueCompilerOptions(unrelatedRoot, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('reports every malformed explicit Vite config', () => {
+    const root = createProject({
+      'config/custom.ts': `const unrelated = { broken: ;`,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      viteConfigPath: 'config/custom.ts',
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not parse the Vue project config file'
+    );
+  });
+
+  it('reports malformed project config when source discovery is explicit', () => {
+    const root = createProject({
+      'nuxt.config.ts': `const unrelated = { broken: ;`,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      sourceDiscoveryIsExplicit: true,
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not parse the Vue project config file'
+    );
+  });
+
+  it('lets explicit source discovery bypass only Nuxt layout validation', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        export default defineNuxtConfig({
+          srcDir: 'custom-app',
+          vue: { compilerOptions: { whitespace: 'preserve' } },
+        });
+      `,
+    });
+
+    expect(
+      resolveVueCompilerOptions(root, undefined, {
+        sourceDiscoveryIsExplicit: true,
+      })
+    ).toEqual({
+      compilerOptions: { whitespace: 'preserve' },
+      errors: [],
+    });
+  });
+
+  it('rejects cross-framework config ambiguity even when options match', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: {
+          whitespace: 'preserve',
+        } } })] };
+      `,
+      'nuxt.config.ts': `
+        export default defineNuxtConfig({
+          vue: { compilerOptions: { whitespace: 'preserve' } },
+        });
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, {
+      whitespace: 'preserve',
+    });
+
+    expect(result.compilerOptions).toEqual({ whitespace: 'preserve' });
+    expect(result.errors.join('\n')).toContain(
+      'Found both Nuxt and Vite project config files'
+    );
+  });
+
+  it('rejects malformed explicit options at runtime', () => {
+    const root = createProject({});
+
+    const invalidWhitespace = resolveVueCompilerOptions(root, {
+      whitespace: 'collapse',
+    } as never);
+    const invalidDelimiters = resolveVueCompilerOptions(root, {
+      delimiters: ['[[', ''],
+    });
+
+    expect(invalidWhitespace.errors.join('\n')).toContain(
+      'invalid Vue whitespace compiler option'
+    );
+    expect(invalidDelimiters.errors.join('\n')).toContain(
+      'invalid Vue interpolation delimiters'
+    );
+  });
+
+  it('ignores unrelated dynamic plugin options', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ script: getScriptOptions() })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it.each([
+    {
+      name: 'dead Vue plugin calls',
+      source: `
+        import { defineConfig } from 'vite';
+        import vue from '@vitejs/plugin-vue';
+        const unused = vue({ template: { compilerOptions: { whitespace: 'preserve' } } });
+        export default defineConfig({ plugins: [vue()] });
+      `,
+      expected: {},
+    },
+    {
+      name: 'a defineConfig function return',
+      source: `
+        import { defineConfig } from 'vite';
+        import vue from '@vitejs/plugin-vue';
+        export default defineConfig(() => ({ plugins: [vue({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        })] }));
+      `,
+      expected: { whitespace: 'preserve' },
+    },
+    {
+      name: 'an immutable config alias and plugin-array spreads',
+      source: `
+        import { defineConfig } from 'vite';
+        import vue from '@vitejs/plugin-vue';
+        const gtPlugins = [vue({ template: { compilerOptions: { delimiters: ['[[', ']]'] } } })];
+        const plugins = [...gtPlugins];
+        const shared = { plugins };
+        const config = { ...shared };
+        const wrap = defineConfig;
+        export default wrap(config);
+      `,
+      expected: { delimiters: ['[[', ']]'] },
+    },
+    {
+      name: 'a statically selected plugin branch',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [true ? vue({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        }) : vue()] };
+      `,
+      expected: { whitespace: 'preserve' },
+    },
+  ])(
+    'resolves only the active Vite graph through $name',
+    ({ source, expected }) => {
+      const root = createProject({ 'vite.config.ts': source });
+
+      expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+        compilerOptions: expected,
+        errors: [],
+      });
+    }
+  );
+
+  it.each([
+    {
+      name: 'a dynamic plugin branch',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [flag ? vue({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        }) : vue()] };
+      `,
+    },
+    {
+      name: 'a wrapper that returns the Vue plugin',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const makeVue = () => vue({ template: { compilerOptions: { whitespace: 'preserve' } } });
+        export default { plugins: [makeVue()] };
+      `,
+    },
+    {
+      name: 'multiple active Vue plugin instances',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue(), vue({
+          template: { compilerOptions: { whitespace: 'preserve' } },
+        })] };
+      `,
+    },
+    {
+      name: 'a config function with multiple possible returns',
+      source: `
+        import { defineConfig } from 'vite';
+        import vue from '@vitejs/plugin-vue';
+        export default defineConfig((env) => {
+          if (env.command === 'build') return { plugins: [vue()] };
+          return { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+        });
+      `,
+    },
+    {
+      name: 'a mutated defineConfig alias',
+      source: `
+        import { defineConfig } from 'vite';
+        import vue from '@vitejs/plugin-vue';
+        let wrap = defineConfig;
+        wrap = (value) => value;
+        export default wrap({ plugins: [vue()] });
+      `,
+    },
+  ])('fails closed for $name', ({ source }) => {
+    const root = createProject({ 'vite.config.ts': source });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it.each([
+    {
+      name: 'nested plugin options mutated by assignment',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const options = { template: { compilerOptions: { whitespace: 'condense' } } };
+        options.template.compilerOptions.whitespace = 'preserve';
+        export default { plugins: [vue(options)] };
+      `,
+    },
+    {
+      name: 'an active plugin array mutated with push',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const plugins = [];
+        plugins.push(vue({ template: { compilerOptions: { whitespace: 'preserve' } } }));
+        export default { plugins };
+      `,
+    },
+    {
+      name: 'an aliased config object mutated by assignment',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const config = { plugins: [vue()] };
+        const alias = config;
+        alias.plugins = [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })];
+        export default config;
+      `,
+    },
+    {
+      name: 'a compiler options object mutated with Object.assign',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const compilerOptions = { whitespace: 'condense' };
+        Object.assign(compilerOptions, { whitespace: 'preserve' });
+        export default { plugins: [vue({ template: { compilerOptions } })] };
+      `,
+    },
+    {
+      name: 'plugin options escape to an unknown mutator call',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const options = { template: { compilerOptions: { whitespace: 'condense' } } };
+        mutate(options);
+        export default { plugins: [vue(options)] };
+      `,
+    },
+    {
+      name: 'an assignment alias mutates plugin options',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const options = { template: { compilerOptions: { whitespace: 'condense' } } };
+        let alias;
+        alias = options;
+        alias.template.compilerOptions.whitespace = 'preserve';
+        export default { plugins: [vue(options)] };
+      `,
+    },
+    {
+      name: 'a destructured alias mutates plugin options',
+      source: `
+        import vue from '@vitejs/plugin-vue';
+        const options = { template: { compilerOptions: { whitespace: 'condense' } } };
+        const { template } = options;
+        template.compilerOptions.whitespace = 'preserve';
+        export default { plugins: [vue(options)] };
+      `,
+    },
+  ])('fails closed when $name', ({ source }) => {
+    const root = createProject({ 'vite.config.ts': source });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it('uses only Vite’s first standard config file', () => {
+    const root = createProject({
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue()] };
+      `,
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('uses Vite’s mjs config before its TypeScript config', () => {
+    const root = createProject({
+      'vite.config.mjs': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue()] };
+      `,
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('does not fall through when Vite’s first config candidate is a directory', () => {
+    const root = createProject({
+      'vite.config.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+    fs.mkdirSync(path.join(root, 'vite.config.js'));
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain('not a regular file');
+  });
+
+  it('does not auto-discover JSX or TSX Vite config names', () => {
+    const root = createProject({
+      'vite.config.tsx': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('uses the last direct CommonJS overwrite and ignores the earlier value', () => {
+    const root = createProject({
+      'vite.config.cjs': `
+        const vue = require('@vitejs/plugin-vue').default;
+        module.exports = { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+        module.exports = { plugins: [vue()] };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('ignores dead Nuxt helper calls and reads only the exported config', () => {
+    const root = createProject({
+      'nuxt.config.ts': `
+        const unused = defineNuxtConfig({ vue: { compilerOptions: { whitespace: 'preserve' } } });
+        export default defineNuxtConfig({});
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: {},
+      errors: [],
+    });
+  });
+
+  it('uses only Nuxt’s first standard config file', () => {
+    const root = createProject({
+      'nuxt.config.js': `export default { vue: { compilerOptions: { whitespace: 'condense' } } };`,
+      'nuxt.config.ts': `export default defineNuxtConfig({ vue: { compilerOptions: { whitespace: 'preserve' } } });`,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { whitespace: 'condense' },
+      errors: [],
+    });
+  });
+
+  it('uses Nuxt’s TypeScript config before its mjs config', () => {
+    const root = createProject({
+      'nuxt.config.mjs': `export default { vue: { compilerOptions: { whitespace: 'preserve' } } };`,
+      'nuxt.config.ts': `export default defineNuxtConfig({ vue: { compilerOptions: { whitespace: 'condense' } } });`,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { whitespace: 'condense' },
+      errors: [],
+    });
+  });
+
+  it('fails closed when both standard Nuxt and Vite configs exist', () => {
+    const root = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ vue: { compilerOptions: { whitespace: 'condense' } } });`,
+      'vite.config.js': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Found both Nuxt and Vite project config files'
+    );
+  });
+
+  it('keeps framework-config ambiguity fatal with explicit source patterns', () => {
+    const root = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({});`,
+      'vite.config.ts': `export default {};`,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      sourceDiscoveryIsExplicit: true,
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Found both Nuxt and Vite project config files'
+    );
+  });
+
+  it('uses the last direct Nuxt CommonJS overwrite', () => {
+    const root = createProject({
+      'nuxt.config.cjs': `
+        module.exports = { vue: { compilerOptions: { whitespace: 'preserve' } } };
+        module.exports = { vue: { compilerOptions: { whitespace: 'condense' } } };
+      `,
+    });
+
+    expect(resolveVueCompilerOptions(root, undefined)).toEqual({
+      compilerOptions: { whitespace: 'condense' },
+      errors: [],
+    });
+  });
+
+  it('fails closed for mixed CommonJS export targets', () => {
+    const root = createProject({
+      'nuxt.config.cjs': `
+        module.exports = { vue: { compilerOptions: { whitespace: 'preserve' } } };
+        exports.default = { vue: { compilerOptions: { whitespace: 'condense' } } };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not statically resolve Vue compiler options'
+    );
+  });
+
+  it('uses one explicit in-root Vite config and bypasses standard discovery', () => {
+    const root = createProject({
+      'nuxt.config.ts': `export default defineNuxtConfig({ vue: { compilerOptions: { whitespace: 'condense' } } });`,
+      'config/custom.ts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    expect(
+      resolveVueCompilerOptions(root, undefined, {
+        viteConfigPath: 'config/custom.ts',
+      })
+    ).toEqual({
+      compilerOptions: { whitespace: 'preserve' },
+      errors: [],
+    });
+  });
+
+  it.each([
+    ['a missing file', 'missing.ts', 'Could not find'],
+    ['an outside-root file', '../outside.ts', 'outside the project'],
+    [
+      'a node_modules file',
+      'node_modules/vite.config.ts',
+      'outside the project',
+    ],
+    ['an unsupported file', 'vite.config.json', 'unsupported Vite config'],
+  ])(
+    'rejects %s as an explicit Vite config',
+    (_name, viteConfigPath, error) => {
+      const root = createProject({
+        'node_modules/vite.config.ts': 'export default {};',
+        'vite.config.json': '{}',
+      });
+
+      const result = resolveVueCompilerOptions(root, undefined, {
+        viteConfigPath,
+      });
+
+      expect(result.compilerOptions).toEqual({});
+      expect(result.errors.join('\n')).toContain(error);
+    }
+  );
+
+  it('rejects an explicit Vite config path that names a directory', () => {
+    const root = createProject({});
+    fs.mkdirSync(path.join(root, 'config.ts'));
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      viteConfigPath: 'config.ts',
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain('not a regular file');
+  });
+
+  it('reports an unreadable explicit Vite config without throwing', () => {
+    const root = createProject({ 'vite.config.ts': 'export default {};' });
+    const error = Object.assign(new Error('permission denied'), {
+      code: 'EACCES',
+    });
+    vi.spyOn(fs, 'accessSync').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      viteConfigPath: 'vite.config.ts',
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not read the Vue project config file'
+    );
+    expect(result.errors.join('\n')).toContain('permission denied');
+  });
+
+  it('reports a standard config removed after discovery', () => {
+    const root = createProject({ 'vite.config.ts': 'export default {};' });
+    const error = Object.assign(new Error('config disappeared'), {
+      code: 'ENOENT',
+    });
+    vi.spyOn(fs, 'accessSync').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined);
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not read the Vue project config file'
+    );
+    expect(result.errors.join('\n')).toContain('config disappeared');
+  });
+
+  it('reports a config removed between inspection and reading', () => {
+    const root = createProject({ 'vite.config.ts': 'export default {};' });
+    const error = Object.assign(new Error('file vanished'), { code: 'ENOENT' });
+    vi.spyOn(fs, 'readFileSync').mockImplementationOnce(() => {
+      throw error;
+    });
+
+    const result = resolveVueCompilerOptions(root, undefined, {
+      viteConfigPath: 'vite.config.ts',
+    });
+
+    expect(result.compilerOptions).toEqual({});
+    expect(result.errors.join('\n')).toContain(
+      'Could not read the Vue project config file'
+    );
+    expect(result.errors.join('\n')).toContain('file vanished');
+  });
+
+  it('conflict-checks explicit options against a custom Vite config', () => {
+    const root = createProject({
+      'custom.mts': `
+        import vue from '@vitejs/plugin-vue';
+        export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };
+      `,
+    });
+
+    const result = resolveVueCompilerOptions(
+      root,
+      { whitespace: 'condense' },
+      { viteConfigPath: 'custom.mts' }
+    );
+
+    expect(result.compilerOptions).toEqual({ whitespace: 'condense' });
+    expect(result.errors.join('\n')).toContain(
+      'conflicting Vue whitespace compiler options'
+    );
+  });
+});
+
+function createProject(files: Record<string, string>): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gt-vue-extractor-config-')
+  );
+  temporaryDirectories.push(directory);
+  for (const [filename, source] of Object.entries(files)) {
+    const file = path.join(directory, filename);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, source);
+  }
+  return directory;
+}

--- a/packages/vue-extractor/src/internal/__tests__/richWireFormatParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/richWireFormatParity.test.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { hashSource } from 'generaltranslation/id';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+type WireFormatFixture = {
+  description: string;
+  hash: string;
+  id: keyof typeof sources;
+  source: JsxChildren;
+};
+
+const sources = {
+  'nested-element': `
+    <script setup>
+    import { T } from 'gt-vue';
+    </script>
+    <template><T>Hello <strong>wonderful <em>world</em></strong>.</T></template>
+  `,
+  'typed-variables': `
+    <script setup>
+    import { Num, T, Var } from 'gt-vue';
+    const count = 3;
+    const name = 'Ada';
+    </script>
+    <template><T>Hello <Var>{{ name }}</Var>, you have <Num :value="count" /> messages.</T></template>
+  `,
+  'independent-branch-numbering': `
+    <script setup>
+    import { Branch, T, Var } from 'gt-vue';
+    const name = 'Ada';
+    </script>
+    <template><T><Branch branch="formal"><template #formal><strong>Hello</strong> <Var>{{ name }}</Var></template><template #casual><em>Hi</em> <Var>{{ name }}</Var></template><template #default>Fallback</template></Branch><span>After</span></T></template>
+  `,
+  'independent-plural-numbering': `
+    <script setup>
+    import { Num, Plural, T } from 'gt-vue';
+    const count = 2;
+    </script>
+    <template><T><Plural :n="count"><template #one>One <Num :value="1" /></template><template #other>Many <Num :value="count" /></template><template #default>Fallback</template></Plural><span>After</span></T></template>
+  `,
+} satisfies Record<string, string>;
+
+const fixtures = JSON.parse(
+  readFileSync(
+    new URL(
+      '../../../../../test-fixtures/rich-content-wire-format.json',
+      import.meta.url
+    ),
+    'utf8'
+  )
+) as WireFormatFixture[];
+
+describe('shared rich-content wire format', () => {
+  it.each(fixtures)('$id: $description', async (fixture) => {
+    const output = await extractFromVueSource(
+      sources[fixture.id],
+      `${fixture.id}.vue`
+    );
+    const richResults = output.results.filter(
+      (result) => result.dataFormat === 'JSX'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.warnings).toEqual([]);
+    expect(richResults).toHaveLength(1);
+    expect(richResults[0].source).toEqual(fixture.source);
+    expect(
+      hashSource({ dataFormat: 'JSX', source: richResults[0].source })
+    ).toBe(fixture.hash);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/scriptAuditWave2.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/scriptAuditWave2.test.ts
@@ -1,0 +1,723 @@
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+type AuditCase = {
+  extension?: string;
+  name: string;
+  source: string;
+  sources: string[];
+  contexts?: Record<string, string>;
+};
+
+const positiveCases: AuditCase[] = [
+  {
+    name: 'mixed type and aliased value imports',
+    source: setup(
+      `import { type GTFunction, msg as defineMessage } from 'gt-vue';
+       void (null as GTFunction | null);
+       defineMessage('Mixed import');`
+    ),
+    sources: ['Mixed import'],
+  },
+  {
+    name: 'string-named ESM import',
+    source: setup(
+      `import { 'msg' as defineMessage } from 'gt-vue';
+       defineMessage('String named import');`
+    ),
+    sources: ['String named import'],
+  },
+  {
+    name: 'nested translator destructuring',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const { nested: { translate } } = { nested: { translate: useGT() } };
+       translate('Nested translator');`
+    ),
+    sources: ['Nested translator'],
+  },
+  {
+    name: 'object destructuring default translator',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const { translate = useGT() } = {};
+       translate('Object default translator');`
+    ),
+    sources: ['Object default translator'],
+  },
+  {
+    name: 'array destructuring default translator',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const [translate = useGT()] = [];
+       translate('Array default translator');`
+    ),
+    sources: ['Array default translator'],
+  },
+  {
+    name: 'object translator default for explicit undefined',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const { translate = useGT() } = { translate: undefined };
+       translate('Object explicit undefined translator');`
+    ),
+    sources: ['Object explicit undefined translator'],
+  },
+  {
+    name: 'array translator default for void value',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const [translate = useGT()] = [void 0];
+       translate('Array void translator');`
+    ),
+    sources: ['Array void translator'],
+  },
+  {
+    name: 'object assignment default translator',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       let translate;
+       ({ translate = useGT() } = {});
+       translate('Object assignment default');`
+    ),
+    sources: ['Object assignment default'],
+  },
+  {
+    name: 'array assignment default translator',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       let translate;
+       [translate = useGT()] = [];
+       translate('Array assignment default');`
+    ),
+    sources: ['Array assignment default'],
+  },
+  {
+    name: 'nested destructured static source',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const { nested: { title } } = { nested: { title: 'Nested static source' } };
+       msg(title);`
+    ),
+    sources: ['Nested static source'],
+  },
+  {
+    name: 'object destructuring default source',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const { title = 'Object default source' } = {};
+       msg(title);`
+    ),
+    sources: ['Object default source'],
+  },
+  {
+    name: 'array destructuring default source',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const [title = 'Array default source'] = [];
+       msg(title);`
+    ),
+    sources: ['Array default source'],
+  },
+  {
+    name: 'object source default for explicit undefined',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const { title = 'Object explicit undefined source' } = { title: undefined };
+       msg(title);`
+    ),
+    sources: ['Object explicit undefined source'],
+  },
+  {
+    name: 'array source default for void value',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const [title = 'Array void source'] = [void 0];
+       msg(title);`
+    ),
+    sources: ['Array void source'],
+  },
+  {
+    name: 'static computed context key',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const gt = useGT();
+       gt('Computed context key', { ['$context']: 'computed' });`
+    ),
+    sources: ['Computed context key'],
+    contexts: { 'Computed context key': 'computed' },
+  },
+  {
+    name: 'shorthand static context value',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const gt = useGT();
+       const $context = 'shorthand';
+       gt('Shorthand context', { $context });`
+    ),
+    sources: ['Shorthand context'],
+    contexts: { 'Shorthand context': 'shorthand' },
+  },
+  {
+    name: 'static msg array identifiers',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const first = 'Array identifier one';
+       const second = 'Array identifier two';
+       msg([first, second], { $context: 'array' });`
+    ),
+    sources: ['Array identifier one', 'Array identifier two'],
+    contexts: {
+      'Array identifier one': 'array',
+      'Array identifier two': 'array',
+    },
+  },
+  {
+    name: 'optional namespace member call',
+    source: setup(
+      `import * as GT from 'gt-vue';
+       GT?.msg?.('Optional namespace member');`
+    ),
+    sources: ['Optional namespace member'],
+  },
+  {
+    name: 'statically computed namespace member call in a template',
+    source: setup(
+      `import * as GT from 'gt-vue';
+       const key = 'msg';`,
+      `{{ GT[key]('Computed namespace member') }} {{ GT['m' + 'sg']('Concatenated namespace member') }}`
+    ),
+    sources: ['Computed namespace member', 'Concatenated namespace member'],
+  },
+  {
+    extension: '.cjs',
+    name: 'direct CommonJS member hook chain',
+    source: `require('gt-vue').useGT()('Direct require chain');`,
+    sources: ['Direct require chain'],
+  },
+  {
+    extension: '.cjs',
+    name: 'computed CommonJS destructuring import',
+    source: `const { ['msg']: defineMessage } = require('gt-vue');
+             defineMessage('Computed require import');`,
+    sources: ['Computed require import'],
+  },
+  {
+    extension: '.cts',
+    name: 'TypeScript import-equals member alias',
+    source: `import GT = require('gt-vue');
+             const defineMessage = GT.msg;
+             defineMessage('Import equals alias');`,
+    sources: ['Import equals alias'],
+  },
+  {
+    name: 'TypeScript parameter decorator',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       function decorate(..._args: unknown[]) {}
+       class Example { method(@decorate value: string) { return value; } }
+       msg('Parameter decorator');`
+    ),
+    sources: ['Parameter decorator'],
+  },
+  {
+    name: 'reverse cross-block import visibility',
+    source: `<script>
+      const gt = useGT();
+      gt('Reverse cross-block import');
+      export default {};
+    </script>
+    <script setup>import { useGT } from 'gt-vue';</script>
+    <template><p>Valid</p></template>`,
+    sources: ['Reverse cross-block import'],
+  },
+  {
+    name: 'normal-script alias used by script setup',
+    source: `<script>
+      import { useGT } from 'gt-vue';
+      const createTranslator = useGT;
+      export { createTranslator };
+    </script>
+    <script setup>
+      const gt = createTranslator();
+      gt('Cross-block hook alias');
+    </script>`,
+    sources: ['Cross-block hook alias'],
+  },
+  {
+    name: 'normal-script static source used by script setup',
+    source: `<script>
+      import { msg } from 'gt-vue';
+      const title = 'Cross-block static source';
+      export { msg, title };
+    </script>
+    <script setup>msg(title);</script>`,
+    sources: ['Cross-block static source'],
+  },
+  {
+    name: 'static setup identifier passed to useMessages in template',
+    source: setup(
+      `import { useMessages } from 'gt-vue';
+       const messages = useMessages();
+       const title = 'Template static messages';`,
+      `{{ messages(title) }}`
+    ),
+    sources: ['Template static messages'],
+  },
+  {
+    name: 'static setup source and context passed to gt in template',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const gt = useGT();
+       const source = 'Template static gt';
+       const context = 'template-static';`,
+      `{{ gt(source, { $context: context }) }}`
+    ),
+    sources: ['Template static gt'],
+    contexts: { 'Template static gt': 'template-static' },
+  },
+  {
+    name: 'computed Options API component registration',
+    source: options(
+      `import { T } from 'gt-vue';
+       export default { components: { ['LocalT']: T } };`,
+      `<LocalT>Computed component registration</LocalT>`
+    ),
+    sources: ['Computed component registration'],
+  },
+  {
+    name: 'consistent multiple Options API setup returns',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default {
+         setup() {
+           const translate = useGT();
+           if (Math.random() > 0.5) return { translate };
+           return { translate };
+         },
+       };`,
+      `{{ translate('Consistent setup returns') }}`
+    ),
+    sources: ['Consistent setup returns'],
+  },
+  {
+    name: 'Options API returned static useMessages source',
+    source: options(
+      `import { useMessages } from 'gt-vue';
+       export default {
+         setup() {
+           const messages = useMessages();
+           const title = 'Options static messages';
+           return { messages, title };
+         },
+       };`,
+      `{{ messages(title) }}`
+    ),
+    sources: ['Options static messages'],
+  },
+  {
+    name: 'Options API returned static gt source and context',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default {
+         setup() {
+           const gt = useGT();
+           return { gt, source: 'Options static gt', context: 'options-static' };
+         },
+       };`,
+      `{{ gt(source, { $context: context }) }}`
+    ),
+    sources: ['Options static gt'],
+    contexts: { 'Options static gt': 'options-static' },
+  },
+  {
+    name: 'async concise Options API setup',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default { setup: async () => ({ gt: useGT() }) };`,
+      `{{ gt('Async concise setup') }}`
+    ),
+    sources: ['Async concise setup'],
+  },
+  {
+    name: 'computed Options API setup key',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default { ['setup']: () => ({ gt: useGT() }) };`,
+      `{{ gt('Computed setup key') }}`
+    ),
+    sources: ['Computed setup key'],
+  },
+  {
+    extension: '.mjs',
+    name: 'standalone mjs extraction',
+    source: `import { msg } from 'gt-vue'; msg('MJS source');`,
+    sources: ['MJS source'],
+  },
+  {
+    extension: '.mts',
+    name: 'standalone mts extraction',
+    source: `import { msg } from 'gt-vue'; msg('MTS source' satisfies string);`,
+    sources: ['MTS source'],
+  },
+  {
+    name: 'empty source with context',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       msg('', { $context: 'empty' });`
+    ),
+    sources: [''],
+    contexts: { '': 'empty' },
+  },
+  {
+    name: 'BigInt static concatenation',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       msg('BigInt ' + 12n);`
+    ),
+    sources: ['BigInt 12'],
+  },
+  {
+    name: 'unquoted TypeScript SFC language',
+    source: `<script setup lang=ts>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+    </script>
+    <template><Card v-slot="{ value = gt!('Unquoted TypeScript') }" /></template>`,
+    sources: ['Unquoted TypeScript'],
+  },
+  {
+    name: 'unquoted TSX SFC language',
+    source: `<script setup lang=tsx>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+    </script>
+    <template><Card v-slot="{ value = gt!('Unquoted TSX') }" /></template>`,
+    sources: ['Unquoted TSX'],
+  },
+  {
+    name: 'uppercase unquoted TypeScript language value',
+    source: `<script setup lang = TS>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+    </script>
+    <template><Card v-slot="{ value = gt!('Uppercase TypeScript') }" /></template>`,
+    sources: ['Uppercase TypeScript'],
+  },
+  {
+    name: 'mixed-case quoted TSX language value',
+    source: `<script setup lang = 'TsX'>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+    </script>
+    <template><Card v-slot="{ value = gt!('Mixed-case TSX') }" /></template>`,
+    sources: ['Mixed-case TSX'],
+  },
+];
+
+const ignoredCases: AuditCase[] = [
+  {
+    name: 'object default bypassed by supplied non-GT value',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const { translate = useGT() } = { translate: String };
+       translate('Supplied object value');`
+    ),
+    sources: [],
+  },
+  {
+    name: 'array default bypassed by supplied non-GT value',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const [translate = useGT()] = [String];
+       translate('Supplied array value');`
+    ),
+    sources: [],
+  },
+  {
+    name: 'script-setup local shadows normal-script alias',
+    source: `<script>
+      import { msg } from 'gt-vue';
+      const defineMessage = msg;
+      export { defineMessage };
+    </script>
+    <script setup>
+      const defineMessage = String;
+      defineMessage('Cross-block shadow');
+    </script>`,
+    sources: [],
+  },
+  {
+    extension: '.cjs',
+    name: 'shadowed CommonJS require',
+    source: `function run(require) {
+      const { msg } = require('gt-vue');
+      msg('Shadowed require');
+    }
+    void run;`,
+    sources: [],
+  },
+  {
+    name: 'default gt-vue import',
+    source: setup(
+      `import GT from 'gt-vue';
+       GT.msg('Default import');`
+    ),
+    sources: [],
+  },
+  {
+    name: 'multiple late assignments',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       let translate;
+       translate = useGT();
+       translate = String;
+       translate('Multiple assignments');`
+    ),
+    sources: [],
+  },
+];
+
+const diagnosticCases: Array<AuditCase & { diagnostic: string }> = [
+  {
+    name: 'dynamic gt-vue import',
+    source: setup(
+      `const load = async () => {
+         const GT = await import('gt-vue');
+         GT.msg('Dynamic import');
+       };
+       void load;`
+    ),
+    sources: [],
+    diagnostic: 'possible gt-vue string function alias',
+  },
+  {
+    name: 'Options API setup may fall through without returning bindings',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default {
+         setup() {
+           if (Math.random() > 0.5) return { translate: useGT() };
+         },
+       };`,
+      `{{ translate('Fallthrough return') }}`
+    ),
+    sources: [],
+    diagnostic:
+      'Could not statically resolve consistent Options API setup returns',
+  },
+  {
+    name: 'inconsistent Options API setup return values',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default {
+         setup() {
+           if (Math.random() > 0.5) return { translate: useGT() };
+           return { translate: String };
+         },
+       };`,
+      `{{ translate('Inconsistent return') }}`
+    ),
+    sources: [],
+    diagnostic:
+      'Could not statically resolve consistent Options API setup returns',
+  },
+  {
+    name: 'Options API setup key absent from one return',
+    source: options(
+      `import { useGT } from 'gt-vue';
+       export default {
+         setup() {
+           if (Math.random() > 0.5) return { translate: useGT() };
+           return {};
+         },
+       };`,
+      `{{ translate('Missing return key') }}`
+    ),
+    sources: [],
+    diagnostic:
+      'Could not statically resolve consistent Options API setup returns',
+  },
+  {
+    name: 'dynamic computed Options API component key',
+    source: options(
+      `import { T } from 'gt-vue';
+       const key = String(Date.now());
+       export default { components: { [key]: T } };`,
+      `<LocalT>Dynamic registration key</LocalT>`
+    ),
+    sources: [],
+    diagnostic: 'Could not statically resolve the Vue Options API components',
+  },
+  {
+    name: 'msg without arguments',
+    source: setup(`import { msg } from 'gt-vue'; msg();`),
+    sources: [],
+    diagnostic: 'dynamic content',
+  },
+  {
+    name: 'gt without arguments',
+    source: setup(`import { useGT } from 'gt-vue'; const gt = useGT(); gt();`),
+    sources: [],
+    diagnostic: 'dynamic content',
+  },
+  {
+    name: 'sparse msg array',
+    source: setup(`import { msg } from 'gt-vue'; msg(['One', , 'Three']);`),
+    sources: [],
+    diagnostic: 'dynamic entry',
+  },
+  {
+    name: 'spread msg array',
+    source: setup(
+      `import { msg } from 'gt-vue'; const rest = ['Two']; msg(['One', ...rest]);`
+    ),
+    sources: [],
+    diagnostic: 'dynamic entry',
+  },
+  {
+    name: 'dynamic computed context key',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const gt = useGT();
+       const key = '$context';
+       gt('Dynamic context key', { [key]: 'context' });`
+    ),
+    sources: [],
+    diagnostic: 'unsupported options',
+  },
+  {
+    name: 'spread context options',
+    source: setup(
+      `import { useGT } from 'gt-vue';
+       const gt = useGT();
+       gt('Spread options', { ...{ $context: 'spread' } });`
+    ),
+    sources: [],
+    diagnostic: 'unsupported options',
+  },
+  {
+    name: 'extra msg-array argument',
+    source: setup(`import { msg } from 'gt-vue'; msg(['One'], {}, 'extra');`),
+    sources: [],
+    diagnostic: 'unsupported arguments',
+  },
+  {
+    name: 'tagged namespace alias',
+    source: setup(
+      `import * as GT from 'gt-vue'; const m = GT.msg; m\`Tagged\`;`
+    ),
+    sources: [],
+    diagnostic: 'unsupported tagged template',
+  },
+  {
+    name: 'numeric context value',
+    source: setup(
+      `import { msg } from 'gt-vue'; msg('Numeric context', { $context: 1 });`
+    ),
+    sources: [],
+    diagnostic: 'dynamic $context',
+  },
+  {
+    name: 'nested dynamic destructured source',
+    source: setup(
+      `import { msg } from 'gt-vue';
+       const { nested: { title } } = { nested: { title: String(Date.now()) } };
+       msg(title);`
+    ),
+    sources: [],
+    diagnostic: 'dynamic content',
+  },
+];
+
+describe('Vue script extraction independent audit wave 2', () => {
+  it.each(positiveCases)('$name', async (testCase) => {
+    assertVueValid(testCase);
+    const output = await extractCase(testCase);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual(
+      testCase.sources
+    );
+    for (const [source, context] of Object.entries(testCase.contexts ?? {})) {
+      expect(
+        output.results.find((result) => result.source === source)?.metadata
+          .context
+      ).toBe(context);
+    }
+  });
+
+  it.each(ignoredCases)('$name', async (testCase) => {
+    assertVueValid(testCase);
+    const output = await extractCase(testCase);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual(
+      testCase.sources
+    );
+  });
+
+  it.each(diagnosticCases)('$name', async (testCase) => {
+    assertVueValid(testCase);
+    const output = await extractCase(testCase);
+
+    expect(output.results.map((result) => result.source)).toEqual(
+      testCase.sources
+    );
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain(testCase.diagnostic);
+  });
+
+  it('reports a malformed script exactly once', async () => {
+    const output = await extractFromVueSource(
+      `<script setup>import { msg } from 'gt-vue'; msg(</script>`,
+      '/fixtures/Malformed.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('Could not parse a gt-vue script block');
+  });
+});
+
+function setup(script: string, template = ''): string {
+  return `<script setup lang="ts">${script}</script>${template ? `<template>${template}</template>` : ''}`;
+}
+
+function options(script: string, template: string): string {
+  return `<script lang="ts">${script}</script><template>${template}</template>`;
+}
+
+async function extractCase(testCase: AuditCase) {
+  const extension = testCase.extension ?? '.vue';
+  return extractFromVueSource(
+    testCase.source,
+    `/fixtures/${slug(testCase.name)}${extension}`,
+    { projectRoot: '/fixtures' }
+  );
+}
+
+function assertVueValid(testCase: AuditCase): void {
+  if (testCase.extension && testCase.extension !== '.vue') return;
+  const filename = `/fixtures/${slug(testCase.name)}.vue`;
+  const parsed = parse(testCase.source, { filename });
+  expect(parsed.errors, `${testCase.name}: SFC parse`).toEqual([]);
+  const script = compileScript(parsed.descriptor, {
+    id: `audit-${slug(testCase.name)}`,
+  });
+  const template = parsed.descriptor.template;
+  if (!template) return;
+  const compiled = compileTemplate({
+    id: `audit-${slug(testCase.name)}`,
+    filename,
+    source: template.content,
+    compilerOptions: { bindingMetadata: script.bindings },
+  });
+  expect(compiled.errors, `${testCase.name}: template compile`).toEqual([]);
+}
+
+function slug(value: string): string {
+  return value.toLowerCase().replaceAll(/[^a-z0-9]+/g, '-');
+}

--- a/packages/vue-extractor/src/internal/__tests__/scriptExtraction.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/scriptExtraction.test.ts
@@ -1,0 +1,593 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue script extraction', () => {
+  it('resolves static TypeScript expressions and safe binding flows', async () => {
+    const result = await extractFixture('script-static.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'AB',
+      'BigInt 1',
+      'Typed context',
+      'Satisfies context',
+      'Static satisfies',
+      'Static message',
+      'Direct hook call',
+      'Optional call',
+      'Non-null call',
+      'Assigned hook result',
+      'Array destructured hook result',
+      'Object destructured hook result',
+      'Typed component alias',
+      'Digit component alias',
+    ]);
+    expect(
+      result.results.find(({ source }) => source === 'Typed context')?.metadata
+    ).toMatchObject({ context: 'typed' });
+    expect(
+      result.results.find(({ source }) => source === 'Satisfies context')
+        ?.metadata
+    ).toMatchObject({ context: 'satisfies' });
+    expect(result.results.map(({ source }) => source)).not.toContain(
+      'Not a GT message'
+    );
+  });
+
+  it('supports ESM namespaces and their component aliases', async () => {
+    const result = await extractFixture('script-namespace.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Namespace hook',
+      'Namespace message',
+      'Computed namespace hook',
+      'Computed namespace message',
+      'Namespace alias component',
+      'Namespace component',
+    ]);
+  });
+
+  it('ports applicable React alias, scope, wrapper, and call-form cases', async () => {
+    const result = await extractFixture('script-react-parity.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Hello, Vue parity',
+      'Count -2 / true / null',
+      'Wrapped static',
+      'Aliased msg',
+      'Raw messages identifier',
+      'Wrapped direct hook call',
+      'Optional direct hook call',
+      'Object assignment flow',
+      'Array assignment flow',
+      'Wrapped component alias',
+    ]);
+    expect(result.results.map(({ source }) => source)).not.toEqual(
+      expect.arrayContaining([
+        'Shadowed local binding',
+        'Shadowed parameter binding',
+        'Reassigned alias',
+      ])
+    );
+  });
+
+  it('diagnoses dynamic calls without following unsupported callbacks', async () => {
+    const result = await extractFixture('script-react-parity-dynamic.vue');
+
+    expect(result.errors).toHaveLength(3);
+    expect(result.errors[0]).toContain('dynamic content');
+    expect(result.errors[1]).toContain('dynamic options');
+    expect(result.errors[2]).toContain(
+      'Could not statically resolve possible gt-vue string function alias'
+    );
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Optional direct msg',
+    ]);
+  });
+
+  it('shares imports between normal script and script setup', async () => {
+    const result = await extractFixture('script-cross-block.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Cross-block script call',
+      'Cross-block component',
+      'Cross-block template call',
+    ]);
+  });
+
+  it('exposes direct, spread, and concise Options API setup returns', async () => {
+    const files = [
+      'options-direct-return.vue',
+      'options-spread-return.vue',
+      'options-concise-return.vue',
+    ];
+    const results = await Promise.all(files.map(extractFixture));
+
+    expect(results.flatMap(({ errors }) => errors)).toEqual([]);
+    expect(
+      results.flatMap(({ results: entries }) =>
+        entries.map(({ source }) => source)
+      )
+    ).toEqual([
+      'Direct setup return',
+      'Spread setup return',
+      'Concise setup return',
+    ]);
+  });
+
+  it('follows a secondary defineComponent alias', async () => {
+    const result = await extractFixture('options-define-alias.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Aliased defineComponent',
+    ]);
+  });
+
+  it('ports React-style aliases through an Options API object', async () => {
+    const result = await extractFixture('options-react-parity.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Options registered alias',
+      'Options returned alias',
+    ]);
+  });
+
+  it('accepts TypeScript decorators supported by Vue', async () => {
+    const result = await extractFixture('script-decorators.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'Decorated script',
+    ]);
+  });
+
+  it('supports static CommonJS and TypeScript import-equals forms', async () => {
+    const results = await Promise.all([
+      extractFixture('script-commonjs.cjs'),
+      extractFixture('script-commonjs.cts'),
+    ]);
+
+    expect(results.flatMap(({ errors }) => errors)).toEqual([]);
+    expect(
+      results.flatMap(({ results: entries }) =>
+        entries.map(({ source }) => source)
+      )
+    ).toEqual([
+      'CommonJS message',
+      'CommonJS translation',
+      'CTS namespace message',
+      'CTS namespace translation',
+    ]);
+  });
+
+  it('keeps every SFC fixture valid in the Vue compiler', () => {
+    const files = [
+      'script-static.vue',
+      'script-namespace.vue',
+      'script-react-parity.vue',
+      'script-react-parity-dynamic.vue',
+      'script-cross-block.vue',
+      'options-direct-return.vue',
+      'options-spread-return.vue',
+      'options-concise-return.vue',
+      'options-define-alias.vue',
+      'options-react-parity.vue',
+      'script-decorators.vue',
+    ];
+
+    for (const file of files) {
+      const filename = fixturePath(file);
+      const parsed = parse(fs.readFileSync(filename, 'utf8'), { filename });
+      expect(parsed.errors, file).toEqual([]);
+      const script = compileScript(parsed.descriptor, {
+        id: `script-extraction-${file}`,
+        babelParserPlugins: ['decorators-legacy'],
+      });
+      if (parsed.descriptor.template) {
+        const template = compileTemplate({
+          id: `script-extraction-${file}`,
+          filename,
+          source: parsed.descriptor.template.content,
+          compilerOptions: { bindingMetadata: script.bindings },
+        });
+        expect(template.errors, file).toEqual([]);
+      }
+    }
+  });
+});
+
+type ScriptMatrixCase = {
+  name: string;
+  script: string;
+  sources: string[];
+  template?: string;
+  contexts?: Record<string, string>;
+};
+
+const positiveScriptCases: ScriptMatrixCase[] = [
+  {
+    name: 'direct msg call',
+    script: `import { msg } from 'gt-vue'; msg('Direct msg');`,
+    sources: ['Direct msg'],
+  },
+  {
+    name: 'aliased msg import',
+    script: `import { msg as message } from 'gt-vue'; message('Import alias');`,
+    sources: ['Import alias'],
+  },
+  {
+    name: 'useGT result',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Hook result');`,
+    sources: ['Hook result'],
+  },
+  {
+    name: 'aliased useGT import',
+    script: `import { useGT as createTranslator } from 'gt-vue'; const gt = createTranslator(); gt('Hook import alias');`,
+    sources: ['Hook import alias'],
+  },
+  {
+    name: 'hook function alias',
+    script: `import { useGT } from 'gt-vue'; const hook = useGT; const gt = hook(); gt('Hook function alias');`,
+    sources: ['Hook function alias'],
+  },
+  {
+    name: 'deep translator aliases',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const a = gt; const b = a; const c = b; c('Deep alias');`,
+    sources: ['Deep alias'],
+  },
+  {
+    name: 'useMessages literal',
+    script: `import { useMessages } from 'gt-vue'; const m = useMessages(); m('Messages literal');`,
+    sources: ['Messages literal'],
+  },
+  {
+    name: 'useMessages const identifier',
+    script: `import { useMessages } from 'gt-vue'; const m = useMessages(); const title = 'Messages identifier'; m(title);`,
+    sources: ['Messages identifier'],
+  },
+  {
+    name: 'namespace msg call',
+    script: `import * as GT from 'gt-vue'; GT.msg('Namespace msg');`,
+    sources: ['Namespace msg'],
+  },
+  {
+    name: 'computed namespace msg call',
+    script: `import * as GT from 'gt-vue'; GT['msg']('Computed namespace msg');`,
+    sources: ['Computed namespace msg'],
+  },
+  {
+    name: 'namespace hook call',
+    script: `import * as GT from 'gt-vue'; GT.useGT()('Namespace hook call');`,
+    sources: ['Namespace hook call'],
+  },
+  {
+    name: 'direct hook-result call',
+    script: `import { useGT } from 'gt-vue'; useGT()('Direct hook-result call');`,
+    sources: ['Direct hook-result call'],
+  },
+  {
+    name: 'optional translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt?.('Optional translator');`,
+    sources: ['Optional translator'],
+  },
+  {
+    name: 'non-null translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt!('Non-null translator');`,
+    sources: ['Non-null translator'],
+  },
+  {
+    name: 'type-cast translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); (gt as typeof gt)('Type-cast translator');`,
+    sources: ['Type-cast translator'],
+  },
+  {
+    name: 'satisfies-wrapped translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); (gt satisfies typeof gt)('Satisfies translator');`,
+    sources: ['Satisfies translator'],
+  },
+  {
+    name: 'const source identifier',
+    script: `import { msg } from 'gt-vue'; const source = 'Const source'; msg(source);`,
+    sources: ['Const source'],
+  },
+  {
+    name: 'chained const source identifiers',
+    script: `import { msg } from 'gt-vue'; const first = 'Const chain'; const second = first; msg(second);`,
+    sources: ['Const chain'],
+  },
+  {
+    name: 'static concatenation',
+    script: `import { msg } from 'gt-vue'; const first = 'Static '; const second = 'concat'; msg(first + second);`,
+    sources: ['Static concat'],
+  },
+  {
+    name: 'static template expression',
+    script:
+      "import { msg } from 'gt-vue'; const value = 'template'; msg(`Static ${value}`);",
+    sources: ['Static template'],
+  },
+  {
+    name: 'static primitive coercion',
+    script: `import { msg } from 'gt-vue'; msg('Primitive ' + -2 + true + null);`,
+    sources: ['Primitive -2truenull'],
+  },
+  {
+    name: 'as-const source wrapper',
+    script: `import { msg } from 'gt-vue'; msg('As const source' as const);`,
+    sources: ['As const source'],
+  },
+  {
+    name: 'satisfies source wrapper',
+    script: `import { msg } from 'gt-vue'; msg('Satisfies source' satisfies string);`,
+    sources: ['Satisfies source'],
+  },
+  {
+    name: 'as-const options wrapper',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Context cast', { $context: 'cast' } as const);`,
+    sources: ['Context cast'],
+    contexts: { 'Context cast': 'cast' },
+  },
+  {
+    name: 'satisfies options wrapper',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Context satisfies', { $context: 'satisfies' } satisfies { $context: string });`,
+    sources: ['Context satisfies'],
+    contexts: { 'Context satisfies': 'satisfies' },
+  },
+  {
+    name: 'const context value',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const context = 'identifier'; gt('Context identifier', { $context: context });`,
+    sources: ['Context identifier'],
+    contexts: { 'Context identifier': 'identifier' },
+  },
+  {
+    name: 'single late assignment',
+    script: `import { useGT } from 'gt-vue'; let gt; gt = useGT(); gt('Late assignment');`,
+    sources: ['Late assignment'],
+  },
+  {
+    name: 'object destructuring declaration',
+    script: `import { useGT } from 'gt-vue'; const { gt } = { gt: useGT() }; gt('Object declaration');`,
+    sources: ['Object declaration'],
+  },
+  {
+    name: 'array destructuring declaration',
+    script: `import { useGT } from 'gt-vue'; const [gt] = [useGT()]; gt('Array declaration');`,
+    sources: ['Array declaration'],
+  },
+  {
+    name: 'object destructuring assignment',
+    script: `import { useGT } from 'gt-vue'; let gt; ({ gt } = { gt: useGT() }); gt('Object assignment');`,
+    sources: ['Object assignment'],
+  },
+  {
+    name: 'array destructuring assignment',
+    script: `import { useGT } from 'gt-vue'; let gt; [gt] = [useGT()]; gt('Array assignment');`,
+    sources: ['Array assignment'],
+  },
+  {
+    name: 'static msg array',
+    script:
+      "import { msg } from 'gt-vue'; msg(['Array one', `Array ${'two'}`]);",
+    sources: ['Array one', 'Array two'],
+  },
+  {
+    name: 'type-wrapped component alias',
+    script: `import { T as SourceT } from 'gt-vue'; const LocalT = (SourceT as typeof SourceT)!;`,
+    template: '<LocalT>Wrapped component</LocalT>',
+    sources: ['Wrapped component'],
+  },
+  {
+    name: 'digit-normalized component alias',
+    script: `import { T as T2 } from 'gt-vue';`,
+    template: '<t-2>Digit component</t-2>',
+    sources: ['Digit component'],
+  },
+  {
+    name: 'namespace component',
+    script: `import * as GT from 'gt-vue';`,
+    template: '<GT.T>Namespace component matrix</GT.T>',
+    sources: ['Namespace component matrix'],
+  },
+];
+
+const ignoredScriptCases: ScriptMatrixCase[] = [
+  {
+    name: 'lexically shadowed msg import',
+    script: `import { msg } from 'gt-vue'; { const msg = String; msg('Local shadow'); }`,
+    sources: [],
+  },
+  {
+    name: 'parameter-shadowed msg import',
+    script: `import { msg } from 'gt-vue'; function run(msg: typeof String) { msg('Parameter shadow'); } void run;`,
+    sources: [],
+  },
+  {
+    name: 'reassigned callback alias',
+    script: `import { msg } from 'gt-vue'; let callback = msg; callback = String; callback('Reassigned callback');`,
+    sources: [],
+  },
+  {
+    name: 'unrelated same-named function',
+    script: `const useGT = () => String; useGT()('Unrelated function');`,
+    sources: [],
+  },
+  {
+    name: 'type-only import',
+    script: `import type { GTFunction } from 'gt-vue'; const gt = null as unknown as GTFunction; gt('Type-only import');`,
+    sources: [],
+  },
+  {
+    name: 'translator passed as callback',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); function helper(translator: typeof gt) { translator('Passed callback'); } helper(gt);`,
+    sources: ['Passed callback'],
+  },
+  {
+    name: 'dynamic useMessages input',
+    script: `import { useMessages } from 'gt-vue'; const m = useMessages(); const value = String(Date.now()); m(value);`,
+    sources: [],
+  },
+  {
+    name: 'same exports from another package',
+    script: `import { msg, useGT } from 'another-package'; msg('Other msg'); useGT()('Other hook');`,
+    sources: [],
+  },
+];
+
+const diagnosticScriptCases: Array<ScriptMatrixCase & { diagnostic: string }> =
+  [
+    {
+      name: 'dynamic gt source',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); const value = String(Date.now()); gt(value);`,
+      sources: [],
+      diagnostic: 'dynamic content',
+    },
+    {
+      name: 'dynamic msg source',
+      script: `import { msg } from 'gt-vue'; const value = String(Date.now()); msg(value);`,
+      sources: [],
+      diagnostic: 'dynamic content',
+    },
+    {
+      name: 'dynamic template expression',
+      script:
+        "import { useGT } from 'gt-vue'; const gt = useGT(); gt(`Now ${String(Date.now())}`);",
+      sources: [],
+      diagnostic: 'dynamic content',
+    },
+    {
+      name: 'dynamic options object',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); const options = { $context: 'named' }; gt('Named options', options);`,
+      sources: [],
+      diagnostic: 'dynamic options',
+    },
+    {
+      name: 'dynamic context value',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Dynamic context', { $context: String(Date.now()) });`,
+      sources: [],
+      diagnostic: 'dynamic $context',
+    },
+    {
+      name: 'unsupported option',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Unsupported option', { $id: 'id' });`,
+      sources: [],
+      diagnostic: 'unsupported gt-vue string option',
+    },
+    {
+      name: 'excess call argument',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); gt('Excess argument', {}, 'extra');`,
+      sources: [],
+      diagnostic: 'unsupported arguments',
+    },
+    {
+      name: 'dynamic msg array entry',
+      script: `import { msg } from 'gt-vue'; const value = String(Date.now()); msg(['Static', value]);`,
+      sources: [],
+      diagnostic: 'dynamic entry',
+    },
+    {
+      name: 'tagged template translation',
+      script: "import { msg } from 'gt-vue'; msg`Tagged`;",
+      sources: [],
+      diagnostic: 'unsupported tagged template',
+    },
+  ];
+
+describe('Vue script extraction parity matrix', () => {
+  it.each(positiveScriptCases)('$name', async (testCase) => {
+    const result = await extractInlineScript(testCase);
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual(
+      testCase.sources
+    );
+    for (const [source, expectedContext] of Object.entries(
+      testCase.contexts ?? {}
+    )) {
+      expect(
+        result.results.find((entry) => entry.source === source)?.metadata
+      ).toMatchObject({ context: expectedContext });
+    }
+  });
+
+  it.each(ignoredScriptCases)('$name', async (testCase) => {
+    const result = await extractInlineScript(testCase);
+
+    expect(result.errors).toEqual([]);
+    expect(result.results.map(({ source }) => source)).toEqual(
+      testCase.sources
+    );
+  });
+
+  it.each(diagnosticScriptCases)('$name', async (testCase) => {
+    const result = await extractInlineScript(testCase);
+
+    expect(result.results.map(({ source }) => source)).toEqual(
+      testCase.sources
+    );
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(testCase.diagnostic);
+  });
+
+  it('diagnoses a call before a late assignment and extracts the later call', async () => {
+    const result = await extractInlineScript({
+      name: 'call before a late assignment',
+      script: `import { useGT } from 'gt-vue'; let gt; gt('Before assignment'); gt = useGT(); gt('After unsafe assignment');`,
+      sources: [],
+    });
+
+    expect(result.results.map(({ source }) => source)).toEqual([
+      'After unsafe assignment',
+    ]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(
+          'Could not statically resolve possible gt-vue string function alias'
+        ),
+      ])
+    );
+  });
+
+  it('fails closed for a conditional translator selection', async () => {
+    const result = await extractInlineScript({
+      name: 'conditional translator selection',
+      script: `import { useGT } from 'gt-vue'; const gt = useGT(); const callback = Date.now() > 0 ? gt : String; callback('Conditional callback');`,
+      sources: [],
+    });
+
+    expect(result.results).toEqual([]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(
+      'Could not statically resolve possible gt-vue string function alias'
+    );
+  });
+});
+
+async function extractFixture(name: string) {
+  const file = fixturePath(name);
+  return extractFromVueSource(fs.readFileSync(file, 'utf8'), file, {
+    projectRoot: path.dirname(file),
+  });
+}
+
+function fixturePath(name: string): string {
+  return path.join(__dirname, 'fixtures', name);
+}
+
+async function extractInlineScript(testCase: ScriptMatrixCase) {
+  const file = path.join(__dirname, 'fixtures', 'inline-script-matrix.vue');
+  const source = `<script setup lang="ts">\n${testCase.script}\n</script>\n${
+    testCase.template ? `<template>${testCase.template}</template>` : ''
+  }`;
+  return extractFromVueSource(source, file, {
+    projectRoot: path.dirname(file),
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/scriptProvenanceSoundness.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/scriptProvenanceSoundness.test.ts
@@ -1,0 +1,466 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue script provenance soundness', () => {
+  it('extracts nested translators and script-side ref/computed msg aliases', async () => {
+    const output = await extract(`
+      <script setup>
+      import { computed, ref } from 'vue';
+      import { msg, useGT, useMessages } from 'gt-vue';
+      const baseGT = useGT();
+      const baseM = useMessages();
+      const nested = { deep: { gt: baseGT, m: baseM, msg } };
+      const msgRef = ref(msg);
+      const msgComputed = computed(() => msg);
+      msgRef.value('Ref msg', { $context: 'ref-msg' });
+      msgComputed.value('Computed msg', { $context: 'computed-msg' });
+      </script>
+      <template>
+        {{ nested.deep.gt('Nested gt', { $context: 'nested-gt' }) }}
+        {{ nested.deep.m('Nested raw m', { $context: 'nested-m' }) }}
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results.map(({ metadata, source }) => [source, metadata.context])
+    ).toEqual([
+      ['Ref msg', 'ref-msg'],
+      ['Computed msg', 'computed-msg'],
+      ['Nested gt', 'nested-gt'],
+      ['Nested raw m', 'nested-m'],
+    ]);
+  });
+
+  it('preserves sibling translators after calling a known nested msg leaf', async () => {
+    const output = await extract(`
+      <script setup>
+      import { msg, useGT, useMessages } from 'gt-vue';
+      const baseGT = useGT();
+      const baseM = useMessages();
+      const nested = { deep: { gt: baseGT, m: baseM, msg } };
+      const messages = { nested: nested.deep.msg('Nested msg') };
+      </script>
+      <template>
+        {{ nested.deep.gt('Nested gt') }}
+        {{ nested.deep.m('Nested m') }}
+        {{ messages.nested }}
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Nested msg',
+      'Nested gt',
+      'Nested m',
+    ]);
+  });
+
+  it('still invalidates siblings after calling an arbitrary mutating method', async () => {
+    const output = await extract(`
+      <script setup>
+      import { useGT } from 'gt-vue';
+      const baseGT = useGT();
+      const nested = {
+        deep: {
+          gt: baseGT,
+          mutate() { nested.deep.gt = String; },
+        },
+      };
+      nested.deep.mutate();
+      </script>
+      <template>{{ nested.deep.gt('Not translated') }}</template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue translation function alias'
+    );
+  });
+
+  it('recognizes an ordinary replacement of a ref-held msg function', async () => {
+    const output = await extract(`
+      <script setup>
+        import { ref } from 'vue';
+        import { msg } from 'gt-vue';
+        const msgRef = ref(msg);
+        msgRef.value = String;
+        msgRef.value('Not a message');
+      </script>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toEqual([]);
+  });
+
+  it('extracts a ref-held msg call that precedes a later replacement', async () => {
+    const output = await extract(`
+      <script setup>
+      import { ref } from 'vue';
+      import { msg } from 'gt-vue';
+      const msgRef = ref(msg);
+      msgRef.value('Before replacement');
+      msgRef.value = String;
+      </script>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Before replacement',
+    ]);
+  });
+
+  it.each([
+    ['gt', 'useGT()', 'Getter gt'],
+    ['m', 'useMessages()', 'Getter messages'],
+    ['message', 'msg', 'Getter msg'],
+  ])(
+    'fails closed for a getter-returned %s function',
+    async (name, value, source) => {
+      const output = await extract(
+        setup(
+          `
+          import { msg, useGT, useMessages } from 'gt-vue';
+          const kit = { get ${name}() { return ${value}; } };
+          `,
+          `{{ kit.${name}('${source}') }}`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue translation function alias'
+      );
+    }
+  );
+
+  it.each([
+    ['gt', 'useGT()', 'Getter gt'],
+    ['m', 'useMessages()', 'Getter messages'],
+    ['message', 'msg', 'Getter msg'],
+  ])(
+    'fails closed for a script-called getter-returned %s function',
+    async (name, value, source) => {
+      const output = await extract(`
+        <script setup>
+        import { msg, useGT, useMessages } from 'gt-vue';
+        const kit = { get ${name}() { return ${value}; } };
+        kit.${name}('${source}');
+        </script>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue string function alias'
+      );
+    }
+  );
+
+  it.each([
+    {
+      name: 'template msg getter snapshot',
+      importName: 'msg',
+      initial: 'msg',
+      member: 'message',
+      template: `{{ kit.message('Template msg snapshot') }}`,
+    },
+    {
+      name: 'template gt getter snapshot',
+      importName: 'useGT',
+      initial: 'useGT()',
+      member: 'gt',
+      template: `{{ kit.gt('Template gt snapshot') }}`,
+    },
+  ])('fails closed for a $name', async (testCase) => {
+    const output = await extract(
+      setup(
+        `
+        import { ${testCase.importName} } from 'gt-vue';
+        let current = ${testCase.initial};
+        const kit = {
+          get ${testCase.member}() {
+            const selected = current;
+            current = String;
+            return selected;
+          },
+        };
+        `,
+        testCase.template
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue translation function alias'
+    );
+  });
+
+  it('fails closed for a script-called stateful getter snapshot', async () => {
+    const output = await extract(`
+      <script setup>
+      import { useGT } from 'gt-vue';
+      let current = useGT();
+      const kit = {
+        get gt() {
+          const selected = current;
+          current = String;
+          return selected;
+        },
+      };
+      kit.gt('Script gt snapshot');
+      kit.gt('Ordinary second call');
+      </script>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain(
+      'Could not statically resolve possible gt-vue string function alias "kit.gt"'
+    );
+  });
+
+  it.each([
+    [
+      'reactive object',
+      'reactive',
+      'reactive({ translated: T, ordinary: String })',
+    ],
+    [
+      'shallowReactive object',
+      'shallowReactive',
+      'shallowReactive({ translated: T, ordinary: String })',
+    ],
+    ['readonly array', 'readonly', 'readonly([T, String])'],
+    [
+      'shallowReadonly array',
+      'shallowReadonly',
+      'shallowReadonly([T, String])',
+    ],
+    ['ref array', 'ref', 'ref([T, String])'],
+    ['shallowRef array', 'shallowRef', 'shallowRef([T, String])'],
+    ['computed array', 'computed', 'computed(() => [T, String])'],
+  ])(
+    'keeps a %s non-component root while tracking its selected members',
+    async (_name, wrapper, initializer) => {
+      const script = `
+        import { ${wrapper} } from 'vue';
+        import { T } from 'gt-vue';
+        const registry = ${initializer};
+        const key = Number(Date.now());
+      `;
+      const direct = await extract(
+        setup(script, '<component :is="registry">Ordinary</component>')
+      );
+      const selected = await extract(
+        setup(script, '<component :is="registry[key]">Possible</component>')
+      );
+
+      expect(direct.errors).toEqual([]);
+      expect(direct.results).toEqual([]);
+      expect(selected.results).toEqual([]);
+      expect(selected.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    [
+      'computed key',
+      `const key = String(Date.now());
+       const registry = { translated: 'T', [key]: 'div' };`,
+    ],
+    [
+      'unknown spread',
+      `const unknown = getRegistry();
+       const registry = { translated: 'T', ...unknown };`,
+    ],
+  ])(
+    'downgrades a string selector overwritten by an unresolved %s',
+    async (_name, declaration) => {
+      const output = await extract(
+        optionsAndSetup(
+          `import { T } from 'gt-vue';
+           export default { components: { T } };`,
+          declaration,
+          '<component :is="registry.translated">Possible</component>'
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    `const key = String(Date.now());
+     const registry = { translated: 'T', [key]: 'span', translated: 'div' };`,
+    `const unknown = getRegistry();
+     const registry = { translated: 'T', ...unknown, translated: 'div' };`,
+  ])(
+    'lets a later explicit property restore selector certainty',
+    async (code) => {
+      const output = await extract(
+        optionsAndSetup(
+          `import { T } from 'gt-vue';
+         export default { components: { T } };`,
+          code,
+          '<component :is="registry.translated">Ordinary</component>'
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results).toEqual([]);
+    }
+  );
+
+  it.each([
+    {
+      name: 'script-setup binding',
+      source: optionsAndSetup(
+        `import { T } from 'gt-vue';
+         export default { components: { T } };`,
+        `const flag = Boolean(Date.now());
+         const choice = flag ? 'T' : 'div';`,
+        '<component :is="choice">Possible</component>'
+      ),
+    },
+    {
+      name: 'Options setup return',
+      source: options(
+        `import { T } from 'gt-vue';
+         export default {
+           components: { T },
+           setup() {
+             const flag = Boolean(Date.now());
+             return { choice: flag ? 'T' : 'div' };
+           },
+         };`,
+        '<component :is="choice">Possible</component>'
+      ),
+    },
+    {
+      name: 'Options computed getter',
+      source: options(
+        `import { T } from 'gt-vue';
+         export default {
+           components: { T },
+           computed: {
+             choice() { return Boolean(Date.now()) ? 'T' : 'div'; },
+           },
+         };`,
+        '<component :is="choice">Possible</component>'
+      ),
+    },
+  ])('does not lose a registered T behind a $name', async ({ source }) => {
+    const output = await extract(source);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('preserves object spread copy timing', async () => {
+    const output = await extract(
+      setup(
+        `
+        import { useGT } from 'gt-vue';
+        const source = { gt: useGT() };
+        const copy = { ...source };
+        source.gt = String;
+        `,
+        `{{ copy.gt('Copied translator') }}`
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Copied translator',
+    ]);
+  });
+
+  it('extracts an immutable GT namespace rest member', async () => {
+    const output = await extract(
+      setup(
+        `import * as GT from 'gt-vue'; const { ...rest } = GT;`,
+        '<component :is="rest.T">Possible</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(['Possible']);
+  });
+
+  it.each([
+    [
+      'object rest',
+      `const { ordinary, ...rest } = { ordinary: String, translated: T };`,
+    ],
+    ['array rest', `const [ordinary, ...rest] = [String, T, String];`],
+  ])(
+    'keeps a %s root ordinary while tracking copied members',
+    async (_name, declaration) => {
+      const script = `import { T } from 'gt-vue';
+        ${declaration}
+        const key = String(Date.now());`;
+      const direct = await extract(
+        setup(script, '<component :is="rest">Ordinary</component>')
+      );
+      const selected = await extract(
+        setup(script, '<component :is="rest[key]">Possible</component>')
+      );
+
+      expect(direct.errors).toEqual([]);
+      expect(direct.results).toEqual([]);
+      expect(selected.results).toEqual([]);
+      expect(selected.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it('extracts translator members copied through object rest', async () => {
+    const output = await extract(
+      setup(
+        `import { msg, useGT, useMessages } from 'gt-vue';
+         const source = { unused: String, gt: useGT(), m: useMessages(), msg };
+         const { unused, ...rest } = source;`,
+        `{{ rest.gt('Rest gt') }}
+         {{ rest.m('Rest messages') }}
+         {{ rest.msg('Rest msg') }}`
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Rest gt',
+      'Rest messages',
+      'Rest msg',
+    ]);
+  });
+});
+
+function setup(script: string, template = '<div />'): string {
+  return `<script setup>${script}</script><template>${template}</template>`;
+}
+
+function options(script: string, template: string): string {
+  return `<script>${script}</script><template>${template}</template>`;
+}
+
+function optionsAndSetup(
+  normalScript: string,
+  scriptSetup: string,
+  template: string
+): string {
+  return `<script>${normalScript}</script><script setup>${scriptSetup}</script><template>${template}</template>`;
+}
+
+async function extract(source: string) {
+  return extractFromVueSource(source, '/fixtures/ScriptProvenance.vue', {
+    projectRoot: '/fixtures',
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/selectorAndContainerProvenance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/selectorAndContainerProvenance.test.ts
@@ -1,0 +1,2095 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue selector and container provenance', () => {
+  it.each(['`T`', "'T' + ''"])(
+    'resolves a static string dynamic selector from %s',
+    async (selector) => {
+      const output = await extract(`
+        <script>
+        import { T } from 'gt-vue';
+        export default { components: { T } };
+        </script>
+        <template><component :is="${selector}">Static selector</component></template>
+      `);
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map(({ source }) => source)).toEqual([
+        'Static selector',
+      ]);
+    }
+  );
+
+  it.each([
+    ['literal array', '[T][0]', ''],
+    ['nested literal arrays', '[[T]][0][0]', ''],
+    ['literal array spread', '[...[T]][0]', ''],
+    ['immutable array binding', 'kit[0]', 'const kit = [T];'],
+    [
+      'identical conditional branches',
+      'flag ? T : T',
+      'const flag = Boolean(Date.now());',
+    ],
+    ['sequence result', '(0, T)', ''],
+    ['truthy logical result', 'T || String', ''],
+    ['Vue identity wrapper', 'markRaw(T)', "import { markRaw } from 'vue';"],
+  ])(
+    'extracts an exact T selected through %s',
+    async (_name, selector, code) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue'; ${code}`,
+          `<component :is="${selector}">Hello</component>`
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map(({ source }) => source)).toEqual(['Hello']);
+    }
+  );
+
+  it.each([
+    ['object shorthand', '{ Component } in [{ Component: T }]'],
+    ['array element', '[Component] in [[T]]'],
+    ['object default', '{ Component = T } in [{}]'],
+    ['array default', '[Component = T] in [[]]'],
+    [
+      'renamed object member',
+      '{ translated: Component } in [{ translated: T }]',
+    ],
+    [
+      'nested object member',
+      '{ nested: { Component } } in [{ nested: { Component: T } }]',
+    ],
+  ])(
+    'does not silently drop T from a destructured v-for %s',
+    async (_name, loop) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue';`,
+          `<component v-for="${loop}" :is="Component">Hidden</component>`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    ['v-for alias', '<component v-for="C in [Num]" :is="C" />'],
+    [
+      'scoped-slot default',
+      '<Wrapper v-slot="{ C = Num }"><component :is="C" /></Wrapper>',
+    ],
+  ])('does not conflate Num with T for a %s', async (_name, template) => {
+    const output = await extract(
+      setup(`import { Num } from 'gt-vue';`, template)
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'v-for alias',
+      `<component
+         v-for="Component in [T]"
+         :is="Component"
+       >Hidden</component>`,
+    ],
+    [
+      'scoped-slot default',
+      `<Wrapper v-slot="{ Component = T }">
+         <component :is="Component">Hidden</component>
+       </Wrapper>`,
+    ],
+  ])(
+    'does not silently drop a possible T from a %s',
+    async (_name, template) => {
+      const output = await extract(
+        setup(`import { T } from 'gt-vue';`, template)
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toMatch(
+        /Could not statically resolve possible gt-vue component alias|source-shaping directive/
+      );
+    }
+  );
+
+  it.each([
+    [
+      'a conditional result',
+      'flag ? T : String',
+      'const flag = Boolean(Date.now());',
+    ],
+    ['a logical result', 'flag && T', 'const flag = Boolean(Date.now());'],
+    ['a component factory', 'make()', 'const make = () => T;'],
+    [
+      'an object-method factory',
+      'helpers.make()',
+      'const helpers = { make() { return T; } };',
+    ],
+    [
+      'an array with an unknown spread offset',
+      '[...items, T][0]',
+      'const items = getItems();',
+    ],
+    [
+      'an object with a dynamic key',
+      '({ translated: T, ordinary: String })[key]',
+      'const key = getKey();',
+    ],
+    ['an unknown identity call', 'identity(T)', 'const identity = (x) => x;'],
+    [
+      'a bound array with a dynamic index',
+      'registry[index]',
+      'const registry = [T, String]; const index = getIndex();',
+    ],
+    [
+      'a bound object with a dynamic key',
+      'registry[key]',
+      `const registry = { translated: T, ordinary: String };
+       const key = getKey();`,
+    ],
+    [
+      'a selecting method on a bound array',
+      'registry.at(index)',
+      'const registry = [T, String]; const index = getIndex();',
+    ],
+    [
+      'a nested bound array selected at both depths',
+      'matrix[row][column]',
+      `const matrix = [[T, String]];
+       const row = getRow();
+       const column = getColumn();`,
+    ],
+    [
+      'an inline object spread',
+      '({ ...{ translated: T }, ordinary: String })[key]',
+      'const key = getKey();',
+    ],
+  ])(
+    'fails closed when T is one possible value of %s',
+    async (_name, selector, code) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue'; ${code}`,
+          `<component :is="${selector}">Hidden</component>`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it('keeps ordinary dynamic selector provenance out of GT diagnostics', async () => {
+    const output = await extract(
+      setup(
+        `const Card = String;
+         const flag = Boolean(Date.now());
+         const helpers = { make() { return Card; } };`,
+        '<component :is="flag ? Card : helpers.make()">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'array index',
+      'registry[index]',
+      'const registry = [String, Number]; const index = getIndex();',
+    ],
+    [
+      'object key',
+      'registry[key]',
+      `const registry = { text: String, count: Number };
+       const key = getKey();`,
+    ],
+    [
+      'array selection method',
+      'registry.at(index)',
+      'const registry = [String, Number]; const index = getIndex();',
+    ],
+    [
+      'nested object value',
+      'registry[key]',
+      `import { T } from 'gt-vue';
+       const registry = { nested: { translated: T } };
+       const key = getKey();`,
+    ],
+    [
+      'overridden inline object member',
+      '({ translated: T, translated: String })[key]',
+      `import { T } from 'gt-vue';
+       const key = getKey();`,
+    ],
+    [
+      'ordinary object method named at',
+      'registry.at(index)',
+      `import { T } from 'gt-vue';
+       const registry = { translated: T, at() { return String; } };
+       const index = getIndex();`,
+    ],
+    [
+      'out-of-range array at call',
+      'registry.at(100)',
+      `import { T } from 'gt-vue';
+       const registry = [T];`,
+    ],
+  ])(
+    'does not report an ordinary bound container selected by %s',
+    async (_name, selector, code) => {
+      const output = await extract(
+        setup(code, `<component :is="${selector}">Ordinary</component>`)
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results).toEqual([]);
+    }
+  );
+
+  it('keeps an exact bound member selector exact', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { translated: T };`,
+        '<component :is="registry.translated">Exact</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(['Exact']);
+  });
+
+  it('keeps dotted property names distinct from nested member paths', async () => {
+    const nested = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { nested: { value: String }, 'nested.value': T };`,
+        '<component :is="registry.nested.value">Ordinary</component>'
+      )
+    );
+    const dotted = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { 'nested.value': T, nested: { value: String } };`,
+        `<component :is="registry['nested.value']">Translated</component>`
+      )
+    );
+    const dynamic = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { 'nested.value': T };
+         const key = getKey();`,
+        '<component :is="registry[key]">Hidden</component>'
+      )
+    );
+
+    expect(nested.errors).toEqual([]);
+    expect(nested.results).toEqual([]);
+    expect(dotted.errors).toEqual([]);
+    expect(dotted.results.map(({ source }) => source)).toEqual(['Translated']);
+    expect(dynamic.results).toEqual([]);
+    expect(dynamic.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('preserves an empty static property key', async () => {
+    const exact = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { '': T };`,
+        `<component :is="registry['']">Exact</component>`
+      )
+    );
+    const dynamic = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = { '': T };
+         const key = getKey();`,
+        '<component :is="registry[key]">Hidden</component>'
+      )
+    );
+
+    expect(exact.errors).toEqual([]);
+    expect(exact.results.map(({ source }) => source)).toEqual(['Exact']);
+    expect(dynamic.results).toEqual([]);
+    expect(dynamic.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'array',
+      'names[index]',
+      `const names = ['T', 'div'];
+       const index = getIndex();`,
+    ],
+    [
+      'object',
+      'names[key]',
+      `const names = { translated: 'T', ordinary: 'div' };
+       const key = getKey();`,
+    ],
+  ])(
+    'fails closed for a registered T name selected from a bound %s',
+    async (_name, selector, code) => {
+      const output = await extract(`
+        <script>
+        import { T } from 'gt-vue';
+        export default { components: { T } };
+        </script>
+        <script setup>${code}</script>
+        <template><component :is="${selector}">Hidden</component></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it('fails closed for a component factory returned from Options API setup', async () => {
+    const output = await extract(`
+      <script>
+      import { T } from 'gt-vue';
+      export default {
+        setup() {
+          const make = () => T;
+          return { make };
+        },
+      };
+      </script>
+      <template><component :is="make()">Hidden</component></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias "make()"'
+    );
+  });
+
+  it('terminates recursive factory analysis while preserving GT provenance', async () => {
+    const ordinary = await extract(
+      setup(
+        'function recurse() { return recurse(); }',
+        '<component :is="recurse()">Ordinary</component>'
+      )
+    );
+    const possibleT = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         function recurse(flag) { return flag ? T : recurse(flag); }`,
+        '<component :is="recurse(Boolean(Date.now()))">Hidden</component>'
+      )
+    );
+
+    expect(ordinary.errors).toEqual([]);
+    expect(ordinary.results).toEqual([]);
+    expect(possibleT.results).toEqual([]);
+    expect(possibleT.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'destructured object method factory',
+      `const { make } = { make() { return OriginalT; } };
+       const LocalT = make();`,
+    ],
+    [
+      'dynamic object default',
+      `const source = getSource();
+       const { [getKey()]: LocalT = OriginalT } = source;`,
+    ],
+    [
+      'dynamic array default',
+      `const source = getSource();
+       const [LocalT = OriginalT] = source;`,
+    ],
+    [
+      'for-of assignment',
+      `let LocalT = String;
+       for (LocalT of [OriginalT]) {}`,
+    ],
+    [
+      'for-of lexical value',
+      `let LocalT = String;
+       for (const candidate of [OriginalT]) { LocalT = candidate; }`,
+    ],
+    [
+      'destructured for-of lexical value',
+      `let LocalT = String;
+       for (const { component } of [{ component: OriginalT }]) {
+         LocalT = component;
+       }`,
+    ],
+  ])('fails closed for a T alias from %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T as OriginalT } from 'gt-vue'; ${code}`,
+        '<LocalT>Hidden</LocalT>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias "LocalT"'
+    );
+  });
+
+  it('resolves nested arrays and statically computed destructuring keys', async () => {
+    const output = await extract(
+      setup(
+        `import { T as OriginalT } from 'gt-vue';
+         const registry = [[OriginalT]];
+         const NestedT = registry[0][0];
+         const key = 'ComputedT';
+         const { [key]: ComputedT } = { ['Computed' + 'T']: OriginalT };`,
+        '<NestedT>Nested</NestedT><ComputedT>Computed</ComputedT>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Nested',
+      'Computed',
+    ]);
+  });
+
+  it('preserves component identity copied by an array spread', async () => {
+    const output = await extract(
+      setup(
+        `import { T as OriginalT } from 'gt-vue';
+         const source = [OriginalT];
+         const copy = [...source];
+         source[0] = String;
+         const [LocalT] = copy;`,
+        '<LocalT>Copied</LocalT>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(['Copied']);
+  });
+
+  it('distinguishes copied spread values from retained nested references', async () => {
+    const copied = await extract(
+      setup(
+        `import { useGT } from 'gt-vue';
+         const config = { context: 'old' };
+         const outer = { ...config };
+         config.context = 'new';
+         const { context } = outer;
+         const gt = useGT();
+         gt('Copied', { $context: context });`
+      )
+    );
+    const retained = await extract(
+      setup(
+        `import { useGT } from 'gt-vue';
+         const config = { context: 'old' };
+         const outer = { config };
+         config.context = 'new';
+         const { config: { context } } = outer;
+         const gt = useGT();
+         gt('Retained', { $context: context });`
+      )
+    );
+
+    expect(copied.errors).toEqual([]);
+    expect(copied.results[0]?.metadata.context).toBe('old');
+    expect(retained.results).toEqual([]);
+    expect(retained.errors.join('\n')).toContain('dynamic $context');
+  });
+
+  it.each([
+    ['unknown spread', '...unknown'],
+    ['unknown computed key', '[unknownKey]: 1'],
+  ])(
+    'uses order-sensitive certainty around an %s',
+    async (_name, unknownEntry) => {
+      const leading = await extract(
+        crossBlock(
+          `const unknown = getUnknown();
+           const unknownKey = getKey();
+           const kit = { ${unknownEntry}, T, Suspense, Card: String };`
+        )
+      );
+      const trailing = await extract(
+        crossBlock(
+          `const unknown = getUnknown();
+           const unknownKey = getKey();
+           const kit = { T, Suspense, Card: String, ${unknownEntry} };`
+        )
+      );
+
+      expect(leading.errors).toEqual([]);
+      expect(leading.results.map(({ source }) => source)).toEqual([
+        'Translated',
+        [
+          { t: 'Suspense', i: 1, c: 'Ready' },
+          { t: 'kit.Card', i: 2 },
+        ],
+      ]);
+      expect(trailing.results).toEqual([]);
+      expect(trailing.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias "kit.T"'
+      );
+      expect(trailing.errors.join('\n')).toContain(
+        'Could not statically resolve component alias "kit.Suspense"'
+      );
+      expect(trailing.errors.join('\n')).not.toContain('kit.Card');
+    }
+  );
+
+  it('keeps exact cross-block members through known object and array spreads', async () => {
+    const output = await extract(`
+      <script>
+      import { T } from 'gt-vue';
+      import { Suspense } from 'vue';
+      const base = { T, Suspense };
+      const kit = { ...base, Card: String };
+      const list = [...[T]];
+      </script>
+      <script setup>const keepScriptSetup = true;</script>
+      <template>
+        <component :is="list[0]">Array</component>
+        <kit.T>Object</kit.T>
+        <T><kit.Suspense>Ready</kit.Suspense><kit.Card>Opaque</kit.Card></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Array',
+      'Object',
+      [
+        { t: 'Suspense', i: 1, c: 'Ready' },
+        { t: 'kit.Card', i: 2 },
+      ],
+    ]);
+  });
+
+  it('resolves cross-block members reused by script-setup aliases', async () => {
+    const output = await extract(`
+      <script>
+      import { Suspense } from 'vue';
+      const objectRegistry = { Boundary: Suspense };
+      const arrayRegistry = [Suspense];
+      </script>
+      <script setup>
+      import { T } from 'gt-vue';
+      const { Boundary: ObjectBoundary } = objectRegistry;
+      const ArrayBoundary = arrayRegistry[0];
+      </script>
+      <template>
+        <T><ObjectBoundary>Object</ObjectBoundary><ArrayBoundary>Array</ArrayBoundary></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      { t: 'Suspense', i: 1, c: 'Object' },
+      { t: 'Suspense', i: 2, c: 'Array' },
+    ]);
+  });
+
+  it('fails closed when an exported cross-block container can be mutated', async () => {
+    const output = await extract(`
+      <script>
+      import { Suspense } from 'vue';
+      export const registry = { Boundary: Suspense };
+      </script>
+      <script setup>
+      import { T } from 'gt-vue';
+      const { Boundary } = registry;
+      </script>
+      <template><T><Boundary>Hidden</Boundary></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "Boundary"'
+    );
+  });
+
+  it('rejects a nested getter read that can mutate a selected sibling', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         import { Suspense } from 'vue';
+         const registry = {
+           Boundary: Suspense,
+           nested: {
+             get trigger() {
+               registry.Boundary = String;
+               return true;
+             },
+           },
+         };
+         void registry.nested.trigger;
+         const { Boundary } = registry;`,
+        '<T><Boundary>Hidden</Boundary></T>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "Boundary"'
+    );
+  });
+
+  it.each([
+    [
+      'a conditional registry',
+      `const flag = Boolean(Date.now());
+       const registry = flag ? [T] : [String];`,
+      '',
+    ],
+    [
+      'an array with an unknown spread',
+      'const registry = [...getItems(), T];',
+      '',
+    ],
+    ['a destructured registry', 'const { registry } = { registry: [T] };', ''],
+    ['a definitely assigned registry', 'let registry; registry = [T];', ''],
+    [
+      'a mutated reactive registry',
+      'const registry = reactive([String]); registry.push(T);',
+      "import { reactive } from 'vue';",
+    ],
+    [
+      'a reassigned ref registry',
+      'const registry = ref([String]); registry.value = [T];',
+      "import { ref } from 'vue';",
+    ],
+    [
+      'a conditional computed registry',
+      `const flag = Boolean(Date.now());
+       const registry = computed(() => flag ? [T] : [String]);`,
+      "import { computed } from 'vue';",
+    ],
+    [
+      'a markRaw registry',
+      'const registry = markRaw([T]);',
+      "import { markRaw } from 'vue';",
+    ],
+    [
+      'a nested ref unwrapped with unref',
+      'const registry = unref(ref([T]));',
+      "import { ref, unref } from 'vue';",
+    ],
+    [
+      'a local registry factory',
+      'const makeRegistry = () => [T];',
+      '',
+      'makeRegistry()[index]',
+    ],
+  ])(
+    'fails closed when T can be selected from %s',
+    async (_name, code, imports, selector = 'registry[index]') => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue';
+           ${imports}
+           ${code}
+           const index = getIndex();`,
+          `<component :is="${selector}">Hidden</component>`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    [
+      'a conditional nested array',
+      `const flag = Boolean(Date.now());
+       const registry = flag ? [[T]] : [[String]];`,
+    ],
+    ['an inserted nested array', 'const registry = []; registry.push([T]);'],
+    [
+      'a mutated existing nested array',
+      'const registry = [[String]]; registry[0].push(T);',
+    ],
+    ['a mapped nested array', 'const registry = [String].map(() => [T]);'],
+    ['a concatenated nested array', 'const registry = [String].concat([[T]]);'],
+  ])('preserves selection depth for %s', async (_name, code) => {
+    const first = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+           const index = getIndex();`,
+        '<component :is="registry[index]">Ordinary</component>'
+      )
+    );
+    const second = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+           const index = getIndex(); const nestedIndex = getNestedIndex();`,
+        '<component :is="registry[index][nestedIndex]">Hidden</component>'
+      )
+    );
+    const third = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+           const index = getIndex(); const nestedIndex = getNestedIndex();
+           const property = getKey();`,
+        '<component :is="registry[index][nestedIndex][property]">Ordinary</component>'
+      )
+    );
+
+    expect(first.errors).toEqual([]);
+    expect(first.results).toEqual([]);
+    expect(second.results).toEqual([]);
+    expect(second.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+    expect(third.errors).toEqual([]);
+    expect(third.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'mutation through an alias',
+      'const registry = [String]; const alias = registry; alias.push(T);',
+    ],
+    [
+      'reassignment after an initializer',
+      'let registry = [String]; registry = [T];',
+    ],
+    [
+      'Object.assign',
+      'const registry = { ordinary: String }; Object.assign(registry, { translated: T });',
+    ],
+    [
+      'Reflect.set',
+      "const registry = { ordinary: String }; Reflect.set(registry, 'translated', T);",
+    ],
+    [
+      'a copy after source mutation',
+      'const source = [String]; source.push(T); const registry = [...source];',
+    ],
+  ])('tracks T introduced by %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'an Options setup conditional registry',
+      `import { T } from 'gt-vue';
+       export default {
+         setup() {
+           const flag = Boolean(Date.now());
+           return { registry: flag ? [T] : [String], index: getIndex() };
+         },
+       };`,
+      'registry[index]',
+    ],
+    [
+      'an Options setup alias mutation',
+      `import { T } from 'gt-vue';
+       export default {
+         setup() {
+           const registry = [String];
+           const alias = registry;
+           alias.push(T);
+           return { registry, index: getIndex() };
+         },
+       };`,
+      'registry[index]',
+    ],
+    [
+      'an Options setup computed registry',
+      `import { computed } from 'vue';
+       import { T } from 'gt-vue';
+       export default {
+         setup() {
+           const flag = Boolean(Date.now());
+           const registry = computed(() => flag ? [T] : [String]);
+           return { registry, index: getIndex() };
+         },
+       };`,
+      'registry[index]',
+    ],
+    [
+      'an Options computed registry',
+      `import { T } from 'gt-vue';
+       export default {
+         data: () => ({ index: getIndex() }),
+         computed: {
+           registry() {
+             return Boolean(Date.now()) ? [T] : [String];
+           },
+         },
+       };`,
+      'registry[index]',
+    ],
+    [
+      'an Options registry factory method',
+      `import { T } from 'gt-vue';
+       export default {
+         data: () => ({ index: getIndex() }),
+         methods: { makeRegistry() { return [T, String]; } },
+       };`,
+      'makeRegistry()[index]',
+    ],
+  ])('tracks T through %s', async (_name, script, selector) => {
+    const output = await extract(
+      `<script>${script}</script>
+       <template><component :is="${selector}">Hidden</component></template>`
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'an exact container copied with slice',
+      'const base = [T];',
+      'const registry = base.slice();',
+    ],
+    [
+      'a conditional normal-script container',
+      `const flag = Boolean(Date.now());
+       const base = flag ? [T] : [String];`,
+      'const registry = base;',
+    ],
+  ])(
+    'tracks T across script blocks through %s',
+    async (_name, normalDeclaration, setupDeclaration) => {
+      const output = await extract(`
+        <script>
+        import { T } from 'gt-vue';
+        ${normalDeclaration}
+        </script>
+        <script setup>
+        ${setupDeclaration}
+        const index = getIndex();
+        </script>
+        <template><component :is="registry[index]">Hidden</component></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    ['flat', 'const registry = [[T]].flat();'],
+    ['flatMap', 'const registry = [String].flatMap(() => [T]);'],
+    [
+      'reduce',
+      'const registry = [[T]].reduce((result, value) => result.concat(value), []);',
+    ],
+    [
+      'splice return',
+      'const source = [T, String]; const registry = source.splice(0, 1);',
+    ],
+    [
+      'Object.values',
+      'const registry = Object.values({ translated: T, ordinary: String });',
+    ],
+    ['an identity map', 'const registry = [T, String].map((value) => value);'],
+  ])('tracks T through the bound %s transform', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('preserves the exact leaf depth of a bound reduce flatten', async () => {
+    const source = `import { T } from 'gt-vue';
+      const registry = [[T]].reduce(
+        (accumulator, value) => accumulator.concat(value),
+        []
+      );
+      const first = getIndex(); const second = getIndex();`;
+    const direct = await extract(
+      setup(source, '<component :is="registry[first]">Hidden</component>')
+    );
+    const below = await extract(
+      setup(
+        source,
+        '<component :is="registry[first][second]">Ordinary</component>'
+      )
+    );
+
+    expect(direct.results).toEqual([]);
+    expect(direct.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+    expect(below.errors).toEqual([]);
+    expect(below.results).toEqual([]);
+  });
+
+  it('preserves Object.entries tuple depth', async () => {
+    const script = `import { T } from 'gt-vue';
+      const registry = Object.entries({ translated: T });
+      const index = getIndex();`;
+    const tuple = await extract(
+      setup(script, '<component :is="registry[index]">Ordinary</component>')
+    );
+    const value = await extract(
+      setup(script, '<component :is="registry[index][1]">Hidden</component>')
+    );
+
+    expect(tuple.errors).toEqual([]);
+    expect(tuple.results).toEqual([]);
+    expect(value.results).toEqual([]);
+    expect(value.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('preserves Object.entries depth when its object is a binding', async () => {
+    const script = `import { T } from 'gt-vue';
+      const source = { translated: T };
+      const registry = Object.entries(source);
+      const index = getIndex();`;
+    const tuple = await extract(
+      setup(script, '<component :is="registry[index]">Ordinary</component>')
+    );
+    const value = await extract(
+      setup(script, '<component :is="registry[index][1]">Hidden</component>')
+    );
+
+    expect(tuple.errors).toEqual([]);
+    expect(tuple.results).toEqual([]);
+    expect(value.results).toEqual([]);
+    expect(value.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'an arrow identity',
+      'const identity = (value) => value; const registry = identity([T, String]);',
+    ],
+    [
+      'a function identity',
+      'function identity(value) { return value; } const registry = identity([T, String]);',
+    ],
+    [
+      'a copied argument',
+      'const copy = (value) => [...value]; const registry = copy([T, String]);',
+    ],
+    [
+      'a sliced argument',
+      'const copy = (value) => value.slice(); const registry = copy([T, String]);',
+    ],
+    [
+      'a conditional argument',
+      `const identity = (value) => value;
+       const registry = identity(Boolean(Date.now()) ? [T] : [String]);`,
+    ],
+    [
+      'a destructured argument',
+      'const values = ({ registry }) => registry; const registry = values({ registry: [T] });',
+    ],
+  ])('tracks T across %s call boundary', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('does not taint an ordinary value across a local call boundary', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const identity = (value) => value;
+         const registry = identity([String]);
+         const index = getIndex();`,
+        '<component :is="registry[index]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    ['map callback', 'const registry = [String].map(() => T);'],
+    ['Array.from mapper', 'const registry = Array.from([String], () => T);'],
+    [
+      'Object.assign return value',
+      'const registry = Object.assign({}, { translated: T });',
+    ],
+  ])('tracks T created by a %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['map callback', 'const registry = [T].map(() => String);'],
+    ['Array.from mapper', 'const registry = Array.from([T], () => String);'],
+  ])('does not retain T erased by a %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'map wrapping its parameter',
+      'const registry = [T].map((value) => [value]);',
+      'registry[index][nested]',
+    ],
+    [
+      'Array.from wrapping its parameter',
+      'const registry = Array.from([T], (value) => [value]);',
+      'registry[index][nested]',
+    ],
+    [
+      'flatMap wrapping its parameter',
+      'const registry = [T].flatMap((value) => [value]);',
+      'registry[index]',
+    ],
+    [
+      'Object.entries mapped to its value',
+      `const registry = Object.entries({ translated: T })
+         .map(([, value]) => value);`,
+      'registry[index]',
+    ],
+  ])('preserves T through %s', async (_name, code, selector) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex(); const nested = getIndex();`,
+        `<component :is="${selector}">Hidden</component>`
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'the map source and index parameters',
+      `const registry = [T].map((_value, index, source) => source[index]);`,
+    ],
+    [
+      'a named map source callback',
+      `function select(_value, index, source) { return source[index]; }
+       const registry = [T].map(select);`,
+    ],
+    [
+      'callback rest parameters',
+      `const registry = [T].map((...args) => args[0]);`,
+    ],
+    [
+      'an Array.from index closure',
+      `const source = [T];
+       const registry = Array.from(source, (_value, index) => source[index]);`,
+    ],
+  ])('preserves T through %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['with', 'const registry = [String].with(0, T);', 'registry[index]'],
+    [
+      'nested with',
+      'const registry = [[String]].with(0, [T]);',
+      'registry[index][nested]',
+    ],
+    [
+      'toSpliced',
+      'const registry = [String].toSpliced(0, 0, T);',
+      'registry[index]',
+    ],
+    [
+      'nested toSpliced',
+      'const registry = [[String]].toSpliced(0, 0, [T]);',
+      'registry[index][nested]',
+    ],
+  ])('tracks inserted T values through %s', async (_name, code, selector) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex(); const nested = getIndex();`,
+        `<component :is="${selector}">Hidden</component>`
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('tracks a component returned by reduce', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = [String];
+         const selected = registry.reduce(() => T, String);`,
+        '<component :is="selected">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'a singleton without an initial value',
+      'const selected = [T].reduce(() => String);',
+    ],
+    [
+      'the current value',
+      'const selected = [String, T].reduce((_accumulator, value) => value);',
+    ],
+    [
+      'the reverse current value',
+      'const selected = [T, String].reduceRight((_accumulator, value) => value);',
+    ],
+  ])('tracks T returned by reduce through %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}`,
+        '<component :is="selected">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('does not retain an initial T erased by reduce', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const selected = [String].reduce(() => String, T);`,
+        '<component :is="selected">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'arrow rest arguments',
+      'const collect = (...values) => values; const registry = collect(T, String);',
+    ],
+    [
+      'unknown imported transform',
+      `import { transform } from './transform';
+       const registry = transform([T, String]);`,
+    ],
+  ])('fails closed across %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('respects explicit flat depths', async () => {
+    const depthZero = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = [[T]].flat(0);
+         const index = getIndex();`,
+        '<component :is="registry[index]">Ordinary</component>'
+      )
+    );
+    const depthZeroNested = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = [[T]].flat(0);
+         const index = getIndex(); const nested = getIndex();`,
+        '<component :is="registry[index][nested]">Hidden</component>'
+      )
+    );
+    const depthTwo = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = [[[T]]].flat(2);
+         const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(depthZero.errors).toEqual([]);
+    expect(depthZero.results).toEqual([]);
+    expect(depthZeroNested.results).toEqual([]);
+    expect(depthZeroNested.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+    expect(depthTwo.results).toEqual([]);
+    expect(depthTwo.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['flat', '[[T]].flat()[index]'],
+    ['map', '[String].map(() => T)[index]'],
+    ['flatMap', '[String].flatMap(() => [T])[index]'],
+    ['Object.values', 'Object.values({ translated: T })[index]'],
+    ['Object.entries value', 'Object.entries({ translated: T })[index][1]'],
+  ])('tracks T through an inline %s transform', async (_name, selector) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; const index = getIndex();`,
+        `<component :is="${selector}">Hidden</component>`
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('does not retain T erased by an inline map', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; const index = getIndex();`,
+        '<component :is="[T].map(() => String)[index]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    ['map identity', 'Component in [T].map((value) => value)', 'Component'],
+    [
+      'flatMap wrapped identity',
+      'Component in [T].flatMap((value) => [value])',
+      'Component',
+    ],
+    ['flat', 'Component in [[T]].flat()', 'Component'],
+    [
+      'Array.from mapper',
+      'Component in Array.from([String], () => T)',
+      'Component',
+    ],
+    [
+      'Object.entries tuple member',
+      'entry in Object.entries({ translated: T })',
+      'entry[1]',
+    ],
+    [
+      'Object.entries destructuring',
+      '[, Component] in Object.entries({ translated: T })',
+      'Component',
+    ],
+    ['with insertion', 'Component in [String].with(0, T)', 'Component'],
+    [
+      'toSpliced insertion',
+      'Component in [String].toSpliced(0, 0, T)',
+      'Component',
+    ],
+  ])('tracks T through a v-for %s', async (_name, loop, selector) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';`,
+        `<component v-for="${loop}" :is="${selector}">Hidden</component>`
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['map wrapper', 'row in [T].map((value) => [value])', 'Component in row'],
+    [
+      'Object.values',
+      'row in Object.values({ translated: [T] })',
+      'Component in row',
+    ],
+    ['Array.from', 'row in Array.from([[T]])', 'Component in row'],
+  ])(
+    'tracks T through nested v-for aliases from %s',
+    async (_name, outer, inner) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue';`,
+          `<template v-for="${outer}">
+           <component v-for="${inner}" :is="Component">Hidden</component>
+         </template>`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it('tracks an inline T argument passed to concat', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const source = [String]; const index = getIndex();`,
+        '<component :is="source.concat(T)[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['slice', "const registry = ['T', 'div'].slice();"],
+    ['concat', "const registry = ['div'].concat('T');"],
+    ['Array.from', "const registry = Array.from(['T', 'div']);"],
+    ['push mutation', "const registry = ['div']; registry.push('T');"],
+    ['reassignment', "let registry = ['div']; registry = ['T'];"],
+    [
+      'conditional arrays',
+      "const registry = Boolean(Date.now()) ? ['T'] : ['div'];",
+    ],
+    [
+      'computed conditional arrays',
+      "const registry = computed(() => Boolean(Date.now()) ? ['T'] : ['div']);",
+      "import { computed } from 'vue';",
+    ],
+    ['identity map', "const registry = ['T', 'div'].map((value) => value);"],
+  ])(
+    'tracks a registered T name through %s',
+    async (_name, code, extraImport = '') => {
+      const output = await extract(`
+        <script>
+        import { T } from 'gt-vue';
+        export default { components: { T } };
+        </script>
+        <script setup>
+        ${extraImport}
+        ${code}
+        const index = getIndex();
+        </script>
+        <template><component :is="registry[index]">Hidden</component></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    ['constant map', "const registry = ['div'].map(() => 'T');"],
+    ['flat', "const registry = [['T']].flat();"],
+    ['flatMap', "const registry = ['div'].flatMap(() => ['T']);"],
+    [
+      'copy after mutation',
+      "const source = ['div']; source.push('T'); const registry = [...source];",
+    ],
+    [
+      'Object.values binding',
+      "const source = { translated: 'T' }; const registry = Object.values(source);",
+    ],
+    [
+      'Object.entries binding',
+      "const source = { translated: 'T' }; const registry = Object.entries(source);",
+      'registry[index][1]',
+    ],
+    [
+      'spread-copy function',
+      "const copy = (value) => [...value]; const registry = copy(['T']);",
+    ],
+    [
+      'unknown imported transform',
+      "import { transform } from './transform'; const registry = transform(['T']);",
+    ],
+    [
+      'Object.assign return',
+      "const registry = Object.assign({}, { translated: 'T' });",
+    ],
+  ])(
+    'tracks a registered T name through %s',
+    async (_name, code, selector = 'registry[index]') => {
+      const output = await extract(`
+        <script>
+        import { T } from 'gt-vue';
+        export default { components: { T } };
+        </script>
+        <script setup>
+        ${code}
+        const index = getIndex();
+        </script>
+        <template><component :is="${selector}">Hidden</component></template>
+      `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    ['a singleton', '[T].reduce(() => String)'],
+    ['the current value', '[String, T].reduce((_accumulator, value) => value)'],
+    [
+      'the first accumulator',
+      '[T, String].reduce((accumulator) => accumulator)',
+    ],
+    [
+      'the reverse current value',
+      '[T, String].reduceRight((_accumulator, value) => value)',
+    ],
+  ])('evaluates inline reduce through %s', async (_name, selector) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';`,
+        `<component :is="${selector}">Reduced</component>`
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(['Reduced']);
+  });
+
+  it('extracts T from an inline reduce callback-created container', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';`,
+        '<component :is="[String].reduce(() => [T], [])[0]">Reduced</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual(['Reduced']);
+  });
+
+  it.each([
+    [
+      'a concatenated container',
+      '[[T]].reduce((accumulator, value) => accumulator.concat(value), [])[index]',
+    ],
+    ['copyWithin', '[String, T].copyWithin(0, 1)[index]'],
+    ['fill', '[String].fill(T)[index]'],
+    ['nested fill', '[String].fill([T])[index][nested]'],
+    [
+      'Object.entries with a bound source',
+      'Object.entries(source)[index][1]',
+      'const source = { translated: T };',
+    ],
+  ])(
+    'does not silently lose T through inline %s',
+    async (_name, selector, declaration = '') => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue'; ${declaration}
+           const index = getIndex(); const nested = getIndex();`,
+          `<component :is="${selector}">Hidden</component>`
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve possible gt-vue component alias'
+      );
+    }
+  );
+
+  it.each([
+    'Object.entries(source)[index]',
+    'Object.entries(source)[index][0]',
+  ])(
+    'preserves the ordinary Object.entries tuple projection %s',
+    async (selector) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue';
+           const source = { translated: T }; const index = getIndex();`,
+          `<component :is="${selector}">Ordinary</component>`
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results).toEqual([]);
+    }
+  );
+
+  it('does not retain an inline reduce initial value erased by its callback', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';`,
+        '<component :is="[String].reduce(() => String, T)">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    [
+      'map rest source/index arguments',
+      'const registry = [T].map((...args) => args[2][args[1]]);',
+    ],
+    [
+      'flatMap rest source/index arguments',
+      'const registry = [T].flatMap((...args) => [args[2][args[1]]]);',
+    ],
+    [
+      'Array.from rest index arguments',
+      'const source = [T]; const registry = Array.from(source, (...args) => source[args[1]]);',
+    ],
+    [
+      'a map source alias',
+      'const source = [T], alias = source; const registry = source.map((_value, index) => alias[index]);',
+    ],
+    [
+      'a flatMap source alias',
+      'const source = [T], alias = source; const registry = source.flatMap((_value, index) => [alias[index]]);',
+    ],
+    [
+      'an Array.from source alias',
+      'const source = [T], alias = source; const registry = Array.from(source, (_value, index) => alias[index]);',
+    ],
+    [
+      'an Array.from rest source alias',
+      'const source = [T], alias = source; const registry = Array.from(source, (...args) => alias[args[1]]);',
+    ],
+    [
+      'a named source callback',
+      'const source = [T]; function pick(_value, index) { return source[index]; } const registry = source.map(pick);',
+    ],
+  ])('tracks T through %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code} const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'map',
+      'const registry = [String].map(function () { return this.Component; }, { Component: T });',
+    ],
+    [
+      'flatMap',
+      'const registry = [String].flatMap(function () { return [this.Component]; }, { Component: T });',
+    ],
+    [
+      'Array.from',
+      'const registry = Array.from([String], function () { return this.Component; }, { Component: T });',
+    ],
+  ])('tracks a mapper thisArg through %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code} const index = getIndex();`,
+        '<component :is="registry[index]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('does not bind a mapper thisArg into an arrow function', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         const registry = [String].map(() => String, { Component: T });
+         const index = getIndex();`,
+        '<component :is="registry[index]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    ['slice', 'const registry = [T, String].slice(1);'],
+    ['filter', 'const registry = [T].filter(() => false);'],
+    ['splice return', 'const registry = [String, T].splice(0, 1);'],
+    ['toSpliced deletion', 'const registry = [T, String].toSpliced(0, 1);'],
+    ['toSpliced replacement', 'const registry = [T].toSpliced(0, 1, String);'],
+    ['with replacement', 'const registry = [T].with(0, String);'],
+    ['fill replacement', 'const registry = [T].fill(String);'],
+  ])(
+    'does not retain T deterministically erased by %s',
+    async (_name, code) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue'; ${code} const index = getIndex();`,
+          '<component :is="registry[index]">Ordinary</component>'
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results).toEqual([]);
+    }
+  );
+
+  it.each([
+    [
+      'array reassignment',
+      'let registry = [T]; registry = [String]; const key = getIndex();',
+    ],
+    [
+      'pop followed by an ordinary push',
+      'const registry = [T]; registry.pop(); registry.push(String); const key = getIndex();',
+    ],
+    [
+      'splice replacement',
+      'const registry = [T]; registry.splice(0, 1, String); const key = getIndex();',
+    ],
+    [
+      'object member replacement',
+      'const registry = { x: T }; registry.x = String; const key = getKey();',
+    ],
+    [
+      'Object.assign replacement',
+      'const registry = { x: T }; Object.assign(registry, { x: String }); const key = getKey();',
+    ],
+    [
+      'member replacement through an alias',
+      'const registry = [T]; const alias = registry; alias[0] = String; const key = getIndex();',
+    ],
+    [
+      'length truncation through an alias',
+      'const registry = [T]; const alias = registry; alias.length = 0; const key = getIndex();',
+    ],
+    [
+      'pop through an alias',
+      'const registry = [T]; const alias = registry; alias.pop(); const key = getIndex();',
+    ],
+  ])('uses the final ordinary state after %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; ${code}`,
+        '<component :is="registry[key]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('does not merge an alias identity across root reassignment', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         let registry = [T]; const retained = registry; registry = [String];
+         const key = getIndex();`,
+        '<component :is="retained[key]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('uses a mutable binding value assigned before an alias is captured', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         let registry = [T]; registry = [String]; const retained = registry;
+         const key = getIndex();`,
+        '<component :is="retained[key]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('fails closed for a conditional write before an alias is captured', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue';
+         let registry = [String]; if (getFlag()) registry = [T];
+         const retained = registry; const key = getIndex();`,
+        '<component :is="retained[key]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    [
+      'readonly member assignment',
+      'const registry = readonly([String]); registry[0] = T;',
+    ],
+    ['readonly push', 'const registry = readonly([String]); registry.push(T);'],
+    [
+      'readonly alias push',
+      'const registry = readonly([String]); const alias = registry; alias.push(T);',
+    ],
+    [
+      'shallowReadonly alias assignment',
+      'const registry = shallowReadonly([String]); const alias = registry; alias[0] = T;',
+    ],
+  ])('ignores a blocked %s', async (_name, code) => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; import { readonly, shallowReadonly } from 'vue'; ${code} const key = getIndex();`,
+        '<component :is="registry[key]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('retains T when readonly blocks its replacement', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; import { readonly } from 'vue';
+         const registry = readonly([T]); registry[0] = String; const key = getIndex();`,
+        '<component :is="registry[key]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('tracks writes through the raw source behind readonly', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; import { readonly } from 'vue';
+         const raw = [String]; const registry = readonly(raw); raw[0] = T; const key = getIndex();`,
+        '<component :is="registry[key]">Hidden</component>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each(['alias[0] = String;', 'alias.length = 0;', 'alias.pop();'])(
+    'replays raw alias erasure through readonly: %s',
+    async (mutation) => {
+      const output = await extract(
+        setup(
+          `import { T } from 'gt-vue'; import { readonly } from 'vue';
+         const raw = [T]; const alias = raw; ${mutation}
+         const registry = readonly(raw); const key = getIndex();`,
+          '<component :is="registry[key]">Ordinary</component>'
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results).toEqual([]);
+    }
+  );
+
+  it('preserves readonly copy timing for later raw mutation', async () => {
+    const output = await extract(
+      setup(
+        `import { T } from 'gt-vue'; import { readonly } from 'vue';
+         const raw = [String]; const registry = readonly(raw.slice());
+         raw[0] = T; const key = getIndex();`,
+        '<component :is="registry[key]">Ordinary</component>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('preserves the exact leaf depth for flat(Infinity)', async () => {
+    const script = `import { T } from 'gt-vue';
+      const registry = [[[T]]].flat(Infinity);
+      const index = getIndex(); const nested = getIndex();`;
+    const exact = await extract(
+      setup(script, '<component :is="registry[index]">Hidden</component>')
+    );
+    const belowLeaf = await extract(
+      setup(
+        script,
+        '<component :is="registry[index][nested]">Ordinary</component>'
+      )
+    );
+
+    expect(exact.results).toEqual([]);
+    expect(exact.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+    expect(belowLeaf.errors).toEqual([]);
+    expect(belowLeaf.results).toEqual([]);
+  });
+
+  it('coerces a NaN flat depth to zero', async () => {
+    const script = `import { T } from 'gt-vue';
+      const registry = [[[T]]].flat(NaN);
+      const index = getIndex(); const nested = getIndex(); const leaf = getIndex();`;
+    const depthOne = await extract(
+      setup(script, '<component :is="registry[index]">Ordinary</component>')
+    );
+    const depthTwo = await extract(
+      setup(
+        script,
+        '<component :is="registry[index][nested]">Ordinary</component>'
+      )
+    );
+    const exact = await extract(
+      setup(
+        script,
+        '<component :is="registry[index][nested][leaf]">Hidden</component>'
+      )
+    );
+
+    expect(depthOne.errors).toEqual([]);
+    expect(depthOne.results).toEqual([]);
+    expect(depthTwo.errors).toEqual([]);
+    expect(depthTwo.results).toEqual([]);
+    expect(exact.results).toEqual([]);
+    expect(exact.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('preserves inline flat(Infinity) leaf depth', async () => {
+    const script = `import { T } from 'gt-vue';
+      const index = getIndex(); const nested = getIndex();`;
+    const exact = await extract(
+      setup(
+        script,
+        '<component :is="[[[T]]].flat(Infinity)[index]">Hidden</component>'
+      )
+    );
+    const belowLeaf = await extract(
+      setup(
+        script,
+        '<component :is="[[[T]]].flat(Infinity)[index][nested]">Ordinary</component>'
+      )
+    );
+
+    expect(exact.results).toEqual([]);
+    expect(exact.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+    expect(belowLeaf.errors).toEqual([]);
+    expect(belowLeaf.results).toEqual([]);
+  });
+
+  it('preserves inline flat(NaN) leaf depth', async () => {
+    const script = `import { T } from 'gt-vue';
+      const index = getIndex(); const nested = getIndex(); const leaf = getIndex();`;
+    const depthOne = await extract(
+      setup(
+        script,
+        '<component :is="[[[T]]].flat(NaN)[index]">Ordinary</component>'
+      )
+    );
+    const depthTwo = await extract(
+      setup(
+        script,
+        '<component :is="[[[T]]].flat(NaN)[index][nested]">Ordinary</component>'
+      )
+    );
+    const exact = await extract(
+      setup(
+        script,
+        '<component :is="[[[T]]].flat(NaN)[index][nested][leaf]">Hidden</component>'
+      )
+    );
+
+    expect(depthOne.errors).toEqual([]);
+    expect(depthOne.results).toEqual([]);
+    expect(depthTwo.errors).toEqual([]);
+    expect(depthTwo.results).toEqual([]);
+    expect(exact.results).toEqual([]);
+    expect(exact.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it.each([
+    ['map rest', 'Component in [T].map((...args) => args[0])', 'Component'],
+    [
+      'nested map rest',
+      'row in [[T]].map((...args) => args[0])',
+      'Component in row',
+    ],
+    [
+      'reduce flatten',
+      'Component in [[T]].reduce((accumulator, value) => accumulator.concat(value), [])',
+      'Component',
+    ],
+    ['copyWithin', 'Component in [String, T].copyWithin(0, 1)', 'Component'],
+    ['fill', 'Component in [String].fill(T)', 'Component'],
+  ])('tracks T through a v-for %s', async (name, outerLoop, selector) => {
+    const template =
+      name === 'nested map rest'
+        ? `<template v-for="${outerLoop}"><component v-for="${selector}" :is="Component">Hidden</component></template>`
+        : `<component v-for="${outerLoop}" :is="${selector}">Hidden</component>`;
+    const output = await extract(
+      setup(`import { T } from 'gt-vue';`, template)
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve possible gt-vue component alias'
+    );
+  });
+
+  it('does not retain a registered T name erased by map', async () => {
+    const output = await extract(`
+      <script>
+      import { T } from 'gt-vue';
+      export default { components: { T } };
+      </script>
+      <script setup>
+      const registry = ['T'].map(() => 'div');
+      const index = getIndex();
+      </script>
+      <template><component :is="registry[index]">Ordinary</component></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+});
+
+function setup(script: string, template = '<div />'): string {
+  return `<script setup>${script}</script><template>${template}</template>`;
+}
+
+function crossBlock(declaration: string): string {
+  return `
+    <script>
+    import { T } from 'gt-vue';
+    import { Suspense } from 'vue';
+    ${declaration}
+    </script>
+    <script setup>const keepScriptSetup = true;</script>
+    <template>
+      <kit.T>Translated</kit.T>
+      <T><kit.Suspense>Ready</kit.Suspense><kit.Card>Opaque</kit.Card></T>
+    </template>
+  `;
+}
+
+async function extract(source: string) {
+  return extractFromVueSource(source, '/fixtures/SelectorProvenance.vue', {
+    projectRoot: '/fixtures',
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/sfcClassification.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/sfcClassification.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { isVueSfcSource } from '../project/inspectVueProject.js';
+
+describe('isVueSfcSource', () => {
+  it.each([
+    ['root template', '<template><T>Message</T></template>'],
+    ['root script', '<script setup>const message = 1;</script>'],
+    ['same-line text', 'Copyright 2026 <template><T>Message</T></template>'],
+    [
+      'multiline text',
+      'Copyright 2026\nAll rights reserved\n<template>Message</template>',
+    ],
+    [
+      'text before script setup',
+      'Generated file <script setup>const message = 1;</script>',
+    ],
+    [
+      'text and custom block',
+      'Metadata <i18n>{"locale":"en"}</i18n><template>Message</template>',
+    ],
+    [
+      'comments and doctype',
+      '<!-- license --><!DOCTYPE html>/* generated */<template>Message</template>',
+    ],
+  ])('recognizes an SFC with %s', (_name, source) => {
+    expect(isVueSfcSource(source)).toBe(true);
+  });
+
+  it.each([
+    [
+      'an import and exported JSX',
+      "import { T } from 'gt-react'; export const value = <T>Message</T>;",
+    ],
+    ['typed parenthesized JSX', 'const value: JSX.Element = (<T>Message</T>);'],
+    ['a JSX fragment', 'const value = <><T>Message</T></>;'],
+    [
+      'a comment containing a standard tag',
+      '/* <template>fake</template> */ <T>Message</T>;',
+    ],
+    [
+      'a string containing a standard tag',
+      "const fake = '<template>fake</template>'; const value = <T>Message</T>;",
+    ],
+    [
+      'a template literal containing a standard tag',
+      'const fake = `<script>fake</script>`; const value = <T>Message</T>;',
+    ],
+    ['a root custom element', '<T>Message</T>'],
+    ['a root member element', '<GT.T>Message</GT.T>'],
+    ['a hyphenated custom element', '<gt-widget>Message</gt-widget>'],
+    [
+      'custom and standard-named JSX expressions',
+      '<T>Message</T>; <template><T>Nested</T></template>;',
+    ],
+    [
+      'a parenthesized standard-named JSX expression',
+      '(<template><T>Message</T></template>);',
+    ],
+  ])('preserves a legacy module with %s', (_name, source) => {
+    expect(isVueSfcSource(source)).toBe(false);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/sfcClassification.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/sfcClassification.test.ts
@@ -53,6 +53,14 @@ describe('isVueSfcSource', () => {
       '<T>Message</T>; <template><T>Nested</T></template>;',
     ],
     [
+      'a leading standard-named JSX expression followed by module syntax',
+      "<template><T>Message</T></template>; import { T } from 'gt-react';",
+    ],
+    [
+      'a directive before a standard-named JSX expression',
+      "'Copyright 2026'; <template><T>Message</T></template>; import { T } from 'gt-react';",
+    ],
+    [
       'a parenthesized standard-named JSX expression',
       '(<template><T>Message</T></template>);',
     ],

--- a/packages/vue-extractor/src/internal/__tests__/sourcePositionAndCallMaterialization.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/sourcePositionAndCallMaterialization.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type LocalCallProbe = {
+  /** Human-readable local-call data flow exercised by the probe. */
+  name: string;
+  /** Statements inserted into the fixture's script setup block. */
+  code: string;
+  /** Dynamic component expression read by the template. */
+  selector: string;
+  /** Whether the selector resolves to `<T>` at runtime. */
+  possibleT: boolean;
+};
+
+/**
+ * Local function calls substitute arguments before resolving returned members.
+ * Nested member and rest paths must retain an imported `<T>` possibility. The
+ * safe requirement is detection: exact rich extraction or the conservative
+ * possible-alias diagnostic are both valid, while complete silence is not.
+ */
+const localCallProbes: LocalCallProbe[] = [
+  {
+    name: 'a direct local-call member return selects T at an exact index',
+    code: 'const read = (value) => value.registry; const selected = read({ registry: [T] });',
+    selector: 'selected[0]',
+    possibleT: true,
+  },
+  {
+    name: 'a direct local-call member return selects T at a dynamic index',
+    code: 'const read = (value) => value.registry; const selected = read({ registry: [T] });',
+    selector: 'selected[index]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested local-call member return selects T',
+    code: 'const read = (value) => value.nested.registry; const selected = read({ nested: { registry: [T] } });',
+    selector: 'selected[index]',
+    possibleT: true,
+  },
+  {
+    name: 'a deeply nested local-call member return selects T',
+    code: 'const read = (value) => value.first.second.registry; const selected = read({ first: { second: { registry: [T] } } });',
+    selector: 'selected[index]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary local-call member return stays silent',
+    code: 'const read = (value) => value.registry; const selected = read({ registry: [String] });',
+    selector: 'selected[index]',
+    possibleT: false,
+  },
+  {
+    name: 'a rest parameter return selects nested T at an exact index',
+    code: 'const read = (...values) => values[0]; const selected = read([T]);',
+    selector: 'selected[0]',
+    possibleT: true,
+  },
+  {
+    name: 'a rest parameter return selects nested T at a dynamic index',
+    code: 'const read = (...values) => values[0]; const selected = read([T]);',
+    selector: 'selected[index]',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary rest parameter return stays silent',
+    code: 'const read = (...values) => values[0]; const selected = read([String]);',
+    selector: 'selected[index]',
+    possibleT: false,
+  },
+];
+
+describe('local-call component materialization', () => {
+  it.each(localCallProbes)('$name', async ({ code, selector, possibleT }) => {
+    const output = await extractFromVueSource(
+      createComponentFixture(code, selector),
+      '/fixtures/LocalCallMaterialization.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    if (possibleT) {
+      const extracted = output.results.some(
+        ({ source }) => source === 'Hidden'
+      );
+      const diagnosed = output.errors
+        .join('\n')
+        .includes(POSSIBLE_ALIAS_DIAGNOSTIC);
+      expect(extracted || diagnosed).toBe(true);
+    } else {
+      expect(output.results).toEqual([]);
+      expect(output.errors).toEqual([]);
+    }
+  });
+});
+
+describe('string-function bindings at each call position', () => {
+  it('extracts a useGT call made before the binding becomes ordinary', async () => {
+    const output = await extractScript(`
+      import { useGT } from 'gt-vue';
+      let translate = useGT();
+      translate('Before useGT reassignment');
+      translate = String;
+      translate('Ordinary after useGT');
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Before useGT reassignment',
+    ]);
+  });
+
+  it('extracts a useGT call made after an ordinary binding is replaced', async () => {
+    const output = await extractScript(`
+      import { useGT } from 'gt-vue';
+      let translate = String;
+      translate('Ordinary before useGT');
+      translate = useGT();
+      translate('After useGT reassignment');
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'After useGT reassignment',
+    ]);
+  });
+
+  it('extracts a msg call made before the binding becomes ordinary', async () => {
+    const output = await extractScript(`
+      import { msg } from 'gt-vue';
+      let message = msg;
+      message('Before msg reassignment');
+      message = String;
+      message('Ordinary after msg');
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Before msg reassignment',
+    ]);
+  });
+
+  it('extracts a msg call made after an ordinary binding is replaced', async () => {
+    const output = await extractScript(`
+      import { msg } from 'gt-vue';
+      let message = String;
+      message('Ordinary before msg');
+      message = msg;
+      message('After msg reassignment');
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'After msg reassignment',
+    ]);
+  });
+});
+
+/** Creates an SFC that resolves a local-call result in the template. */
+function createComponentFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    ${code}
+    const index = getIndex();
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}
+
+/** Extracts a script-only SFC for source-position string-call assertions. */
+function extractScript(script: string) {
+  return extractFromVueSource(
+    `<script setup>${script}</script><template><div /></template>`,
+    '/fixtures/StringFunctionSourcePosition.vue',
+    { projectRoot: '/fixtures' }
+  );
+}

--- a/packages/vue-extractor/src/internal/__tests__/staticAnalysisSoundness.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/staticAnalysisSoundness.test.ts
@@ -1,0 +1,502 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue static-analysis soundness', () => {
+  it.each([
+    {
+      name: 'destructured Vue namespace',
+      script: `const Vue = require('vue'); Vue.Suspense = String; const { Suspense: Boundary } = Vue;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'aliased Vue namespace',
+      script: `const Vue = require('vue'); const Alias = Vue; Vue.Suspense = String; const Boundary = Alias.Suspense;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'computed Vue namespace write',
+      script: `const Vue = require('vue'); Vue['Suspense'] = String; const Boundary = Vue.Suspense;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'Object.assign namespace write',
+      script: `const Vue = require('vue'); Object.assign(Vue, { Suspense: String }); const Boundary = Vue.Suspense;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'Reflect.set namespace write',
+      script: `const Vue = require('vue'); Reflect.set(Vue, 'Suspense', String); const Boundary = Vue.Suspense;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'escaped Vue namespace',
+      script: `const Vue = require('vue'); mutate(Vue); const Boundary = Vue.Suspense;`,
+      tag: 'Boundary',
+    },
+    {
+      name: 'destructured GT namespace',
+      script: `const GT = require('gt-vue'); GT.T = String; const { T: LocalT } = GT;`,
+      tag: 'LocalT',
+    },
+  ])('fails closed for a mutated $name', async ({ script, tag }) => {
+    const output = await extract(
+      setup(script, `<T><${tag}>Hidden</${tag}></T>`)
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      `Could not statically resolve component alias "${tag}"`
+    );
+  });
+
+  it.each([
+    `const registry = { nested: { Boundary: Suspense } }; mutate(registry.nested); const { nested: { Boundary } } = registry;`,
+    `const registry = { nested: { Boundary: Suspense } }; const { nested } = registry; nested.Boundary = String; const { Boundary } = registry.nested;`,
+    `const registry = { nested: { Boundary: Suspense } }; const copy = { ...registry }; copy.nested.Boundary = String; const { Boundary } = registry.nested;`,
+    `const registry = { nested: { Boundary: Suspense } }; Object.assign(registry.nested, { Boundary: String }); const { nested: { Boundary } } = registry;`,
+    `const registry = { nested: { Boundary: Suspense } }; Reflect.set(registry.nested, 'Boundary', String); const { nested: { Boundary } } = registry;`,
+  ])(
+    'fails closed when a nested component container escapes: %s',
+    async (script) => {
+      const output = await extract(
+        setup(
+          `import { Suspense } from 'vue'; ${script}`,
+          '<T><Boundary>Hidden</Boundary></T>'
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve component alias "Boundary"'
+      );
+    }
+  );
+
+  it('resolves a component read through an immutable array member', async () => {
+    const output = await extract(
+      setup(
+        `import { Suspense } from 'vue'; const registry = [Suspense]; const Boundary = registry[0];`,
+        '<T><Boundary>Hidden</Boundary></T>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: 'Hidden',
+    });
+  });
+
+  it('does not expose a function-local CommonJS import to the template', async () => {
+    const output = await extract(`
+      <script setup>
+      function hidden() {
+        const { T } = require('gt-vue');
+        return T;
+      }
+      </script>
+      <template><T>Not GT at runtime</T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    `const Card = defineComponent({ setup() { void Suspense; return () => h('div'); } });`,
+    `const Card = { nested: Suspense };`,
+    `const Card = () => h('div', [h(Suspense)]);`,
+    `const Card = markRaw(defineComponent({ render() { return h('div', [h(Suspense)]); } }));`,
+  ])(
+    'keeps an ordinary component opaque when its implementation mentions Suspense',
+    async (script) => {
+      const output = await extract(
+        setup(
+          `import { defineComponent, h, markRaw, Suspense } from 'vue'; ${script}`,
+          '<T><Card>Hidden</Card></T>'
+        )
+      );
+
+      expect(output.errors).toEqual([]);
+      expect(output.results[0]?.source).toEqual({ t: 'Card', i: 1 });
+    }
+  );
+
+  it.each([
+    `const Boundary = (() => { const Inner = Suspense; return Inner; })();`,
+    `const Boundary = computed(() => { const Inner = Suspense; return Inner; });`,
+    `const holder = { get Boundary() { const Inner = Suspense; return Inner; } }; const { Boundary } = holder;`,
+    `const make = () => { const Inner = Suspense; return Inner; }; const Boundary = make();`,
+  ])(
+    'tracks component identity through a function-local alias: %s',
+    async (script) => {
+      const output = await extract(
+        setup(
+          `import { computed, Suspense } from 'vue'; ${script}`,
+          '<T><Boundary>Hidden</Boundary></T>'
+        )
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve component alias "Boundary"'
+      );
+    }
+  );
+
+  it.each([
+    `const Boundary = (() => { const Suspense = String; return Suspense; })();`,
+    `const Boundary = computed(() => { const Suspense = String; return Suspense; });`,
+    `const holder = { get Boundary() { const Suspense = String; return Suspense; } }; const { Boundary } = holder;`,
+  ])('respects a function-local shadow of Suspense: %s', async (script) => {
+    const output = await extract(
+      setup(
+        `import { computed, Suspense } from 'vue'; ${script}`,
+        '<T><Boundary>Hidden</Boundary></T>'
+      )
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual({ t: 'Boundary', i: 1 });
+  });
+
+  it('lets script setup shadow a normal-script Suspense binding', async () => {
+    const output = await extract(`
+      <script>import { Suspense as Boundary } from 'vue'; export { Boundary };</script>
+      <script setup>import { T } from 'gt-vue'; const Boundary = String;</script>
+      <template><T><Boundary>Hidden</Boundary></T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual({ t: 'Boundary', i: 1 });
+  });
+
+  it('lets script setup shadow a normal-script GT component', async () => {
+    const output = await extract(`
+      <script>import { T } from 'gt-vue'; export { T };</script>
+      <script setup>const T = String;</script>
+      <template><T>Not GT at runtime</T></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('removes a stale cross-block static value when script setup shadows it', async () => {
+    const output = await extract(`
+      <script>export const value = 'Hello';</script>
+      <script setup>import { T } from 'gt-vue'; const value = Date.now();</script>
+      <template><T>{{ value }}</T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic template content');
+  });
+
+  it('keeps registration identity separate from a script-setup shadow', async () => {
+    const direct = await extract(
+      optionsWithSetupShadow('<AsyncBoundary>Hidden</AsyncBoundary>')
+    );
+    const literal = await extract(
+      optionsWithSetupShadow(
+        `<component :is="'AsyncBoundary'"><main>Source</main></component>`
+      )
+    );
+    const expression = await extract(
+      optionsWithSetupShadow(
+        '<component :is="AsyncBoundary">Hidden</component>'
+      )
+    );
+
+    expect(direct.errors).toEqual([]);
+    expect(direct.results[0]?.source).toEqual({ t: 'AsyncBoundary', i: 1 });
+    expect(literal.errors).toEqual([]);
+    expect(literal.results[0]?.source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: { t: 'main', i: 2, c: 'Source' },
+    });
+    expect(expression.results).toEqual([]);
+    expect(expression.errors.join('\n')).toContain('dynamic <component>');
+  });
+
+  it('does not use a registration to resolve an Options data selector', async () => {
+    const output = await extract(`
+      <script>
+      import { Suspense } from 'vue';
+      import { T } from 'gt-vue';
+      export default {
+        components: { T, AsyncBoundary: Suspense },
+        data() { return { AsyncBoundary: String }; },
+      };
+      </script>
+      <template><T><component :is="AsyncBoundary">Hidden</component></T></template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic <component>');
+  });
+
+  it.each([
+    {
+      name: 'factory call',
+      prelude: `const makeSetup = () => () => ({ gt: useGT() });`,
+      setup: 'makeSetup()',
+    },
+    {
+      name: 'dynamic conditional',
+      prelude: `const direct = () => ({ gt: useGT() }); const other = () => ({}); const flag = Boolean(Date.now());`,
+      setup: 'flag ? direct : other',
+    },
+    {
+      name: 'external import',
+      prelude: `import { setup as externalSetup } from './external';`,
+      setup: 'externalSetup',
+    },
+  ])(
+    'rejects an unresolvable Options setup $name',
+    async ({ prelude, setup }) => {
+      const output = await extract(`
+      <script>
+      import { useGT } from 'gt-vue';
+      ${prelude}
+      export default { setup: ${setup} };
+      </script>
+      <template>{{ gt('Hidden') }}</template>
+    `);
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain(
+        'Could not statically resolve the Vue Options API setup function'
+      );
+    }
+  );
+
+  it('accepts explicit absent Options components and setup values', async () => {
+    const output = await extract(`
+      <script>
+      import { T } from 'gt-vue';
+      export default { components: undefined, setup: undefined };
+      </script>
+      <template><div>Nothing to extract</div></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it('keeps a dynamic Options setup-return spread blocking after an explicit binding', async () => {
+    const output = await extract(`
+      <script>
+      import { useGT } from 'gt-vue';
+      const getState = () => ({});
+      export default {
+        setup() {
+          const gt = useGT();
+          return { ...getState(), gt };
+        },
+      };
+      </script>
+      <template>{{ gt('Known but incomplete') }}</template>
+    `);
+
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve an Options API setup return'
+    );
+  });
+
+  it('resolves exact same-script component members without a wildcard', async () => {
+    const output = await extract(`
+      <script setup>
+      import { T } from 'gt-vue';
+      import { Suspense } from 'vue';
+      const kit = { nested: { T }, Suspense, Card: String };
+      </script>
+      <template>
+        <kit.nested.T>Direct member</kit.nested.T>
+        <component :is="kit.nested.T">Dynamic member</component>
+        <T><kit.Suspense>Ready</kit.Suspense></T>
+        <kit.Card>Not a translation</kit.Card>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Direct member',
+      'Dynamic member',
+      { t: 'Suspense', i: 1, c: 'Ready' },
+    ]);
+  });
+
+  it('resolves a nested component member returned from Options setup', async () => {
+    const output = await extract(`
+      <script>
+      import { T } from 'gt-vue';
+      export default { setup() { return { kit: { nested: { T } } }; } };
+      </script>
+      <template><component :is="kit.nested.T">Options member</component></template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ source }) => source)).toEqual([
+      'Options member',
+    ]);
+  });
+
+  it('fails closed when a nested primitive changes before destructuring', async () => {
+    const output = await extract(`
+      <script setup>
+      import { useGT } from 'gt-vue';
+      const config = { context: 'old' };
+      const outer = { config };
+      config.context = 'new';
+      const { config: { context } } = outer;
+      const gt = useGT();
+      gt('Hello', { $context: context });
+      </script>
+      <template />
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic $context');
+  });
+
+  it('preserves a nested primitive captured before a later mutation', async () => {
+    const output = await extract(`
+      <script setup>
+      import { useGT } from 'gt-vue';
+      const config = { context: 'old' };
+      const outer = { config };
+      const { config: { context } } = outer;
+      config.context = 'new';
+      const gt = useGT();
+      gt('Hello', { $context: context });
+      </script>
+      <template />
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.metadata.context).toBe('old');
+  });
+
+  it('fails closed when a nested component changes before destructuring', async () => {
+    const output = await extract(
+      setup(
+        `import { Suspense } from 'vue';
+         const registry = { Boundary: Suspense };
+         const outer = { inner: registry };
+         registry.Boundary = String;
+         const { inner: { Boundary } } = outer;`,
+        '<T><Boundary>Hidden</Boundary></T>'
+      )
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "Boundary"'
+    );
+  });
+
+  it('distinguishes a getter side effect from a harmless sibling read', async () => {
+    const getter = await extract(
+      setup(
+        `import { Suspense } from 'vue';
+         const registry = {
+           Boundary: Suspense,
+           get trigger() { this.Boundary = String; return true; },
+         };
+         if (registry.trigger) {}
+         const { Boundary } = registry;`,
+        '<T><Boundary>Hidden</Boundary></T>'
+      )
+    );
+    const sibling = await extract(
+      setup(
+        `import { Suspense } from 'vue';
+         const registry = { Boundary: Suspense, label: 'safe' };
+         const label = registry.label;
+         void label;
+         const { Boundary } = registry;`,
+        '<T><Boundary>Ready</Boundary></T>'
+      )
+    );
+
+    expect(getter.results).toEqual([]);
+    expect(getter.errors.join('\n')).toContain(
+      'Could not statically resolve component alias "Boundary"'
+    );
+    expect(sibling.errors).toEqual([]);
+    expect(sibling.results[0]?.source).toEqual({
+      t: 'Suspense',
+      i: 1,
+      c: 'Ready',
+    });
+  });
+
+  it.each([
+    `if (Math.random() > 0.5) context = 'chosen';`,
+    `for (const value of []) context = 'chosen';`,
+    `function neverCalled() { context = 'chosen'; }`,
+  ])(
+    'does not treat a conditional deferred assignment as definite: %s',
+    async (assignment) => {
+      const output = await extractFromVueSource(
+        `<script setup>
+        import { useGT } from 'gt-vue';
+        const gt = useGT();
+        let context;
+        ${assignment}
+        gt('Hello', { $context: context });
+        </script><template />`,
+        '/fixtures/ConditionalAssignment.vue',
+        { projectRoot: '/fixtures' }
+      );
+
+      expect(output.results).toEqual([]);
+      expect(output.errors.join('\n')).toContain('dynamic $context');
+    }
+  );
+
+  it('does not apply a later deferred assignment to an earlier function call', async () => {
+    const output = await extractFromVueSource(
+      `<script setup>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+      let context;
+      translateBeforeAssignment();
+      context = 'chosen';
+      function translateBeforeAssignment() {
+        gt('Hello', { $context: context });
+      }
+      </script><template />`,
+      '/fixtures/CrossFunctionAssignment.vue',
+      { projectRoot: '/fixtures' }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('dynamic $context');
+  });
+});
+
+function setup(script: string, template: string): string {
+  return `<script setup>import { T } from 'gt-vue'; ${script}</script><template>${template}</template>`;
+}
+
+function optionsWithSetupShadow(content: string): string {
+  return `
+    <script>
+    import { Suspense } from 'vue';
+    import { T } from 'gt-vue';
+    export default { components: { T, AsyncBoundary: Suspense } };
+    </script>
+    <script setup>const AsyncBoundary = String;</script>
+    <template><T>${content}</T></template>
+  `;
+}
+
+async function extract(source: string) {
+  return extractFromVueSource(source, '/fixtures/StaticSoundness.vue', {
+    projectRoot: '/fixtures',
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/stringFactorySemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/stringFactorySemantics.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue string function alias';
+
+type StringFactoryProbe = {
+  /** Human-readable string-function factory flow under test. */
+  name: string;
+  /** Statements inserted into the fixture's script-setup block. */
+  script: string;
+  /** Source passed to the resulting function call. */
+  source: string;
+  /** Whether the called value can be a gt-vue string function. */
+  possibleGT: boolean;
+};
+
+/**
+ * Local factories and identity functions can return `useGT()`,
+ * `useMessages()`, or `msg` without changing the function's GT provenance.
+ * Conditional factory results need a diagnostic when exact extraction is not
+ * possible, while an entirely ordinary factory must stay silent.
+ */
+const stringFactoryProbes: StringFactoryProbe[] = [
+  {
+    name: 'an arrow factory returns a useGT result',
+    script: `
+      import { useGT } from 'gt-vue';
+      const make = () => useGT();
+      const gt = make();
+      gt('Arrow factory');
+    `,
+    source: 'Arrow factory',
+    possibleGT: true,
+  },
+  {
+    name: 'a function factory returns msg',
+    script: `
+      import { msg } from 'gt-vue';
+      function make() { return msg; }
+      const message = make();
+      message('Function factory');
+    `,
+    source: 'Function factory',
+    possibleGT: true,
+  },
+  {
+    name: 'an identity function returns a useGT result',
+    script: `
+      import { useGT } from 'gt-vue';
+      const identity = (value) => value;
+      const gt = identity(useGT());
+      gt('Identity factory');
+    `,
+    source: 'Identity factory',
+    possibleGT: true,
+  },
+  {
+    name: 'a factory returns an object containing a useGT result',
+    script: `
+      import { useGT } from 'gt-vue';
+      const make = () => ({ fn: useGT() });
+      const holder = make();
+      holder.fn('Object factory');
+    `,
+    source: 'Object factory',
+    possibleGT: true,
+  },
+  {
+    name: 'a function selects a useGT argument',
+    script: `
+      import { useGT } from 'gt-vue';
+      function select(value) { return value; }
+      const gt = select(useGT());
+      gt('Argument selector');
+    `,
+    source: 'Argument selector',
+    possibleGT: true,
+  },
+  {
+    name: 'a conditional binding may be a useGT result',
+    script: `
+      import { useGT } from 'gt-vue';
+      const gt = flag ? useGT() : String;
+      gt('Conditional binding');
+    `,
+    source: 'Conditional binding',
+    possibleGT: true,
+  },
+  {
+    name: 'a factory may return a useGT result',
+    script: `
+      import { useGT } from 'gt-vue';
+      const make = () => flag ? useGT() : String;
+      const gt = make();
+      gt('Conditional factory');
+    `,
+    source: 'Conditional factory',
+    possibleGT: true,
+  },
+  {
+    name: 'a factory returns a useMessages result',
+    script: `
+      import { useMessages } from 'gt-vue';
+      const make = () => useMessages();
+      const m = make();
+      m('Messages factory');
+    `,
+    source: 'Messages factory',
+    possibleGT: true,
+  },
+  {
+    name: 'an ordinary factory stays silent',
+    script: `
+      const make = () => String;
+      const ordinary = make();
+      ordinary('Ordinary factory');
+    `,
+    source: 'Ordinary factory',
+    possibleGT: false,
+  },
+];
+
+describe('string-function factory semantics', () => {
+  it.each(stringFactoryProbes)(
+    '$name',
+    async ({ script, source, possibleGT }) => {
+      const output = await extractFromVueSource(
+        `<script setup>
+          const flag = Boolean(Date.now());
+          ${script}
+        </script><template><div /></template>`,
+        '/fixtures/StringFactorySemantics.vue',
+        { projectRoot: '/fixtures' }
+      );
+      const extracted = output.results.some(
+        (result) => result.source === source
+      );
+      const diagnosed = output.errors.some((error) =>
+        error.includes(POSSIBLE_ALIAS_DIAGNOSTIC)
+      );
+
+      if (possibleGT) {
+        expect(extracted || diagnosed).toBe(true);
+      } else {
+        expect(output.results).toEqual([]);
+        expect(output.errors).toEqual([]);
+      }
+    }
+  );
+});

--- a/packages/vue-extractor/src/internal/__tests__/templateAdversarial.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/templateAdversarial.test.ts
@@ -1,0 +1,507 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue template extraction', () => {
+  it('ports the React rich-content matrix with Vue slot semantics', async () => {
+    const filePath = fixturePath('template-rich-matrix.vue');
+    const source = await readFile(filePath, 'utf8');
+
+    const output = await extractFromVueSource(source, filePath);
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      {
+        t: 'section',
+        i: 1,
+        d: { ti: 'Heading', arl: 'Greeting' },
+        c: [
+          ' Hello ',
+          {
+            t: 'strong',
+            i: 2,
+            c: { i: 3, k: '_gt_value_3', v: 'v' },
+          },
+          ' ! ',
+          { t: 'input', i: 4, d: { pl: 'Your name' } },
+          {
+            t: 'img',
+            i: 5,
+            d: { alt: 'Portrait', ard: 'hint' },
+          },
+          { i: 6, k: '_gt_n_6', v: 'n' },
+          { i: 7, k: '_gt_date_7', v: 'd' },
+          { i: 8, k: '_gt_cost_8', v: 'c' },
+          { t: 'var', i: 9, c: 'native' },
+          {
+            t: 'Branch',
+            i: 10,
+            d: {
+              b: {
+                formal: [' Formal ', { i: 11, k: '_gt_value_11', v: 'v' }],
+                casual: [' Casual ', { i: 11, k: '_gt_value_11', v: 'v' }],
+              },
+              t: 'b',
+            },
+            c: [' Fallback ', { i: 11, k: '_gt_value_11', v: 'v' }],
+          },
+          {
+            t: 'Plural',
+            i: 12,
+            d: {
+              b: {
+                one: [' One ', { i: 13, k: '_gt_value_13', v: 'v' }],
+                other: [' Many ', { i: 13, k: '_gt_value_13', v: 'v' }],
+                zero: 'None',
+              },
+              t: 'p',
+            },
+            c: [' Fallback ', { i: 13, k: '_gt_value_13', v: 'v' }],
+          },
+        ],
+      },
+    ]);
+    expect(output.results[0]?.metadata.context).toBe('matrix');
+  });
+
+  it('matches Vue scope, directive, slot, and component-name behavior', async () => {
+    const filePath = fixturePath('template-adversarial.vue');
+    const source = await readFile(filePath, 'utf8');
+
+    const output = await extractFromVueSource(source, filePath);
+
+    expect(output.errors).toEqual([]);
+    expect(stringSources(output.results)).toEqual([
+      'Outer v-if',
+      'VForDefault',
+      'VForSource',
+      'SlotDefault',
+    ]);
+    expect(richSources(output.results)).toEqual([
+      'Digit-normalized component',
+      'Dynamic component',
+      'Explicit default',
+      {
+        t: 'Branch',
+        i: 1,
+        d: {
+          b: { casual: 'Second', formal: 'First' },
+          t: 'b',
+        },
+      },
+      {
+        t: 'Plural',
+        i: 1,
+        d: {
+          b: { one: 'One', other: 'Other' },
+          t: 'p',
+        },
+      },
+    ]);
+  });
+
+  it('visits executable directive arguments in their Vue scope', async () => {
+    const output = await extractVue(`
+      <script setup>
+      import { useGT } from 'gt-vue';
+      const gt = useGT();
+      const rows = [{}];
+      const value = 'attribute';
+      </script>
+      <template>
+        <div :[gt('DirectiveArgument')]="value" />
+        <div v-for="gt in rows" :[gt('ShadowedDirectiveArgument')]="value" />
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(stringSources(output.results)).toEqual(['DirectiveArgument']);
+  });
+
+  it('ignores comments and whitespace before an explicit default slot', async () => {
+    const output = await extractVue(`
+      <script setup>import { T } from 'gt-vue';</script>
+      <template>
+        <T>
+          <!-- translator note -->
+          <template #default>Explicit default</template>
+        </T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual(['Explicit default']);
+  });
+
+  it.each(['condense', 'preserve'] as const)(
+    'drops named-slot separator whitespace with compiler whitespace %s',
+    async (whitespace) => {
+      const source = vueSource({
+        imports: 'Branch, Plural, T',
+        template:
+          '<T><Branch branch="formal"><template #formal>First</template> <template #casual>Second</template></Branch></T><T><Plural :n="1"><template #one>One</template> <template #other>Other</template></Plural></T>',
+      });
+
+      const output = await extractFromVueSource(source, '/fixtures/Slots.vue', {
+        compilerOptions: { whitespace },
+        projectRoot: '/fixtures',
+      });
+
+      expect(output.errors).toEqual([]);
+      expect(richSources(output.results)).toEqual([
+        {
+          t: 'Branch',
+          i: 1,
+          d: { b: { formal: 'First', casual: 'Second' }, t: 'b' },
+        },
+        {
+          t: 'Plural',
+          i: 1,
+          d: { b: { one: 'One', other: 'Other' }, t: 'p' },
+        },
+      ]);
+    }
+  );
+
+  it.each(['condense', 'preserve'] as const)(
+    'preserves implicit default-slot separators with compiler whitespace %s',
+    async (whitespace) => {
+      const source = vueSource({
+        imports: 'Branch, T',
+        template:
+          '<T><span>A</span> <b>B</b></T><T><Branch branch="formal"><span>A</span> <template #formal>Formal</template> <b>B</b></Branch></T>',
+      });
+
+      const output = await extractFromVueSource(source, '/fixtures/Slots.vue', {
+        compilerOptions: { whitespace },
+        projectRoot: '/fixtures',
+      });
+
+      expect(output.errors).toEqual([]);
+      expect(richSources(output.results)).toEqual([
+        [{ t: 'span', i: 1, c: 'A' }, ' ', { t: 'b', i: 2, c: 'B' }],
+        {
+          t: 'Branch',
+          i: 1,
+          d: { b: { formal: 'Formal' }, t: 'b' },
+          c: [{ t: 'span', i: 2, c: 'A' }, '  ', { t: 'b', i: 3, c: 'B' }],
+        },
+      ]);
+    }
+  );
+
+  it('rejects meaningful implicit content beside an explicit default slot', async () => {
+    const output = await extractVue(`
+      <script setup>import { T } from 'gt-vue';</script>
+      <template>
+        <T><template #default>Explicit</template>Implicit</T>
+      </template>
+    `);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      'more than one default slot definition'
+    );
+  });
+
+  it('evaluates static TypeScript wrappers and BigInt template values', async () => {
+    const output = await extractVue(`
+      <script setup lang="ts">
+      import { Branch, T } from 'gt-vue';
+      </script>
+      <template>
+        <T :context="('catalog' satisfies string)">{{ 'Answer' satisfies string }}|{{ 1n }}|{{ \`X\${2n}\` }}</T>
+        <T><Branch branch="formal" :formal="(1n satisfies bigint)" /></T>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual([
+      'Answer|1|X2',
+      {
+        t: 'Branch',
+        i: 1,
+        d: { b: { formal: '1' }, t: 'b' },
+      },
+    ]);
+    expect(output.results[0]?.metadata.context).toBe('catalog');
+  });
+
+  it('does not resolve a dynamic component through a shadowed GT binding', async () => {
+    const output = await extractVue(`
+      <script setup>
+      import { T } from 'gt-vue';
+      const components = [String];
+      </script>
+      <template>
+        <div v-for="T in components">
+          <component :is="T">Not a GT translation</component>
+        </div>
+      </template>
+    `);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([]);
+  });
+
+  it.each([
+    {
+      name: 'coalesces text around whitespace-free comments',
+      imports: 'T',
+      template: '<T>Hello<!-- translator note -->world</T>',
+      expected: ['Helloworld'] satisfies JsxChildren[],
+    },
+    {
+      name: 'evaluates side-effect-free primitive expressions',
+      imports: 'T',
+      template: "<T>{{ 'A' + 'B' }}|{{ 2 + 3 }}|{{ true }}|{{ null }}</T>",
+      expected: ['AB|5|true|'] satisfies JsxChildren[],
+    },
+    {
+      name: 'serializes statically bound HTML content props',
+      imports: 'T',
+      template:
+        '<T><input :placeholder="\'Name\'" /><img :alt="`Portrait`" :aria-label="\'Photo\'" /></T>',
+      expected: [
+        [
+          { t: 'input', i: 1, d: { pl: 'Name' } },
+          {
+            t: 'img',
+            i: 2,
+            d: { alt: 'Portrait', arl: 'Photo' },
+          },
+        ],
+      ] satisfies JsxChildren[],
+    },
+    {
+      name: 'ignores Vue-reserved branch props',
+      imports: 'Branch, T',
+      setup: 'const handler = () => undefined;',
+      template:
+        '<T><Branch branch="formal" key="stable" ref="branchRef" ref-for ref-key="branch" data-note="ignored" :onVnodeMounted="handler" formal="Hello">Fallback</Branch></T>',
+      expected: [
+        {
+          t: 'Branch',
+          i: 1,
+          d: { b: { formal: 'Hello' }, t: 'b' },
+          c: 'Fallback',
+        },
+      ] satisfies JsxChildren[],
+    },
+    {
+      name: 'matches Vue falsy branch-child semantics',
+      imports: 'Branch, T',
+      template:
+        '<T><Branch branch="zero" :zero="0" :off="false" :empty="null">Fallback</Branch></T>',
+      expected: [
+        {
+          t: 'Branch',
+          i: 1,
+          d: { b: { zero: '0', off: [], empty: [] }, t: 'b' },
+          c: 'Fallback',
+        },
+      ] satisfies JsxChildren[],
+    },
+    {
+      name: 'filters non-CLDR plural branch props',
+      imports: 'Plural, T',
+      template:
+        '<T><Plural :n="2" one="One" other="Other" label="ignored">Fallback</Plural></T>',
+      expected: [
+        {
+          t: 'Plural',
+          i: 1,
+          d: { b: { one: 'One', other: 'Other' }, t: 'p' },
+          c: 'Fallback',
+        },
+      ] satisfies JsxChildren[],
+    },
+    {
+      name: 'extracts a nested translation through an opaque Var',
+      imports: 'T, Var',
+      template: '<T>Outer <Var><T>Inner</T></Var></T>',
+      expected: [
+        ['Outer ', { i: 1, k: '_gt_value_1', v: 'v' }],
+        'Inner',
+      ] satisfies JsxChildren[],
+    },
+    {
+      name: 'ignores setup-only static dynamic-component selectors',
+      imports: 'T',
+      template:
+        '<component is="T">Static attribute</component><component :is="\'T\'">Static binding</component>',
+      expected: [] satisfies JsxChildren[],
+    },
+    {
+      name: 'normalizes numeric kebab-case component aliases',
+      imports: 'DateTime as D2, T',
+      setup: "const date = new Date('2026-01-01');",
+      template: '<T><d-2 :value="date" /><var>native</var></T>',
+      expected: [
+        [
+          { i: 1, k: '_gt_date_1', v: 'd' },
+          { t: 'var', i: 2, c: 'native' },
+        ],
+      ] satisfies JsxChildren[],
+    },
+  ])('$name', async ({ expected, imports, setup = '', template }) => {
+    const output = await extractVue(vueSource({ imports, setup, template }));
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual(expected);
+  });
+
+  it('supports both context prop spellings with static bindings', async () => {
+    const output = await extractVue(
+      vueSource({
+        imports: 'T',
+        template:
+          '<T $context="dollar">Dollar</T><T :context="`bound`">Bound</T>',
+      })
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(richSources(output.results)).toEqual(['Dollar', 'Bound']);
+    expect(output.results.map((result) => result.metadata.context)).toEqual([
+      'dollar',
+      'bound',
+    ]);
+  });
+
+  it.each([
+    {
+      name: 'dynamic interpolation',
+      imports: 'T',
+      setup: 'const value = String(Date.now());',
+      template: '<T>{{ value }}</T>',
+      error: 'dynamic template content',
+    },
+    {
+      name: 'nested T',
+      imports: 'T',
+      template: '<T>Outer <T>Inner</T></T>',
+      error: 'nested gt-vue <T>',
+    },
+    {
+      name: 'source-shaping v-if',
+      imports: 'T',
+      setup: 'const show = true;',
+      template: '<T><span v-if="show">Conditional</span></T>',
+      error: 'source-shaping directive v-if',
+    },
+    {
+      name: 'source-shaping v-html',
+      imports: 'T',
+      setup: "const html = '<b>unsafe</b>';",
+      template: '<T><span v-html="html" /></T>',
+      error: 'source-shaping directive v-html',
+    },
+    {
+      name: 'unknown dynamic component',
+      imports: 'T',
+      setup: "const dynamic = 'section';",
+      template: '<T><component :is="dynamic">Unknown</component></T>',
+      error: 'dynamic <component>',
+    },
+    {
+      name: 'bare template',
+      imports: 'T',
+      template: '<T><template>Body</template></T>',
+      error: 'bare <template>',
+    },
+    {
+      name: 'runtime slot outlet',
+      imports: 'T',
+      template: '<T><slot /></T>',
+      error: 'Found a <slot>',
+    },
+    {
+      name: 'dynamic translatable HTML prop',
+      imports: 'T',
+      setup: 'const label = String(Date.now());',
+      template: '<T><input :placeholder="label" /></T>',
+      error: 'dynamic translatable prop "placeholder"',
+    },
+    {
+      name: 'Var value prop',
+      imports: 'T, Var',
+      template: '<T><Var value="Ada">Ada</Var></T>',
+      error: 'unsupported value prop',
+    },
+    {
+      name: 'Var name prop',
+      imports: 'T, Var',
+      template: '<T><Var name="person">Ada</Var></T>',
+      error: 'unsupported name prop',
+    },
+    {
+      name: 'removed T metadata fields',
+      imports: 'T',
+      template: '<T $maxChars="20">Hello</T>',
+      error: 'unsupported prop "$maxChars"',
+    },
+    {
+      name: 'branch model directive',
+      imports: 'Branch, T',
+      setup: "const value = 'Hello';",
+      template:
+        '<T><Branch branch="formal" formal="Hello" v-model="value">Fallback</Branch></T>',
+      error: 'unsupported directive v-model',
+    },
+    {
+      name: 'scoped branch slot',
+      imports: 'Branch, T',
+      template:
+        '<T><Branch branch="formal"><template #formal="{ value }">{{ value }}</template></Branch></T>',
+      error: 'scoped slot',
+    },
+    {
+      name: 'malformed Vue template',
+      imports: 'T',
+      template: '<T>',
+      error: 'Could not parse a gt-vue single-file component',
+    },
+  ])('diagnoses $name', async ({ error, imports, setup = '', template }) => {
+    const output = await extractVue(vueSource({ imports, setup, template }));
+
+    expect(output.errors.join('\n')).toContain(error);
+  });
+});
+
+type ExtractionOutput = Awaited<ReturnType<typeof extractFromVueSource>>;
+
+async function extractVue(source: string): Promise<ExtractionOutput> {
+  return extractFromVueSource(source, '/fixtures/Template.vue', {
+    projectRoot: '/fixtures',
+  });
+}
+
+function stringSources(results: ExtractionOutput['results']): string[] {
+  return results
+    .filter((result) => result.dataFormat === 'STRING')
+    .map((result) => result.source);
+}
+
+function richSources(results: ExtractionOutput['results']): JsxChildren[] {
+  return results
+    .filter((result) => result.dataFormat === 'JSX')
+    .map((result) => result.source);
+}
+
+function fixturePath(name: string): string {
+  return path.join(__dirname, 'fixtures', name);
+}
+
+function vueSource({
+  imports,
+  setup = '',
+  template,
+}: {
+  imports: string;
+  setup?: string;
+  template: string;
+}): string {
+  return `<script setup>import { ${imports} } from 'gt-vue';${setup}</script><template>${template}</template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/templateMatrix.md
+++ b/packages/vue-extractor/src/internal/__tests__/templateMatrix.md
@@ -1,0 +1,47 @@
+# Vue template extraction matrix
+
+The adversarial template suite ports the stable source-shaping behavior from
+the React JSX extractor and renderer where Vue has an equivalent construct.
+It covers rich native nesting, every supported variable component, static HTML
+content props, context, Branch and Plural fallbacks/branches, independent
+branch variable numbering, comments, whitespace, aliases, and component-name
+normalization.
+
+The React CLI parity audit additionally covers nested Branch/Plural trees,
+legacy and CLDR plural forms, numeric boundaries and alternate literal forms,
+Unicode and control characters, empty translations and branches, HTML
+entities, Vue built-ins, custom and void elements, and formatter components
+using dynamic `value` props. `Num`, `Currency`, and `DateTime` values are opaque
+runtime variables; `Var` continues to require its value in the default slot.
+
+Vue-specific cases cover `v-if`/`v-for` precedence, `v-for` and `v-slot`
+destructuring defaults, executable directive arguments, slot scope, explicit
+default slots, static `<component :is>` resolution, and compiler-valid
+TypeScript expressions. Branch and Plural named slots are the Vue equivalent
+of React branch props containing rich JSX.
+
+The following behavior is intentionally unsupported and must produce a
+diagnostic instead of a partial catalog entry:
+
+- rich extraction from Vue JSX/TSX;
+- dynamic content outside Var, Num, DateTime, or Currency;
+- nested T components unless the inner T is inside an opaque Var;
+- source-shaping directives inside T, including `v-if`, `v-for`, `v-html`, and
+  `v-text`;
+- dynamic translatable HTML props, unknown dynamic components, runtime slot
+  outlets, scoped slots, and named slots on ordinary rich components;
+- React-only Derive/autoderive behavior; and
+- `$maxChars`, `$format`, ICU formatting, and interpolation. gt-vue currently
+  extracts context-only plain strings.
+
+The real-runtime parity probe compiles the same Branch and Plural templates
+with Vue and renders them through gt-vue SSR. Catalog keys computed only from
+extractor output must produce the translated SSR output, which protects the
+hash boundary that ordinary unit snapshots cannot validate alone.
+
+Malformed SFC structure, malformed script blocks, external script/template
+blocks, and unsupported block languages are file-fatal. The extractor emits a
+clear diagnostic and no partial results, preventing Vue's recovery AST from
+shrinking a catalog. A semantic error in one translation remains entry-local:
+other valid entries are returned alongside the diagnostic so the CLI can abort
+the catalog operation without losing precise source feedback.

--- a/packages/vue-extractor/src/internal/__tests__/templatePackageAuditWave2.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/templatePackageAuditWave2.test.ts
@@ -700,7 +700,7 @@ describe('template/package audit wave 2: metadata and public boundary', () => {
     expect(resolveVueCompilerOptions).toBeTypeOf('function');
   });
 
-  it('declares root, config, and types package exports', () => {
+  it('declares every public package export', () => {
     const packageRoot = path.resolve(__dirname, '../../..');
     const packageJson = JSON.parse(
       fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')
@@ -710,6 +710,7 @@ describe('template/package audit wave 2: metadata and public boundary', () => {
       '.',
       './config',
       './detect',
+      './inspect',
       './project',
       './types',
     ]);

--- a/packages/vue-extractor/src/internal/__tests__/templatePackageAuditWave2.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/templatePackageAuditWave2.test.ts
@@ -1,0 +1,784 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { compileScript, compileTemplate, parse } from '@vue/compiler-sfc';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveVueCompilerOptions } from '../../config.js';
+import { extractFromVueSource } from './testVueCompiler.js';
+import type { VueCompilerOptions, VueExtractionOutput } from '../../types.js';
+
+type TemplateAuditCase = {
+  name: string;
+  script: string;
+  sources: JsxChildren[];
+  template: string;
+};
+
+const templateExpressionCases: TemplateAuditCase[] = [
+  {
+    name: 'namespace member call',
+    script: `import * as GT from 'gt-vue';`,
+    template: `{{ GT.msg('Namespace member') }}`,
+    sources: ['Namespace member'],
+  },
+  {
+    name: 'computed namespace member call',
+    script: `import * as GT from 'gt-vue';`,
+    template: `{{ GT['msg']('Computed namespace member') }}`,
+    sources: ['Computed namespace member'],
+  },
+  {
+    name: 'optional namespace member call',
+    script: `import * as GT from 'gt-vue';`,
+    template: `{{ GT?.msg('Optional namespace member') }}`,
+    sources: ['Optional namespace member'],
+  },
+  {
+    name: 'optional computed namespace member call',
+    script: `import * as GT from 'gt-vue';`,
+    template: `{{ GT?.['msg']('Optional computed member') }}`,
+    sources: ['Optional computed member'],
+  },
+  {
+    name: 'optional translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `{{ gt?.('Optional translator') }}`,
+    sources: ['Optional translator'],
+  },
+  {
+    name: 'non-null translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `{{ gt!('Non-null translator') }}`,
+    sources: ['Non-null translator'],
+  },
+  {
+    name: 'type-cast translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `{{ (gt as typeof gt)('Type-cast translator') }}`,
+    sources: ['Type-cast translator'],
+  },
+  {
+    name: 'satisfies-wrapped translator call',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `{{ (gt satisfies typeof gt)('Satisfies translator') }}`,
+    sources: ['Satisfies translator'],
+  },
+  {
+    name: 'script-exposed source identifier',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const title = 'Static title';`,
+    template: `{{ gt(title) }}`,
+    sources: ['Static title'],
+  },
+  {
+    name: 'script-exposed concatenation',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const first = 'Static '; const second = 'concat';`,
+    template: `{{ gt(first + second) }}`,
+    sources: ['Static concat'],
+  },
+  {
+    name: 'script-exposed context identifier',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const context = 'audit';`,
+    template: `{{ gt('Context source', { $context: context }) }}`,
+    sources: ['Context source'],
+  },
+  {
+    name: 'useMessages source identifier',
+    script: `import { useMessages } from 'gt-vue'; const m = useMessages(); const title = 'Messages title';`,
+    template: `{{ m(title) }}`,
+    sources: ['Messages title'],
+  },
+  {
+    name: 'outer translator in a v-for default',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const rows = [{}];`,
+    template: `<div v-for="{ value = gt('VFor outer') } in rows" />`,
+    sources: ['VFor outer'],
+  },
+  {
+    name: 'same-pattern v-for shadow',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const rows = [{}];`,
+    template: `<div v-for="{ gt, value = gt('VFor shadow') } in rows" />`,
+    sources: [],
+  },
+  {
+    name: 'outer translator in a slot default',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `<Card v-slot="{ value = gt('Slot outer') }" />`,
+    sources: ['Slot outer'],
+  },
+  {
+    name: 'same-pattern slot shadow',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT();`,
+    template: `<Card v-slot="{ gt, value = gt('Slot shadow') }" />`,
+    sources: [],
+  },
+  {
+    name: 'nested expression callback shadow',
+    script: `import { useGT } from 'gt-vue'; const gt = useGT(); const rows = [String];`,
+    template: `{{ rows.map((gt) => gt('Callback shadow')) }}`,
+    sources: [],
+  },
+  {
+    name: 'namespace v-for shadow',
+    script: `import * as GT from 'gt-vue'; const rows = [{}];`,
+    template: `<div v-for="GT in rows" :title="GT.msg('Namespace shadow')" />`,
+    sources: [],
+  },
+  {
+    name: 'computed namespace dynamic component',
+    script: `import * as GT from 'gt-vue';`,
+    template: `<component :is="GT['T']">Computed dynamic T</component>`,
+    sources: ['Computed dynamic T'],
+  },
+  {
+    name: 'optional namespace dynamic component',
+    script: `import * as GT from 'gt-vue';`,
+    template: `<component :is="GT?.T">Optional dynamic T</component>`,
+    sources: ['Optional dynamic T'],
+  },
+  {
+    name: 'optional computed namespace dynamic component',
+    script: `import * as GT from 'gt-vue';`,
+    template: `<component :is="GT?.['T']">Optional computed T</component>`,
+    sources: ['Optional computed T'],
+  },
+  {
+    name: 'setup-only static-string dynamic component is not registered',
+    script: `import { T } from 'gt-vue';`,
+    template: `<component :is="'T'">String dynamic T</component>`,
+    sources: [],
+  },
+  {
+    name: 'setup-only static-attribute dynamic component is not registered',
+    script: `import { T } from 'gt-vue';`,
+    template: `<component is="T">Static dynamic T</component>`,
+    sources: [],
+  },
+  {
+    name: 'setup identifier dynamic component',
+    script: `import { T } from 'gt-vue';`,
+    template: `<component :is="T">Identifier dynamic T</component>`,
+    sources: ['Identifier dynamic T'],
+  },
+  {
+    name: 'type-wrapped dynamic component',
+    script: `import { T } from 'gt-vue';`,
+    template: `<component :is="T as typeof T">Wrapped dynamic T</component>`,
+    sources: ['Wrapped dynamic T'],
+  },
+];
+
+describe('template/package audit wave 2: expressions and scopes', () => {
+  it.each(templateExpressionCases)('$name', async (testCase) => {
+    const source = createSfc(testCase.script, testCase.template);
+    assertVueCompiles(source, testCase.name);
+
+    const output = await extractAuditSource(source, testCase.name);
+
+    expect(output.errors).toEqual([]);
+    expect(
+      output.results.map(({ source: resultSource }) => resultSource)
+    ).toEqual(testCase.sources);
+  });
+
+  it.each([
+    ['static attribute', `is="LocalT"`],
+    ['bound static string', `:is="'LocalT'"`],
+  ])(
+    'resolves an Options API alias through a %s selector',
+    async (_name, selector) => {
+      const source = `<script lang="ts">import { T } from 'gt-vue'; export default { components: { LocalT: T } };</script><template><component ${selector}>Registered dynamic T</component></template>`;
+      assertVueCompiles(source, `options-${_name}`);
+
+      const output = await extractAuditSource(source, `options-${_name}`);
+
+      expect(output.errors).toEqual([]);
+      expect(output.results.map((result) => result.source)).toEqual([
+        'Registered dynamic T',
+      ]);
+    }
+  );
+});
+
+type RichAuditCase = {
+  name: string;
+  script: string;
+  source?: JsxChildren;
+  template: string;
+  context?: string;
+};
+
+const richCases: RichAuditCase[] = [
+  {
+    name: 'depth-first native and variable numbering',
+    script: `import { Num, T, Var } from 'gt-vue';`,
+    template: `<T><b>A</b><i><Var>x</Var><Num :value="1" /></i></T>`,
+    source: [
+      { t: 'b', i: 1, c: 'A' },
+      {
+        t: 'i',
+        i: 2,
+        c: [
+          { i: 3, k: '_gt_value_3', v: 'v' },
+          { i: 4, k: '_gt_n_4', v: 'n' },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'comments do not consume element ids',
+    script: `import { T, Var } from 'gt-vue';`,
+    template: `<T>A<!-- note --><Var>x</Var></T>`,
+    source: ['A', { i: 1, k: '_gt_value_1', v: 'v' }],
+  },
+  {
+    name: 'branch slots number independently from fallback and siblings',
+    script: `import { Branch, T, Var } from 'gt-vue';`,
+    template: `<T><Branch branch="formal"><template #formal><b><Var>x</Var></b></template><template #casual><i><Var>y</Var></i></template>Fallback <Var>z</Var></Branch><strong>After</strong></T>`,
+    source: [
+      {
+        t: 'Branch',
+        i: 1,
+        d: {
+          b: {
+            formal: {
+              t: 'b',
+              i: 2,
+              c: { i: 3, k: '_gt_value_3', v: 'v' },
+            },
+            casual: {
+              t: 'i',
+              i: 2,
+              c: { i: 3, k: '_gt_value_3', v: 'v' },
+            },
+          },
+          t: 'b',
+        },
+        c: ['Fallback ', { i: 2, k: '_gt_value_2', v: 'v' }],
+      },
+      { t: 'strong', i: 3, c: 'After' },
+    ],
+  },
+  {
+    name: 'plural slots number independently',
+    script: `import { Plural, T, Var } from 'gt-vue';`,
+    template: `<T><Plural :n="2"><template #one>One <Var>x</Var></template><template #other>Other <Var>y</Var></template>Fallback <Var>z</Var></Plural></T>`,
+    source: {
+      t: 'Plural',
+      i: 1,
+      d: {
+        b: {
+          one: ['One ', { i: 2, k: '_gt_value_2', v: 'v' }],
+          other: ['Other ', { i: 2, k: '_gt_value_2', v: 'v' }],
+        },
+        t: 'p',
+      },
+      c: ['Fallback ', { i: 2, k: '_gt_value_2', v: 'v' }],
+    },
+  },
+  {
+    name: 'named branch slot overrides the same prop',
+    script: `import { Branch, T } from 'gt-vue';`,
+    template: `<T><Branch branch="formal" formal="Prop"><template #formal>Slot</template>Fallback</Branch></T>`,
+    source: {
+      t: 'Branch',
+      i: 1,
+      d: { b: { formal: 'Slot' }, t: 'b' },
+      c: 'Fallback',
+    },
+  },
+  {
+    name: 'script-exposed rich interpolation',
+    script: `import { T } from 'gt-vue'; const title = 'Static rich title';`,
+    template: `<T>{{ title }}</T>`,
+    source: 'Static rich title',
+  },
+  {
+    name: 'script-exposed T context',
+    script: `import { T } from 'gt-vue'; const context = 'rich-audit';`,
+    template: `<T :context="context">Context body</T>`,
+    source: 'Context body',
+    context: 'rich-audit',
+  },
+  {
+    name: 'script-exposed translatable HTML prop',
+    script: `import { T } from 'gt-vue'; const placeholder = 'Static placeholder';`,
+    template: `<T><input :placeholder="placeholder" /></T>`,
+    source: { t: 'input', i: 1, d: { pl: 'Static placeholder' } },
+  },
+  {
+    name: 'script-exposed primitive expression',
+    script: `import { T } from 'gt-vue'; const first = 'A'; const second = 'B';`,
+    template: `<T>{{ first + second }}</T>`,
+    source: 'AB',
+  },
+  {
+    name: 'comments and whitespace before explicit default are omitted',
+    script: `import { T } from 'gt-vue';`,
+    template: `<T><!-- note --> <template #default>Explicit</template></T>`,
+    source: 'Explicit',
+  },
+];
+
+describe('template/package audit wave 2: rich tree parity', () => {
+  it.each(richCases)('$name', async (testCase) => {
+    const source = createSfc(testCase.script, testCase.template);
+    assertVueCompiles(source, testCase.name);
+
+    const output = await extractAuditSource(source, testCase.name);
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toHaveLength(1);
+    expect(output.results[0]).toMatchObject({
+      dataFormat: 'JSX',
+      source: testCase.source,
+    });
+    expect(output.results[0]?.metadata.context).toBe(testCase.context);
+  });
+});
+
+const richDiagnosticCases = [
+  {
+    name: 'runtime interpolation',
+    script: `import { T } from 'gt-vue'; const value = String(Date.now());`,
+    template: `<T>{{ value }}</T>`,
+    diagnostic: 'dynamic template content',
+  },
+  {
+    name: 'v-for shadow masks a static context',
+    script: `import { T } from 'gt-vue'; const context = 'static'; const rows = ['runtime'];`,
+    template: `<T v-for="context in rows" :context="context">Body</T>`,
+    diagnostic: 'dynamic context',
+  },
+  {
+    name: 'nested T',
+    script: `import { T } from 'gt-vue';`,
+    template: `<T>Outer <T>Inner</T></T>`,
+    diagnostic: 'nested gt-vue <T>',
+  },
+  {
+    name: 'named T slot',
+    script: `import { T } from 'gt-vue';`,
+    template: `<T><template #other>Named</template></T>`,
+    diagnostic: 'named slot on a gt-vue <T>',
+  },
+  {
+    name: 'source-shaping v-if',
+    script: `import { T } from 'gt-vue'; const visible = true;`,
+    template: `<T><b v-if="visible">Conditional</b></T>`,
+    diagnostic: 'source-shaping directive v-if',
+  },
+  {
+    name: 'dynamic content prop',
+    script: `import { T } from 'gt-vue'; const label = String(Date.now());`,
+    template: `<T><input :placeholder="label" /></T>`,
+    diagnostic: 'dynamic translatable prop "placeholder"',
+  },
+  {
+    name: 'Var value prop',
+    script: `import { T, Var } from 'gt-vue'; const value = 'runtime';`,
+    template: `<T><Var :value="value">Child</Var></T>`,
+    diagnostic: 'unsupported value prop',
+  },
+  {
+    name: 'scoped branch slot',
+    script: `import { Branch, T } from 'gt-vue';`,
+    template: `<T><Branch branch="formal"><template #formal="{ value }">{{ value }}</template></Branch></T>`,
+    diagnostic: 'scoped slot',
+  },
+  {
+    name: 'dynamic branch slot name',
+    script: `import { Branch, T } from 'gt-vue'; const slotName = 'formal';`,
+    template: `<T><Branch branch="formal"><template #[slotName]>Dynamic</template></Branch></T>`,
+    diagnostic: 'dynamic slot name',
+  },
+  {
+    name: 'duplicate T context',
+    script: `import { T } from 'gt-vue';`,
+    template: `<T context="first" $context="second">Body</T>`,
+    diagnostic: 'duplicate context props',
+  },
+] as const;
+
+describe('template/package audit wave 2: rich diagnostics', () => {
+  it.each(richDiagnosticCases)('$name', async (testCase) => {
+    const source = createSfc(testCase.script, testCase.template);
+    const output = await extractAuditSource(source, testCase.name);
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(testCase.diagnostic);
+  });
+});
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+type ConfigAuditCase = {
+  name: string;
+  file: string;
+  source: string;
+  options?: VueCompilerOptions;
+  expected: VueCompilerOptions;
+  diagnostic?: string;
+};
+
+const configCases: ConfigAuditCase[] = [
+  {
+    name: 'Vite immutable plugin alias',
+    file: 'vite.config.ts',
+    source: `import vue from '@vitejs/plugin-vue'; const plugin = vue; export default { plugins: [plugin({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite deep plugin alias',
+    file: 'vite.config.ts',
+    source: `import vue from '@vitejs/plugin-vue'; const first = vue; const second = first; export default { plugins: [second({ template: { compilerOptions: { delimiters: ['[[', ']]'] } } })] };`,
+    expected: { delimiters: ['[[', ']]'] },
+  },
+  {
+    name: 'Vite CJS destructured default',
+    file: 'vite.config.cjs',
+    source: `const { default: vue } = require('@vitejs/plugin-vue'); module.exports = { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite TS import-equals namespace',
+    file: 'vite.config.cts',
+    source: `import pluginVue = require('@vitejs/plugin-vue'); export default { plugins: [pluginVue.default({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite optional plugin call',
+    file: 'vite.config.ts',
+    source: `import vue from '@vitejs/plugin-vue'; export default { plugins: [vue?.({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite namespace default alias',
+    file: 'vite.config.mjs',
+    source: `import * as pluginVue from '@vitejs/plugin-vue'; const vue = pluginVue.default; export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite computed namespace default',
+    file: 'vite.config.mjs',
+    source: `import * as pluginVue from '@vitejs/plugin-vue'; export default { plugins: [pluginVue['default']({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite optional namespace default',
+    file: 'vite.config.mjs',
+    source: `import * as pluginVue from '@vitejs/plugin-vue'; export default { plugins: [pluginVue?.default({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite optional computed namespace default and call',
+    file: 'vite.config.mjs',
+    source: `import * as pluginVue from '@vitejs/plugin-vue'; export default { plugins: [pluginVue?.['default']?.({ template: { compilerOptions: { delimiters: ['[[', ']]'] } } })] };`,
+    expected: { delimiters: ['[[', ']]'] },
+  },
+  {
+    name: 'Vite computed CJS namespace default',
+    file: 'vite.config.cjs',
+    source: `const vue = require('@vitejs/plugin-vue')['default']; module.exports = { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite computed TS import-equals default',
+    file: 'vite.config.cts',
+    source: `import pluginVue = require('@vitejs/plugin-vue'); export default { plugins: [pluginVue['default']({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Vite mutated plugin alias fails closed',
+    file: 'vite.config.ts',
+    source: `import vue from '@vitejs/plugin-vue'; const other = vue; let plugin = vue; plugin = other; export default { plugins: [plugin({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: {},
+    diagnostic: 'Could not statically resolve Vue compiler options',
+  },
+  {
+    name: 'unrelated Vite function is ignored',
+    file: 'vite.config.ts',
+    source: `const plugin = (value) => value; export default { plugins: [plugin({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    expected: {},
+  },
+  {
+    name: 'Nuxt imported helper alias',
+    file: 'nuxt.config.ts',
+    source: `import { defineNuxtConfig as define } from 'nuxt/config'; export default define({ vue: { compilerOptions: { whitespace: 'preserve' } } });`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Nuxt immutable helper alias chain',
+    file: 'nuxt.config.ts',
+    source: `import { defineNuxtConfig } from 'nuxt/config'; const first = defineNuxtConfig; const define = first; export default define({ vue: { compilerOptions: { delimiters: ['[[', ']]'] } } });`,
+    expected: { delimiters: ['[[', ']]'] },
+  },
+  {
+    name: 'Nuxt module.exports object',
+    file: 'nuxt.config.cjs',
+    source: `module.exports = { vue: { compilerOptions: { whitespace: 'preserve' } } };`,
+    expected: { whitespace: 'preserve' },
+  },
+  {
+    name: 'Nuxt exports.default object',
+    file: 'nuxt.config.cjs',
+    source: `exports.default = { vue: { compilerOptions: { delimiters: ['[[', ']]'] } } };`,
+    expected: { delimiters: ['[[', ']]'] },
+  },
+  {
+    name: 'Nuxt mutated helper alias fails closed',
+    file: 'nuxt.config.ts',
+    source: `import { defineNuxtConfig } from 'nuxt/config'; let define = defineNuxtConfig; define = (value) => value; export default define({ vue: { compilerOptions: { whitespace: 'preserve' } } });`,
+    expected: {},
+    diagnostic: 'Could not statically resolve Vue compiler options',
+  },
+  {
+    name: 'matching explicit and Vite options remain valid',
+    file: 'vite.config.ts',
+    source: `import vue from '@vitejs/plugin-vue'; export default { plugins: [vue({ template: { compilerOptions: { whitespace: 'preserve' } } })] };`,
+    options: { whitespace: 'preserve' },
+    expected: { whitespace: 'preserve' },
+  },
+];
+
+describe('template/package audit wave 2: compiler config boundary', () => {
+  it.each(configCases)('$name', (testCase) => {
+    const root = createConfigProject(testCase.file, testCase.source);
+
+    const result = resolveVueCompilerOptions(root, testCase.options);
+
+    expect(result.compilerOptions).toEqual(testCase.expected);
+    if (testCase.diagnostic) {
+      expect(result.errors.join('\n')).toContain(testCase.diagnostic);
+    } else {
+      expect(result.errors).toEqual([]);
+    }
+  });
+});
+
+describe('template/package audit wave 2: metadata and public boundary', () => {
+  it('rebases direct compiler-dom ranges to full-SFC source positions', async () => {
+    const source = [
+      '<script setup>',
+      "import { T } from 'gt-vue';",
+      'const dynamicContext = getContext();',
+      '</script>',
+      '<template>',
+      '  <section>',
+      '    <T :context="dynamicContext">Invalid</T>',
+      '  </section>',
+      '</template>',
+    ].join('\n');
+    const output = await extractFromVueSource(
+      source,
+      '/project/src/Rebased.vue',
+      {
+        includeSourceCodeContext: true,
+        projectRoot: '/project',
+        surroundingLineCount: 0,
+      }
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(
+      '/project/src/Rebased.vue (7:8)'
+    );
+    expect(output.errors.join('\n')).toContain('dynamic context');
+  });
+
+  it('captures exact source context for script, rich, and template calls', async () => {
+    const source = `<script setup>\nimport { T, useGT } from 'gt-vue';\nconst gt = useGT();\ngt('Script source');\n</script>\n<template>\n  <T>Template source</T>\n  {{ gt('Template call') }}\n</template>`;
+    const output = await extractFromVueSource(
+      source,
+      '/project/src/Context.vue',
+      {
+        includeSourceCodeContext: true,
+        projectRoot: '/project',
+        surroundingLineCount: 1,
+      }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map(({ metadata }) => metadata.sourceCode)).toEqual([
+      {
+        'src/Context.vue': [
+          {
+            before: 'const gt = useGT();',
+            target: `gt('Script source');`,
+            after: '</script>',
+          },
+        ],
+      },
+      {
+        'src/Context.vue': [
+          {
+            before: '<template>',
+            target: '  <T>Template source</T>',
+            after: `  {{ gt('Template call') }}`,
+          },
+        ],
+      },
+      {
+        'src/Context.vue': [
+          {
+            before: '  <T>Template source</T>',
+            target: `  {{ gt('Template call') }}`,
+            after: '</template>',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('supports zero surrounding source lines', async () => {
+    const source = createSfc(`import { T } from 'gt-vue';`, `<T>Zero</T>`);
+    const output = await extractFromVueSource(source, '/project/Zero.vue', {
+      includeSourceCodeContext: true,
+      projectRoot: '/project',
+      surroundingLineCount: 0,
+    });
+    const context = output.results[0]?.metadata.sourceCode?.['Zero.vue']?.[0];
+
+    expect(context).toMatchObject({ before: '', after: '' });
+  });
+
+  it('omits source context unless explicitly enabled', async () => {
+    const output = await extractAuditSource(
+      createSfc(`import { T } from 'gt-vue';`, `<T>No context</T>`),
+      'no-context'
+    );
+
+    expect(output.results[0]?.metadata.sourceCode).toBeUndefined();
+    expect(output.results[0]?.metadata.filePaths).toEqual([
+      'src/no-context.vue',
+    ]);
+  });
+
+  it('honors custom interpolation delimiters through the public API', async () => {
+    const source = createSfc(
+      `import { T, Var } from 'gt-vue'; const name = 'Ada';`,
+      `<T>Hello <Var>[[ name ]]</Var></T>`
+    );
+    const output = await extractAuditSource(source, 'delimiters', {
+      delimiters: ['[[', ']]'],
+    });
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      'Hello ',
+      { i: 1, k: '_gt_value_1', v: 'v' },
+    ]);
+  });
+
+  it('honors preserve versus condense whitespace through the public API', async () => {
+    const source = createSfc(
+      `import { T } from 'gt-vue';`,
+      `<T>First\n    second</T>`
+    );
+    const condensed = await extractAuditSource(source, 'condense', {
+      whitespace: 'condense',
+    });
+    const preserved = await extractAuditSource(source, 'preserve', {
+      whitespace: 'preserve',
+    });
+
+    expect(condensed.errors).toEqual([]);
+    expect(preserved.errors).toEqual([]);
+    expect(condensed.results[0]?.source).not.toEqual(
+      preserved.results[0]?.source
+    );
+  });
+
+  it('exports both public runtime functions from source entry points', () => {
+    expect(extractFromVueSource).toBeTypeOf('function');
+    expect(resolveVueCompilerOptions).toBeTypeOf('function');
+  });
+
+  it('declares root, config, and types package exports', () => {
+    const packageRoot = path.resolve(__dirname, '../../..');
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')
+    ) as { exports: Record<string, unknown> };
+
+    expect(Object.keys(packageJson.exports)).toEqual([
+      '.',
+      './config',
+      './detect',
+      './project',
+      './types',
+    ]);
+  });
+
+  it('contains no source import from the CLI package', () => {
+    const packageRoot = path.resolve(__dirname, '../../..');
+    const sourceFiles = listFiles(path.join(packageRoot, 'src')).filter(
+      (file) => /\.[cm]?[jt]sx?$/.test(file)
+    );
+
+    for (const file of sourceFiles) {
+      const source = fs.readFileSync(file, 'utf8');
+      expect(source, file).not.toMatch(
+        /(?:from\s+|require\s*\()['"][^'"]*(?:packages\/cli|\/cli\/src)/
+      );
+    }
+  });
+});
+
+function createSfc(script: string, template: string): string {
+  return `<script setup lang="ts">${script}</script><template>${template}</template>`;
+}
+
+async function extractAuditSource(
+  source: string,
+  name: string,
+  compilerOptions?: VueCompilerOptions
+): Promise<VueExtractionOutput> {
+  return extractFromVueSource(source, `/project/src/${name}.vue`, {
+    compilerOptions,
+    projectRoot: '/project',
+  });
+}
+
+function assertVueCompiles(source: string, name: string): void {
+  const filename = `/project/src/${name}.vue`;
+  const parsed = parse(source, { filename });
+  expect(parsed.errors, name).toEqual([]);
+  const script = compileScript(parsed.descriptor, {
+    babelParserPlugins: ['typescript'],
+    id: `audit-${name}`,
+  });
+  const template = parsed.descriptor.template;
+  if (!template) return;
+  const compiled = compileTemplate({
+    compilerOptions: {
+      bindingMetadata: script.bindings,
+      expressionPlugins: ['typescript'],
+    },
+    filename,
+    id: `audit-${name}`,
+    source: template.content,
+  });
+  expect(compiled.errors, name).toEqual([]);
+}
+
+function createConfigProject(filename: string, source: string): string {
+  const directory = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'gt-vue-wave-two-config-')
+  );
+  temporaryDirectories.push(directory);
+  fs.writeFileSync(path.join(directory, filename), source);
+  return directory;
+}
+
+function listFiles(directory: string): string[] {
+  return fs.readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const file = path.join(directory, entry.name);
+    return entry.isDirectory() ? listFiles(file) : [file];
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/templateRuntimeParity.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/templateRuntimeParity.test.ts
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { JsxChildren } from '@generaltranslation/format/types';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue template runtime parity', () => {
+  it('matches Vue directive scope, slot, and component-name behavior', async () => {
+    const result = await extractFixture('template-runtime-parity.vue');
+
+    expect(result.errors).toEqual([]);
+    expect(
+      result.results
+        .filter((update) => update.dataFormat === 'STRING')
+        .map((update) => update.source)
+    ).toEqual(['Outer v-if', 'v-for default', 'Directive', 'slot default']);
+
+    const richSources = result.results
+      .filter((update) => update.dataFormat === 'JSX')
+      .map((update) => update.source);
+    const branch: JsxChildren = {
+      t: 'Branch',
+      i: 1,
+      d: {
+        b: { casual: 'Second', formal: 'First' },
+        t: 'b',
+      },
+    };
+    const plural: JsxChildren = {
+      t: 'Plural',
+      i: 1,
+      d: {
+        b: { one: 'One', other: 'Other' },
+        t: 'p',
+      },
+    };
+    expect(richSources).toEqual([
+      'Digit-normalized component',
+      'Dynamic component',
+      'Explicit default',
+      branch,
+      plural,
+    ]);
+  });
+
+  it('still rejects meaningful implicit content beside an explicit default slot', async () => {
+    const result = await extractFixture('template-duplicate-default.vue');
+
+    expect(result.results).toEqual([]);
+    expect(result.errors.join('\n')).toContain(
+      'more than one default slot definition'
+    );
+  });
+});
+
+function fixturePath(name: string): string {
+  return path.join(__dirname, 'fixtures', name);
+}
+
+async function extractFixture(name: string) {
+  const file = fixturePath(name);
+  return extractFromVueSource(fs.readFileSync(file, 'utf8'), file, {
+    projectRoot: process.cwd(),
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/temporalSnapshotSemantics.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/temporalSnapshotSemantics.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+const POSSIBLE_ALIAS_DIAGNOSTIC =
+  'Could not statically resolve possible gt-vue component alias';
+
+type TemporalSnapshotProbe = {
+  /** Human-readable snapshot or shared-identity behavior under test. */
+  name: string;
+  /** Statements inserted into the fixture's script-setup block. */
+  code: string;
+  /** Dynamic component expression read after setup completes. */
+  selector: string;
+  /** Whether the selector resolves to `<T>` in the final runtime state. */
+  possibleT: boolean;
+};
+
+/**
+ * Shallow copies capture top-level entries immediately but preserve references
+ * to nested containers. Getter, member, and Map reads likewise capture their
+ * result at the moment of the read. Later writes must affect shared identities
+ * without retroactively changing earlier value snapshots.
+ */
+const temporalSnapshotProbes: TemporalSnapshotProbe[] = [
+  {
+    name: 'an array spread before an escaped mutation stays ordinary',
+    code: `
+      const registry = [String];
+      const copy = [...registry];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an array member snapshot before an escaped mutation stays ordinary',
+    code: `
+      const registry = [String];
+      const selected = registry[0];
+      function mutate(value) { if (flag) value[0] = T; }
+      mutate(registry);
+    `,
+    selector: 'selected',
+    possibleT: false,
+  },
+  {
+    name: 'an object spread before an escaped mutation stays ordinary',
+    code: `
+      const registry = { x: String };
+      const copy = { ...registry };
+      function mutate(value) { if (flag) value.x = T; }
+      mutate(registry);
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'a Map get before an escaped mutation stays ordinary',
+    code: `
+      const registry = new Map([['x', String]]);
+      const selected = registry.get('x');
+      function mutate(value) { if (flag) value.set('x', T); }
+      mutate(registry);
+    `,
+    selector: 'selected',
+    possibleT: false,
+  },
+  {
+    name: 'a shallow object copy preserves its shared nested identity',
+    code: `
+      const root = { box: [String] };
+      const copy = { ...root };
+      function mutate(value) { if (flag) value.box[0] = T; }
+      mutate(root);
+    `,
+    selector: 'copy.box[key]',
+    possibleT: true,
+  },
+  {
+    name: 'a nested array spread before mutation stays ordinary',
+    code: `
+      const root = { box: [String] };
+      const copy = [...root.box];
+      function mutate(value) { if (flag) value.box[0] = T; }
+      mutate(root);
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an ordinary getter snapshot remains ordinary after a later T write',
+    code: `
+      let value = String;
+      const registry = { get x() { return value; } };
+      const selected = registry.x;
+      value = T;
+    `,
+    selector: 'selected',
+    possibleT: false,
+  },
+  {
+    name: 'a T getter snapshot survives a later ordinary write',
+    code: `
+      let value = T;
+      const registry = { get x() { return value; } };
+      const selected = registry.x;
+      value = String;
+    `,
+    selector: 'selected',
+    possibleT: true,
+  },
+  {
+    name: 'an ordinary inherited snapshot remains ordinary after a T write',
+    code: `
+      const prototype = { x: String };
+      const registry = Object.create(prototype);
+      const selected = registry.x;
+      prototype.x = T;
+    `,
+    selector: 'selected',
+    possibleT: false,
+  },
+  {
+    name: 'an inherited T snapshot survives a later ordinary write',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      const selected = registry.x;
+      prototype.x = String;
+    `,
+    selector: 'selected',
+    possibleT: true,
+  },
+  {
+    name: 'an object spread excludes an inherited T property',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      const copy = { ...registry };
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'Object.assign excludes an inherited T property',
+    code: `
+      const prototype = { x: T };
+      const registry = Object.create(prototype);
+      const copy = Object.assign({}, registry);
+    `,
+    selector: 'copy[key]',
+    possibleT: false,
+  },
+  {
+    name: 'an object setter writes T through its receiver',
+    code: `
+      const registry = { value: String, set x(next) { this.value = next; } };
+      registry.x = T;
+    `,
+    selector: 'registry.value',
+    possibleT: true,
+  },
+  {
+    name: 'an object setter overwrites T through its receiver',
+    code: `
+      const registry = { value: T, set x(next) { this.value = next; } };
+      registry.x = String;
+    `,
+    selector: 'registry.value',
+    possibleT: false,
+  },
+  {
+    name: 'a class setter writes T through its receiver',
+    code: `
+      class Registry { value = String; set x(next) { this.value = next; } }
+      const registry = new Registry();
+      registry.x = T;
+    `,
+    selector: 'registry.value',
+    possibleT: true,
+  },
+  {
+    name: 'a class setter overwrites T through its receiver',
+    code: `
+      class Registry { value = T; set x(next) { this.value = next; } }
+      const registry = new Registry();
+      registry.x = String;
+    `,
+    selector: 'registry.value',
+    possibleT: false,
+  },
+  {
+    name: 'an inherited method reads T through the derived receiver',
+    code: `
+      const prototype = { read() { return this.value; } };
+      const registry = Object.create(prototype);
+      registry.value = T;
+    `,
+    selector: 'registry.read()',
+    possibleT: true,
+  },
+  {
+    name: 'an inherited method observes a derived receiver mutation',
+    code: `
+      const prototype = { read() { return this.value; } };
+      const registry = Object.create(prototype);
+      registry.value = T;
+      registry.value = String;
+    `,
+    selector: 'registry.read()',
+    possibleT: false,
+  },
+];
+
+describe('temporal snapshots and shared nested identities', () => {
+  it.each(temporalSnapshotProbes)(
+    '$name',
+    async ({ code, selector, possibleT }) => {
+      const output = await extractFromVueSource(
+        createFixture(code, selector),
+        '/fixtures/TemporalSnapshotSemantics.vue',
+        { projectRoot: '/fixtures' }
+      );
+      const extracted = output.results.some(
+        ({ source }) => source === 'Hidden'
+      );
+      const diagnosed = output.errors.some((error) =>
+        error.includes(POSSIBLE_ALIAS_DIAGNOSTIC)
+      );
+
+      if (possibleT) {
+        expect(extracted || diagnosed).toBe(true);
+      } else {
+        expect(output.results).toEqual([]);
+        expect(output.errors).toEqual([]);
+      }
+    }
+  );
+});
+
+/** Creates an SFC containing one snapshot or shared-identity scenario. */
+function createFixture(code: string, selector: string): string {
+  return `<script setup>
+    import { T } from 'gt-vue';
+    const flag = Boolean(Date.now());
+    const key = getKey();
+    ${code}
+  </script>
+  <template><component :is="${selector}">Hidden</component></template>`;
+}

--- a/packages/vue-extractor/src/internal/__tests__/testVueCompiler.ts
+++ b/packages/vue-extractor/src/internal/__tests__/testVueCompiler.ts
@@ -1,0 +1,16 @@
+import * as testVueCompiler from '#vue-compiler-sfc';
+import { parse as parseTemplate } from '@vue/compiler-dom';
+import type { VueExtractionOptions } from '../../types.js';
+import { extractFromVueSource as extract } from '../extractFromVueSource.js';
+
+/** Extracts virtual fixtures with the exact compiler installed for this test. */
+export function extractFromVueSource(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions = {}
+) {
+  return extract(sourceCode, filePath, {
+    compiler: { ...testVueCompiler, parseTemplate },
+    ...options,
+  });
+}

--- a/packages/vue-extractor/src/internal/__tests__/utils.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/utils.test.ts
@@ -1,0 +1,36 @@
+import * as t from '@babel/types';
+import { describe, expect, it } from 'vitest';
+import { readStaticPrimitive } from '../utils.js';
+
+describe('readStaticPrimitive template literals', () => {
+  it('uses cooked runtime text for every quasi', () => {
+    const template = t.templateLiteral(
+      [
+        t.templateElement({ cooked: 'first\n', raw: 'first\\n' }),
+        t.templateElement({ cooked: '\tlast', raw: '\\tlast' }, true),
+      ],
+      [t.stringLiteral('middle')]
+    );
+
+    expect(readStaticPrimitive(template)).toEqual({
+      ok: true,
+      value: 'first\nmiddle\tlast',
+    });
+  });
+
+  it.each(['first', 'later'] as const)(
+    'fails closed when the %s quasi has no cooked runtime value',
+    (missingQuasi) => {
+      const template = t.templateLiteral(
+        [
+          t.templateElement({ cooked: 'first', raw: 'first' }),
+          t.templateElement({ cooked: 'last', raw: 'last' }, true),
+        ],
+        [t.stringLiteral('middle')]
+      );
+      template.quasis[missingQuasi === 'first' ? 0 : 1].value.cooked = null;
+
+      expect(readStaticPrimitive(template)).toEqual({ ok: false });
+    }
+  );
+});

--- a/packages/vue-extractor/src/internal/__tests__/variableComponentInterface.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/variableComponentInterface.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue variable component interface validation', () => {
+  it('accepts explicit dynamic value props outside T in SFC templates', async () => {
+    const output = await extractFromVueSource(
+      `
+        <script setup lang="ts">
+          import * as GT from 'gt-vue';
+          import { Num as Count } from 'gt-vue';
+          const amount = Math.random();
+          const date = new Date();
+        </script>
+        <template>
+          <Count :value="amount" />
+          <GT.Currency :value="amount" />
+          <GT.DateTime :value="date" />
+        </template>
+      `,
+      '/project/src/View.vue'
+    );
+
+    expect(output.errors).toEqual([]);
+  });
+
+  it('rejects invalid direct, aliased, and namespaced SFC uses outside T', async () => {
+    const output = await extractFromVueSource(
+      `
+        <script setup lang="ts">
+          import * as GT from 'gt-vue';
+          import { Num as Count, Var as Value } from 'gt-vue';
+          const date = new Date();
+          const name = 'Ada';
+        </script>
+        <template>
+          <Count />
+          <GT.DateTime :value="date">{{ date }}</GT.DateTime>
+          <Value :value="name">{{ name }}</Value>
+        </template>
+      `,
+      '/project/src/View.vue'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(3);
+    expect(output.errors.join('\n')).toContain(
+      'gt-vue <Num> component without a value prop'
+    );
+    expect(output.errors.join('\n')).toContain(
+      'children on a gt-vue <DateTime> component'
+    );
+    expect(output.errors.join('\n')).toContain('unsupported value prop');
+  });
+
+  it('reports each invalid SFC use inside T only once', async () => {
+    const output = await extractFromVueSource(
+      `
+        <script setup lang="ts">
+          import { Num, T } from 'gt-vue';
+        </script>
+        <template><T><Num /></T></template>
+      `,
+      '/project/src/View.vue'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('without a value prop');
+  });
+
+  it('accepts explicit dynamic value props outside T in TSX', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as GT from 'gt-vue';
+        import { Num as Count } from 'gt-vue';
+        const amount = Math.random();
+        const date = new Date();
+        export const View = () => <><Count value={amount} /><GT.Currency value={amount} /><GT.DateTime value={date} /></>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+  });
+
+  it('rejects invalid direct, aliased, and namespaced TSX uses outside T', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as GT from 'gt-vue';
+        import { Num as Count, Var as Value } from 'gt-vue';
+        const date = new Date();
+        const name = 'Ada';
+        export const View = () => <><Count /><GT.DateTime value={date}>{date}</GT.DateTime><Value value={name}>{name}</Value></>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(3);
+    expect(output.errors.join('\n')).toContain(
+      'gt-vue <Num> component without a value prop'
+    );
+    expect(output.errors.join('\n')).toContain(
+      'children on a gt-vue <DateTime> component'
+    );
+    expect(output.errors.join('\n')).toContain('unsupported value prop');
+  });
+
+  it('reports each invalid TSX use inside T only once', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { Num, T } from 'gt-vue';
+        export const View = () => <T><Num /></T>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('without a value prop');
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/vueCompiler.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/vueCompiler.test.ts
@@ -1,0 +1,280 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import * as testVueCompiler from '#vue-compiler-sfc';
+import { parse as parseTemplate } from '@vue/compiler-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { VueCompiler } from '../../types.js';
+import { extractFromVueSource } from '../extractFromVueSource.js';
+import { inspectVueCompiler, resolveVueCompiler } from '../vueCompiler.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('consumer Vue compiler resolution', () => {
+  it.each([null, 42, 'compiler', {}, { version: '3.5.40' }])(
+    'fails cleanly for an invalid explicit compiler %#',
+    (compiler) => {
+      expect(inspectVueCompiler(compiler as unknown as VueCompiler)).toEqual({
+        ok: false,
+        details: expect.stringContaining('compiler'),
+      });
+    }
+  );
+
+  it('probes one explicit compiler only once across multiple source files', async () => {
+    const compileTemplate = vi.fn(testVueCompiler.compileTemplate);
+    const compiler = {
+      ...testVueCompiler,
+      compileTemplate,
+      parseTemplate,
+    } as unknown as VueCompiler;
+    const source = `<script setup>import { T } from 'gt-vue';</script><template><T>Hello</T></template>`;
+
+    const outputs = await Promise.all([
+      extractFromVueSource(source, '/fixtures/First.vue', { compiler }),
+      extractFromVueSource(source, '/fixtures/Second.vue', { compiler }),
+      extractFromVueSource(source, '/fixtures/Third.vue', { compiler }),
+    ]);
+
+    expect(outputs.every((output) => output.errors.length === 0)).toBe(true);
+    expect(compileTemplate).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the Vue compiler installed beside the consuming SFC', () => {
+    const file = path.resolve(
+      import.meta.dirname,
+      '../../../../vue/src/CompilerProbe.vue'
+    );
+    const resolution = resolveVueCompiler(file, path.dirname(file));
+
+    expect(resolution.ok).toBe(true);
+    if (!resolution.ok) return;
+    expect(resolution.value.version).toMatch(/^3\.(?:[3-9]|\d{2,})\./);
+    expect(resolution.value.compiler.version).toBe(resolution.value.version);
+    expect(resolution.value.implicitSlotWhitespace).toBe(
+      minorVersion(resolution.value.version) >= 5 ? 'html' : 'ecmascript'
+    );
+  });
+
+  it('loads the consumer compiler browser distributions when Bun cannot follow the Vue proxy', () => {
+    const root = createProject({ vue: '3.5.40' });
+    writeBunIsolatedVuePackage(root, '3.5.40');
+    Object.defineProperty(process.versions, 'bun', {
+      configurable: true,
+      value: '1.3.14',
+    });
+
+    try {
+      const resolution = resolveVueCompiler(
+        path.join(root, 'src/App.vue'),
+        root
+      );
+
+      expect(resolution).toEqual({
+        ok: true,
+        value: expect.objectContaining({
+          implicitSlotWhitespace: 'ecmascript',
+          templateParseOptionsSupported: true,
+          version: '3.5.40',
+        }),
+      });
+    } finally {
+      delete process.versions.bun;
+    }
+  });
+
+  it('rejects unsupported consumer compiler versions through the Bun fallback', () => {
+    const root = createProject({ vue: '3.2.47' });
+    writeBunIsolatedVuePackage(root, '3.2.47');
+    Object.defineProperty(process.versions, 'bun', {
+      configurable: true,
+      value: '1.3.14',
+    });
+
+    try {
+      const resolution = resolveVueCompiler(
+        path.join(root, 'src/App.vue'),
+        root
+      );
+
+      expect(resolution).toEqual({
+        ok: false,
+        details:
+          'Resolved Vue compiler version "3.2.47"; gt-vue supports Vue 3.3 through Vue 3.x.',
+      });
+    } finally {
+      delete process.versions.bun;
+    }
+  });
+
+  it('does not let bundled fallback hide a declared but missing Vue install', () => {
+    const root = createProject({ vue: '^3.3.0' });
+    const resolution = resolveVueCompiler(path.join(root, 'src/App.vue'), root);
+
+    expect(resolution).toEqual({
+      ok: false,
+      details: expect.stringContaining(
+        'declares Vue "^3.3.0" but vue/compiler-sfc could not be resolved'
+      ),
+    });
+  });
+
+  it('does not resolve the extractor package compiler for a project without Vue', () => {
+    const root = createProject({});
+    const resolution = resolveVueCompiler(path.join(root, 'src/App.vue'), root);
+
+    expect(resolution).toEqual({
+      ok: false,
+      details: expect.stringContaining(
+        `Could not resolve vue/compiler-sfc from ${path.join(root, 'src/App.vue')}`
+      ),
+    });
+  });
+
+  it('fails closed when an installed Vue package has no compiler export', () => {
+    const root = createProject({ vue: '3.3.13' });
+    writeVuePackage(root, {
+      exports: { './package.json': './package.json' },
+      version: '3.3.13',
+    });
+
+    const resolution = resolveVueCompiler(path.join(root, 'src/App.vue'), root);
+
+    expect(resolution).toEqual({
+      ok: false,
+      details: expect.stringContaining("Resolved the app's Vue package"),
+    });
+  });
+
+  it('fails closed when Vue and compiler-sfc versions disagree', () => {
+    const root = createProject({ vue: '3.5.40' });
+    writeVuePackage(root, { version: '3.5.40' }, '3.4.38');
+
+    const resolution = resolveVueCompiler(path.join(root, 'src/App.vue'), root);
+
+    expect(resolution).toEqual({
+      ok: false,
+      details: expect.stringContaining(
+        'resolves Vue 3.5.40 but vue/compiler-sfc 3.4.38'
+      ),
+    });
+  });
+
+  it('rejects compiler versions outside the gt-vue peer range', () => {
+    const root = createProject({ vue: '4.0.0' });
+    writeVuePackage(root, { version: '4.0.0' }, '4.0.0');
+
+    const resolution = resolveVueCompiler(path.join(root, 'src/App.vue'), root);
+
+    expect(resolution).toEqual({
+      ok: false,
+      details: expect.stringContaining(
+        'gt-vue supports Vue 3.3 through Vue 3.x'
+      ),
+    });
+  });
+});
+
+function createProject(dependencies: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-compiler-'));
+  temporaryDirectories.push(root);
+  fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({ dependencies, name: 'fixture', private: true })
+  );
+  return root;
+}
+
+function writeVuePackage(
+  root: string,
+  manifest: { exports?: Record<string, string>; version: string },
+  compilerVersion = manifest.version
+): void {
+  const directory = path.join(root, 'node_modules/vue');
+  fs.mkdirSync(directory, { recursive: true });
+  fs.writeFileSync(
+    path.join(directory, 'package.json'),
+    JSON.stringify({
+      exports: manifest.exports ?? {
+        './compiler-sfc': './compiler-sfc.cjs',
+        './package.json': './package.json',
+      },
+      name: 'vue',
+      version: manifest.version,
+    })
+  );
+  if (manifest.exports?.['./compiler-sfc'] === undefined && manifest.exports) {
+    return;
+  }
+  fs.writeFileSync(
+    path.join(directory, 'compiler-sfc.cjs'),
+    `module.exports = { compileTemplate() {}, parse() {}, version: ${JSON.stringify(compilerVersion)} };\n`
+  );
+}
+
+function writeBunIsolatedVuePackage(root: string, version: string): void {
+  writeVuePackage(root, { version });
+  fs.writeFileSync(
+    path.join(root, 'node_modules/vue/compiler-sfc.cjs'),
+    `module.exports = require('@vue/compiler-sfc');\n`
+  );
+
+  const compilerSfcRoot = path.join(root, 'node_modules/@vue/compiler-sfc');
+  const compilerDomRoot = path.join(root, 'node_modules/@vue/compiler-dom');
+  fs.mkdirSync(path.join(compilerSfcRoot, 'dist'), { recursive: true });
+  fs.mkdirSync(path.join(compilerDomRoot, 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(compilerSfcRoot, 'package.json'),
+    JSON.stringify({ name: '@vue/compiler-sfc', version })
+  );
+  fs.writeFileSync(
+    path.join(compilerDomRoot, 'package.json'),
+    JSON.stringify({ name: '@vue/compiler-dom', version })
+  );
+  fs.writeFileSync(
+    path.join(compilerSfcRoot, 'dist/compiler-sfc.esm-browser.js'),
+    `module.exports = {
+  compileTemplate() {
+    return {
+      errors: [],
+      ast: {
+        children: [{
+          tag: 'Probe',
+          codegenNode: { children: { properties: [] } }
+        }]
+      }
+    };
+  },
+  parse(_source, options) {
+    return {
+      descriptor: {
+        template: {
+          ast: {
+            children: [{
+              type: 2,
+              content: options.templateParseOptions.whitespace
+            }]
+          }
+        }
+      }
+    };
+  },
+  version: ${JSON.stringify(version)}
+};\n`
+  );
+  fs.writeFileSync(
+    path.join(compilerDomRoot, 'dist/compiler-dom.esm-browser.js'),
+    `module.exports = { compile() {}, parse() {} };\n`
+  );
+}
+
+function minorVersion(version: string): number {
+  return Number(version.split('.')[1]);
+}

--- a/packages/vue-extractor/src/internal/__tests__/vueJsxRichExtraction.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/vueJsxRichExtraction.test.ts
@@ -1,0 +1,577 @@
+import { hashSource } from 'generaltranslation/id';
+import { describe, expect, it } from 'vitest';
+import { extractFromVueSource } from './testVueCompiler.js';
+
+describe('Vue JSX rich extraction', () => {
+  it('extracts a direct T import into the runtime wire format', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-vue';
+        export const View = () => (
+          <T context="card">Hello <strong>world</strong>!</T>
+        );
+      `,
+      '/project/src/View.tsx',
+      { projectRoot: '/project' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([
+      {
+        dataFormat: 'JSX',
+        source: ['Hello ', { c: 'world', i: 1, t: 'strong' }, '!'],
+        metadata: {
+          context: 'card',
+          filePaths: ['src/View.tsx'],
+        },
+      },
+    ]);
+    expect(
+      hashSource({
+        context: 'card',
+        dataFormat: 'JSX',
+        source: output.results[0]!.source,
+      })
+    ).toBe('fcd7d4e98f673df0');
+  });
+
+  it.each([
+    {
+      name: 'default functional component',
+      component: `export default () => <T>Functional</T>;`,
+      source: 'Functional',
+    },
+    {
+      name: 'defineComponent setup renderer',
+      component: `
+        import { defineComponent } from 'vue';
+        export default defineComponent({
+          setup() {
+            return () => <T>Setup renderer</T>;
+          },
+        });
+      `,
+      source: 'Setup renderer',
+    },
+  ])('extracts T from a $name', async ({ component, source }) => {
+    const output = await extractFromVueSource(
+      `import { T } from 'gt-vue'; ${component}`,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual([source]);
+  });
+
+  it.each([
+    {
+      filename: '/project/src/View.jsx',
+      name: 'standalone JSX',
+      source: `
+        import { T } from 'gt-vue';
+        export const View = () => <T>JavaScript JSX</T>;
+      `,
+      translation: 'JavaScript JSX',
+    },
+    {
+      filename: '/project/src/View.vue',
+      name: 'SFC script setup TSX',
+      source: `
+        <script setup lang="tsx">
+          import { T } from 'gt-vue';
+          const View = () => <T>Script setup TSX</T>;
+        </script>
+        <template><View /></template>
+      `,
+      translation: 'Script setup TSX',
+    },
+    {
+      filename: '/project/src/View.vue',
+      name: 'SFC normal TSX render function',
+      source: `
+        <script lang="tsx">
+          import { defineComponent } from 'vue';
+          import { T } from 'gt-vue';
+          export default defineComponent({
+            setup() {
+              return () => <T>Normal script TSX</T>;
+            },
+          });
+        </script>
+      `,
+      translation: 'Normal script TSX',
+    },
+  ])('extracts rich translations from $name', async (fixture) => {
+    const output = await extractFromVueSource(
+      fixture.source,
+      fixture.filename,
+      { projectRoot: '/project' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual([
+      fixture.translation,
+    ]);
+  });
+
+  it('tracks aliases, namespaces, fragments, static values, and typed variables', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as GT from 'gt-vue';
+        import {
+          Currency,
+          DateTime,
+          Num,
+          T as Translate,
+          Var as Value,
+        } from 'gt-vue';
+        const Alias = Translate;
+        const context = 'hero';
+        const label = 'Greeting';
+        const name = getName();
+        const count = getCount();
+        const cost = getCost();
+        const date = getDate();
+        export const View = () => (
+          <>
+            <Alias $context={context}><>Hello {1}{false}{null}<strong title={label}>world</strong></><Value>{name}</Value><Num value={count}/><Currency value={cost}/><DateTime value={date}/></Alias>
+            <GT.T>Namespace</GT.T>
+          </>
+        );
+      `,
+      '/project/src/View.tsx',
+      { projectRoot: '/project' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results).toEqual([
+      {
+        dataFormat: 'JSX',
+        source: [
+          'Hello 1',
+          { c: 'world', d: { ti: 'Greeting' }, i: 1, t: 'strong' },
+          { i: 2, k: '_gt_value_2', v: 'v' },
+          { i: 3, k: '_gt_n_3', v: 'n' },
+          { i: 4, k: '_gt_cost_4', v: 'c' },
+          { i: 5, k: '_gt_date_5', v: 'd' },
+        ],
+        metadata: {
+          context: 'hero',
+          filePaths: ['src/View.tsx'],
+        },
+      },
+      {
+        dataFormat: 'JSX',
+        source: 'Namespace',
+        metadata: { filePaths: ['src/View.tsx'] },
+      },
+    ]);
+    expect(
+      hashSource({
+        context: 'hero',
+        dataFormat: 'JSX',
+        source: output.results[0]!.source,
+      })
+    ).toBe('3a680d85faf2fc41');
+  });
+
+  it('matches the Fragment spellings Vue JSX keeps transparent', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as Vue from 'vue';
+        import { T } from 'gt-vue';
+        const CustomFragment = () => null;
+        const Fragment = CustomFragment;
+        export const View = () => (
+          <T><>short</><Fragment><span>one</span></Fragment><Vue.Fragment><b>three</b></Vue.Fragment><CustomFragment><i>opaque</i></CustomFragment></T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      'short',
+      { c: 'one', i: 1, t: 'span' },
+      { c: 'three', i: 2, t: 'b' },
+      { i: 3, t: 'CustomFragment' },
+    ]);
+  });
+
+  it('rejects renamed Fragment imports that Vue JSX compiles as component slots', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { Fragment as VueFragment } from 'vue';
+        import { T } from 'gt-vue';
+        export const View = () => <T><VueFragment><b>Lost</b></VueFragment></T>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain('renamed Vue Fragment binding');
+  });
+
+  it('keeps arbitrary component slots opaque and extracts their nested T independently', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-vue';
+        import Card from './Card.vue';
+        export const View = () => (
+          <T><Card title="Card"><span>Opaque</span><T>Independent</T></Card></T>
+        );
+      `,
+      '/project/src/View.tsx',
+      { projectRoot: '/project' }
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual([
+      { d: { ti: 'Card' }, i: 1, t: 'Card' },
+      'Independent',
+    ]);
+  });
+
+  it('traverses bound tags only when every possible value is a string element', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-vue';
+        const StaticTag = 'strong';
+        const DynamicTag = enabled ? 'em' : 'i';
+        export const View = () => (
+          <T><StaticTag>Static</StaticTag><DynamicTag>Dynamic</DynamicTag></T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      { c: 'Static', i: 1, t: 'strong' },
+      { c: 'Dynamic', i: 2, t: 'DynamicTag' },
+    ]);
+  });
+
+  it('serializes Branch v-slots with independent IDs and slot precedence', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as GT from 'gt-vue';
+        const name = getName();
+        const tone = getTone();
+        export const View = () => (
+          <GT.T><GT.Branch branch={tone} formal="ignored attribute" v-slots={{
+            formal: () => <><strong>Hello</strong> <GT.Var>{name}</GT.Var></>,
+            casual: () => <><em>Hi</em> <GT.Var>{name}</GT.Var></>,
+            default: () => 'Fallback',
+          }} /><span>After</span></GT.T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      {
+        c: 'Fallback',
+        d: {
+          b: {
+            casual: [
+              { c: 'Hi', i: 2, t: 'em' },
+              ' ',
+              { i: 3, k: '_gt_value_3', v: 'v' },
+            ],
+            formal: [
+              { c: 'Hello', i: 2, t: 'strong' },
+              ' ',
+              { i: 3, k: '_gt_value_3', v: 'v' },
+            ],
+          },
+          t: 'b',
+        },
+        i: 1,
+        t: 'Branch',
+      },
+      { c: 'After', i: 2, t: 'span' },
+    ]);
+  });
+
+  it('serializes Plural v-slots and primitive attribute branches', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { Num, Plural, T } from 'gt-vue';
+        const count = getCount();
+        export const View = () => (
+          <T><Plural n={count} zero="None" title="Tip" v-slots={{
+            one: () => <>One <Num value={1} /></>,
+            other: () => <>Many <Num value={count} /></>,
+            invalid: () => 'ignored',
+            default: () => 'Fallback',
+          }} /><span>After</span></T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      {
+        c: 'Fallback',
+        d: {
+          b: {
+            one: ['One ', { i: 2, k: '_gt_n_2', v: 'n' }],
+            other: ['Many ', { i: 2, k: '_gt_n_2', v: 'n' }],
+            zero: 'None',
+          },
+          t: 'p',
+          ti: 'Tip',
+        },
+        i: 1,
+        t: 'Plural',
+      },
+      { c: 'After', i: 2, t: 'span' },
+    ]);
+  });
+
+  it('serializes only the normalized default roots of imported Vue Suspense forms', async () => {
+    const output = await extractFromVueSource(
+      `
+        import * as Vue from 'vue';
+        import { Suspense, Suspense as Wait, Transition } from 'vue';
+        import { T } from 'gt-vue';
+        export const View = () => (
+          <T>
+            <Suspense title="Boundary" v-slots={{ fallback: () => <i>Loading direct</i> }}><section>Direct</section></Suspense>
+            <Wait v-slots={{ default: () => <article>Alias</article>, fallback: () => <i>Loading alias</i> }} />
+            <Vue.Suspense>{() => <div>Namespace</div>}</Vue.Suspense>
+            <Transition><b>Opaque transition child</b></Transition>
+          </T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results[0]?.source).toEqual([
+      {
+        c: { c: 'Direct', i: 2, t: 'section' },
+        d: { ti: 'Boundary' },
+        i: 1,
+        t: 'Suspense',
+      },
+      { c: { c: 'Alias', i: 4, t: 'article' }, i: 3, t: 'Suspense' },
+      { c: { c: 'Namespace', i: 6, t: 'div' }, i: 5, t: 'Suspense' },
+      { i: 7, t: 'Transition' },
+    ]);
+  });
+
+  it('rejects nested T in normalized Suspense content without extracting it twice', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { Suspense } from 'vue';
+        import { T } from 'gt-vue';
+        export const View = () => <T><Suspense><T>Nested</T></Suspense></T>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('nested gt-vue <T>');
+  });
+
+  it('rejects nested T in a traversed native subtree without duplicating extraction', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-vue';
+        export const View = () => <T><div><T>Nested</T></div></T>;
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('nested gt-vue <T>');
+  });
+
+  it('extracts T returned by an element callback independently from outer children', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { T } from 'gt-vue';
+        export const View = () => (
+          <T><button onClick={() => <T>Deferred</T>}>Outer</button></T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.errors).toEqual([]);
+    expect(output.results.map((result) => result.source)).toEqual([
+      { c: 'Outer', i: 1, t: 'button' },
+      'Deferred',
+    ]);
+  });
+
+  it('rejects nested T inside a traversed Branch slot without extracting it twice', async () => {
+    const output = await extractFromVueSource(
+      `
+        import { Branch, T } from 'gt-vue';
+        export const View = () => (
+          <T><Branch v-slots={{ formal: () => <T>Nested</T> }} /></T>
+        );
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors).toHaveLength(1);
+    expect(output.errors[0]).toContain('nested gt-vue <T>');
+  });
+
+  it.each([
+    {
+      name: 'dynamic context',
+      source: `<T context={route.name}>Hello</T>`,
+      diagnostic: 'dynamic context',
+    },
+    {
+      name: 'conditional context',
+      source: `<T context={true ? 'one' : 'two'}>Hello</T>`,
+      diagnostic: 'conditional context',
+    },
+    {
+      name: 'spread T props',
+      source: `<T {...props}>Hello</T>`,
+      diagnostic: 'spread prop',
+    },
+    {
+      name: 'internal hash override',
+      source: `<T _hash="wrong">Hello</T>`,
+      diagnostic: 'unsupported prop "_hash"',
+    },
+    {
+      name: 'dynamic child',
+      source: `<T>Hello {name}</T>`,
+      diagnostic: 'dynamic JSX content',
+    },
+    {
+      name: 'conditional child',
+      source: `<T>{enabled && <strong>Hello</strong>}</T>`,
+      diagnostic: 'conditional JSX content',
+    },
+    {
+      name: 'custom JSX pragma',
+      source: `<T>{/* @jsx customVNode */}Hello</T>`,
+      diagnostic: 'custom @jsx pragma',
+    },
+    {
+      name: 'duplicate content prop',
+      source: `<T><span title="first" title="second">Hello</span></T>`,
+      diagnostic: 'duplicate translatable prop "title"',
+    },
+    {
+      name: 'missing formatter value',
+      source: `<T><Num /></T>`,
+      diagnostic: 'without a value prop',
+    },
+    {
+      name: 'formatter children',
+      source: `<T><DateTime value={date}>{date}</DateTime></T>`,
+      diagnostic: 'children on a gt-vue <DateTime>',
+    },
+    {
+      name: 'Var value prop',
+      source: `<T><Var value={name} /></T>`,
+      diagnostic: 'unsupported value prop',
+    },
+    {
+      name: 'unbound custom element',
+      source: `<T><custom-element>Unknown mode</custom-element></T>`,
+      diagnostic: 'component or custom element',
+    },
+    {
+      name: 'mixed element and component tag',
+      source: `<T><MixedTag>Unknown shape</MixedTag></T>`,
+      setup: `const Card = () => null; const MixedTag = enabled ? 'div' : Card;`,
+      diagnostic: 'renders an element or component',
+    },
+    {
+      name: 'unknown dynamic tag factory',
+      source: `<T><DynamicTag>Unknown shape</DynamicTag></T>`,
+      setup: `const DynamicTag = getTag();`,
+      diagnostic: 'renders an element or component',
+    },
+    {
+      name: 'scoped branch slot',
+      source: `<T><Branch v-slots={{ formal: (props) => <b>{props.label}</b> }} /></T>`,
+      diagnostic: 'dynamic or scoped JSX slot',
+    },
+    {
+      name: 'dynamic slots object',
+      source: `<T><Branch v-slots={getSlots()} /></T>`,
+      diagnostic: 'dynamic v-slots',
+    },
+    {
+      name: 'duplicate branch prop',
+      source: `<T><Branch formal="First" formal="Second" /></T>`,
+      diagnostic: 'duplicate branch prop "formal"',
+    },
+    {
+      name: 'missing plural selector',
+      source: `<T><Plural v-slots={{ other: () => 'Many' }} /></T>`,
+      diagnostic: 'without an n prop',
+    },
+    {
+      name: 'compiler-dependent object slots',
+      source: `<T><Branch>{{ formal: () => 'Formal' }}</Branch></T>`,
+      diagnostic: 'object-slot child syntax',
+    },
+    {
+      name: 'source-shaping Vue JSX directive',
+      source: `<T><div v-html={html} /></T>`,
+      diagnostic: 'Vue JSX directive "v-html"',
+    },
+    {
+      name: 'multi-root Suspense children',
+      source: `<T><Suspense><span>One</span><span>Two</span></Suspense></T>`,
+      diagnostic: 'invalid default root inside Vue <Suspense>',
+    },
+    {
+      name: 'scoped Suspense default slot',
+      source: `<T><Suspense>{(props) => <span>{props.label}</span>}</Suspense></T>`,
+      diagnostic: 'dynamic or scoped default slot on Vue <Suspense>',
+    },
+    {
+      name: 'dynamic Suspense slots',
+      source: `<T><Suspense v-slots={getSlots()} /></T>`,
+      diagnostic: 'dynamic v-slots',
+    },
+    {
+      name: 'unsupported Suspense named slot',
+      source: `<T><Suspense v-slots={{ pending: () => <span>Pending</span> }} /></T>`,
+      diagnostic: 'unsupported named slot "pending"',
+    },
+    {
+      name: 'ambiguous Suspense child',
+      source: `<T><Suspense>{child}</Suspense></T>`,
+      diagnostic: 'Could not statically prove the default root',
+    },
+    {
+      name: 'invalid Suspense slot array',
+      source: `<T><Suspense v-slots={{ default: () => [<span>One</span>, 'Two'] }} /></T>`,
+      diagnostic: 'invalid default root inside Vue <Suspense>',
+    },
+  ])('fails closed for $name', async ({ source, setup = '', diagnostic }) => {
+    const output = await extractFromVueSource(
+      `
+        import { Suspense } from 'vue';
+        import { Branch, DateTime, Num, Plural, T, Var } from 'gt-vue';
+        ${setup}
+        export const View = () => (${source});
+      `,
+      '/project/src/View.tsx'
+    );
+
+    expect(output.results).toEqual([]);
+    expect(output.errors.join('\n')).toContain(diagnostic);
+  });
+});

--- a/packages/vue-extractor/src/internal/__tests__/workspaceInspectionAsync.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/workspaceInspectionAsync.test.ts
@@ -1,0 +1,131 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  inspectVueProject,
+  inspectVueProjectAsync,
+} from '../project/inspectVueProject.js';
+import { readJavaScriptPackageManifest } from '../project/manifest.js';
+import { extractFromVueProject } from '../project/extractFromVueProject.js';
+import {
+  createWorkspaceDiscoveryCache,
+  readDeclaredWorkspacePackages,
+  readDeclaredWorkspacePackagesAsync,
+} from '../project/workspaces.js';
+import {
+  createProjectFixture,
+  linkInstalledVue,
+  removeProjectFixture,
+  translatableSfc,
+} from './projectTestUtils.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    removeProjectFixture(directory);
+  }
+});
+
+describe('asynchronous Vue workspace inspection', () => {
+  it('matches synchronous discovery without synchronously reading child manifests', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['stale/*'],
+      }),
+      'pnpm-workspace.yaml': `packages:
+  - 'apps/*'
+  - '!apps/excluded'
+`,
+      'apps/vue/package.json': JSON.stringify({
+        name: 'vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'apps/ordinary/package.json': JSON.stringify({
+        name: 'ordinary-app',
+        dependencies: { 'gt-react': '*' },
+      }),
+      'apps/excluded/package.json': JSON.stringify({
+        name: 'excluded-vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'apps/invalid/package.json': '{invalid',
+    });
+    const rootManifest = readJavaScriptPackageManifest(
+      path.join(root, 'package.json')
+    );
+    expect(rootManifest).toBeDefined();
+    const synchronous = readDeclaredWorkspacePackages(
+      root,
+      rootManifest!,
+      createWorkspaceDiscoveryCache()
+    );
+    const readFileSync = vi.spyOn(fs, 'readFileSync');
+
+    const asynchronous = await readDeclaredWorkspacePackagesAsync(
+      root,
+      rootManifest!,
+      createWorkspaceDiscoveryCache()
+    );
+
+    expect(normalizeWorkspacePackages(root, asynchronous)).toEqual(
+      normalizeWorkspacePackages(root, synchronous)
+    );
+    const synchronousChildManifestReads = readFileSync.mock.calls.filter(
+      ([file]) =>
+        typeof file === 'string' &&
+        file.startsWith(path.join(root, 'apps') + path.sep) &&
+        path.basename(file) === 'package.json'
+    );
+    expect(synchronousChildManifestReads).toEqual([]);
+  });
+
+  it('produces the same reusable extraction plan as synchronous inspection', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['apps/*'],
+      }),
+      'apps/vue/package.json': JSON.stringify({
+        name: 'vue-app',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'apps/vue/src/App.vue': translatableSfc(
+        'Asynchronously discovered message'
+      ),
+    });
+    linkInstalledVue(root);
+
+    const asynchronous = await inspectVueProjectAsync(root);
+
+    expect(asynchronous).toEqual(inspectVueProject(root));
+    const output = await extractFromVueProject({
+      cwd: root,
+      inspection: asynchronous,
+    });
+    expect(output.errors).toEqual([]);
+    expect(output.updates.map(({ source }) => source)).toEqual([
+      'Asynchronously discovered message',
+    ]);
+  });
+});
+
+function createFixture(files: Record<string, string>): string {
+  const root = createProjectFixture(files);
+  temporaryDirectories.push(root);
+  return root;
+}
+
+function normalizeWorkspacePackages(
+  root: string,
+  packages: ReturnType<typeof readDeclaredWorkspacePackages>
+) {
+  return packages.map(({ directory, manifest }) => ({
+    directory: path.relative(root, directory),
+    manifest,
+  }));
+}

--- a/packages/vue-extractor/src/internal/__tests__/workspaceInspectionAsync.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/workspaceInspectionAsync.test.ts
@@ -112,12 +112,244 @@ describe('asynchronous Vue workspace inspection', () => {
       'Asynchronously discovered message',
     ]);
   });
+
+  it('rejects symlink escapes in static and dynamic workspace paths', async () => {
+    const outside = createFixture({
+      'static/vue/package.json': JSON.stringify({
+        name: 'outside-static-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'dynamic/package.json': JSON.stringify({
+        name: 'outside-dynamic-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['linked/*', 'packages/*'],
+      }),
+      'packages/local/package.json': JSON.stringify({
+        name: 'local-react-package',
+        dependencies: { 'gt-react': '*' },
+      }),
+    });
+    fs.symlinkSync(
+      path.join(outside, 'static'),
+      path.join(root, 'linked'),
+      'dir'
+    );
+    fs.symlinkSync(
+      path.join(outside, 'dynamic'),
+      path.join(root, 'packages/escaped'),
+      'dir'
+    );
+    const rootManifest = readJavaScriptPackageManifest(
+      path.join(root, 'package.json')
+    );
+    expect(rootManifest).toBeDefined();
+
+    const synchronous = readDeclaredWorkspacePackages(
+      root,
+      rootManifest!,
+      createWorkspaceDiscoveryCache()
+    );
+    const asynchronous = await readDeclaredWorkspacePackagesAsync(
+      root,
+      rootManifest!,
+      createWorkspaceDiscoveryCache()
+    );
+
+    expect(normalizeWorkspacePackages(root, synchronous)).toEqual([
+      {
+        directory: 'packages/local',
+        manifest: {
+          name: 'local-react-package',
+          dependencies: { 'gt-react': '*' },
+        },
+      },
+    ]);
+    expect(normalizeWorkspacePackages(root, asynchronous)).toEqual(
+      normalizeWorkspacePackages(root, synchronous)
+    );
+  });
+
+  it('retains physical containment for every glob fallback match', async () => {
+    const outside = createFixture({
+      'x/package.json': JSON.stringify({
+        name: 'outside-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['link-out/x', '.'],
+      }),
+    });
+    fs.symlinkSync(outside, path.join(root, 'link-out'), 'dir');
+
+    expect(readWorkspacePackagesSync(root)).toEqual([]);
+    expect(await readWorkspacePackages(root)).toEqual([]);
+  });
+
+  it('rejects a shallow base redirected into node_modules', async () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['alias/*'],
+      }),
+      'node_modules/bad/package.json': JSON.stringify({
+        name: 'installed-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    fs.symlinkSync(path.join(root, 'node_modules'), path.join(root, 'alias'));
+
+    expect(readWorkspacePackagesSync(root)).toEqual([]);
+    expect(await readWorkspacePackages(root)).toEqual([]);
+  });
+
+  it('matches the glob fallback for bounded shallow workspace patterns', async () => {
+    const outside = createFixture({
+      'manifest.json': JSON.stringify({
+        name: 'outside-manifest-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'directory/package.json': JSON.stringify({
+        name: 'outside-directory-vue',
+        dependencies: { 'gt-vue': '*' },
+      }),
+    });
+    const optimizedRoot = createShallowWorkspaceFixture(outside, false);
+    const fallbackRoot = createShallowWorkspaceFixture(outside, true);
+
+    const optimized = await readWorkspacePackages(optimizedRoot);
+    const fallback = await readWorkspacePackages(fallbackRoot);
+
+    expect(normalizeWorkspacePackages(optimizedRoot, optimized)).toEqual([
+      {
+        directory: 'apps/valid',
+        manifest: { name: 'valid-app' },
+      },
+      {
+        directory: 'packages/valid',
+        manifest: { name: 'valid-package' },
+      },
+    ]);
+    expect(normalizeWorkspacePackages(fallbackRoot, fallback)).toEqual(
+      normalizeWorkspacePackages(optimizedRoot, optimized)
+    );
+  });
+
+  it('resolves shallow workspace bases instead of every child manifest', async () => {
+    const packageCount = 128;
+    const files: Record<string, string> = {
+      'package.json': JSON.stringify({
+        name: 'workspace-root',
+        private: true,
+        workspaces: ['packages/*'],
+      }),
+    };
+    for (let index = 0; index < packageCount; index += 1) {
+      files[`packages/package-${index}/package.json`] = JSON.stringify({
+        name: `react-package-${index}`,
+        dependencies: { 'gt-react': '*' },
+      });
+    }
+    const root = createFixture(files);
+    const rootManifest = readJavaScriptPackageManifest(
+      path.join(root, 'package.json')
+    );
+    expect(rootManifest).toBeDefined();
+    const realpath = vi.spyOn(fs.promises, 'realpath');
+
+    const packages = await readDeclaredWorkspacePackagesAsync(
+      root,
+      rootManifest!,
+      createWorkspaceDiscoveryCache()
+    );
+
+    expect(packages).toHaveLength(packageCount);
+    expect(
+      realpath.mock.calls.filter(
+        ([file]) =>
+          typeof file === 'string' && path.basename(file) === 'package.json'
+      )
+    ).toEqual([]);
+    expect(realpath).toHaveBeenCalledTimes(2);
+  });
 });
 
 function createFixture(files: Record<string, string>): string {
   const root = createProjectFixture(files);
   temporaryDirectories.push(root);
   return root;
+}
+
+function createShallowWorkspaceFixture(
+  outside: string,
+  forceGlobFallback: boolean
+): string {
+  const patterns = ['packages/*', 'apps/*', 'missing/*'];
+  const root = createFixture({
+    'package.json': JSON.stringify({
+      name: 'workspace-root',
+      private: true,
+      workspaces: patterns,
+    }),
+    ...(forceGlobFallback
+      ? {
+          'pnpm-workspace.yaml': `packages:\n${patterns
+            .map((pattern) => `  - '${pattern}'`)
+            .join('\n')}\n  - '!packages/not-present'\n`,
+        }
+      : {}),
+    'apps/valid/package.json': JSON.stringify({ name: 'valid-app' }),
+    'packages/valid/package.json': JSON.stringify({ name: 'valid-package' }),
+    'packages/.hidden/package.json': JSON.stringify({ name: 'hidden-vue' }),
+    'packages/malformed/package.json': '{invalid',
+    'packages/missing/README.md': 'No manifest',
+    'packages/symlink-manifest/README.md': 'Linked manifest',
+  });
+  fs.symlinkSync(
+    path.join(outside, 'manifest.json'),
+    path.join(root, 'packages/symlink-manifest/package.json'),
+    'file'
+  );
+  fs.symlinkSync(
+    path.join(outside, 'directory'),
+    path.join(root, 'packages/symlink-directory'),
+    'dir'
+  );
+  return root;
+}
+
+async function readWorkspacePackages(root: string) {
+  const manifest = readJavaScriptPackageManifest(
+    path.join(root, 'package.json')
+  );
+  expect(manifest).toBeDefined();
+  return readDeclaredWorkspacePackagesAsync(
+    root,
+    manifest!,
+    createWorkspaceDiscoveryCache()
+  );
+}
+
+function readWorkspacePackagesSync(root: string) {
+  const manifest = readJavaScriptPackageManifest(
+    path.join(root, 'package.json')
+  );
+  expect(manifest).toBeDefined();
+  return readDeclaredWorkspacePackages(
+    root,
+    manifest!,
+    createWorkspaceDiscoveryCache()
+  );
 }
 
 function normalizeWorkspacePackages(

--- a/packages/vue-extractor/src/internal/__tests__/wrapperProvenance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/wrapperProvenance.test.ts
@@ -50,6 +50,246 @@ describe('local Vue wrapper provenance', () => {
     }
   );
 
+  it('follows an immutable local alias exported under a wrapper name', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/derived-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': `
+        import { T } from 'gt-vue';
+        export const WrapperT = T;
+      `,
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it.each([
+    "import { T } from 'gt-vue'; export default T;",
+    "import { T } from 'gt-vue'; const Alias = T; export default Alias;",
+    "import { T } from 'gt-vue'; const Alias = T; export { Alias as default };",
+  ])('follows a default alias: %s', (source) => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/default-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': source,
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it.each([
+    `
+      import { T } from 'gt-vue';
+      import { h } from 'vue';
+      export const WrapperT = (props) => h(T, props);
+    `,
+    `
+      import { T } from 'gt-vue';
+      import { defineComponent, h } from 'vue';
+      export const WrapperT = defineComponent({
+        setup(props) {
+          return () => h(T, props);
+        },
+      });
+    `,
+    `
+      import { T } from 'gt-vue';
+      export const WrapperT = (props) => <T>{props.children}</T>;
+    `,
+    `
+      import * as GT from 'gt-vue';
+      export const WrapperT = (props) => <GT.T>{props.children}</GT.T>;
+    `,
+  ])('recognizes a public wrapper component: %s', (source) => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/component-wrapper',
+        exports: './src/index.tsx',
+      }),
+      'src/index.tsx': source,
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it.each([
+    `
+      import { T } from 'gt-vue';
+      import * as Vue from 'vue';
+      export const WrapperT = (props) => Vue.h(T, props);
+    `,
+    `
+      import { T } from 'gt-vue';
+      import * as Vue from 'vue';
+      export const WrapperT = (props) => Vue.createVNode(T, props);
+    `,
+    `
+      import { T } from 'gt-vue';
+      import * as Vue from 'vue';
+      export const WrapperT = Vue.defineComponent({
+        setup(props) {
+          return () => Vue.h(T, props);
+        },
+      });
+    `,
+  ])('recognizes a namespace-imported Vue helper: %s', (source) => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/vue-namespace-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': source,
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it('follows an exact leaf destructured from an imported GT namespace', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/destructured-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': `
+        import * as GT from 'gt-vue';
+        const { T: WrapperT } = GT;
+        export { WrapperT };
+      `,
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it.each(['gt-react', 'gt-next', 'gt-react-native', 'gt-tanstack-start'])(
+    'does not treat the %s namespace as gt-vue wrapper provenance',
+    (runtime) => {
+      const root = createPackage({
+        'package.json': JSON.stringify({
+          name: '@fixture/react-family-wrapper',
+          exports: './src/index.tsx',
+        }),
+        'src/index.tsx': `
+          import * as GT from '${runtime}';
+          export const WrapperT = () => <GT.T>React wrapper</GT.T>;
+        `,
+      });
+
+      expect(exposesGT(root)).toBe(false);
+    }
+  );
+
+  it.each([
+    `
+      import { T } from 'gt-vue';
+      export const ordinary = (T) => T;
+    `,
+    `
+      import { T } from 'gt-vue';
+      export const ordinary = () => {
+        void T;
+        return 'ordinary';
+      };
+    `,
+    `
+      import { T } from 'gt-vue';
+      let Alias = T;
+      Alias = String;
+      export { Alias };
+    `,
+    `
+      import { T } from 'gt-vue';
+      export const ordinary = unknownFactory(T);
+    `,
+    `
+      import * as GT from 'gt-vue';
+      export const WrapperT = (GT) => <GT.T>Shadowed wrapper</GT.T>;
+    `,
+    `
+      import * as GT from 'gt-vue';
+      const { ...Rest } = GT;
+      export const WrapperT = Rest.T;
+    `,
+    `
+      import * as GT from 'gt-vue';
+      const key = 'T';
+      const { [key]: WrapperT } = GT;
+      export { WrapperT };
+    `,
+    `
+      import * as GT from 'gt-vue';
+      let { T: WrapperT } = GT;
+      WrapperT = String;
+      export { WrapperT };
+    `,
+    `
+      import * as GT from 'gt-vue';
+      GT.T = String;
+      const { T: WrapperT } = GT;
+      export { WrapperT };
+    `,
+    `
+      import * as GT from 'gt-react';
+      const { T: WrapperT } = GT;
+      export { WrapperT };
+    `,
+    `
+      import { T } from 'gt-vue';
+      import * as Vue from 'vue';
+      Vue.h = unknownFactory;
+      export const WrapperT = () => Vue.h(T);
+    `,
+    `
+      import { T } from 'gt-vue';
+      import * as Vue from 'react';
+      export const WrapperT = () => Vue.h(T);
+    `,
+  ])(
+    'does not infer wrapper provenance from an unsafe derivation: %s',
+    (source) => {
+      const root = createPackage({
+        'package.json': JSON.stringify({
+          name: '@fixture/unsafe-wrapper',
+          exports: './src/index.tsx',
+        }),
+        'src/index.tsx': source,
+      });
+
+      expect(exposesGT(root)).toBe(false);
+    }
+  );
+
+  it.each([
+    "export * as Components from 'gt-vue';",
+    "import * as GT from 'gt-vue'; export const Components = GT;",
+  ])('does not promote a namespace container to a GT leaf: %s', (source) => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/namespace-container',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': source,
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('retains an exact primitive selected from a namespace', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/namespace-leaf',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts':
+        "import * as GT from 'gt-vue'; export const WrapperT = GT.T;",
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
   it('rejects nonexistent gt-vue value exports', () => {
     const root = createPackage({
       'package.json': JSON.stringify({

--- a/packages/vue-extractor/src/internal/__tests__/wrapperProvenance.test.ts
+++ b/packages/vue-extractor/src/internal/__tests__/wrapperProvenance.test.ts
@@ -1,0 +1,285 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { readJavaScriptPackageManifest } from '../project/manifest.js';
+import { packagePubliclyExposesGT } from '../project/wrapperProvenance.js';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe('local Vue wrapper provenance', () => {
+  it('follows an import-only exact public subpath through local barrels', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/wrapper',
+        exports: {
+          '.': { import: './src/ordinary.ts' },
+          './gt': {
+            require: './src/ordinary.cjs',
+            import: './src/gt.ts',
+          },
+        },
+      }),
+      'src/ordinary.ts': "export const ordinary = 'ordinary';\n",
+      'src/ordinary.cjs': "module.exports = require('gt-vue');\n",
+      'src/gt.ts': "export { LocalT } from './barrel';\n",
+      'src/barrel.ts': "export { T as LocalT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it.each(['createGT', 'useLocale', 'useSetLocale'])(
+    'recognizes the non-extraction runtime export %s',
+    (exportName) => {
+      const root = createPackage({
+        'package.json': JSON.stringify({
+          name: '@fixture/runtime-wrapper',
+          exports: './src/index.ts',
+        }),
+        'src/index.ts': `export { ${exportName} } from 'gt-vue';\n`,
+      });
+
+      expect(exposesGT(root)).toBe(true);
+    }
+  );
+
+  it('rejects nonexistent gt-vue value exports', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/invalid-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': "export { NotActuallyExported } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('expands conditional wildcard exports through the import branch', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/wildcard-wrapper',
+        exports: {
+          './*': {
+            require: './cjs/*.cjs',
+            import: './src/*.ts',
+          },
+        },
+      }),
+      'cjs/runtime.cjs': "module.exports = require('ordinary');\n",
+      'src/runtime.ts': "export { createGT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it('maps repeated wildcard captures to the same public subpath', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/repeated-wildcard',
+        exports: { './pair/*': './src/*/copy-*.ts' },
+      }),
+      'src/runtime/copy-runtime.ts': "export { useLocale } from 'gt-vue';\n",
+      'src/runtime/copy-other.ts': "export const ordinary = 'ordinary';\n",
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it('maps emitted wildcard JavaScript targets to TypeScript source', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/source-wildcard',
+        exports: { './*': './dist/*.js' },
+      }),
+      'dist/runtime.ts': "export { useSetLocale } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(true);
+  });
+
+  it('does not use an inactive wildcard require branch as provenance', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/conditional-wildcard',
+        exports: {
+          './*': {
+            import: './src/*.ts',
+            require: './cjs/*.js',
+          },
+        },
+      }),
+      'src/runtime.ts': "export const ordinary = 'ordinary';\n",
+      'cjs/runtime.js': "export { createGT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('honors an exact export that shadows a wildcard target', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/shadowed-wildcard',
+        exports: {
+          './secret': './src/ordinary.ts',
+          './*': './src/*.ts',
+        },
+      }),
+      'src/ordinary.ts': "export const ordinary = 'ordinary';\n",
+      'src/secret.ts': "export { createGT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('ignores private and out-of-package wildcard targets', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/contained-wildcard',
+        exports: {
+          './public/*': './src/public/*.ts',
+          './escape/*': '../outside/*.ts',
+        },
+      }),
+      'src/public/ordinary.ts': "export const ordinary = 'ordinary';\n",
+      'src/private.ts': "export { createGT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('ignores malformed wildcard targets', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/malformed-wildcard',
+        exports: { './*': [null, 42, 'src/*.ts'] },
+      }),
+      'src/runtime.ts': "export { createGT } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('does not follow wildcard targets through a symlink outside the package', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/symlink-wildcard',
+        exports: { './*': './src/*.ts' },
+      }),
+    });
+    const outside = createPackage({
+      'index.ts': "export { createGT } from 'gt-vue';\n",
+    });
+    fs.mkdirSync(path.join(root, 'src'), { recursive: true });
+    fs.symlinkSync(outside, path.join(root, 'src/escape'), 'dir');
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('fails closed after the finite wildcard file budget is exhausted', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/oversized-wildcard',
+        exports: { './*': './src/*.ts' },
+      }),
+    });
+    const sourceDirectory = path.join(root, 'src');
+    fs.mkdirSync(sourceDirectory, { recursive: true });
+    for (let index = 0; index <= 2_000; index += 1) {
+      fs.writeFileSync(
+        path.join(sourceDirectory, `${index}.ts`),
+        index === 2_000
+          ? "export { createGT } from 'gt-vue';\n"
+          : "export const ordinary = 'ordinary';\n"
+      );
+    }
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('does not treat internal gt-vue use as a public wrapper API', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/ordinary',
+        exports: { '.': { import: './src/index.ts' } },
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'src/index.ts': `
+        import { T } from 'gt-vue';
+        void T;
+        export const ordinary = 'ordinary';
+      `,
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('uses the import condition rather than a GT require branch', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/conditional',
+        exports: {
+          '.': {
+            import: './src/ordinary.ts',
+            require: './src/gt.js',
+          },
+        },
+      }),
+      'src/ordinary.ts': "export const ordinary = 'ordinary';\n",
+      'src/gt.js': "export { T } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('fails closed when the public entrypoint is malformed', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/malformed',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts': "export { T } from 'gt-vue'; const broken = @;\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+
+  it('does not treat a type-only gt-vue reexport as runtime provenance', () => {
+    const root = createPackage({
+      'package.json': JSON.stringify({
+        name: '@fixture/type-wrapper',
+        exports: './src/index.ts',
+      }),
+      'src/index.ts':
+        "export type { CreateGTOptions, GTPlugin } from 'gt-vue';\n",
+    });
+
+    expect(exposesGT(root)).toBe(false);
+  });
+});
+
+function exposesGT(root: string): boolean {
+  const manifest = readJavaScriptPackageManifest(
+    path.join(root, 'package.json')
+  );
+  if (!manifest) throw new Error('Expected a valid fixture manifest');
+  return packagePubliclyExposesGT(root, manifest);
+}
+
+function createPackage(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-vue-wrapper-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, source] of Object.entries(files)) {
+    const file = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, source);
+  }
+  return root;
+}

--- a/packages/vue-extractor/src/internal/compilerAst.ts
+++ b/packages/vue-extractor/src/internal/compilerAst.ts
@@ -1,0 +1,119 @@
+/**
+ * Vue compiler node discriminants used by the extractor.
+ *
+ * These values are defined locally so the production bundle can inspect the
+ * compiler-sfc AST without importing a second runtime copy of compiler-dom.
+ * The matching test intentionally compares them with the installed compiler.
+ */
+export const NodeTypes = {
+  ELEMENT: 1,
+  TEXT: 2,
+  COMMENT: 3,
+  SIMPLE_EXPRESSION: 4,
+  INTERPOLATION: 5,
+  ATTRIBUTE: 6,
+  DIRECTIVE: 7,
+} as const;
+
+/** Vue element discriminants used by the extractor. */
+export const ElementTypes = {
+  COMPONENT: 1,
+  SLOT: 2,
+} as const;
+
+type CompilerPosition = {
+  column: number;
+  line: number;
+  offset: number;
+};
+
+type CompilerLocation = {
+  end?: Partial<CompilerPosition>;
+  source?: string;
+  start?: Partial<CompilerPosition>;
+};
+
+/**
+ * Rebases a compiler AST from template-content coordinates to its full SFC.
+ *
+ * The input is intentionally `unknown`: Vue compiler AST types are not part
+ * of the extractor's public declaration graph and differ across supported
+ * Vue releases. Runtime structural guards preserve safety at this internal
+ * boundary without making consumers install the extractor's test compiler.
+ */
+export function shiftCompilerAstLocations(
+  ast: unknown,
+  origin: CompilerPosition
+): void {
+  const seen = new WeakSet<object>();
+  const shiftedPositions = new WeakSet<object>();
+
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== 'object' || seen.has(value)) return;
+    seen.add(value);
+
+    if (isCompilerLocation(value)) {
+      shiftCompilerLocation(value, origin, shiftedPositions);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) visit(child);
+      return;
+    }
+    for (const child of Object.values(value)) visit(child);
+  };
+
+  visit(ast);
+}
+
+/** Rebases one structurally validated Vue compiler source range. */
+export function shiftCompilerLocation(
+  location: CompilerLocation,
+  origin: CompilerPosition,
+  shiftedPositions = new WeakSet<object>()
+): void {
+  if (location.start) {
+    shiftCompilerPosition(location.start, origin, shiftedPositions);
+  }
+  if (location.end) {
+    shiftCompilerPosition(location.end, origin, shiftedPositions);
+  }
+}
+
+/** Rebases a template-relative position to the containing SFC. */
+function shiftCompilerPosition(
+  position: Partial<CompilerPosition>,
+  origin: CompilerPosition,
+  shiftedPositions: WeakSet<object>
+): void {
+  if (shiftedPositions.has(position)) return;
+  shiftedPositions.add(position);
+  const line = position.line ?? 1;
+  const column = position.column ?? 1;
+  const offset = position.offset ?? 0;
+  position.line = origin.line + line - 1;
+  position.column = line === 1 ? origin.column + column - 1 : column;
+  position.offset = origin.offset + offset;
+}
+
+/** Identifies Vue compiler source locations while skipping Babel AST ranges. */
+function isCompilerLocation(value: object): value is CompilerLocation {
+  if (!('start' in value) || !('end' in value) || !('source' in value)) {
+    return false;
+  }
+  return isCompilerPosition(value.start) && isCompilerPosition(value.end);
+}
+
+/** Returns whether a value has Vue compiler line, column, and offset fields. */
+function isCompilerPosition(value: unknown): value is CompilerPosition {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'line' in value &&
+    typeof value.line === 'number' &&
+    'column' in value &&
+    typeof value.column === 'number' &&
+    'offset' in value &&
+    typeof value.offset === 'number'
+  );
+}

--- a/packages/vue-extractor/src/internal/config/configFiles.ts
+++ b/packages/vue-extractor/src/internal/config/configFiles.ts
@@ -1,0 +1,31 @@
+/** Vite's standard config filenames in lookup precedence order. */
+export const VITE_CONFIG_FILES = [
+  'vite.config.js',
+  'vite.config.mjs',
+  'vite.config.ts',
+  'vite.config.cjs',
+  'vite.config.mts',
+  'vite.config.cts',
+] as const;
+
+/** Nuxt's standard config filenames in lookup precedence order. */
+export const NUXT_CONFIG_FILES = [
+  'nuxt.config.js',
+  'nuxt.config.ts',
+  'nuxt.config.mjs',
+  'nuxt.config.cjs',
+  'nuxt.config.mts',
+  'nuxt.config.cts',
+] as const;
+
+/** JavaScript and TypeScript extensions accepted for an explicit Vite config. */
+export const VITE_CONFIG_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+]);

--- a/packages/vue-extractor/src/internal/config/resolveVueCompilerOptions.ts
+++ b/packages/vue-extractor/src/internal/config/resolveVueCompilerOptions.ts
@@ -1,0 +1,2188 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse, type ParserPlugin } from '@babel/parser';
+import traverseModule, {
+  type Binding,
+  type NodePath,
+  type Scope,
+} from '@babel/traverse';
+import type * as t from '@babel/types';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import type { VueCompilerOptions } from '../../types.js';
+import {
+  NUXT_CONFIG_FILES,
+  VITE_CONFIG_EXTENSIONS,
+  VITE_CONFIG_FILES,
+} from './configFiles.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+type CompilerOptionName = keyof VueCompilerOptions;
+
+type OptionSource = {
+  file: string;
+  node?: t.Node;
+};
+
+type CompilerOptionState = {
+  options: VueCompilerOptions;
+  sources: Partial<Record<CompilerOptionName, OptionSource>>;
+};
+
+type ObjectEntry = {
+  node: t.Node;
+  scope: Scope;
+};
+
+type StaticObject = {
+  entries: Map<string, ObjectEntry>;
+};
+
+type ObjectResolution =
+  | { ok: true; value: StaticObject }
+  | { ok: false; node: t.Node };
+
+type ActiveConfigResolution =
+  | { ok: true; value: ObjectEntry }
+  | { ok: false; node: t.Node };
+
+type ConfigHelperResolution = 'dynamic' | 'static' | undefined;
+
+type ScopedPluginCall = {
+  node: t.CallExpression | t.OptionalCallExpression;
+  scope: Scope;
+};
+
+type VitePluginContext = {
+  moduleSource: '@vitejs/plugin-vue' | '@vitejs/plugin-vue-jsx';
+  namespaceBindings: Set<Binding>;
+  pluginBindings: Set<Binding>;
+  referencePositions: number[];
+};
+
+/** Result of resolving hash-affecting options from project configuration. */
+export type VueCompilerOptionsResolution = {
+  /** Static compiler options that must be passed to Vue source extraction. */
+  compilerOptions: VueCompilerOptions;
+  /** Diagnostics that make extraction unsafe until the configuration is fixed. */
+  errors: string[];
+};
+
+/** Controls project configuration discovery for compiler-option resolution. */
+export type VueCompilerOptionsResolverOptions = {
+  /** A single explicit Vite config path, resolved relative to the project root. */
+  viteConfigPath?: string;
+  /**
+   * Whether caller-supplied source globs already cover custom Nuxt layouts.
+   * This relaxes only layout validation; discovered config remains mandatory
+   * to read and parse successfully.
+   */
+  sourceDiscoveryIsExplicit?: boolean;
+};
+
+/**
+ * Resolves hash-affecting Vue template compiler options without executing
+ * project configuration files.
+ *
+ * Explicit `gt.config.json` values are combined with statically analyzable
+ * Vite and Nuxt configuration. Conflicting, dynamic, or unsupported relevant
+ * options produce errors so extraction never publishes hashes calculated with
+ * compiler behavior that the runtime does not share.
+ */
+export function resolveVueCompilerOptions(
+  cwd: string,
+  explicitOptions: VueCompilerOptions | undefined,
+  resolverOptions: VueCompilerOptionsResolverOptions = {}
+): VueCompilerOptionsResolution {
+  const state: CompilerOptionState = { options: {}, sources: {} };
+  const errors: string[] = [];
+
+  readExplicitOptions(explicitOptions, state, errors);
+
+  if (resolverOptions.viteConfigPath !== undefined) {
+    const file = resolveCustomViteConfig(
+      cwd,
+      resolverOptions.viteConfigPath,
+      errors
+    );
+    if (file) readViteConfig(file, state, errors, true);
+    return { compilerOptions: state.options, errors };
+  }
+
+  const nuxtConfig = findFirstConfig(cwd, NUXT_CONFIG_FILES, errors);
+  const viteConfig = findFirstConfig(cwd, VITE_CONFIG_FILES, errors);
+  if (nuxtConfig && viteConfig) {
+    errors.push(
+      optionError(
+        'Found both Nuxt and Vite project config files',
+        'For direct Vite builds, set files.gt.parsingFlags.viteConfigPath to the active Vite config. For Nuxt builds, remove or relocate the inactive Vite config so the compiler configuration is unambiguous'
+      )
+    );
+    return { compilerOptions: state.options, errors };
+  }
+  if (nuxtConfig) {
+    readNuxtConfig(
+      nuxtConfig,
+      state,
+      errors,
+      resolverOptions.sourceDiscoveryIsExplicit ?? false
+    );
+    return { compilerOptions: state.options, errors };
+  }
+
+  if (viteConfig) {
+    readViteConfig(
+      viteConfig,
+      state,
+      errors,
+      resolverOptions.sourceDiscoveryIsExplicit ?? false
+    );
+  }
+
+  return { compilerOptions: state.options, errors };
+}
+
+/** Selects the first config file in the framework's documented lookup order. */
+function findFirstConfig(
+  cwd: string,
+  filenames: readonly string[],
+  errors: string[]
+): string | undefined {
+  for (const filename of filenames) {
+    const resolution = inspectConfigFile(
+      path.resolve(cwd),
+      path.resolve(cwd, filename),
+      false,
+      errors
+    );
+    if (resolution.kind === 'file') return resolution.file;
+    if (resolution.kind === 'invalid') return undefined;
+  }
+  return undefined;
+}
+
+/** Validates an explicit Vite config without searching or executing files. */
+function resolveCustomViteConfig(
+  cwd: string,
+  configuredPath: unknown,
+  errors: string[]
+): string | undefined {
+  if (typeof configuredPath !== 'string' || !configuredPath.trim()) {
+    errors.push(
+      optionError(
+        'Found an empty Vite config path',
+        'Set files.gt.parsingFlags.viteConfigPath to one in-project Vite config file'
+      )
+    );
+    return undefined;
+  }
+  const root = path.resolve(cwd);
+  const candidate = path.resolve(root, configuredPath);
+  const relativeCandidate = path.relative(root, candidate);
+  if (
+    relativeCandidate.startsWith(`..${path.sep}`) ||
+    relativeCandidate === '..' ||
+    path.isAbsolute(relativeCandidate) ||
+    relativeCandidate.split(path.sep).includes('node_modules')
+  ) {
+    errors.push(
+      optionError(
+        'Found a Vite config path outside the project source boundary',
+        'Choose a Vite config file inside the project root and outside node_modules'
+      )
+    );
+    return undefined;
+  }
+  if (!VITE_CONFIG_EXTENSIONS.has(path.extname(candidate).toLowerCase())) {
+    errors.push(
+      optionError(
+        'Found an unsupported Vite config file extension',
+        'Use a JavaScript or TypeScript Vite config file'
+      )
+    );
+    return undefined;
+  }
+  const resolution = inspectConfigFile(root, candidate, true, errors);
+  return resolution.kind === 'file' ? resolution.file : undefined;
+}
+
+type ConfigFileResolution =
+  | { kind: 'file'; file: string }
+  | { kind: 'invalid' }
+  | { kind: 'missing' };
+
+/** Validates one config candidate without letting filesystem races escape. */
+function inspectConfigFile(
+  root: string,
+  candidate: string,
+  missingIsError: boolean,
+  errors: string[]
+): ConfigFileResolution {
+  let candidateWasFound = false;
+  try {
+    const stats = fs.statSync(candidate);
+    candidateWasFound = true;
+    if (!stats.isFile()) {
+      errors.push(
+        configFileDiagnostic(
+          'Found a Vue project config path that is not a regular file',
+          'Replace it with a readable JavaScript or TypeScript config file',
+          candidate
+        )
+      );
+      return { kind: 'invalid' };
+    }
+
+    fs.accessSync(candidate, fs.constants.R_OK);
+    const realRoot = fs.realpathSync(root);
+    const realCandidate = fs.realpathSync(candidate);
+    const realRelative = path.relative(realRoot, realCandidate);
+    if (
+      realRelative.startsWith(`..${path.sep}`) ||
+      realRelative === '..' ||
+      path.isAbsolute(realRelative) ||
+      realRelative.split(path.sep).includes('node_modules')
+    ) {
+      errors.push(
+        optionError(
+          'Found a Vue project config path outside the project source boundary',
+          'Choose a project config file inside the project root and outside node_modules'
+        )
+      );
+      return { kind: 'invalid' };
+    }
+    return { kind: 'file', file: realCandidate };
+  } catch (error) {
+    if (isMissingPathError(error) && !missingIsError && !candidateWasFound) {
+      return { kind: 'missing' };
+    }
+    if (isMissingPathError(error) && missingIsError && !candidateWasFound) {
+      errors.push(
+        configFileDiagnostic(
+          'Could not find the configured Vite config file',
+          'Set files.gt.parsingFlags.viteConfigPath to an existing file inside the project root',
+          candidate,
+          error
+        )
+      );
+    } else {
+      errors.push(
+        configFileDiagnostic(
+          'Could not read the Vue project config file',
+          'Restore read access to the config file and try extraction again',
+          candidate,
+          error
+        )
+      );
+    }
+    return { kind: 'invalid' };
+  }
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'ENOENT'
+  );
+}
+
+function readExplicitOptions(
+  input: VueCompilerOptions | undefined,
+  state: CompilerOptionState,
+  errors: string[]
+): void {
+  if (input === undefined) return;
+  if (!isRecord(input)) {
+    errors.push(
+      optionError(
+        'Found an invalid vueCompilerOptions parsing setting',
+        'Set files.gt.parsingFlags.vueCompilerOptions to an object containing only whitespace and delimiters'
+      )
+    );
+    return;
+  }
+
+  for (const key of Object.keys(input)) {
+    if (key !== 'whitespace' && key !== 'delimiters') {
+      errors.push(
+        optionError(
+          `Found unsupported Vue compiler option "${key}" in gt.config.json`,
+          'Configure only whitespace and delimiters in files.gt.parsingFlags.vueCompilerOptions'
+        )
+      );
+    }
+  }
+
+  if (input.whitespace !== undefined) {
+    if (input.whitespace !== 'condense' && input.whitespace !== 'preserve') {
+      errors.push(
+        optionError(
+          'Found an invalid Vue whitespace compiler option in gt.config.json',
+          'Set whitespace to either "condense" or "preserve"'
+        )
+      );
+    } else {
+      mergeOption(
+        state,
+        'whitespace',
+        input.whitespace,
+        { file: 'gt.config.json' },
+        errors
+      );
+    }
+  }
+
+  if (input.delimiters !== undefined) {
+    if (!isDelimiterPair(input.delimiters)) {
+      errors.push(
+        optionError(
+          'Found invalid Vue interpolation delimiters in gt.config.json',
+          'Set delimiters to exactly two non-empty strings, such as ["[[", "]]"]'
+        )
+      );
+    } else {
+      mergeOption(
+        state,
+        'delimiters',
+        input.delimiters,
+        { file: 'gt.config.json' },
+        errors
+      );
+    }
+  }
+}
+
+function readViteConfig(
+  file: string,
+  state: CompilerOptionState,
+  errors: string[],
+  reportAllSyntaxErrors: boolean
+): void {
+  const ast = parseConfig(file, errors, reportAllSyntaxErrors);
+  if (!ast) return;
+
+  const pluginBindings = new Set<Binding>();
+  const namespaceBindings = new Set<Binding>();
+  const jsxPluginBindings = new Set<Binding>();
+  const jsxNamespaceBindings = new Set<Binding>();
+  const defineConfigBindings = new Set<Binding>();
+
+  traverse(ast, {
+    ImportDeclaration(importPath) {
+      if (importPath.node.source.value === 'vite') {
+        for (const specifierPath of importPath.get('specifiers')) {
+          const specifier = specifierPath.node;
+          if (
+            specifier.type !== 'ImportSpecifier' ||
+            (specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value) !== 'defineConfig'
+          ) {
+            continue;
+          }
+          const binding = specifierPath.scope.getBinding(specifier.local.name);
+          if (binding) defineConfigBindings.add(binding);
+        }
+        return;
+      }
+      const moduleSource = importPath.node.source.value;
+      if (
+        moduleSource !== '@vitejs/plugin-vue' &&
+        moduleSource !== '@vitejs/plugin-vue-jsx'
+      ) {
+        return;
+      }
+      const targetPluginBindings =
+        moduleSource === '@vitejs/plugin-vue-jsx'
+          ? jsxPluginBindings
+          : pluginBindings;
+      const targetNamespaceBindings =
+        moduleSource === '@vitejs/plugin-vue-jsx'
+          ? jsxNamespaceBindings
+          : namespaceBindings;
+      for (const specifierPath of importPath.get('specifiers')) {
+        const specifier = specifierPath.node;
+        const binding = specifierPath.scope.getBinding(specifier.local.name);
+        if (!binding) continue;
+        if (specifier.type === 'ImportNamespaceSpecifier') {
+          targetNamespaceBindings.add(binding);
+        } else if (
+          specifier.type === 'ImportDefaultSpecifier' ||
+          (specifier.type === 'ImportSpecifier' &&
+            (specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value) === 'default')
+        ) {
+          targetPluginBindings.add(binding);
+        }
+      }
+    },
+    TSImportEqualsDeclaration(importPath) {
+      const reference = importPath.node.moduleReference;
+      if (
+        reference.type !== 'TSExternalModuleReference' ||
+        reference.expression.type !== 'StringLiteral' ||
+        (reference.expression.value !== '@vitejs/plugin-vue' &&
+          reference.expression.value !== '@vitejs/plugin-vue-jsx')
+      ) {
+        return;
+      }
+      const binding = importPath.scope.getBinding(importPath.node.id.name);
+      if (!binding) return;
+      if (reference.expression.value === '@vitejs/plugin-vue-jsx') {
+        jsxNamespaceBindings.add(binding);
+      } else {
+        namespaceBindings.add(binding);
+      }
+    },
+    VariableDeclarator(variablePath) {
+      const vueRequireKind = getPluginVueRequireKind(
+        variablePath.node.init,
+        '@vitejs/plugin-vue'
+      );
+      const jsxRequireKind = getPluginVueRequireKind(
+        variablePath.node.init,
+        '@vitejs/plugin-vue-jsx'
+      );
+      const requireKind = vueRequireKind ?? jsxRequireKind;
+      if (!requireKind) return;
+      const targetPluginBindings = jsxRequireKind
+        ? jsxPluginBindings
+        : pluginBindings;
+      const targetNamespaceBindings = jsxRequireKind
+        ? jsxNamespaceBindings
+        : namespaceBindings;
+      if (variablePath.node.id.type === 'Identifier') {
+        const binding = variablePath.scope.getBinding(
+          variablePath.node.id.name
+        );
+        if (!binding) return;
+        if (requireKind === 'namespace') targetNamespaceBindings.add(binding);
+        else targetPluginBindings.add(binding);
+        return;
+      }
+      if (
+        requireKind !== 'namespace' ||
+        variablePath.node.id.type !== 'ObjectPattern'
+      ) {
+        return;
+      }
+      for (const property of variablePath.node.id.properties) {
+        if (
+          property.type !== 'ObjectProperty' ||
+          readPropertyKey(property) !== 'default'
+        ) {
+          continue;
+        }
+        const localName = readBindingIdentifier(property.value);
+        const binding = localName
+          ? variablePath.scope.getBinding(localName)
+          : undefined;
+        if (binding) targetPluginBindings.add(binding);
+      }
+    },
+  });
+
+  const activeExport = findActiveConfigExport(ast, file, errors);
+  if (!activeExport) return;
+  const functionReturns = collectFunctionReturns(ast);
+  const configRoot = resolveActiveConfigRoot(
+    activeExport.node,
+    activeExport.scope,
+    functionReturns,
+    (callee, scope) =>
+      resolveConfigHelperCall(callee, scope, defineConfigBindings, undefined),
+    new Set()
+  );
+  if (!configRoot.ok) {
+    errors.push(dynamicConfigError(file, configRoot.node));
+    return;
+  }
+
+  const configObject = resolveStaticObject(
+    configRoot.value.node,
+    configRoot.value.scope,
+    new Set()
+  );
+  if (!configObject.ok) {
+    errors.push(dynamicConfigError(file, configObject.node));
+    return;
+  }
+  const plugins = configObject.value.entries.get('plugins');
+  if (!plugins) return;
+
+  const pluginContext: VitePluginContext = {
+    moduleSource: '@vitejs/plugin-vue',
+    namespaceBindings,
+    pluginBindings,
+    referencePositions: [...pluginBindings, ...namespaceBindings].flatMap(
+      (binding) =>
+        binding.referencePaths
+          .map((reference) => reference.node.start)
+          .filter((position): position is number => position !== null)
+    ),
+  };
+  const calls: ScopedPluginCall[] = [];
+  const unresolved = collectActiveVuePluginCalls(
+    plugins.node,
+    plugins.scope,
+    pluginContext,
+    calls,
+    new Set()
+  );
+  if (unresolved) {
+    errors.push(dynamicConfigError(file, unresolved));
+    return;
+  }
+  if (calls.length > 1) {
+    errors.push(dynamicConfigError(file, calls[1]!.node));
+    return;
+  }
+  const call = calls[0];
+  if (call) {
+    const argument = call.node.arguments[0];
+    if (
+      argument?.type === 'SpreadElement' ||
+      argument?.type === 'ArgumentPlaceholder'
+    ) {
+      errors.push(dynamicConfigError(file, argument));
+      return;
+    }
+    if (argument) {
+      rejectCustomVueCompiler(argument, call.scope, file, errors);
+      readNestedCompilerOptions(
+        argument,
+        call.scope,
+        ['template', 'compilerOptions'],
+        file,
+        true,
+        state,
+        errors
+      );
+    }
+  }
+
+  const jsxPluginContext: VitePluginContext = {
+    moduleSource: '@vitejs/plugin-vue-jsx',
+    namespaceBindings: jsxNamespaceBindings,
+    pluginBindings: jsxPluginBindings,
+    referencePositions: [...jsxPluginBindings, ...jsxNamespaceBindings].flatMap(
+      (binding) =>
+        binding.referencePaths
+          .map((reference) => reference.node.start)
+          .filter((position): position is number => position !== null)
+    ),
+  };
+  const jsxCalls: ScopedPluginCall[] = [];
+  const unresolvedJSX = collectActiveVuePluginCalls(
+    plugins.node,
+    plugins.scope,
+    jsxPluginContext,
+    jsxCalls,
+    new Set()
+  );
+  if (unresolvedJSX) {
+    errors.push(dynamicVueJSXConfigError(file, unresolvedJSX));
+    return;
+  }
+  if (jsxCalls.length > 1) {
+    errors.push(dynamicVueJSXConfigError(file, jsxCalls[1]!.node));
+    return;
+  }
+  if (jsxCalls[0]) readVueJSXPluginOptions(jsxCalls[0], file, errors);
+}
+
+/** Rejects Vite JSX options that can invalidate source-to-VNode parity. */
+function readVueJSXPluginOptions(
+  call: ScopedPluginCall,
+  file: string,
+  errors: string[]
+): void {
+  const argument = call.node.arguments[0];
+  if (!argument) return;
+  if (
+    argument.type === 'SpreadElement' ||
+    argument.type === 'ArgumentPlaceholder'
+  ) {
+    errors.push(dynamicVueJSXConfigError(file, argument));
+    return;
+  }
+  const options = resolveStaticObject(argument, call.scope, new Set());
+  if (!options.ok) {
+    errors.push(dynamicVueJSXConfigError(file, options.node));
+    return;
+  }
+
+  for (const [name, entry] of options.value.entries) {
+    let supported = false;
+    if (name === 'optimize') {
+      // Optimization changes patch metadata only. The real dev/production
+      // oracle proves both values preserve GT source data.
+      supported =
+        resolveStaticBoolean(entry.node, entry.scope, new Set()) !== undefined;
+    } else if (name === 'transformOn') {
+      supported =
+        resolveStaticBoolean(entry.node, entry.scope, new Set()) === false;
+    } else if (name === 'enableObjectSlots' || name === 'mergeProps') {
+      supported =
+        resolveStaticBoolean(entry.node, entry.scope, new Set()) === true;
+    } else if (name === 'resolveType') {
+      supported =
+        resolveStaticBoolean(entry.node, entry.scope, new Set()) === false;
+    } else if (name === 'pragma') {
+      supported =
+        resolveStaticString(entry.node, entry.scope, new Set()) === '';
+    } else if (name === 'defineComponentName') {
+      supported = isDefaultDefineComponentNames(
+        entry.node,
+        entry.scope,
+        new Set()
+      );
+    } else if (name === 'babelPlugins') {
+      supported = isDefinitelyEmptyArray(entry.node, entry.scope, new Set());
+    } else if (name === 'tsPluginOptions') {
+      const resolved = resolveStaticObject(entry.node, entry.scope, new Set());
+      supported = resolved.ok && resolved.value.entries.size === 0;
+    }
+    if (supported) continue;
+    errors.push(
+      locatedOptionError(
+        file,
+        entry.node,
+        `Found unsupported @vitejs/plugin-vue-jsx option "${name}"`,
+        'Use default-equivalent Vue JSX options; only a static optimize value may differ in files containing gt-vue translations'
+      )
+    );
+  }
+}
+
+/** Resolves an immutable boolean option without coercing another type. */
+function resolveStaticBoolean(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean | undefined {
+  const node = unwrapExpression(input);
+  if (node.type === 'BooleanLiteral') return node.value;
+  if (node.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(node.name);
+  if (!binding?.constant || bindingHasMutation(binding) || seen.has(binding)) {
+    return undefined;
+  }
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  return resolveStaticBoolean(declaration.init, binding.path.scope, nextSeen);
+}
+
+/** Proves the explicit component-name option equals the plugin default. */
+function isDefaultDefineComponentNames(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean {
+  const node = unwrapExpression(input);
+  if (node.type === 'ArrayExpression') {
+    return (
+      node.elements.length === 1 &&
+      node.elements[0]?.type === 'StringLiteral' &&
+      node.elements[0].value === 'defineComponent'
+    );
+  }
+  if (node.type !== 'Identifier') return false;
+  const binding = scope.getBinding(node.name);
+  if (!binding?.constant || bindingHasMutation(binding) || seen.has(binding)) {
+    return false;
+  }
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return false;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  return isDefaultDefineComponentNames(
+    declaration.init,
+    binding.path.scope,
+    nextSeen
+  );
+}
+
+/** Proves an immutable config value is an empty array. */
+function isDefinitelyEmptyArray(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean {
+  const node = unwrapExpression(input);
+  if (node.type === 'ArrayExpression') return node.elements.length === 0;
+  if (node.type !== 'Identifier') return false;
+  const binding = scope.getBinding(node.name);
+  if (!binding?.constant || bindingHasMutation(binding) || seen.has(binding)) {
+    return false;
+  }
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return false;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  return isDefinitelyEmptyArray(declaration.init, binding.path.scope, nextSeen);
+}
+
+/**
+ * Rejects Vite's custom compiler override because source-file resolution can
+ * only prove parity with that app's `vue/compiler-sfc` export.
+ */
+function rejectCustomVueCompiler(
+  root: t.Node,
+  scope: Scope,
+  file: string,
+  errors: string[]
+): void {
+  const rootObject = resolveStaticObject(root, scope, new Set());
+  if (!rootObject.ok) return;
+  const compiler = rootObject.value.entries.get('compiler');
+  if (!compiler) return;
+  errors.push(
+    locatedOptionError(
+      file,
+      compiler.node,
+      'Found a custom Vue compiler instance in the Vite plugin',
+      "Remove the compiler override so extraction and Vite both use the app's vue/compiler-sfc version"
+    )
+  );
+}
+
+function readNuxtConfig(
+  file: string,
+  state: CompilerOptionState,
+  errors: string[],
+  sourceDiscoveryIsExplicit: boolean
+): void {
+  const ast = parseConfig(file, errors, sourceDiscoveryIsExplicit);
+  if (!ast) return;
+
+  const defineNuxtConfigBindings = new Set<Binding>();
+  traverse(ast, {
+    ImportDeclaration(importPath) {
+      if (
+        importPath.node.source.value !== 'nuxt/config' &&
+        importPath.node.source.value !== 'nuxt' &&
+        importPath.node.source.value !== '#imports'
+      ) {
+        return;
+      }
+      for (const specifierPath of importPath.get('specifiers')) {
+        const specifier = specifierPath.node;
+        if (
+          specifier.type !== 'ImportSpecifier' ||
+          (specifier.imported.type === 'Identifier'
+            ? specifier.imported.name
+            : specifier.imported.value) !== 'defineNuxtConfig'
+        ) {
+          continue;
+        }
+        const binding = specifierPath.scope.getBinding(specifier.local.name);
+        if (binding) defineNuxtConfigBindings.add(binding);
+      }
+    },
+  });
+
+  const activeExport = findActiveConfigExport(ast, file, errors);
+  if (!activeExport) return;
+  const configRoot = resolveActiveConfigRoot(
+    activeExport.node,
+    activeExport.scope,
+    collectFunctionReturns(ast),
+    (callee, scope) =>
+      resolveConfigHelperCall(
+        callee,
+        scope,
+        defineNuxtConfigBindings,
+        'defineNuxtConfig'
+      ),
+    new Set()
+  );
+  if (!configRoot.ok) {
+    errors.push(dynamicConfigError(file, configRoot.node));
+    return;
+  }
+  const configObject = resolveStaticObject(
+    configRoot.value.node,
+    configRoot.value.scope,
+    new Set()
+  );
+  if (!configObject.ok) {
+    errors.push(dynamicConfigError(file, configObject.node));
+    return;
+  }
+  const extendsEntry = configObject.value.entries.get('extends');
+  if (
+    extendsEntry &&
+    !isDefinitelyEmptyNuxtExtends(extendsEntry.node, extendsEntry.scope)
+  ) {
+    errors.push(
+      locatedOptionError(
+        file,
+        extendsEntry.node,
+        'Found Nuxt layer inheritance that could change Vue compiler options',
+        'Run extraction from a Nuxt configuration without inherited layers until gt-vue can resolve the complete layer chain safely'
+      )
+    );
+    return;
+  }
+  const unsupportedSourceLayout = sourceDiscoveryIsExplicit
+    ? undefined
+    : findUnsupportedNuxtSourceLayout(configObject.value);
+  if (unsupportedSourceLayout) {
+    errors.push(
+      locatedOptionError(
+        file,
+        unsupportedSourceLayout,
+        'Found custom Nuxt source directories that default Vue discovery cannot scan safely',
+        'Use Nuxt source directories covered by the default app, src, pages, layouts, plugins, and related globs until custom directory discovery is supported'
+      )
+    );
+    return;
+  }
+  readNestedCompilerOptions(
+    configRoot.value.node,
+    configRoot.value.scope,
+    ['vue', 'compilerOptions'],
+    file,
+    true,
+    state,
+    errors
+  );
+}
+
+/** Finds a Nuxt source-layout override not covered by default CLI globs. */
+function findUnsupportedNuxtSourceLayout(
+  config: StaticObject
+): t.Node | undefined {
+  const srcDir = config.entries.get('srcDir');
+  if (srcDir) {
+    const value = resolveStaticString(srcDir.node, srcDir.scope, new Set());
+    const normalized = value
+      ? path.posix.normalize(value.replaceAll('\\', '/')).replace(/\/+$/, '') ||
+        '.'
+      : undefined;
+    if (!normalized || !['.', 'app', 'src'].includes(normalized)) {
+      return srcDir.node;
+    }
+  }
+
+  const directoryOptions = config.entries.get('dir');
+  if (directoryOptions) {
+    const resolved = resolveStaticObject(
+      directoryOptions.node,
+      directoryOptions.scope,
+      new Set()
+    );
+    if (!resolved.ok || resolved.value.entries.size > 0) {
+      return directoryOptions.node;
+    }
+  }
+  return undefined;
+}
+
+/** Returns true only when a Nuxt extends value provably selects no layers. */
+function isDefinitelyEmptyNuxtExtends(input: t.Node, scope: Scope): boolean {
+  const node = unwrapExpression(input);
+  if (node.type === 'NullLiteral') return true;
+  if (node.type === 'ArrayExpression') return node.elements.length === 0;
+  if (node.type !== 'Identifier') return false;
+  if (node.name === 'undefined' && !scope.getBinding(node.name)) return true;
+  const binding = scope.getBinding(node.name);
+  const declaration = binding?.path.node;
+  return !!(
+    binding?.constant &&
+    !bindingHasMutation(binding) &&
+    declaration?.type === 'VariableDeclarator' &&
+    declaration.init &&
+    isDefinitelyEmptyNuxtExtends(declaration.init, binding.path.scope)
+  );
+}
+
+/** Returns the one top-level export that the config loader evaluates. */
+function findActiveConfigExport(
+  ast: t.File,
+  file: string,
+  errors: string[]
+): ObjectEntry | undefined {
+  const esmExports: ObjectEntry[] = [];
+  const commonJsExports = new Map<
+    'exports-default' | 'module-exports',
+    ObjectEntry[]
+  >();
+
+  traverse(ast, {
+    ExportDefaultDeclaration(exportPath) {
+      esmExports.push({
+        node: exportPath.node.declaration,
+        scope: exportPath.scope,
+      });
+    },
+    AssignmentExpression(assignmentPath) {
+      if (
+        assignmentPath.node.operator !== '=' ||
+        assignmentPath.getFunctionParent() ||
+        !assignmentPath.parentPath.isExpressionStatement() ||
+        !assignmentPath.parentPath.parentPath?.isProgram()
+      ) {
+        return;
+      }
+      const kind = readCommonJsConfigExportKind(
+        assignmentPath.node.left,
+        assignmentPath.scope
+      );
+      if (!kind) return;
+      const entries = commonJsExports.get(kind) ?? [];
+      entries.push({
+        node: assignmentPath.node.right,
+        scope: assignmentPath.scope,
+      });
+      commonJsExports.set(kind, entries);
+    },
+  });
+
+  const commonJsKinds = [...commonJsExports.keys()];
+  if (
+    esmExports.length > 1 ||
+    (esmExports.length > 0 && commonJsKinds.length > 0) ||
+    commonJsKinds.length > 1
+  ) {
+    const node =
+      esmExports[1]?.node ??
+      commonJsExports.get(commonJsKinds[1]!)?.[0]?.node ??
+      esmExports[0]?.node ??
+      ast.program;
+    errors.push(dynamicConfigError(file, node));
+    return undefined;
+  }
+  if (esmExports[0]) return esmExports[0];
+  const commonJs = commonJsExports.get(commonJsKinds[0]!);
+  return commonJs?.[commonJs.length - 1];
+}
+
+/** Records return expressions by their immediately containing function. */
+function collectFunctionReturns(ast: t.File): Map<t.Function, ObjectEntry[]> {
+  const result = new Map<t.Function, ObjectEntry[]>();
+  traverse(ast, {
+    ReturnStatement(returnPath) {
+      if (!returnPath.node.argument) return;
+      const functionPath = returnPath.getFunctionParent();
+      if (!functionPath) return;
+      const entries = result.get(functionPath.node) ?? [];
+      entries.push({ node: returnPath.node.argument, scope: returnPath.scope });
+      result.set(functionPath.node, entries);
+    },
+  });
+  return result;
+}
+
+/** Resolves an exported object or single-return config function statically. */
+function resolveActiveConfigRoot(
+  input: t.Node,
+  scope: Scope,
+  functionReturns: Map<t.Function, ObjectEntry[]>,
+  resolveHelper: (input: t.Node, scope: Scope) => ConfigHelperResolution,
+  seen: Set<t.Node>
+): ActiveConfigResolution {
+  const node = unwrapExpression(input);
+  if (seen.has(node)) return { ok: false, node };
+  const nextSeen = new Set(seen);
+  nextSeen.add(node);
+
+  if (node.type === 'ObjectExpression') {
+    return { ok: true, value: { node, scope } };
+  }
+  if (node.type === 'Identifier') {
+    const binding = scope.getBinding(node.name);
+    if (!binding?.constant || bindingHasMutation(binding)) {
+      return { ok: false, node };
+    }
+    if (binding.path.isFunctionDeclaration()) {
+      return resolveActiveConfigRoot(
+        binding.path.node,
+        binding.path.scope,
+        functionReturns,
+        resolveHelper,
+        nextSeen
+      );
+    }
+    const declaration = binding.path.node;
+    return declaration.type === 'VariableDeclarator' && declaration.init
+      ? resolveActiveConfigRoot(
+          declaration.init,
+          binding.path.scope,
+          functionReturns,
+          resolveHelper,
+          nextSeen
+        )
+      : { ok: false, node };
+  }
+  if (
+    node.type === 'CallExpression' ||
+    node.type === 'OptionalCallExpression'
+  ) {
+    const helper = resolveHelper(node.callee, scope);
+    if (helper !== 'static') return { ok: false, node: node.callee };
+    const argument = node.arguments[0];
+    return argument &&
+      argument.type !== 'SpreadElement' &&
+      argument.type !== 'ArgumentPlaceholder'
+      ? resolveActiveConfigRoot(
+          argument,
+          scope,
+          functionReturns,
+          resolveHelper,
+          nextSeen
+        )
+      : { ok: false, node };
+  }
+  if (
+    node.type === 'ArrowFunctionExpression' ||
+    node.type === 'FunctionExpression' ||
+    node.type === 'FunctionDeclaration'
+  ) {
+    if (
+      node.type === 'ArrowFunctionExpression' &&
+      node.body.type !== 'BlockStatement'
+    ) {
+      return resolveActiveConfigRoot(
+        node.body,
+        scope,
+        functionReturns,
+        resolveHelper,
+        nextSeen
+      );
+    }
+    const returns = functionReturns.get(node) ?? [];
+    return returns.length === 1
+      ? resolveActiveConfigRoot(
+          returns[0]!.node,
+          returns[0]!.scope,
+          functionReturns,
+          resolveHelper,
+          nextSeen
+        )
+      : { ok: false, node };
+  }
+  if (node.type === 'ConditionalExpression') {
+    const condition = resolveStaticTruthiness(node.test, scope, new Set());
+    return condition === undefined
+      ? { ok: false, node }
+      : resolveActiveConfigRoot(
+          condition ? node.consequent : node.alternate,
+          scope,
+          functionReturns,
+          resolveHelper,
+          nextSeen
+        );
+  }
+  if (node.type === 'SequenceExpression') {
+    const last = node.expressions[node.expressions.length - 1];
+    return last
+      ? resolveActiveConfigRoot(
+          last,
+          scope,
+          functionReturns,
+          resolveHelper,
+          nextSeen
+        )
+      : { ok: false, node };
+  }
+  if (node.type === 'AwaitExpression') {
+    return resolveActiveConfigRoot(
+      node.argument,
+      scope,
+      functionReturns,
+      resolveHelper,
+      nextSeen
+    );
+  }
+  return { ok: false, node };
+}
+
+/** Resolves imported/global config helpers and their immutable aliases. */
+function resolveConfigHelperCall(
+  input: t.Node,
+  scope: Scope,
+  knownBindings: Set<Binding>,
+  globalName: string | undefined,
+  seen: Set<Binding> = new Set()
+): ConfigHelperResolution {
+  const node = unwrapExpression(input);
+  if (node.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(node.name);
+  if (!binding) return node.name === globalName ? 'static' : undefined;
+  if (knownBindings.has(binding)) return 'static';
+  if (seen.has(binding)) return undefined;
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  const initialValue = resolveConfigHelperCall(
+    declaration.init,
+    binding.path.scope,
+    knownBindings,
+    globalName,
+    nextSeen
+  );
+  return !binding.constant && initialValue ? 'dynamic' : initialValue;
+}
+
+/** Collects Vue plugin calls reachable through the active `plugins` value. */
+function collectActiveVuePluginCalls(
+  input: t.Node,
+  scope: Scope,
+  context: VitePluginContext,
+  calls: ScopedPluginCall[],
+  seen: Set<Binding>
+): t.Node | undefined {
+  const node = unwrapExpression(input);
+
+  if (node.type === 'Identifier') {
+    const value = resolvePluginVueValue(
+      node,
+      scope,
+      context.pluginBindings,
+      context.namespaceBindings,
+      context.moduleSource,
+      new Set()
+    );
+    if (value === 'dynamic' || value === 'default') return node;
+    const binding = scope.getBinding(node.name);
+    if (!binding || seen.has(binding)) {
+      return mayReferenceVuePlugin(node, scope, context, new Set())
+        ? node
+        : undefined;
+    }
+    const declaration = binding.path.node;
+    if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+      return mayReferenceVuePlugin(node, scope, context, new Set())
+        ? node
+        : undefined;
+    }
+    if (bindingHasMutation(binding)) return node;
+    if (!binding.constant) {
+      return mayReferenceVuePlugin(
+        declaration.init,
+        binding.path.scope,
+        context,
+        new Set()
+      )
+        ? node
+        : undefined;
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(binding);
+    return collectActiveVuePluginCalls(
+      declaration.init,
+      binding.path.scope,
+      context,
+      calls,
+      nextSeen
+    );
+  }
+  if (node.type === 'ArrayExpression') {
+    for (const element of node.elements) {
+      if (!element) continue;
+      const unresolved = collectActiveVuePluginCalls(
+        element.type === 'SpreadElement' ? element.argument : element,
+        scope,
+        context,
+        calls,
+        seen
+      );
+      if (unresolved) return unresolved;
+    }
+    return undefined;
+  }
+  if (
+    node.type === 'CallExpression' ||
+    node.type === 'OptionalCallExpression'
+  ) {
+    const value = resolvePluginVueValue(
+      node.callee,
+      scope,
+      context.pluginBindings,
+      context.namespaceBindings,
+      context.moduleSource,
+      new Set()
+    );
+    if (value === 'dynamic') return node.callee;
+    if (value === 'default') {
+      calls.push({ node, scope });
+      return undefined;
+    }
+    return mayReferenceVuePlugin(node, scope, context, new Set())
+      ? node
+      : undefined;
+  }
+  if (node.type === 'ConditionalExpression') {
+    const condition = resolveStaticTruthiness(node.test, scope, new Set());
+    if (condition !== undefined) {
+      return collectActiveVuePluginCalls(
+        condition ? node.consequent : node.alternate,
+        scope,
+        context,
+        calls,
+        seen
+      );
+    }
+    return mayReferenceVuePlugin(node, scope, context, new Set())
+      ? node
+      : undefined;
+  }
+  if (node.type === 'LogicalExpression') {
+    const left = resolveStaticTruthiness(node.left, scope, new Set());
+    if (left !== undefined) {
+      const selected =
+        node.operator === '&&'
+          ? left
+            ? node.right
+            : node.left
+          : node.operator === '||'
+            ? left
+              ? node.left
+              : node.right
+            : undefined;
+      if (selected) {
+        return collectActiveVuePluginCalls(
+          selected,
+          scope,
+          context,
+          calls,
+          seen
+        );
+      }
+    }
+    return mayReferenceVuePlugin(node, scope, context, new Set())
+      ? node
+      : undefined;
+  }
+  if (node.type === 'SequenceExpression') {
+    const last = node.expressions[node.expressions.length - 1];
+    return last
+      ? collectActiveVuePluginCalls(last, scope, context, calls, seen)
+      : undefined;
+  }
+  return mayReferenceVuePlugin(node, scope, context, new Set())
+    ? node
+    : undefined;
+}
+
+/** Conservatively follows wrapper bindings that reference the Vue plugin. */
+function mayReferenceVuePlugin(
+  input: t.Node,
+  scope: Scope,
+  context: VitePluginContext,
+  seen: Set<Binding>
+): boolean {
+  const node = unwrapExpression(input);
+  const start = node.start;
+  const end = node.end;
+  if (
+    typeof start === 'number' &&
+    typeof end === 'number' &&
+    context.referencePositions.some(
+      (position) => position >= start && position <= end
+    )
+  ) {
+    return true;
+  }
+  const target =
+    node.type === 'Identifier'
+      ? node
+      : node.type === 'CallExpression' || node.type === 'OptionalCallExpression'
+        ? unwrapExpression(node.callee)
+        : undefined;
+  if (target?.type !== 'Identifier') return false;
+  const binding = scope.getBinding(target.name);
+  if (!binding) return false;
+  if (
+    context.pluginBindings.has(binding) ||
+    context.namespaceBindings.has(binding)
+  ) {
+    return true;
+  }
+  if (seen.has(binding)) return false;
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  const declaration = binding.path.node;
+  if (declaration.type === 'VariableDeclarator' && declaration.init) {
+    return mayReferenceVuePlugin(
+      declaration.init,
+      binding.path.scope,
+      context,
+      nextSeen
+    );
+  }
+  const declarationStart = declaration.start;
+  const declarationEnd = declaration.end;
+  return (
+    typeof declarationStart === 'number' &&
+    typeof declarationEnd === 'number' &&
+    context.referencePositions.some(
+      (position) => position >= declarationStart && position <= declarationEnd
+    )
+  );
+}
+
+/** Evaluates only primitive truthiness used to choose a static config branch. */
+function resolveStaticTruthiness(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean | undefined {
+  const node = unwrapExpression(input);
+  if (node.type === 'BooleanLiteral') return node.value;
+  if (node.type === 'NullLiteral') return false;
+  if (node.type === 'NumericLiteral') return !!node.value;
+  if (node.type === 'BigIntLiteral') return node.value !== '0';
+  if (node.type === 'StringLiteral') return node.value.length > 0;
+  if (node.type === 'UnaryExpression' && node.operator === '!') {
+    const value = resolveStaticTruthiness(node.argument, scope, seen);
+    return value === undefined ? undefined : !value;
+  }
+  if (node.type !== 'Identifier') return undefined;
+  if (node.name === 'undefined' && !scope.getBinding(node.name)) return false;
+  const binding = scope.getBinding(node.name);
+  if (!binding?.constant || bindingHasMutation(binding) || seen.has(binding)) {
+    return undefined;
+  }
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+  return resolveStaticTruthiness(
+    declaration.init,
+    binding.path.scope,
+    nextSeen
+  );
+}
+
+function readNestedCompilerOptions(
+  root: t.Node,
+  scope: Scope,
+  keys: [string, string],
+  file: string,
+  failOnDynamicRoot: boolean,
+  state: CompilerOptionState,
+  errors: string[]
+): void {
+  const rootObject = resolveStaticObject(root, scope, new Set());
+  if (!rootObject.ok) {
+    if (failOnDynamicRoot)
+      errors.push(dynamicConfigError(file, rootObject.node));
+    return;
+  }
+
+  const parentEntry = rootObject.value.entries.get(keys[0]);
+  if (!parentEntry) return;
+  const parentObject = resolveStaticObject(
+    parentEntry.node,
+    parentEntry.scope,
+    new Set()
+  );
+  if (!parentObject.ok) {
+    errors.push(dynamicConfigError(file, parentObject.node));
+    return;
+  }
+
+  const compilerEntry = parentObject.value.entries.get(keys[1]);
+  if (!compilerEntry) return;
+  const compilerObject = resolveStaticObject(
+    compilerEntry.node,
+    compilerEntry.scope,
+    new Set()
+  );
+  if (!compilerObject.ok) {
+    errors.push(dynamicConfigError(file, compilerObject.node));
+    return;
+  }
+
+  readCompilerOptionsObject(compilerObject.value, file, state, errors);
+}
+
+function readCompilerOptionsObject(
+  object: StaticObject,
+  file: string,
+  state: CompilerOptionState,
+  errors: string[]
+): void {
+  for (const [key, entry] of object.entries) {
+    if (key !== 'whitespace' && key !== 'delimiters') {
+      errors.push(
+        locatedOptionError(
+          file,
+          entry.node,
+          `Found unsupported Vue compiler option "${key}"`,
+          'gt-vue extraction currently supports only static whitespace and delimiters compiler options'
+        )
+      );
+    }
+  }
+
+  const whitespaceEntry = object.entries.get('whitespace');
+  if (whitespaceEntry) {
+    const value = resolveStaticString(
+      whitespaceEntry.node,
+      whitespaceEntry.scope,
+      new Set()
+    );
+    if (value !== 'condense' && value !== 'preserve') {
+      errors.push(dynamicConfigError(file, whitespaceEntry.node));
+    } else {
+      mergeOption(
+        state,
+        'whitespace',
+        value,
+        { file, node: whitespaceEntry.node },
+        errors
+      );
+    }
+  }
+
+  const delimitersEntry = object.entries.get('delimiters');
+  if (delimitersEntry) {
+    const value = resolveStaticDelimiters(
+      delimitersEntry.node,
+      delimitersEntry.scope,
+      new Set()
+    );
+    if (!value) {
+      errors.push(dynamicConfigError(file, delimitersEntry.node));
+    } else {
+      mergeOption(
+        state,
+        'delimiters',
+        value,
+        { file, node: delimitersEntry.node },
+        errors
+      );
+    }
+  }
+}
+
+function resolveStaticObject(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>
+): ObjectResolution {
+  const node = unwrapExpression(input);
+  if (seen.has(node)) return { ok: false, node };
+  seen.add(node);
+
+  if (node.type === 'Identifier') {
+    const binding = scope.getBinding(node.name);
+    const declaration = binding?.path.node;
+    if (
+      !binding?.constant ||
+      bindingHasMutation(binding) ||
+      declaration?.type !== 'VariableDeclarator' ||
+      !declaration.init
+    ) {
+      return { ok: false, node };
+    }
+    return resolveStaticObject(declaration.init, binding.path.scope, seen);
+  }
+  if (node.type !== 'ObjectExpression') return { ok: false, node };
+
+  const entries = new Map<string, ObjectEntry>();
+  for (const property of node.properties) {
+    if (property.type === 'SpreadElement') {
+      const spread = resolveStaticObject(property.argument, scope, seen);
+      if (!spread.ok) return { ok: false, node: spread.node };
+      for (const [key, entry] of spread.value.entries) entries.set(key, entry);
+      continue;
+    }
+    const key = readPropertyKey(property);
+    if (!key) return { ok: false, node: property };
+    if (property.type !== 'ObjectProperty') {
+      entries.set(key, { node: property, scope });
+      continue;
+    }
+    entries.set(key, { node: property.value, scope });
+  }
+  return { ok: true, value: { entries } };
+}
+
+function resolveStaticString(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>
+): string | undefined {
+  const node = unwrapExpression(input);
+  if (seen.has(node)) return undefined;
+  seen.add(node);
+  if (node.type === 'StringLiteral') return node.value;
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis
+      .map((quasi) => quasi.value.cooked ?? quasi.value.raw)
+      .join('');
+  }
+  if (node.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(node.name);
+  const declaration = binding?.path.node;
+  return binding?.constant &&
+    !bindingHasMutation(binding) &&
+    declaration?.type === 'VariableDeclarator' &&
+    declaration.init
+    ? resolveStaticString(declaration.init, binding.path.scope, seen)
+    : undefined;
+}
+
+function resolveStaticDelimiters(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>
+): [string, string] | undefined {
+  const node = unwrapExpression(input);
+  if (seen.has(node)) return undefined;
+  seen.add(node);
+  if (node.type === 'Identifier') {
+    const binding = scope.getBinding(node.name);
+    const declaration = binding?.path.node;
+    return binding?.constant &&
+      !bindingHasMutation(binding) &&
+      declaration?.type === 'VariableDeclarator' &&
+      declaration.init
+      ? resolveStaticDelimiters(declaration.init, binding.path.scope, seen)
+      : undefined;
+  }
+  if (node.type !== 'ArrayExpression' || node.elements.length !== 2) {
+    return undefined;
+  }
+  const values = node.elements.map((element) =>
+    element && element.type !== 'SpreadElement'
+      ? resolveStaticString(element, scope, new Set())
+      : undefined
+  );
+  return isDelimiterPair(values) ? values : undefined;
+}
+
+function unwrapExpression(input: t.Node): t.Node {
+  let node = input;
+  while (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSTypeAssertion' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TypeCastExpression' ||
+    node.type === 'ParenthesizedExpression'
+  ) {
+    node = node.expression;
+  }
+  return node;
+}
+
+function readPropertyKey(
+  property: t.ObjectMethod | t.ObjectProperty
+): string | undefined {
+  if (!property.computed && property.key.type === 'Identifier') {
+    return property.key.name;
+  }
+  if (property.key.type === 'StringLiteral') return property.key.value;
+  return undefined;
+}
+
+function getPluginVueRequireKind(
+  input: t.Expression | null | undefined,
+  moduleSource: '@vitejs/plugin-vue' | '@vitejs/plugin-vue-jsx'
+): 'default' | 'namespace' | undefined {
+  if (!input) return undefined;
+  const node = unwrapExpression(input);
+  if (
+    node.type === 'CallExpression' &&
+    node.callee.type === 'Identifier' &&
+    node.callee.name === 'require' &&
+    node.arguments[0]?.type === 'StringLiteral' &&
+    node.arguments[0].value === moduleSource
+  ) {
+    return 'namespace';
+  }
+  if (
+    (node.type === 'MemberExpression' ||
+      node.type === 'OptionalMemberExpression') &&
+    isDefaultMember(node)
+  ) {
+    return getPluginVueRequireKind(node.object as t.Expression, moduleSource)
+      ? 'default'
+      : undefined;
+  }
+  return undefined;
+}
+
+/** Resolves immutable aliases of the Vue Vite plugin without executing config. */
+function resolvePluginVueValue(
+  input: t.Node,
+  scope: Scope,
+  pluginBindings: Set<Binding>,
+  namespaceBindings: Set<Binding>,
+  moduleSource: '@vitejs/plugin-vue' | '@vitejs/plugin-vue-jsx',
+  seen: Set<Binding>
+): 'default' | 'dynamic' | 'namespace' | undefined {
+  const node = unwrapExpression(input);
+  const requireKind =
+    node.type === 'CallExpression' ||
+    node.type === 'MemberExpression' ||
+    node.type === 'OptionalMemberExpression'
+      ? getPluginVueRequireKind(node, moduleSource)
+      : undefined;
+  if (requireKind) return requireKind;
+
+  if (node.type === 'Identifier') {
+    const binding = scope.getBinding(node.name);
+    if (!binding) return undefined;
+    if (pluginBindings.has(binding)) return 'default';
+    if (namespaceBindings.has(binding)) return 'namespace';
+    if (seen.has(binding)) return undefined;
+    const declaration = binding.path.node;
+    if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+      return undefined;
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(binding);
+    const initialValue = resolvePluginVueValue(
+      declaration.init,
+      binding.path.scope,
+      pluginBindings,
+      namespaceBindings,
+      moduleSource,
+      nextSeen
+    );
+    return !binding.constant && initialValue ? 'dynamic' : initialValue;
+  }
+  if (
+    (node.type === 'MemberExpression' ||
+      node.type === 'OptionalMemberExpression') &&
+    isDefaultMember(node)
+  ) {
+    const objectValue = resolvePluginVueValue(
+      node.object,
+      scope,
+      pluginBindings,
+      namespaceBindings,
+      moduleSource,
+      seen
+    );
+    if (objectValue === 'dynamic') return 'dynamic';
+    if (objectValue === 'namespace') return 'default';
+  }
+  return undefined;
+}
+
+/** Recognizes every static spelling of a module namespace default export. */
+function isDefaultMember(
+  node: t.MemberExpression | t.OptionalMemberExpression
+): boolean {
+  return (
+    (!node.computed &&
+      node.property.type === 'Identifier' &&
+      node.property.name === 'default') ||
+    (node.computed &&
+      node.property.type === 'StringLiteral' &&
+      node.property.value === 'default')
+  );
+}
+
+/** Classifies supported unshadowed CommonJS config exports. */
+function readCommonJsConfigExportKind(
+  node: t.Node,
+  scope: Scope
+): 'exports-default' | 'module-exports' | undefined {
+  if (
+    node.type !== 'MemberExpression' ||
+    node.object.type !== 'Identifier' ||
+    !(
+      (!node.computed && node.property.type === 'Identifier') ||
+      (node.computed && node.property.type === 'StringLiteral')
+    )
+  ) {
+    return undefined;
+  }
+  const property =
+    node.property.type === 'Identifier'
+      ? node.property.name
+      : node.property.value;
+  if (
+    node.object.name === 'module' &&
+    property === 'exports' &&
+    !scope.getBinding('module')
+  ) {
+    return 'module-exports';
+  }
+  return node.object.name === 'exports' &&
+    property === 'default' &&
+    !scope.getBinding('exports')
+    ? 'exports-default'
+    : undefined;
+}
+
+function readBindingIdentifier(node: t.Node): string | undefined {
+  if (node.type === 'Identifier') return node.name;
+  return node.type === 'AssignmentPattern' && node.left.type === 'Identifier'
+    ? node.left.name
+    : undefined;
+}
+
+const MUTATING_METHODS = new Set([
+  'clear',
+  'copyWithin',
+  'delete',
+  'fill',
+  'pop',
+  'push',
+  'reverse',
+  'set',
+  'shift',
+  'sort',
+  'splice',
+  'unshift',
+]);
+
+/** Detects property, collection, and alias mutations Babel does not mark constant. */
+function bindingHasMutation(
+  binding: Binding,
+  seen: Set<Binding> = new Set()
+): boolean {
+  if (seen.has(binding)) return false;
+  const nextSeen = new Set(seen);
+  nextSeen.add(binding);
+
+  for (const reference of binding.referencePaths) {
+    let current = reference as NodePath<t.Node>;
+    while (
+      current.parentPath &&
+      (current.parentPath.isMemberExpression() ||
+        current.parentPath.isOptionalMemberExpression()) &&
+      current.parentPath.node.object === current.node
+    ) {
+      current = current.parentPath as NodePath<t.Node>;
+    }
+
+    const parent = current.parentPath;
+    if (
+      (parent?.isAssignmentExpression() && parent.node.left === current.node) ||
+      (parent?.isUpdateExpression() && parent.node.argument === current.node) ||
+      (parent?.isUnaryExpression({ operator: 'delete' }) &&
+        parent.node.argument === current.node)
+    ) {
+      return true;
+    }
+
+    if (parent?.isCallExpression() || parent?.isOptionalCallExpression()) {
+      if (
+        parent.node.callee === current.node &&
+        (current.isMemberExpression() ||
+          current.isOptionalMemberExpression()) &&
+        MUTATING_METHODS.has(readStaticMemberName(current.node) ?? '')
+      ) {
+        return true;
+      }
+      if (
+        parent.node.arguments[0] === current.node &&
+        isGlobalMutationCall(parent.node.callee, parent.scope)
+      ) {
+        return true;
+      }
+      if (
+        parent.node.arguments.some((argument) => argument === current.node) &&
+        !isKnownReadOnlyConfigConsumer(parent.node, current.node, parent.scope)
+      ) {
+        return true;
+      }
+    }
+
+    const aliasParent = reference.parentPath;
+    if (
+      aliasParent?.isVariableDeclarator() &&
+      aliasParent.node.init === reference.node &&
+      aliasParent.node.id.type === 'Identifier'
+    ) {
+      const alias = aliasParent.scope.getBinding(aliasParent.node.id.name);
+      if (alias && bindingHasMutation(alias, nextSeen)) return true;
+    }
+    if (
+      aliasParent?.isVariableDeclarator() &&
+      aliasParent.node.init === reference.node &&
+      aliasParent.node.id.type !== 'Identifier'
+    ) {
+      for (const name of collectBindingNames(aliasParent.node.id)) {
+        const alias = aliasParent.scope.getBinding(name);
+        if (alias && bindingHasMutation(alias, nextSeen)) return true;
+      }
+    }
+    if (
+      parent?.isAssignmentExpression({ operator: '=' }) &&
+      parent.node.right === current.node
+    ) {
+      for (const name of collectBindingNames(parent.node.left)) {
+        const alias = parent.scope.getBinding(name);
+        if (alias && bindingHasMutation(alias, nextSeen)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function collectBindingNames(input: t.Node): string[] {
+  if (input.type === 'Identifier') return [input.name];
+  if (input.type === 'AssignmentPattern') {
+    return collectBindingNames(input.left);
+  }
+  if (input.type === 'RestElement') return collectBindingNames(input.argument);
+  if (input.type === 'ArrayPattern') {
+    return input.elements.flatMap((element) =>
+      element ? collectBindingNames(element) : []
+    );
+  }
+  if (input.type === 'ObjectPattern') {
+    return input.properties.flatMap((property) =>
+      property.type === 'RestElement'
+        ? collectBindingNames(property.argument)
+        : collectBindingNames(property.value)
+    );
+  }
+  return [];
+}
+
+function readStaticMemberName(
+  node: t.MemberExpression | t.OptionalMemberExpression
+): string | undefined {
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name;
+  }
+  return node.computed && node.property.type === 'StringLiteral'
+    ? node.property.value
+    : undefined;
+}
+
+function isGlobalMutationCall(input: t.Node, scope: Scope): boolean {
+  const node = unwrapExpression(input);
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'OptionalMemberExpression'
+  ) {
+    return false;
+  }
+  const method = readStaticMemberName(node);
+  if (node.object.type !== 'Identifier' || scope.getBinding(node.object.name)) {
+    return false;
+  }
+  return (
+    (node.object.name === 'Object' &&
+      (method === 'assign' ||
+        method === 'defineProperty' ||
+        method === 'defineProperties')) ||
+    (node.object.name === 'Reflect' &&
+      (method === 'set' || method === 'deleteProperty'))
+  );
+}
+
+function isKnownReadOnlyConfigConsumer(
+  call: t.CallExpression | t.OptionalCallExpression,
+  argument: t.Node,
+  scope: Scope
+): boolean {
+  if (resolveKnownConfigConsumer(call.callee, scope, new Set())) return true;
+  const callee = unwrapExpression(call.callee);
+  if (
+    callee.type !== 'MemberExpression' &&
+    callee.type !== 'OptionalMemberExpression'
+  ) {
+    return false;
+  }
+  const method = readStaticMemberName(callee);
+  if (
+    callee.object.type !== 'Identifier' ||
+    scope.getBinding(callee.object.name)
+  ) {
+    return false;
+  }
+  const argumentIndex = call.arguments.findIndex(
+    (candidate) => candidate === argument
+  );
+  if (callee.object.name === 'Object') {
+    if (method === 'assign') return argumentIndex > 0;
+    return new Set([
+      'entries',
+      'freeze',
+      'getOwnPropertyDescriptor',
+      'getOwnPropertyDescriptors',
+      'getOwnPropertyNames',
+      'getOwnPropertySymbols',
+      'isExtensible',
+      'isFrozen',
+      'isSealed',
+      'keys',
+      'preventExtensions',
+      'seal',
+      'values',
+    ]).has(method ?? '');
+  }
+  return (
+    (callee.object.name === 'Array' && method === 'isArray') ||
+    (callee.object.name === 'JSON' && method === 'stringify')
+  );
+}
+
+function resolveKnownConfigConsumer(
+  input: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean {
+  const node = unwrapExpression(input);
+  if (node.type === 'Identifier') {
+    const binding = scope.getBinding(node.name);
+    if (!binding) return node.name === 'defineNuxtConfig';
+    if (seen.has(binding)) return false;
+    if (binding.path.isImportDefaultSpecifier()) {
+      const declaration = binding.path.parentPath;
+      return (
+        declaration.isImportDeclaration() &&
+        (declaration.node.source.value === '@vitejs/plugin-vue' ||
+          declaration.node.source.value === '@vitejs/plugin-vue-jsx')
+      );
+    }
+    if (binding.path.isImportSpecifier()) {
+      const declaration = binding.path.parentPath;
+      if (!declaration.isImportDeclaration()) return false;
+      const imported = binding.path.node.imported;
+      const name =
+        imported.type === 'Identifier' ? imported.name : imported.value;
+      const source = declaration.node.source.value;
+      return (
+        ((source === '@vitejs/plugin-vue' ||
+          source === '@vitejs/plugin-vue-jsx') &&
+          name === 'default') ||
+        (source === 'vite' && name === 'defineConfig') ||
+        ((source === 'nuxt' ||
+          source === 'nuxt/config' ||
+          source === '#imports') &&
+          name === 'defineNuxtConfig')
+      );
+    }
+    const declaration = binding.path.node;
+    if (
+      binding.constant &&
+      declaration.type === 'VariableDeclarator' &&
+      declaration.init
+    ) {
+      const nextSeen = new Set(seen);
+      nextSeen.add(binding);
+      return resolveKnownConfigConsumer(
+        declaration.init,
+        binding.path.scope,
+        nextSeen
+      );
+    }
+    return false;
+  }
+  return (
+    (node.type === 'MemberExpression' ||
+      node.type === 'OptionalMemberExpression') &&
+    isDefaultMember(node) &&
+    (getPluginVueRequireKind(node as t.Expression, '@vitejs/plugin-vue') ===
+      'default' ||
+      getPluginVueRequireKind(
+        node as t.Expression,
+        '@vitejs/plugin-vue-jsx'
+      ) === 'default')
+  );
+}
+
+/**
+ * Parses one project config without executing it. Automatic discovery keeps
+ * ignoring malformed configs that contain no Vue-relevant setting, while an
+ * explicit config or source scope reports every syntax error.
+ */
+function parseConfig(
+  file: string,
+  errors: string[],
+  reportAllSyntaxErrors: boolean
+): t.File | undefined {
+  let source: string;
+  try {
+    source = fs.readFileSync(file, 'utf8');
+  } catch (error) {
+    errors.push(
+      configFileDiagnostic(
+        'Could not read the Vue project config file',
+        'Restore the config file and its read permissions, then try extraction again',
+        file,
+        error
+      )
+    );
+    return undefined;
+  }
+
+  try {
+    return parse(source, {
+      sourceType: 'unambiguous',
+      plugins: parserPlugins(file),
+    });
+  } catch (error) {
+    if (
+      !reportAllSyntaxErrors &&
+      !/compilerOptions|whitespace|delimiters|@vitejs\/plugin-vue-jsx|babelPlugins|pragma/.test(
+        source
+      )
+    ) {
+      return undefined;
+    }
+    const syntaxError = error as SyntaxError & {
+      loc?: { column: number; line: number };
+    };
+    errors.push(
+      withLocation(
+        file,
+        createDiagnosticMessage({
+          whatHappened: reportAllSyntaxErrors
+            ? 'Could not parse the Vue project config file'
+            : 'Could not parse a project configuration containing Vue compiler options',
+          details: syntaxError.message,
+          fix: 'Use a statically analyzable Vite or Nuxt configuration, or configure files.gt.parsingFlags.vueCompilerOptions explicitly',
+        }),
+        syntaxError.loc
+          ? `${syntaxError.loc.line}:${syntaxError.loc.column + 1}`
+          : undefined
+      )
+    );
+    return undefined;
+  }
+}
+
+function parserPlugins(file: string): ParserPlugin[] {
+  const extension = path.extname(file).toLowerCase();
+  const plugins: ParserPlugin[] = [];
+  if (
+    extension === '.ts' ||
+    extension === '.mts' ||
+    extension === '.cts' ||
+    extension === '.tsx'
+  ) {
+    plugins.push('typescript', 'decorators-legacy');
+  }
+  if (extension === '.jsx' || extension === '.tsx') plugins.push('jsx');
+  return plugins;
+}
+
+function mergeOption<K extends CompilerOptionName>(
+  state: CompilerOptionState,
+  key: K,
+  value: Required<Pick<VueCompilerOptions, K>>[K],
+  source: OptionSource,
+  errors: string[]
+): void {
+  const existing = state.options[key];
+  if (existing !== undefined && !sameOption(existing, value)) {
+    errors.push(
+      locatedOptionError(
+        source.file,
+        source.node,
+        `Found conflicting Vue ${key} compiler options`,
+        'Use the same Vue compiler options in the project configuration and files.gt.parsingFlags.vueCompilerOptions'
+      )
+    );
+    return;
+  }
+  Object.assign(state.options, { [key]: value });
+  state.sources[key] ??= source;
+}
+
+function sameOption(
+  first: VueCompilerOptions[CompilerOptionName],
+  second: VueCompilerOptions[CompilerOptionName]
+): boolean {
+  return Array.isArray(first) && Array.isArray(second)
+    ? first[0] === second[0] && first[1] === second[1]
+    : first === second;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isDelimiterPair(value: unknown): value is [string, string] {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    value.every(
+      (delimiter) => typeof delimiter === 'string' && delimiter.length > 0
+    )
+  );
+}
+
+function dynamicConfigError(file: string, node: t.Node): string {
+  return locatedOptionError(
+    file,
+    node,
+    'Could not statically resolve Vue compiler options',
+    'Use static object and string literals for Vue whitespace and delimiters compiler options so extraction hashes match the compiled app'
+  );
+}
+
+function dynamicVueJSXConfigError(file: string, node: t.Node): string {
+  return locatedOptionError(
+    file,
+    node,
+    'Could not statically resolve @vitejs/plugin-vue-jsx options',
+    'Use one statically configured Vue JSX plugin with the default VNode transform so extraction hashes match the compiled app'
+  );
+}
+
+function locatedOptionError(
+  file: string,
+  node: t.Node | undefined,
+  whatHappened: string,
+  fix: string
+): string {
+  return withLocation(
+    file,
+    createDiagnosticMessage({ whatHappened, fix }),
+    node?.loc
+      ? `${node.loc.start.line}:${node.loc.start.column + 1}`
+      : undefined
+  );
+}
+
+function optionError(whatHappened: string, fix: string): string {
+  return createDiagnosticMessage({ whatHappened, fix });
+}
+
+/** Formats a filesystem-backed config diagnostic without leaking an exception. */
+function configFileDiagnostic(
+  whatHappened: string,
+  fix: string,
+  file: string,
+  error?: unknown
+): string {
+  const errorDetails =
+    error === undefined ? undefined : formatDiagnosticErrorDetails(error);
+  const details = [file, ...(errorDetails === undefined ? [] : [errorDetails])];
+  return createDiagnosticMessage({ whatHappened, fix, details });
+}
+
+function withLocation(
+  file: string,
+  message: string,
+  location?: string
+): string {
+  return `${file}${location ? ` (${location})` : ''}: ${message}`;
+}

--- a/packages/vue-extractor/src/internal/extractFromVueSource.ts
+++ b/packages/vue-extractor/src/internal/extractFromVueSource.ts
@@ -1,0 +1,1045 @@
+import { extname } from 'node:path';
+import {
+  init as initModuleLexer,
+  parse as parseModuleImports,
+} from 'es-module-lexer';
+import type { ParserPlugin } from '@babel/parser';
+import type { SFCBlock, TemplateCompiler } from '#vue-compiler-sfc';
+import type { RootNode } from '@vue/compiler-dom';
+import type {
+  VueCompilerOptions,
+  VueExtractionOptions,
+  VueExtractionOutput,
+} from '../types.js';
+import {
+  collectVueScriptImports,
+  createVueScriptAnalysis,
+  exposeVueScriptImportsToTemplate,
+  parseVueScript,
+  type VueScriptAnalysis,
+} from './script.js';
+import { parseScriptAst } from './script/parser.js';
+import {
+  shiftCompilerAstLocations,
+  shiftCompilerLocation,
+} from './compilerAst.js';
+import {
+  createLocalModuleResolver,
+  type LocalModuleResolver,
+} from './script/localModules.js';
+import { parseVueTemplate } from './template.js';
+import type { TemplateBindings, VueExtractionContext } from './types.js';
+import { addVueError, createVueExtractionContext } from './utils.js';
+import {
+  inspectVueCompiler,
+  resolveVueCompiler,
+  type ResolvedVueCompiler,
+} from './vueCompiler.js';
+
+const DEFAULT_SURROUNDING_LINE_COUNT = 5;
+const MAX_MALFORMED_SUFFIX_RECOVERIES = 64;
+
+/**
+ * Extracts General Translation content from one Vue SFC or JavaScript file.
+ *
+ * This low-level API lets callers parse an individual in-memory source file.
+ * Use `@generaltranslation/vue-extractor/project` when discovery, I/O,
+ * compiler configuration, hashing, and deduplication should be handled by the
+ * package as one project-level operation.
+ */
+export async function extractFromVueSource(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions = {}
+): Promise<VueExtractionOutput> {
+  const results: VueExtractionOutput['results'] = [];
+  const errors: string[] = [];
+  const warnings = new Set<string>();
+  const context = createVueExtractionContext(
+    filePath,
+    sourceCode,
+    options.projectRoot ?? process.cwd(),
+    options.includeSourceCodeContext ?? false,
+    options.surroundingLineCount ?? DEFAULT_SURROUNDING_LINE_COUNT,
+    results,
+    errors,
+    warnings
+  );
+  const extension = extname(filePath).toLowerCase();
+  const scriptAnalysis = createVueScriptAnalysis();
+  scriptAnalysis.entryFile = filePath;
+  scriptAnalysis.localModules = createLocalModuleResolver(
+    options.resolveModule
+  );
+
+  if (extension === '.vue') {
+    const compilerResolution =
+      options.compiler !== undefined
+        ? inspectVueCompiler(options.compiler)
+        : resolveVueCompiler(filePath, options.projectRoot ?? process.cwd());
+    if (!compilerResolution.ok) {
+      addVueError(
+        context,
+        undefined,
+        'Could not load the Vue compiler used by this single-file component',
+        `Install a supported Vue 3 compiler beside the app. ${compilerResolution.details}`
+      );
+      return { results, errors, warnings: [...warnings] };
+    }
+    context.implicitSlotWhitespace =
+      compilerResolution.value.implicitSlotWhitespace;
+    parseVueSingleFileComponent(
+      sourceCode,
+      context,
+      options.compilerOptions ?? {},
+      compilerResolution.value,
+      scriptAnalysis
+    );
+  } else {
+    if (
+      options.requireGTProvenance &&
+      !(await hasStandaloneGTProvenance(sourceCode, filePath, options))
+    ) {
+      return { results, errors, warnings: [...warnings] };
+    }
+    parseVueScript(
+      sourceCode,
+      languageFromExtension(extension),
+      context,
+      createTemplateBindings(),
+      false,
+      scriptAnalysis,
+      false
+    );
+  }
+
+  return { results, errors, warnings: [...warnings] };
+}
+
+/**
+ * Uses the declared language, then permissive TSX and Flow, to prove gt-vue
+ * ownership without changing the grammar used for extraction.
+ *
+ * The normal extraction pass still parses the file according to its extension.
+ * Diagnostics caused only by GT-shaped names do not establish ownership. This
+ * keeps mixed-framework dispatch from making otherwise valid React files fatal.
+ */
+async function hasStandaloneGTProvenance(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions
+): Promise<boolean> {
+  const extension = extname(filePath).toLowerCase();
+  const probeLanguages = new Set<StandaloneProbeLanguage>([
+    languageFromExtension(extension),
+    'tsx',
+    'flow',
+  ]);
+  const localModules = createLocalModuleResolver(options.resolveModule);
+  for (const language of probeLanguages) {
+    const probe = probeStandaloneGTProvenance(
+      sourceCode,
+      filePath,
+      options,
+      language,
+      localModules
+    );
+    if (probe.hasProvenance) return true;
+    if (probe.parsed) return false;
+  }
+  const suffixSelection = selectMalformedSuffixLanguage(
+    sourceCode,
+    probeLanguages
+  );
+  const moduleRecovery = suffixSelection?.recoverable
+    ? await recoverMalformedModuleReferences(
+        sourceCode,
+        filePath,
+        options,
+        probeLanguages,
+        localModules
+      )
+    : { hasProvenance: false, preamble: '' };
+  if (moduleRecovery.hasProvenance) {
+    return true;
+  }
+  return hasMalformedStandaloneGTProvenance(
+    sourceCode,
+    filePath,
+    options,
+    probeLanguages,
+    localModules,
+    moduleRecovery.preamble
+  );
+}
+
+/**
+ * Recovers static module ownership without reparsing an entire malformed file.
+ *
+ * es-module-lexer ignores comments and literal contents while continuing past
+ * unrelated syntax errors. Each declaration is then analyzed on its own,
+ * preserving type-only and binding-specific local-barrel semantics. Parseable
+ * declarations are also returned as a preamble for later recovered uses.
+ */
+async function recoverMalformedModuleReferences(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions,
+  languages: ReadonlySet<StandaloneProbeLanguage>,
+  localModules: LocalModuleResolver
+): Promise<{ hasProvenance: boolean; preamble: string }> {
+  await initModuleLexer;
+  let imports: ReturnType<typeof parseModuleImports>[0];
+  try {
+    [imports] = parseModuleImports(sourceCode);
+  } catch {
+    imports = [];
+  }
+
+  const declarations = new Set<string>();
+  for (const moduleImport of imports) {
+    if (!moduleImport.n) continue;
+    for (const declaration of readModuleStatementCandidates(
+      sourceCode,
+      moduleImport.ss,
+      moduleImport.se
+    )) {
+      for (const language of languages) {
+        const probe = probeStandaloneGTProvenance(
+          declaration,
+          filePath,
+          options,
+          language,
+          localModules
+        );
+        if (probe.hasProvenance) {
+          return { hasProvenance: true, preamble: '' };
+        }
+        if (probe.parsed) {
+          declarations.add(declaration);
+          break;
+        }
+      }
+      if (declarations.has(declaration)) break;
+    }
+  }
+  return {
+    hasProvenance: false,
+    preamble: [...declarations].join('\n'),
+  };
+}
+
+/** Returns small statement slices enclosing one lexed module reference. */
+function readModuleStatementCandidates(
+  sourceCode: string,
+  statementStart: number,
+  specifierEnd: number
+): string[] {
+  const precedingBoundaries = [';', '\n', '{', '}']
+    .map((separator) => sourceCode.lastIndexOf(separator, statementStart - 1))
+    .filter((offset) => offset >= 0)
+    .map((offset) => offset + 1);
+  precedingBoundaries.push(0);
+  const followingBoundaries = [';', '\n', '}']
+    .map((separator) => sourceCode.indexOf(separator, specifierEnd))
+    .filter((offset) => offset >= 0)
+    .map((offset) => offset + 1);
+  const starts = [
+    ...precedingBoundaries.sort((left, right) => right - left),
+    statementStart,
+  ];
+  const ends = [
+    ...followingBoundaries.sort((left, right) => left - right),
+    specifierEnd,
+  ];
+  const candidates = new Set<string>();
+  for (const start of starts) {
+    for (const end of ends) {
+      if (end <= start) continue;
+      const candidate = sourceCode.slice(start, end).trim();
+      if (candidate) candidates.add(candidate);
+    }
+  }
+  return [...candidates];
+}
+
+type StandaloneProbeLanguage = 'flow' | 'js' | 'jsx' | 'ts' | 'tsx';
+
+/** Runs one syntax-tolerant, read-only provenance classification pass. */
+function probeStandaloneGTProvenance(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions,
+  language: StandaloneProbeLanguage,
+  localModules: LocalModuleResolver
+): { hasProvenance: boolean; parsed: boolean } {
+  const results: VueExtractionOutput['results'] = [];
+  const errors: string[] = [];
+  const warnings = new Set<string>();
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const context = createVueExtractionContext(
+    filePath,
+    sourceCode,
+    projectRoot,
+    false,
+    options.surroundingLineCount ?? DEFAULT_SURROUNDING_LINE_COUNT,
+    results,
+    errors,
+    warnings
+  );
+  const analysis = createVueScriptAnalysis();
+  analysis.entryFile = filePath;
+  analysis.localModules = localModules;
+  const parsed = parseVueScript(
+    sourceCode,
+    language,
+    context,
+    createTemplateBindings(),
+    false,
+    analysis,
+    false
+  );
+  if (results.length > 0 || analysisHasGTProvenance(analysis)) {
+    return { hasProvenance: true, parsed };
+  }
+  return { hasProvenance: false, parsed };
+}
+
+/**
+ * Finds concrete module references when malformed syntax prevents a full AST.
+ *
+ * Each supported grammar recovers a complete prefix, then the grammar that
+ * parsed furthest gets a bounded suffix search. Unterminated literal errors
+ * never receive suffix recovery, so literal contents cannot become code.
+ */
+function hasMalformedStandaloneGTProvenance(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions,
+  languages: ReadonlySet<StandaloneProbeLanguage>,
+  localModules: LocalModuleResolver,
+  recoveredPreamble: string
+): boolean {
+  for (const language of languages) {
+    if (
+      leadingStatementPrefixHasGTProvenance(
+        sourceCode,
+        filePath,
+        options,
+        language,
+        localModules
+      )
+    ) {
+      return true;
+    }
+  }
+  const suffixSelection = selectMalformedSuffixLanguage(sourceCode, languages);
+  return Boolean(
+    suffixSelection?.recoverable &&
+    malformedSuffixHasGTProvenance(
+      sourceCode,
+      filePath,
+      options,
+      suffixSelection.language,
+      localModules,
+      recoveredPreamble
+    )
+  );
+}
+
+/** Preserves CommonJS and TypeScript import ownership before a syntax error. */
+function leadingStatementPrefixHasGTProvenance(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions,
+  language: StandaloneProbeLanguage,
+  localModules: LocalModuleResolver
+): boolean {
+  let errorOffset: number;
+  try {
+    parseScriptAst(sourceCode, language);
+    return false;
+  } catch (error) {
+    const offset = (error as { pos?: unknown }).pos;
+    if (typeof offset !== 'number') return false;
+    errorOffset = offset;
+  }
+  const boundary = Math.max(
+    sourceCode.lastIndexOf(';', errorOffset - 1) + 1,
+    sourceCode.lastIndexOf('\n', errorOffset - 1) + 1,
+    sourceCode.lastIndexOf('}', errorOffset - 1) + 1
+  );
+  if (boundary <= 0) return false;
+  const prefix = sourceCode.slice(0, boundary).trimEnd();
+  if (!prefix) return false;
+  const probe = probeStandaloneGTProvenance(
+    prefix,
+    filePath,
+    options,
+    language,
+    localModules
+  );
+  return probe.hasProvenance;
+}
+
+/** Recovers later imports and CommonJS calls after a bounded number of errors. */
+function malformedSuffixHasGTProvenance(
+  sourceCode: string,
+  filePath: string,
+  options: VueExtractionOptions,
+  language: StandaloneProbeLanguage,
+  localModules: LocalModuleResolver,
+  recoveredPreamble: string
+): boolean {
+  let remaining = sourceCode;
+  for (let attempt = 0; attempt < MAX_MALFORMED_SUFFIX_RECOVERIES; attempt++) {
+    let errorOffset: number;
+    try {
+      parseScriptAst(remaining, language);
+      const recoveredSource = recoveredPreamble
+        ? `${recoveredPreamble}\n${remaining}`
+        : remaining;
+      const recoveredProbe = probeStandaloneGTProvenance(
+        recoveredSource,
+        filePath,
+        options,
+        language,
+        localModules
+      );
+      if (recoveredProbe.parsed) return recoveredProbe.hasProvenance;
+      // The remaining suffix may already contain the declaration retained in
+      // the preamble. Probe it alone to avoid a duplicate-binding parse error.
+      return probeStandaloneGTProvenance(
+        remaining,
+        filePath,
+        options,
+        language,
+        localModules
+      ).hasProvenance;
+    } catch (error) {
+      const parseError = readRecoverableParseError(error);
+      if (!parseError) return false;
+      errorOffset = parseError.offset;
+    }
+    const boundary = findMalformedRecoveryBoundary(remaining, errorOffset);
+    if (boundary <= 0 || boundary >= remaining.length) return false;
+    remaining = remaining.slice(boundary);
+    const recoveredSource = recoveredPreamble
+      ? `${recoveredPreamble}\n${remaining}`
+      : remaining;
+    let probe = probeStandaloneGTProvenance(
+      recoveredSource,
+      filePath,
+      options,
+      language,
+      localModules
+    );
+    if (!probe.parsed && recoveredPreamble) {
+      const trimmedRemaining = trimTrailingRecoveryClosers(remaining);
+      if (trimmedRemaining !== remaining) {
+        probe = probeStandaloneGTProvenance(
+          `${recoveredPreamble}\n${trimmedRemaining}`,
+          filePath,
+          options,
+          language,
+          localModules
+        );
+      }
+    }
+    if (probe.hasProvenance) return true;
+    if (probe.parsed) return false;
+  }
+  return false;
+}
+
+/** Removes block closers orphaned when recovery starts inside a function. */
+function trimTrailingRecoveryClosers(sourceCode: string): string {
+  return sourceCode.replace(/(?:\s*\}\s*)+$/u, '').trimEnd();
+}
+
+/** Chooses the grammar that parsed furthest before a recoverable error. */
+function selectMalformedSuffixLanguage(
+  sourceCode: string,
+  languages: ReadonlySet<StandaloneProbeLanguage>
+): { language: StandaloneProbeLanguage; recoverable: boolean } | undefined {
+  let selected:
+    | { language: StandaloneProbeLanguage; recoverable: boolean }
+    | undefined;
+  let furthestOffset = -1;
+  for (const language of languages) {
+    try {
+      parseScriptAst(sourceCode, language);
+    } catch (error) {
+      const parseError = readParseError(error);
+      if (parseError && parseError.offset > furthestOffset) {
+        selected = {
+          language,
+          recoverable: parseError.recoverable,
+        };
+        furthestOffset = parseError.offset;
+      }
+    }
+  }
+  return selected;
+}
+
+/** Rejects recovery that could reinterpret unterminated literal contents. */
+function readRecoverableParseError(
+  error: unknown
+): { offset: number } | undefined {
+  const parsed = readParseError(error);
+  return parsed?.recoverable ? { offset: parsed.offset } : undefined;
+}
+
+/** Reads one Babel parser error without trusting unterminated literal state. */
+function readParseError(
+  error: unknown
+): { offset: number; recoverable: boolean } | undefined {
+  const parsed = error as { pos?: unknown; reasonCode?: unknown };
+  if (typeof parsed.pos !== 'number') return undefined;
+  const unsafeReasonCodes = new Set([
+    'UnterminatedComment',
+    'UnterminatedJsxContent',
+    'UnterminatedRegExp',
+    'UnterminatedString',
+    'UnterminatedTemplate',
+  ]);
+  return {
+    offset: parsed.pos,
+    recoverable:
+      typeof parsed.reasonCode !== 'string' ||
+      !unsafeReasonCodes.has(parsed.reasonCode),
+  };
+}
+
+/** Selects the first statement-like boundary after a parser error. */
+function findMalformedRecoveryBoundary(
+  sourceCode: string,
+  errorOffset: number
+): number {
+  const candidates = [';', '\n', '}']
+    .map((separator) => sourceCode.indexOf(separator, errorOffset))
+    .filter((offset) => offset >= 0);
+  return candidates.length > 0 ? Math.min(...candidates) + 1 : -1;
+}
+
+/** Returns whether permissive analysis reached a concrete gt-vue identity. */
+function analysisHasGTProvenance(analysis: VueScriptAnalysis): boolean {
+  return analysis.hasGTSourceReference;
+}
+
+function parseVueSingleFileComponent(
+  source: string,
+  context: VueExtractionContext,
+  compilerOptions: VueCompilerOptions,
+  resolvedCompiler: ResolvedVueCompiler,
+  scriptAnalysis: VueScriptAnalysis
+): void {
+  const { compiler } = resolvedCompiler;
+  if (
+    compilerOptions.delimiters &&
+    !resolvedCompiler.templateCompiler &&
+    !resolvedCompiler.templateParseOptionsSupported
+  ) {
+    addVueError(
+      context,
+      undefined,
+      'Could not safely apply custom Vue template delimiters with the supplied compiler',
+      'Let the extractor resolve the consuming app compiler, or supply a Vue compiler that applies templateParseOptions during SFC parsing'
+    );
+    return;
+  }
+  const expressionPlugins: ParserPlugin[] = sourceUsesTypeScript(source)
+    ? ['typescript']
+    : [];
+  const templateCompiler = createConfiguredTemplateCompiler(
+    resolvedCompiler,
+    compilerOptions,
+    expressionPlugins,
+    true
+  );
+  const result = compiler.parse(source, {
+    ...(templateCompiler && { compiler: templateCompiler }),
+    filename: context.file,
+    pad: 'space',
+    sourceMap: false,
+    templateParseOptions: {
+      ...compilerOptions,
+      comments: true,
+      expressionPlugins,
+    },
+  });
+
+  for (const error of result.errors) {
+    const compilerError =
+      typeof error === 'string'
+        ? undefined
+        : (error as SyntaxError & {
+            loc?: Parameters<typeof normalizeCompilerLocation>[0];
+          });
+    addVueError(
+      context,
+      compilerError?.loc
+        ? normalizeCompilerLocation(compilerError.loc)
+        : undefined,
+      `Could not parse a gt-vue single-file component: ${typeof error === 'string' ? error : error.message}`,
+      'Fix the Vue template syntax before extracting translations'
+    );
+  }
+  // Vue's SFC parser recovers a partial AST for malformed markup. Publishing
+  // translations from that recovery tree can replace complete catalogs with
+  // an incomplete source set, so structural parse errors are file-fatal.
+  if (result.errors.length > 0) return;
+
+  const bindings = createTemplateBindings();
+  collectScriptBlockImports(result.descriptor.script, scriptAnalysis);
+  collectScriptBlockImports(result.descriptor.scriptSetup, scriptAnalysis);
+  const scriptValid = parseScriptBlock(
+    result.descriptor.script,
+    false,
+    context,
+    bindings,
+    scriptAnalysis
+  );
+  if (result.descriptor.scriptSetup) {
+    exposeVueScriptImportsToTemplate(scriptAnalysis, bindings);
+  }
+  const scriptSetupValid = parseScriptBlock(
+    result.descriptor.scriptSetup,
+    true,
+    context,
+    bindings,
+    scriptAnalysis
+  );
+  if (!scriptValid || !scriptSetupValid) {
+    context.results.length = 0;
+    return;
+  }
+
+  const template = result.descriptor.template;
+  if (!template) return;
+  if (template.lang && template.lang !== 'html') {
+    addVueError(
+      context,
+      template.loc,
+      `Found unsupported Vue template language "${template.lang}"`,
+      'Use a standard HTML Vue template for gt-vue extraction'
+    );
+    context.results.length = 0;
+    return;
+  }
+  if (template.src) {
+    addVueError(
+      context,
+      template.loc,
+      'Found an externally sourced Vue template',
+      'Keep the template in the .vue file so gt-vue can extract it'
+    );
+    context.results.length = 0;
+    return;
+  }
+  const templateAst = resolvedCompiler.parseTemplate
+    ? parseTemplateWithCompiler(
+        template.content,
+        compilerOptions,
+        expressionPlugins,
+        true,
+        context,
+        resolvedCompiler.parseTemplate,
+        template.loc.start
+      )
+    : template.ast;
+  if (templateAst) {
+    const templateResultStart = context.results.length;
+    const templateErrorStart = context.errors.length;
+    parseVueTemplate(templateAst, bindings, expressionPlugins, context);
+    if (
+      context.errors.length === templateErrorStart &&
+      template.content.includes('<!--') &&
+      !matchesProductionTemplate(
+        source,
+        compilerOptions,
+        expressionPlugins,
+        bindings,
+        context,
+        templateResultStart,
+        resolvedCompiler
+      )
+    ) {
+      context.results.length = templateResultStart;
+      addVueError(
+        context,
+        template.loc,
+        'Found translatable Vue content whose hash changes between development and production',
+        'Remove comments that split translatable text or whitespace, or move those comments outside gt-vue <T> components'
+      );
+    }
+  }
+}
+
+/**
+ * Verifies that Vite's production comment stripping preserves extracted data.
+ *
+ * Vue parses templates with comments in development and without them in
+ * production. Removing a comment can renormalize adjacent whitespace, so a
+ * single persisted catalog key cannot serve both builds. The second parse is
+ * limited to templates that contain comments and never executes project code.
+ */
+function matchesProductionTemplate(
+  source: string,
+  compilerOptions: VueCompilerOptions,
+  expressionPlugins: ParserPlugin[],
+  bindings: TemplateBindings,
+  context: VueExtractionContext,
+  developmentResultStart: number,
+  resolvedCompiler: ResolvedVueCompiler
+): boolean {
+  const { compiler } = resolvedCompiler;
+  const templateCompiler = createConfiguredTemplateCompiler(
+    resolvedCompiler,
+    compilerOptions,
+    expressionPlugins,
+    false
+  );
+  const production = compiler.parse(source, {
+    ...(templateCompiler && { compiler: templateCompiler }),
+    filename: context.file,
+    pad: 'space',
+    sourceMap: false,
+    templateParseOptions: {
+      ...compilerOptions,
+      comments: false,
+      expressionPlugins,
+    },
+  });
+  const template = production.descriptor.template;
+  if (production.errors.length > 0 || !template) return false;
+
+  const productionContext: VueExtractionContext = {
+    ...context,
+    errors: [],
+    results: [],
+    warnings: new Set(),
+  };
+  const templateAst = resolvedCompiler.parseTemplate
+    ? parseTemplateWithCompiler(
+        template.content,
+        compilerOptions,
+        expressionPlugins,
+        false,
+        productionContext,
+        resolvedCompiler.parseTemplate,
+        template.loc.start
+      )
+    : template.ast;
+  if (!templateAst) return false;
+  parseVueTemplate(templateAst, bindings, expressionPlugins, productionContext);
+  if (productionContext.errors.length > 0) return false;
+
+  const developmentResults = context.results.slice(developmentResultStart);
+  return (
+    comparableTemplateResults(developmentResults) ===
+    comparableTemplateResults(productionContext.results)
+  );
+}
+
+/**
+ * Applies hash-affecting options during compiler-sfc's structural parse.
+ *
+ * Vue 3.3 ignores `templateParseOptions`, which can make delimiter-shaped text
+ * close an SFC block before the exact template-content parse runs. Supplying
+ * the adjacent compiler-dom parser makes the descriptor structural parse use
+ * the same delimiters and whitespace. Vue 3.3 caches SFC parses using the
+ * parser function's string form, so its deterministic identity includes every
+ * closure-captured option to prevent cross-option cache poisoning.
+ */
+function createConfiguredTemplateCompiler(
+  resolvedCompiler: ResolvedVueCompiler,
+  compilerOptions: VueCompilerOptions,
+  expressionPlugins: ParserPlugin[],
+  comments: boolean
+): TemplateCompiler | undefined {
+  const templateCompiler = resolvedCompiler.templateCompiler;
+  if (!templateCompiler) return undefined;
+
+  const parse: TemplateCompiler['parse'] = (source, baseOptions) =>
+    templateCompiler.parse(source, {
+      ...baseOptions,
+      ...compilerOptions,
+      comments,
+      expressionPlugins,
+    });
+  const identity = JSON.stringify({
+    comments,
+    delimiters: compilerOptions.delimiters,
+    expressionPlugins,
+    version: resolvedCompiler.version,
+    whitespace: compilerOptions.whitespace,
+  });
+  Object.defineProperty(parse, 'toString', {
+    value: () => `gtVueTemplateParse:${identity}`,
+  });
+
+  return { compile: templateCompiler.compile, parse };
+}
+
+/** Parses template content with the exact compiler-dom beside consumer Vue. */
+function parseTemplateWithCompiler(
+  source: string,
+  compilerOptions: VueCompilerOptions,
+  expressionPlugins: ParserPlugin[],
+  comments: boolean,
+  context: VueExtractionContext,
+  parseTemplate: NonNullable<ResolvedVueCompiler['parseTemplate']>,
+  origin: CompilerPosition
+): RootNode | undefined {
+  const errors: Array<SyntaxError & { loc?: ExtractionLocationLike }> = [];
+  const ast = parseTemplate(source, {
+    ...compilerOptions,
+    comments,
+    expressionPlugins,
+    onError(error) {
+      errors.push(error as SyntaxError & { loc?: ExtractionLocationLike });
+    },
+  });
+  if (errors.length === 0) {
+    shiftCompilerAstLocations(ast, origin);
+    return ast;
+  }
+  const shiftedErrorPositions = new WeakSet<object>();
+  for (const error of errors) {
+    if (error.loc) {
+      shiftCompilerLocation(error.loc, origin, shiftedErrorPositions);
+    }
+    addVueError(
+      context,
+      error.loc ? normalizeCompilerLocation(error.loc) : undefined,
+      `Could not parse a gt-vue template: ${error.message}`,
+      'Fix the Vue template syntax before extracting translations'
+    );
+  }
+  return undefined;
+}
+
+type ExtractionLocationLike = Parameters<typeof normalizeCompilerLocation>[0];
+type CompilerPosition = {
+  column: number;
+  line: number;
+  offset: number;
+};
+
+/** Omits location-only metadata while comparing persisted template content. */
+function comparableTemplateResults(
+  results: VueExtractionOutput['results']
+): string {
+  return JSON.stringify(
+    results.map((result) => ({
+      dataFormat: result.dataFormat,
+      context: result.metadata.context,
+      source: result.source,
+    }))
+  );
+}
+
+function collectScriptBlockImports(
+  block: SFCBlock | null,
+  scriptAnalysis: VueScriptAnalysis
+): void {
+  if (!block || block.src || !isSupportedScriptLanguage(block.lang)) return;
+  collectVueScriptImports(block.content, block.lang, scriptAnalysis);
+}
+
+function parseScriptBlock(
+  block: SFCBlock | null,
+  exposeToTemplate: boolean,
+  context: VueExtractionContext,
+  bindings: TemplateBindings,
+  scriptAnalysis: VueScriptAnalysis
+): boolean {
+  if (!block) return true;
+  if (block.src) {
+    addVueError(
+      context,
+      block.loc,
+      'Found an externally sourced Vue script block',
+      'Keep translation calls and gt-vue imports in the .vue file'
+    );
+    return false;
+  }
+  if (!isSupportedScriptLanguage(block.lang)) {
+    addVueError(
+      context,
+      block.loc,
+      `Found unsupported Vue script language "${block.lang}"`,
+      'Use JavaScript or TypeScript for gt-vue extraction'
+    );
+    return false;
+  }
+
+  return parseVueScript(
+    block.content,
+    block.lang,
+    context,
+    bindings,
+    exposeToTemplate,
+    scriptAnalysis
+  );
+}
+
+function createTemplateBindings(): TemplateBindings {
+  return {
+    arrayLengths: new Map(),
+    componentFactories: new Set(),
+    components: new Map(),
+    containerKinds: new Map(),
+    possibleGTContainers: new Set(),
+    gtContainerFactories: new Set(),
+    directBindings: new Set(),
+    registeredComponents: new Map(),
+    registeredVueBuiltins: new Map(),
+    staticValues: new Map(),
+    identityFunctions: new Set(),
+    possibleStaticStrings: new Map(),
+    stringFunctions: new Map(),
+    uncertainStringFunctions: new Set(),
+    uncertainComponents: new Set(),
+    uncertainGTComponents: new Set(),
+    gtComponentFactories: new Set(),
+    uncertainRegisteredComponents: new Set(),
+    uncertainRegisteredGTComponents: new Set(),
+    vueBuiltins: new Map(),
+  };
+}
+
+function sourceUsesTypeScript(source: string): boolean {
+  let offset = 0;
+  while (offset < source.length) {
+    const start = source.indexOf('<script', offset);
+    if (start === -1) return false;
+    const boundary = source[start + '<script'.length];
+    if (boundary !== '>' && !boundary?.match(/\s/)) {
+      offset = start + '<script'.length;
+      continue;
+    }
+
+    const end = findOpeningTagEnd(source, start + '<script'.length);
+    if (end === -1) return false;
+    const language = readOpeningTagAttribute(
+      source.slice(start + '<script'.length, end),
+      'lang'
+    );
+    if (typeof language === 'string' && /^tsx?$/i.test(language)) return true;
+    offset = end + 1;
+  }
+  return false;
+}
+
+function isSupportedScriptLanguage(language: string | undefined): boolean {
+  const normalizedLanguage = language?.toLowerCase();
+  return (
+    normalizedLanguage === undefined ||
+    normalizedLanguage === 'js' ||
+    normalizedLanguage === 'jsx' ||
+    normalizedLanguage === 'ts' ||
+    normalizedLanguage === 'tsx'
+  );
+}
+
+/** Finds an opening tag boundary while respecting quoted attribute values. */
+function findOpeningTagEnd(source: string, start: number): number {
+  let quote: '"' | "'" | undefined;
+  for (let index = start; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) quote = undefined;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return index;
+    }
+  }
+  return -1;
+}
+
+/** Reads one case-sensitive SFC attribute with quoted or unquoted syntax. */
+function readOpeningTagAttribute(
+  attributes: string,
+  requestedName: string
+): string | true | undefined {
+  let offset = 0;
+  while (offset < attributes.length) {
+    while (offset < attributes.length && /\s/.test(attributes[offset])) {
+      offset += 1;
+    }
+    if (attributes[offset] === '/') {
+      offset += 1;
+      continue;
+    }
+    const nameStart = offset;
+    while (offset < attributes.length && !/[\s=]/.test(attributes[offset])) {
+      offset += 1;
+    }
+    const name = attributes.slice(nameStart, offset);
+    if (!name) break;
+
+    while (offset < attributes.length && /\s/.test(attributes[offset])) {
+      offset += 1;
+    }
+    let value: string | true = true;
+    if (attributes[offset] === '=') {
+      offset += 1;
+      while (offset < attributes.length && /\s/.test(attributes[offset])) {
+        offset += 1;
+      }
+      const quote = attributes[offset];
+      if (quote === '"' || quote === "'") {
+        offset += 1;
+        const valueStart = offset;
+        while (offset < attributes.length && attributes[offset] !== quote) {
+          offset += 1;
+        }
+        value = attributes.slice(valueStart, offset);
+        if (attributes[offset] === quote) offset += 1;
+      } else {
+        const valueStart = offset;
+        while (offset < attributes.length && !/\s/.test(attributes[offset])) {
+          offset += 1;
+        }
+        value = attributes.slice(valueStart, offset);
+      }
+    }
+    if (name === requestedName) return value;
+  }
+  return undefined;
+}
+
+function languageFromExtension(
+  extension: string
+): Exclude<StandaloneProbeLanguage, 'flow'> {
+  if (extension === '.ts' || extension === '.mts' || extension === '.cts') {
+    return 'ts';
+  }
+  if (extension === '.tsx') return 'tsx';
+  if (extension === '.jsx') return 'jsx';
+  return 'js';
+}
+
+function normalizeCompilerLocation(location: {
+  end?: { column?: number; line?: number; offset?: number };
+  start?: { column?: number; line?: number; offset?: number };
+}) {
+  const start = location.start ?? {};
+  const end = location.end ?? start;
+  return {
+    start: {
+      column: start.column ?? 1,
+      line: start.line ?? 1,
+      offset: start.offset ?? 0,
+    },
+    end: {
+      column: end.column ?? start.column ?? 1,
+      line: end.line ?? start.line ?? 1,
+      offset: end.offset ?? start.offset ?? 0,
+    },
+  };
+}

--- a/packages/vue-extractor/src/internal/project/consumerUsage.ts
+++ b/packages/vue-extractor/src/internal/project/consumerUsage.ts
@@ -5,7 +5,7 @@ import traverseModule, {
   type NodePath,
   type Scope,
 } from '@babel/traverse';
-import type * as t from '@babel/types';
+import * as t from '@babel/types';
 import { parseScriptAst } from '../script/parser.js';
 import {
   readJavaScriptPackageManifest,
@@ -15,6 +15,7 @@ import { DEFAULT_VUE_SOURCE_DIRECTORIES } from './sourcePatterns.js';
 import {
   readPublicGTImports,
   readPublicImportEntries,
+  type PublicGTImport,
 } from './wrapperProvenance.js';
 
 const traverse = traverseModule.default || traverseModule;
@@ -35,6 +36,7 @@ const IGNORED_CONSUMER_DIRECTORIES = new Set([
   'build',
   'coverage',
   'dist',
+  'lib',
   'node_modules',
   'out',
   'storybook-static',
@@ -51,6 +53,34 @@ type ConsumerImport = {
   source: string;
 };
 
+type ConsumerImportIndex = Map<string, ReadonlySet<string> | '*'>;
+
+type ConsumerSourceIndex = {
+  exhausted: boolean;
+  importsBySpecifier: ConsumerImportIndex;
+  pendingDirectories: string[];
+  pendingFiles: string[];
+  root: string;
+  seenFiles: Set<string>;
+  sourceFiles: number;
+};
+
+/** Per-inspection state that prevents repeated wrapper provenance scans. */
+export type ConsumerUsageCache = {
+  consumers: Map<string, ConsumerSourceIndex>;
+  publicImports: Map<string, PublicGTImport[]>;
+  queries: Map<string, boolean>;
+};
+
+/** Creates an edit-fresh cache for one project detection or inspection. */
+export function createConsumerUsageCache(): ConsumerUsageCache {
+  return {
+    consumers: new Map(),
+    publicImports: new Map(),
+    queries: new Map(),
+  };
+}
+
 /**
  * Returns whether consumer source actually imports a wrapper's public GT API.
  *
@@ -65,11 +95,23 @@ export function packageConsumesPublicGT(
   consumerDirectory: string,
   dependencyName: string,
   packageDirectory: string,
-  manifest: JavaScriptPackageManifest
+  manifest: JavaScriptPackageManifest,
+  cache: ConsumerUsageCache = createConsumerUsageCache()
 ): boolean {
   const packageName = readPackageName(manifest);
   if (!packageName) return false;
-  const publicImports = readPublicGTImports(packageDirectory, manifest).map(
+  const consumerRoot = resolveRealPath(consumerDirectory);
+  const packageRoot = resolveRealPath(packageDirectory);
+  const queryKey = `${consumerRoot}\0${dependencyName}\0${packageRoot}`;
+  const cachedQuery = cache.queries.get(queryKey);
+  if (cachedQuery !== undefined) return cachedQuery;
+
+  let packagePublicImports = cache.publicImports.get(packageRoot);
+  if (!packagePublicImports) {
+    packagePublicImports = readPublicGTImports(packageDirectory, manifest);
+    cache.publicImports.set(packageRoot, packagePublicImports);
+  }
+  const publicImports = packagePublicImports.map(
     ({ entry: _entry, exportNames, specifier }) => ({
       exportNames,
       specifier: `${dependencyName}${specifier.slice(packageName.length)}`,
@@ -85,48 +127,121 @@ export function packageConsumesPublicGT(
       existing ? new Set([...existing, ...exportNames]) : exportNames
     );
   }
-  return consumerSourceUsesGT(consumerDirectory, importsBySpecifier);
+  const result = consumerSourceUsesGT(consumerRoot, importsBySpecifier, cache);
+  cache.queries.set(queryKey, result);
+  return result;
+}
+
+/** Returns whether a wrapper exposes any public gt-vue-derived value. */
+export function packageExposesPublicGT(
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest,
+  cache: ConsumerUsageCache
+): boolean {
+  const packageRoot = resolveRealPath(packageDirectory);
+  let publicImports = cache.publicImports.get(packageRoot);
+  if (!publicImports) {
+    publicImports = readPublicGTImports(packageDirectory, manifest);
+    cache.publicImports.set(packageRoot, publicImports);
+  }
+  return publicImports.length > 0;
 }
 
 /** Scans one package boundary for static imports of its dependency's GT API. */
 function consumerSourceUsesGT(
   consumerDirectory: string,
-  importsBySpecifier: ReadonlyMap<string, ReadonlySet<string>>
+  importsBySpecifier: ReadonlyMap<string, ReadonlySet<string>>,
+  cache: ConsumerUsageCache
 ): boolean {
-  const root = resolveRealPath(consumerDirectory);
-  const pending = DEFAULT_VUE_SOURCE_DIRECTORIES.map((directory) =>
-    path.join(root, directory)
-  )
-    .filter((directory) => isContainedPhysicalDirectory(root, directory))
-    .reverse();
-  const sourceFileQueue = new Set<string>();
+  let consumer = cache.consumers.get(consumerDirectory);
+  if (!consumer) {
+    consumer = createConsumerSourceIndex(consumerDirectory);
+    cache.consumers.set(consumerDirectory, consumer);
+  }
+  if (
+    consumerImportIndexMatches(consumer.importsBySpecifier, importsBySpecifier)
+  ) {
+    return true;
+  }
+  while (!consumer.exhausted) {
+    const file = readNextConsumerSourceFile(consumer);
+    if (!file) break;
+    mergeConsumerImports(
+      consumer.importsBySpecifier,
+      readConsumerImports(file)
+    );
+    if (
+      consumerImportIndexMatches(
+        consumer.importsBySpecifier,
+        importsBySpecifier
+      )
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Creates a lazy, single-pass source index for one consumer package. */
+function createConsumerSourceIndex(root: string): ConsumerSourceIndex {
+  const pendingFiles = new Set<string>();
   const consumerManifest = readJavaScriptPackageManifest(
     path.join(root, 'package.json')
   );
   if (consumerManifest) {
     for (const { entry } of readPublicImportEntries(root, consumerManifest)) {
-      if (!isIgnoredConsumerPath(root, entry)) sourceFileQueue.add(entry);
+      if (isConsumerSourceFile(entry) && !isIgnoredConsumerPath(root, entry)) {
+        pendingFiles.add(entry);
+      }
     }
   }
   try {
     for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
       if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.vue') {
-        sourceFileQueue.add(path.join(root, entry.name));
+        pendingFiles.add(path.join(root, entry.name));
       }
     }
   } catch {
     // Public entries may still establish usage when the root cannot be listed.
   }
-  let sourceFiles = 0;
+  return {
+    exhausted: false,
+    importsBySpecifier: new Map(),
+    pendingDirectories: DEFAULT_VUE_SOURCE_DIRECTORIES.map((directory) =>
+      path.join(root, directory)
+    )
+      .filter((directory) => isContainedPhysicalDirectory(root, directory))
+      .reverse(),
+    pendingFiles: [...pendingFiles].reverse(),
+    root,
+    seenFiles: new Set(),
+    sourceFiles: 0,
+  };
+}
 
-  for (const file of sourceFileQueue) {
-    sourceFiles += 1;
-    if (sourceFiles > MAX_CONSUMER_SOURCE_FILES) return false;
-    if (sourceFileUsesGT(file, importsBySpecifier)) return true;
-  }
+/** Returns each consumer source file at most once across every wrapper query. */
+function readNextConsumerSourceFile(
+  consumer: ConsumerSourceIndex
+): string | undefined {
+  while (true) {
+    const pendingFile = consumer.pendingFiles.pop();
+    if (pendingFile) {
+      const file = resolveRealPath(pendingFile);
+      if (consumer.seenFiles.has(file) || !isConsumerSourceFile(file)) continue;
+      consumer.seenFiles.add(file);
+      consumer.sourceFiles += 1;
+      if (consumer.sourceFiles > MAX_CONSUMER_SOURCE_FILES) {
+        consumer.exhausted = true;
+        return undefined;
+      }
+      return file;
+    }
 
-  while (pending.length > 0) {
-    const current = pending.pop()!;
+    const current = consumer.pendingDirectories.pop();
+    if (!current) {
+      consumer.exhausted = true;
+      return undefined;
+    }
     if (fs.existsSync(path.join(current, 'package.json'))) {
       // Nested workspace packages establish their own ownership. Their imports
       // must never promote an aggregator or sibling package.
@@ -139,42 +254,49 @@ function consumerSourceUsesGT(
     } catch {
       continue;
     }
+    const sourceFiles: string[] = [];
     for (const entry of entries) {
       if (shouldIgnoreConsumerEntry(entry)) continue;
       const candidate = path.join(current, entry.name);
       if (entry.isDirectory()) {
-        pending.push(candidate);
-        continue;
-      }
-      if (
-        !entry.isFile() ||
-        !CONSUMER_SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
-      ) {
-        continue;
-      }
-      sourceFiles += 1;
-      if (sourceFiles > MAX_CONSUMER_SOURCE_FILES) return false;
-      if (
-        !sourceFileQueue.has(candidate) &&
-        sourceFileUsesGT(candidate, importsBySpecifier)
-      ) {
-        return true;
+        consumer.pendingDirectories.push(candidate);
+      } else if (entry.isFile() && isConsumerSourceFile(candidate)) {
+        sourceFiles.push(candidate);
       }
     }
+    // The stack remains lazy while preserving the historical readdir order,
+    // including which files fall inside the finite source budget.
+    consumer.pendingFiles.push(...sourceFiles.reverse());
   }
-  return false;
 }
 
-function sourceFileUsesGT(
-  file: string,
-  importsBySpecifier: ReadonlyMap<string, ReadonlySet<string>>
+function mergeConsumerImports(
+  importsBySpecifier: ConsumerImportIndex,
+  imports: readonly ConsumerImport[]
+): void {
+  for (const consumerImport of imports) {
+    const existing = importsBySpecifier.get(consumerImport.source);
+    if (existing === '*' || consumerImport.importedNames === '*') {
+      importsBySpecifier.set(consumerImport.source, '*');
+      continue;
+    }
+    importsBySpecifier.set(
+      consumerImport.source,
+      new Set([...(existing ?? []), ...consumerImport.importedNames])
+    );
+  }
+}
+
+function consumerImportIndexMatches(
+  consumerImports: ReadonlyMap<string, ReadonlySet<string> | '*'>,
+  gtImports: ReadonlyMap<string, ReadonlySet<string>>
 ): boolean {
-  for (const consumerImport of readConsumerImports(file)) {
-    const gtExportNames = importsBySpecifier.get(consumerImport.source);
-    if (!gtExportNames) continue;
+  for (const [specifier, gtExportNames] of gtImports) {
+    const importedNames = consumerImports.get(specifier);
     if (
-      consumerImport.importedNames === '*' ||
-      [...consumerImport.importedNames].some((name) => gtExportNames.has(name))
+      importedNames === '*' ||
+      (importedNames &&
+        [...importedNames].some((name) => gtExportNames.has(name)))
     ) {
       return true;
     }
@@ -189,6 +311,13 @@ function shouldIgnoreConsumerEntry(entry: fs.Dirent): boolean {
       (entry.name.startsWith('.') ||
         IGNORED_CONSUMER_DIRECTORIES.has(entry.name)))
   );
+}
+
+/** Accepts executable source while rejecting ambient declaration artifacts. */
+function isConsumerSourceFile(file: string): boolean {
+  const fileName = path.basename(file).toLowerCase();
+  if (/\.d\.(?:c|m)?ts$/.test(fileName)) return false;
+  return CONSUMER_SOURCE_EXTENSIONS.has(path.extname(fileName));
 }
 
 /** Rejects public entries that resolve only into generated package output. */
@@ -236,24 +365,169 @@ function readVueScriptBlocks(source: string): {
   templateSource: string;
 } {
   const blocks: Array<{ language: string | undefined; source: string }> = [];
-  const expression = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
-  for (const match of source.matchAll(expression)) {
-    const attributes = match[1] ?? '';
+  const templateSources: string[] = [];
+  for (const block of readTopLevelSfcBlocks(source)) {
+    if (block.name === 'template') {
+      templateSources.push(block.source);
+      continue;
+    }
+    if (block.name !== 'script') continue;
+    const attributes = block.attributes;
     const quotedLanguage = /\blang\s*=\s*(["'])([^"']+)\1/i.exec(
       attributes
     )?.[2];
     const bareLanguage = /\blang\s*=\s*([^\s>]+)/i.exec(attributes)?.[1];
     blocks.push({
       language: quotedLanguage ?? bareLanguage,
-      source: match[2] ?? '',
+      source: block.source,
     });
   }
-  const templateSource = [
-    ...source.matchAll(/<template\b[^>]*>([\s\S]*?)<\/template\s*>/gi),
-  ]
-    .map((match) => match[1] ?? '')
-    .join('\n');
-  return { blocks, templateSource };
+  return { blocks, templateSource: templateSources.join('\n') };
+}
+
+type SfcBlock = {
+  attributes: string;
+  name: string;
+  source: string;
+};
+
+type MarkupTag = {
+  attributes: string;
+  closing: boolean;
+  end: number;
+  name: string;
+  selfClosing: boolean;
+  start: number;
+};
+
+/** Reads real top-level SFC blocks without loading the Vue compiler. */
+function readTopLevelSfcBlocks(source: string): SfcBlock[] {
+  const blocks: SfcBlock[] = [];
+  let index = 0;
+  while (index < source.length) {
+    if (source.startsWith('<!--', index)) {
+      index = readHtmlCommentEnd(source, index);
+      continue;
+    }
+    if (source[index] !== '<') {
+      index += 1;
+      continue;
+    }
+    const tag = readMarkupTag(source, index);
+    if (!tag) {
+      index += 1;
+      continue;
+    }
+    index = tag.end;
+    if (tag.closing || tag.selfClosing) continue;
+
+    const closingTag =
+      tag.name === 'script' || tag.name === 'style'
+        ? findRawBlockClosingTag(source, tag.name, tag.end)
+        : findStructuredBlockClosingTag(source, tag.name, tag.end);
+    if (!closingTag) continue;
+    if (tag.name === 'script' || tag.name === 'template') {
+      blocks.push({
+        attributes: tag.attributes,
+        name: tag.name,
+        source: source.slice(tag.end, closingTag.start),
+      });
+    }
+    index = closingTag.end;
+  }
+  return blocks;
+}
+
+/** Reads one quote-aware markup tag at an exact source offset. */
+function readMarkupTag(source: string, start: number): MarkupTag | undefined {
+  if (source[start] !== '<' || source.startsWith('<!--', start)) {
+    return undefined;
+  }
+  let cursor = start + 1;
+  const closing = source[cursor] === '/';
+  if (closing) cursor += 1;
+  const nameStart = cursor;
+  while (cursor < source.length && /[A-Za-z0-9:_-]/.test(source[cursor]!)) {
+    cursor += 1;
+  }
+  if (cursor === nameStart) return undefined;
+  const name = source.slice(nameStart, cursor).toLowerCase();
+  const attributesStart = cursor;
+  let quote: string | undefined;
+  while (cursor < source.length) {
+    const character = source[cursor]!;
+    if (quote) {
+      if (character === quote) quote = undefined;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      const attributes = source.slice(attributesStart, cursor);
+      return {
+        attributes,
+        closing,
+        end: cursor + 1,
+        name,
+        selfClosing: !closing && /\/\s*$/.test(attributes),
+        start,
+      };
+    }
+    cursor += 1;
+  }
+  return undefined;
+}
+
+/** Finds a raw-text script/style closing tag using HTML parsing semantics. */
+function findRawBlockClosingTag(
+  source: string,
+  name: string,
+  start: number
+): MarkupTag | undefined {
+  const expression = new RegExp(
+    `<\\/\\s*${escapeRegularExpression(name)}\\s*>`,
+    'gi'
+  );
+  expression.lastIndex = start;
+  const match = expression.exec(source);
+  return match ? readMarkupTag(source, match.index) : undefined;
+}
+
+/** Finds a matching structured block while respecting comments and nesting. */
+function findStructuredBlockClosingTag(
+  source: string,
+  name: string,
+  start: number
+): MarkupTag | undefined {
+  let depth = 1;
+  let index = start;
+  while (index < source.length) {
+    if (source.startsWith('<!--', index)) {
+      index = readHtmlCommentEnd(source, index);
+      continue;
+    }
+    if (source[index] !== '<') {
+      index += 1;
+      continue;
+    }
+    const tag = readMarkupTag(source, index);
+    if (!tag) {
+      index += 1;
+      continue;
+    }
+    index = tag.end;
+    if (tag.name !== name) continue;
+    if (tag.closing) {
+      depth -= 1;
+      if (depth === 0) return tag;
+    } else if (!tag.selfClosing) {
+      depth += 1;
+    }
+  }
+  return undefined;
+}
+
+function readHtmlCommentEnd(source: string, start: number): number {
+  const end = source.indexOf('-->', start + 4);
+  return end < 0 ? source.length : end + 3;
 }
 
 /** Accepts project-compatible syntax while extracting only static ESM edges. */
@@ -293,6 +567,9 @@ function collectStaticImports(
     },
   });
   if (!programScope) return [];
+  const templateUsage = templateSource
+    ? readTemplateUsage(templateSource)
+    : undefined;
 
   const imports: ConsumerImport[] = [];
   for (const statement of ast.program.body) {
@@ -304,18 +581,31 @@ function collectStaticImports(
       const importedNames = new Set<string>();
       for (const specifier of statement.specifiers) {
         if (specifier.type === 'ImportDefaultSpecifier') {
-          importedNames.add('default');
+          if (
+            bindingHasRuntimeUsage(
+              programScope,
+              specifier.local.name,
+              templateUsage
+            )
+          ) {
+            importedNames.add('default');
+          }
         } else if (specifier.type === 'ImportNamespaceSpecifier') {
           for (const name of readUsedNamespaceMembers(
             programScope,
             specifier.local.name,
-            templateSource
+            templateUsage
           )) {
             importedNames.add(name);
           }
         } else if (
           specifier.importKind !== 'type' &&
-          specifier.importKind !== 'typeof'
+          specifier.importKind !== 'typeof' &&
+          bindingHasRuntimeUsage(
+            programScope,
+            specifier.local.name,
+            templateUsage
+          )
         ) {
           importedNames.add(readModuleName(specifier.imported));
         }
@@ -364,11 +654,44 @@ function readModuleName(node: t.Identifier | t.StringLiteral): string {
   return node.type === 'Identifier' ? node.name : node.value;
 }
 
+/** Requires a named/default import to participate in executable source. */
+function bindingHasRuntimeUsage(
+  scope: Scope,
+  localName: string,
+  templateUsage: TemplateUsage | undefined
+): boolean {
+  const binding = scope.getBinding(localName);
+  return Boolean(
+    binding?.referencePaths.some(
+      (reference) => !isTypeOnlyReference(reference)
+    ) || templateUsage?.identifiers.has(localName)
+  );
+}
+
+function isTypeOnlyReference(reference: NodePath<t.Node>): boolean {
+  if (
+    reference.findParent(
+      (parent) => t.isTSType(parent.node) || t.isFlow(parent.node)
+    )
+  ) {
+    return true;
+  }
+  const exportSpecifier = reference.findParent((parent) =>
+    parent.isExportSpecifier()
+  );
+  return Boolean(
+    exportSpecifier?.isExportSpecifier() &&
+    (exportSpecifier.node.exportKind === 'type' ||
+      (exportSpecifier.parentPath?.isExportNamedDeclaration() &&
+        exportSpecifier.parentPath.node.exportKind === 'type'))
+  );
+}
+
 /** Returns only statically named namespace members used by source or template. */
 function readUsedNamespaceMembers(
   scope: Scope,
   localName: string,
-  templateSource?: string
+  templateUsage?: TemplateUsage
 ): Set<string> {
   const names = new Set<string>();
   const bindings = new Set<Binding>();
@@ -442,12 +765,10 @@ function readUsedNamespaceMembers(
       }
     }
   }
-  if (templateSource) {
+  if (templateUsage) {
     for (const templateName of templateNames) {
-      for (const name of readTemplateNamespaceMembers(
-        templateSource,
-        templateName
-      )) {
+      for (const name of templateUsage.namespaceMembers.get(templateName) ??
+        []) {
         if (!writtenMembers.has(name)) names.add(name);
       }
     }
@@ -483,33 +804,519 @@ function isMemberWrite(
   );
 }
 
-/** Reads namespace members only from component tags and executable markup. */
-function readTemplateNamespaceMembers(
-  templateSource: string,
-  localName: string
-): Set<string> {
-  const names = new Set<string>();
-  const source = templateSource.replace(/<!--[\s\S]*?-->/g, '');
-  const memberPattern = `${escapeRegularExpression(localName)}\\s*\\.\\s*([A-Za-z_$][\\w$]*)`;
-  const tagExpression = new RegExp(`<\\/?\\s*${memberPattern}(?=[\\s/>])`, 'g');
-  for (const match of source.matchAll(tagExpression)) {
-    if (match[1]) names.add(match[1]);
-  }
+type TemplateUsage = {
+  identifiers: Set<string>;
+  namespaceMembers: Map<string, Set<string>>;
+};
 
-  const executableExpressions = [
-    ...source.matchAll(/{{([\s\S]*?)}}/g),
-    ...source.matchAll(
-      /(?:^|\s)(?:[:@#][^\s=]+|v-[^\s=]+)\s*=\s*(["'])([\s\S]*?)\1/g
-    ),
-  ];
-  const memberExpression = new RegExp(`\\b${memberPattern}`, 'g');
-  for (const executable of executableExpressions) {
-    const value = executable[2] ?? executable[1] ?? '';
-    for (const match of value.matchAll(memberExpression)) {
-      if (match[1]) names.add(match[1]);
+const VUE_BUILTIN_TEMPLATE_TAGS = new Set([
+  'BaseTransition',
+  'KeepAlive',
+  'Suspense',
+  'Teleport',
+  'Transition',
+  'TransitionGroup',
+  'base-transition',
+  'keep-alive',
+  'slot',
+  'suspense',
+  'teleport',
+  'template',
+  'transition',
+  'transition-group',
+]);
+
+const VUE_RAW_TEXT_TEMPLATE_TAGS = new Set([
+  'script',
+  'style',
+  'textarea',
+  'title',
+]);
+
+const VUE_VOID_TEMPLATE_TAGS = new Set(
+  'area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr'.split(
+    ','
+  )
+);
+
+/**
+ * Native platform tags recognized by Vue templates.
+ *
+ * Detection deliberately keeps this list local instead of importing
+ * `@vue/shared`: `/detect` runs for every CLI extraction and must not load a
+ * Vue runtime dependency before a project has proven Vue ownership.
+ */
+const VUE_NATIVE_TEMPLATE_TAGS = new Set(
+  (
+    'html,body,base,head,link,meta,style,title,address,article,aside,footer,' +
+    'header,hgroup,h1,h2,h3,h4,h5,h6,nav,section,div,dd,dl,dt,figcaption,' +
+    'figure,picture,hr,img,li,main,ol,p,pre,ul,a,b,abbr,bdi,bdo,br,cite,' +
+    'code,data,dfn,em,i,kbd,mark,q,rp,rt,ruby,s,samp,small,span,strong,sub,' +
+    'sup,time,u,var,wbr,area,audio,map,track,video,embed,object,param,source,' +
+    'canvas,script,noscript,del,ins,caption,col,colgroup,table,thead,tbody,td,' +
+    'th,tr,button,datalist,fieldset,form,input,label,legend,meter,optgroup,' +
+    'option,output,progress,select,textarea,details,dialog,menu,summary,' +
+    'template,blockquote,iframe,tfoot,svg,animate,animateMotion,' +
+    'animateTransform,circle,clipPath,color-profile,defs,desc,discard,ellipse,' +
+    'feBlend,feColorMatrix,feComponentTransfer,feComposite,feConvolveMatrix,' +
+    'feDiffuseLighting,feDisplacementMap,feDistantLight,feDropShadow,' +
+    'feFlood,feFuncA,feFuncB,feFuncG,feFuncR,feGaussianBlur,feImage,' +
+    'feMerge,feMergeNode,feMorphology,feOffset,fePointLight,' +
+    'feSpecularLighting,feSpotLight,feTile,feTurbulence,filter,foreignObject,' +
+    'g,hatch,hatchpath,image,line,linearGradient,marker,mask,mesh,' +
+    'meshgradient,meshpatch,meshrow,metadata,mpath,path,pattern,polygon,' +
+    'polyline,radialGradient,rect,set,solidcolor,stop,switch,symbol,text,' +
+    'textPath,tspan,unknown,use,view,annotation,annotation-xml,maction,' +
+    'maligngroup,malignmark,math,menclose,merror,mfenced,mfrac,mfraction,' +
+    'mglyph,mi,mlabeledtr,mlongdiv,mmultiscripts,mn,mo,mover,mpadded,' +
+    'mphantom,mprescripts,mroot,mrow,ms,mscarries,mscarry,msgroup,msline,' +
+    'mspace,msqrt,msrow,mstack,mstyle,msub,msubsup,msup,mtable,mtd,mtext,' +
+    'mtr,munder,munderover,none,semantics'
+  ).split(',')
+);
+
+/** Parses component tags and executable expressions without raw-text guesses. */
+function readTemplateUsage(templateSource: string): TemplateUsage {
+  const usage: TemplateUsage = {
+    identifiers: new Set(),
+    namespaceMembers: new Map(),
+  };
+  const activeBindings = new Map<string, number>();
+  const elementStack: Array<{ bindings: Set<string>; name: string }> = [];
+  let index = 0;
+  while (index < templateSource.length) {
+    if (templateSource.startsWith('<!--', index)) {
+      index = readHtmlCommentEnd(templateSource, index);
+      continue;
+    }
+    if (templateSource.startsWith('{{', index)) {
+      const interpolation = readTemplateInterpolation(templateSource, index);
+      if (interpolation.ast) {
+        collectTemplateAstUsage(interpolation.ast, usage, activeBindings);
+      }
+      index = interpolation.end;
+      continue;
+    }
+    if (templateSource[index] !== '<') {
+      index += 1;
+      continue;
+    }
+    const tag = readTemplateMarkupTag(templateSource, index);
+    if (!tag) {
+      index += 1;
+      continue;
+    }
+    recordTemplateTagUsage(tag.name, usage);
+    if (tag.closing) {
+      closeTemplateElementScope(tag.name, elementStack, activeBindings);
+      index = tag.end;
+      continue;
+    }
+    const declaredBindings = collectTemplateDirectiveUsage(
+      tag.attributes,
+      usage,
+      activeBindings
+    );
+    const rawTextClosingTag =
+      !tag.selfClosing && VUE_RAW_TEXT_TEMPLATE_TAGS.has(tag.name)
+        ? findRawBlockClosingTag(templateSource, tag.name, tag.end)
+        : undefined;
+    if (rawTextClosingTag) {
+      index = rawTextClosingTag.end;
+      continue;
+    }
+    if (!tag.selfClosing && !VUE_VOID_TEMPLATE_TAGS.has(tag.name)) {
+      elementStack.push({ bindings: declaredBindings, name: tag.name });
+      for (const binding of declaredBindings) {
+        activeBindings.set(binding, (activeBindings.get(binding) ?? 0) + 1);
+      }
+    }
+    index = tag.end;
+  }
+  return usage;
+}
+
+function closeTemplateElementScope(
+  name: string,
+  elementStack: Array<{ bindings: Set<string>; name: string }>,
+  activeBindings: Map<string, number>
+): void {
+  let matchingIndex = -1;
+  for (let index = elementStack.length - 1; index >= 0; index -= 1) {
+    if (elementStack[index]?.name === name) {
+      matchingIndex = index;
+      break;
     }
   }
-  return names;
+  if (matchingIndex < 0) return;
+  while (elementStack.length > matchingIndex) {
+    const element = elementStack.pop()!;
+    for (const binding of element.bindings) {
+      const remaining = (activeBindings.get(binding) ?? 1) - 1;
+      if (remaining > 0) activeBindings.set(binding, remaining);
+      else activeBindings.delete(binding);
+    }
+  }
+}
+
+type TemplateMarkupTag = {
+  attributes: string;
+  closing: boolean;
+  end: number;
+  name: string;
+  selfClosing: boolean;
+};
+
+/** Reads one real template tag while keeping quoted attribute data opaque. */
+function readTemplateMarkupTag(
+  source: string,
+  start: number
+): TemplateMarkupTag | undefined {
+  if (source[start] !== '<' || source.startsWith('<!--', start)) {
+    return undefined;
+  }
+  let cursor = start + 1;
+  const closing = source[cursor] === '/';
+  if (closing) cursor += 1;
+  const nameStart = cursor;
+  while (cursor < source.length && /[A-Za-z0-9_$.:?-]/.test(source[cursor]!)) {
+    cursor += 1;
+  }
+  if (cursor === nameStart || !/[A-Za-z_$]/.test(source[nameStart]!)) {
+    return undefined;
+  }
+  const name = source.slice(nameStart, cursor);
+  const attributesStart = cursor;
+  let quote: string | undefined;
+  while (cursor < source.length) {
+    const character = source[cursor]!;
+    if (quote) {
+      if (character === quote) quote = undefined;
+    } else if (character === '"' || character === "'") {
+      quote = character;
+    } else if (character === '>') {
+      return {
+        attributes: source.slice(attributesStart, cursor),
+        closing,
+        end: cursor + 1,
+        name,
+        selfClosing:
+          !closing && /\/\s*$/.test(source.slice(attributesStart, cursor)),
+      };
+    }
+    cursor += 1;
+  }
+  return undefined;
+}
+
+function recordTemplateTagUsage(tag: string, usage: TemplateUsage): void {
+  const member = /^([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)$/.exec(tag);
+  if (member?.[1] && member[2]) {
+    usage.identifiers.add(member[1]);
+    addTemplateNamespaceMember(usage, member[1], member[2]);
+    return;
+  }
+  if (VUE_BUILTIN_TEMPLATE_TAGS.has(tag) || VUE_NATIVE_TEMPLATE_TAGS.has(tag)) {
+    return;
+  }
+  for (const name of normalizeTemplateBindingNames(tag)) {
+    usage.identifiers.add(name);
+  }
+}
+
+/** Collects dynamic directive arguments and executable directive values. */
+function collectTemplateDirectiveUsage(
+  attributes: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): Set<string> {
+  const directives = readTemplateDirectives(attributes);
+  const declaredBindings = new Set<string>();
+  for (const directive of directives.filter(({ name }) =>
+    isTemplateForDirective(name)
+  )) {
+    for (const binding of collectTemplateDirective(
+      directive.name,
+      directive.value,
+      usage,
+      shadowedBindings
+    )) {
+      declaredBindings.add(binding);
+    }
+  }
+  for (const directive of directives.filter(({ name }) =>
+    isTemplateConditionalDirective(name)
+  )) {
+    collectTemplateDirective(
+      directive.name,
+      directive.value,
+      usage,
+      shadowedBindings
+    );
+  }
+  const loopBindings = new Map(shadowedBindings);
+  for (const binding of declaredBindings) {
+    loopBindings.set(binding, (loopBindings.get(binding) ?? 0) + 1);
+  }
+  for (const directive of directives) {
+    if (
+      isTemplateForDirective(directive.name) ||
+      isTemplateConditionalDirective(directive.name)
+    ) {
+      continue;
+    }
+    for (const binding of collectTemplateDirective(
+      directive.name,
+      directive.value,
+      usage,
+      loopBindings
+    )) {
+      declaredBindings.add(binding);
+    }
+  }
+  return declaredBindings;
+}
+
+type TemplateDirective = {
+  name: string;
+  value: string | undefined;
+};
+
+function readTemplateDirectives(attributes: string): TemplateDirective[] {
+  const directives: TemplateDirective[] = [];
+  let index = 0;
+  while (index < attributes.length) {
+    while (/\s/.test(attributes[index] ?? '')) index += 1;
+    if (index >= attributes.length || attributes[index] === '/') {
+      return directives;
+    }
+    const nameStart = index;
+    while (index < attributes.length && !/[\s=]/.test(attributes[index]!)) {
+      index += 1;
+    }
+    const name = attributes.slice(nameStart, index);
+    while (/\s/.test(attributes[index] ?? '')) index += 1;
+
+    let value: string | undefined;
+    if (attributes[index] === '=') {
+      index += 1;
+      while (/\s/.test(attributes[index] ?? '')) index += 1;
+      const quote = attributes[index];
+      if (quote === '"' || quote === "'") {
+        index += 1;
+        const valueStart = index;
+        while (index < attributes.length && attributes[index] !== quote) {
+          index += 1;
+        }
+        value = attributes.slice(valueStart, index);
+        if (attributes[index] === quote) index += 1;
+      } else {
+        const valueStart = index;
+        while (index < attributes.length && !/[\s>]/.test(attributes[index]!)) {
+          index += 1;
+        }
+        value = attributes.slice(valueStart, index);
+      }
+    }
+    if (/^[:@#]|^v-/.test(name)) directives.push({ name, value });
+  }
+  return directives;
+}
+
+function isTemplateForDirective(name: string): boolean {
+  return /^v-for(?::|$)/.test(name);
+}
+
+function isTemplateConditionalDirective(name: string): boolean {
+  return /^v-(?:if|else-if)(?::|$)/.test(name);
+}
+
+function collectTemplateDirective(
+  name: string,
+  value: string | undefined,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): Set<string> {
+  if (!/^[:@#]|^v-/.test(name)) return new Set();
+  const argument = readDynamicDirectiveArgument(name);
+  if (argument) {
+    collectTemplateExpressionUsage(argument, usage, shadowedBindings);
+  }
+  if (value === undefined) {
+    if (name.startsWith(':') && !argument) {
+      collectTemplateExpressionUsage(
+        name.slice(1).split('.')[0] ?? '',
+        usage,
+        shadowedBindings
+      );
+    }
+    return new Set();
+  }
+  if (/^(?:#|v-slot(?::|$))/.test(name)) {
+    return collectTemplateBindingUsage(value, usage, shadowedBindings);
+  } else if (/^v-for(?::|$)/.test(name)) {
+    return collectTemplateForUsage(value, usage, shadowedBindings);
+  } else {
+    collectTemplateExpressionUsage(value, usage, shadowedBindings);
+  }
+  return new Set();
+}
+
+function readDynamicDirectiveArgument(name: string): string | undefined {
+  const start = name.indexOf('[');
+  const end = name.lastIndexOf(']');
+  return start >= 0 && end > start ? name.slice(start + 1, end) : undefined;
+}
+
+function collectTemplateExpressionUsage(
+  source: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): void {
+  const ast = parseTemplateExpression(source);
+  if (ast) collectTemplateAstUsage(ast, usage, shadowedBindings);
+}
+
+function collectTemplateBindingUsage(
+  source: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): Set<string> {
+  try {
+    const ast = parseScriptAst(`((${source}) => {})`, 'tsx');
+    collectTemplateAstUsage(ast, usage, shadowedBindings);
+    const statement = ast.program.body[0];
+    if (
+      statement?.type !== 'ExpressionStatement' ||
+      statement.expression.type !== 'ArrowFunctionExpression'
+    ) {
+      return new Set();
+    }
+    return new Set(
+      statement.expression.params.flatMap((parameter) =>
+        Object.keys(t.getBindingIdentifiers(parameter))
+      )
+    );
+  } catch {
+    // Invalid bindings are diagnosed by the owning Vue compiler later.
+    return new Set();
+  }
+}
+
+function collectTemplateForUsage(
+  source: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): Set<string> {
+  const separator = /\s+(?:in|of)\s+/.exec(source);
+  if (!separator || separator.index === undefined) {
+    collectTemplateExpressionUsage(source, usage, shadowedBindings);
+    return new Set();
+  }
+  const left = source.slice(0, separator.index).trim();
+  const right = source.slice(separator.index + separator[0].length).trim();
+  const bindings = collectTemplateBindingUsage(left, usage, shadowedBindings);
+  collectTemplateExpressionUsage(right, usage, shadowedBindings);
+  return bindings;
+}
+
+/** Finds the first syntactically complete interpolation closing delimiter. */
+function readTemplateInterpolation(
+  source: string,
+  start: number
+): { ast?: t.File; end: number } {
+  let closing = source.indexOf('}}', start + 2);
+  while (closing >= 0) {
+    const ast = parseTemplateExpression(source.slice(start + 2, closing));
+    if (ast) return { ast, end: closing + 2 };
+    closing = source.indexOf('}}', closing + 1);
+  }
+  return { end: source.length };
+}
+
+/** Accepts expression, binding-pattern, and event-statement template syntax. */
+function parseTemplateExpression(source: string): t.File | undefined {
+  for (const candidate of [
+    `(${source})`,
+    `((${source}) => {})`,
+    `function __gt_template_expression__() { ${source} }`,
+  ]) {
+    try {
+      return parseScriptAst(candidate, 'tsx');
+    } catch {
+      // Try the next executable wrapper.
+    }
+  }
+  return undefined;
+}
+
+/** Records only unshadowed runtime identifiers and static namespace members. */
+function collectTemplateAstUsage(
+  ast: t.File,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): void {
+  traverse(ast, {
+    ReferencedIdentifier(path) {
+      if (
+        shadowedBindings.has(path.node.name) ||
+        path.scope.getBinding(path.node.name) ||
+        path.findParent(
+          (parent) => t.isTSType(parent.node) || t.isFlow(parent.node)
+        )
+      ) {
+        return;
+      }
+      usage.identifiers.add(path.node.name);
+    },
+    MemberExpression(path) {
+      collectTemplateMemberUsage(path, usage, shadowedBindings);
+    },
+    OptionalMemberExpression(path) {
+      collectTemplateMemberUsage(path, usage, shadowedBindings);
+    },
+  });
+}
+
+function collectTemplateMemberUsage(
+  path: NodePath<t.MemberExpression | t.OptionalMemberExpression>,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): void {
+  const object = path.node.object;
+  if (
+    object.type !== 'Identifier' ||
+    shadowedBindings.has(object.name) ||
+    path.scope.getBinding(object.name) ||
+    path.findParent(
+      (parent) => t.isTSType(parent.node) || t.isFlow(parent.node)
+    )
+  ) {
+    return;
+  }
+  const member = readStaticPropertyName(path.node);
+  if (member) addTemplateNamespaceMember(usage, object.name, member);
+}
+
+function addTemplateNamespaceMember(
+  usage: TemplateUsage,
+  namespace: string,
+  member: string
+): void {
+  const members = usage.namespaceMembers.get(namespace) ?? new Set<string>();
+  members.add(member);
+  usage.namespaceMembers.set(namespace, members);
+}
+
+/** Mirrors Vue's kebab/camel/Pascal lookup for setup template bindings. */
+function normalizeTemplateBindingNames(sourceName: string): Set<string> {
+  const camelized = sourceName.replace(/-(\w)/g, (_match, letter: string) =>
+    letter.toUpperCase()
+  );
+  const pascalized = camelized
+    ? camelized[0]!.toUpperCase() + camelized.slice(1)
+    : camelized;
+  return new Set([sourceName, camelized, pascalized]);
 }
 
 function readStaticPropertyName(

--- a/packages/vue-extractor/src/internal/project/consumerUsage.ts
+++ b/packages/vue-extractor/src/internal/project/consumerUsage.ts
@@ -47,6 +47,7 @@ const IGNORED_CONSUMER_DIRECTORIES = new Set([
 
 const GENERATED_CONSUMER_ROOT_DIRECTORIES = new Set([
   'cjs',
+  'es',
   'esm',
   'generated',
   'lib',
@@ -361,8 +362,26 @@ function readConsumerImports(file: string): ConsumerImport[] {
       return readScriptImports(source, 'tsx');
     }
     const { blocks, templateSource } = readVueScriptBlocks(source);
-    return blocks.flatMap(({ language, source }) =>
-      readScriptImports(source, language, templateSource)
+    const parsedBlocks = blocks.map((block) => ({
+      ...block,
+      ast: parseConsumerScript(block.source, block.language),
+    }));
+    const hasScriptSetup = parsedBlocks.some(
+      ({ ast, setup, source }) =>
+        setup && Boolean(ast) && Boolean(source.trim())
+    );
+    const templateBindings = hasScriptSetup
+      ? readTemplateBindingMetadata(parsedBlocks)
+      : undefined;
+    const setupExternalUsage = readSetupExternalUsage(parsedBlocks);
+    return parsedBlocks.flatMap(({ ast, setup }) =>
+      ast
+        ? collectStaticImports(ast, {
+            externalUsage: setup ? undefined : setupExternalUsage,
+            templateBindings,
+            templateSource: hasScriptSetup ? templateSource : undefined,
+          })
+        : []
     );
   }
   const language =
@@ -376,10 +395,10 @@ function readConsumerImports(file: string): ConsumerImport[] {
 
 /** Reads SFC script blocks without loading a project Vue compiler. */
 function readVueScriptBlocks(source: string): {
-  blocks: Array<{ language: string | undefined; source: string }>;
+  blocks: ConsumerScriptBlock[];
   templateSource: string;
 } {
-  const blocks: Array<{ language: string | undefined; source: string }> = [];
+  const blocks: ConsumerScriptBlock[] = [];
   const templateSources: string[] = [];
   for (const block of readTopLevelSfcBlocks(source)) {
     if (block.name === 'template') {
@@ -387,17 +406,38 @@ function readVueScriptBlocks(source: string): {
       continue;
     }
     if (block.name !== 'script') continue;
-    const attributes = block.attributes;
-    const quotedLanguage = /\blang\s*=\s*(["'])([^"']+)\1/i.exec(
-      attributes
-    )?.[2];
-    const bareLanguage = /\blang\s*=\s*([^\s>]+)/i.exec(attributes)?.[1];
+    const attributes = readTemplateAttributes(block.attributes);
     blocks.push({
-      language: quotedLanguage ?? bareLanguage,
+      language: attributes.find(({ name }) => name === 'lang')?.value,
+      setup: attributes.some(({ name }) => name === 'setup'),
       source: block.source,
     });
   }
   return { blocks, templateSource: templateSources.join('\n') };
+}
+
+type ConsumerScriptBlock = {
+  language: string | undefined;
+  setup: boolean;
+  source: string;
+};
+
+type ParsedConsumerScriptBlock = ConsumerScriptBlock & {
+  ast: t.File | undefined;
+};
+
+/** Collects ordinary-script bindings referenced from a sibling setup block. */
+function readSetupExternalUsage(
+  blocks: readonly ParsedConsumerScriptBlock[]
+): TemplateUsage | undefined {
+  const usage = createTemplateUsage();
+  let parsedSetup = false;
+  for (const block of blocks) {
+    if (!block.setup || !block.ast) continue;
+    parsedSetup = true;
+    collectTemplateAstUsage(block.ast, usage, new Map());
+  }
+  return parsedSetup ? usage : undefined;
 }
 
 type SfcBlock = {
@@ -548,9 +588,17 @@ function readHtmlCommentEnd(source: string, start: number): number {
 /** Accepts project-compatible syntax while extracting only static ESM edges. */
 function readScriptImports(
   source: string,
-  declaredLanguage: string | undefined,
-  templateSource?: string
+  declaredLanguage: string | undefined
 ): ConsumerImport[] {
+  const ast = parseConsumerScript(source, declaredLanguage);
+  return ast ? collectStaticImports(ast) : [];
+}
+
+/** Parses syntax accepted by consumer discovery without requiring Vue. */
+function parseConsumerScript(
+  source: string,
+  declaredLanguage: string | undefined
+): t.File | undefined {
   const languages = new Set<string | undefined>([declaredLanguage]);
   languages.add('tsx');
   if (
@@ -563,20 +611,530 @@ function readScriptImports(
 
   for (const language of languages) {
     try {
-      return collectStaticImports(
-        parseScriptAst(source, language),
-        templateSource
-      );
+      return parseScriptAst(source, language);
     } catch {
       // Try the next syntax accepted by source extraction.
     }
   }
-  return [];
+  return undefined;
 }
+
+type TemplateBindingType =
+  | 'setup-const'
+  | 'setup-reactive-const'
+  | 'literal-const'
+  | 'setup-let'
+  | 'setup-ref'
+  | 'setup-maybe-ref'
+  | 'props';
+
+type TemplateBinding = {
+  owner: t.Program;
+  type: TemplateBindingType;
+};
+
+const TEMPLATE_BINDING_RESOLUTION_ORDER: readonly TemplateBindingType[] = [
+  'setup-const',
+  'setup-reactive-const',
+  'literal-const',
+  'setup-let',
+  'setup-ref',
+  'setup-maybe-ref',
+  'props',
+];
+
+/**
+ * Reproduces the binding metadata needed by Vue's component-tag resolver.
+ *
+ * Project detection cannot load a consumer's Vue compiler before ownership is
+ * proven. This self-contained model lets the detector choose one setup binding
+ * with Vue's type and spelling precedence without introducing a compiler
+ * dependency into the lightweight entrypoint. Where supported Vue versions or
+ * compiler options differ, the stronger local binding wins so ambiguous source
+ * cannot activate Vue in an existing non-Vue project.
+ */
+function readTemplateBindingMetadata(
+  blocks: readonly ParsedConsumerScriptBlock[]
+): Map<string, TemplateBinding> {
+  const bindings = new Map<string, TemplateBinding>();
+  const normalBlocks = blocks.filter(({ setup }) => !setup);
+  const setupBlocks = blocks.filter(({ setup }) => setup);
+  const vueImportAliases = new Map<t.Program, Map<string, string>>();
+
+  for (const block of [...normalBlocks, ...setupBlocks]) {
+    if (!block.ast) continue;
+    const aliases = new Map<string, string>();
+    registerTemplateImportBindings(block.ast, bindings, aliases);
+    vueImportAliases.set(block.ast.program, aliases);
+  }
+  for (const block of normalBlocks) {
+    if (!block.ast) continue;
+    registerTemplateDeclarationBindings(
+      block.ast,
+      bindings,
+      vueImportAliases.get(block.ast.program) ?? new Map(),
+      'script',
+      true
+    );
+  }
+  for (const block of setupBlocks) {
+    if (!block.ast) continue;
+    registerTemplateDeclarationBindings(
+      block.ast,
+      bindings,
+      vueImportAliases.get(block.ast.program) ?? new Map(),
+      'script-setup',
+      normalBlocks.length === 0
+    );
+  }
+  return bindings;
+}
+
+function registerTemplateImportBindings(
+  ast: t.File,
+  bindings: Map<string, TemplateBinding>,
+  vueImportAliases: Map<string, string>
+): void {
+  for (const statement of ast.program.body) {
+    if (
+      statement.type !== 'ImportDeclaration' ||
+      statement.importKind === 'type' ||
+      statement.importKind === 'typeof'
+    ) {
+      continue;
+    }
+    const source = statement.source.value;
+    for (const specifier of statement.specifiers) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        (specifier.importKind === 'type' || specifier.importKind === 'typeof')
+      ) {
+        continue;
+      }
+      const imported =
+        specifier.type === 'ImportDefaultSpecifier'
+          ? 'default'
+          : specifier.type === 'ImportNamespaceSpecifier'
+            ? '*'
+            : readModuleName(specifier.imported);
+      if (source === 'vue') {
+        vueImportAliases.set(imported, specifier.local.name);
+      }
+      if (!bindings.has(specifier.local.name)) {
+        setTemplateBinding(
+          bindings,
+          specifier.local.name,
+          imported === '*' ||
+            (imported === 'default' && source.endsWith('.vue')) ||
+            source === 'vue'
+            ? 'setup-const'
+            : 'setup-maybe-ref',
+          ast.program
+        );
+      }
+    }
+  }
+}
+
+/** Adds script declarations after imports in compiler-sfc's merge order. */
+function registerTemplateDeclarationBindings(
+  ast: t.File,
+  bindings: Map<string, TemplateBinding>,
+  vueImportAliases: ReadonlyMap<string, string>,
+  source: 'script' | 'script-setup',
+  hoistStatic: boolean
+): void {
+  for (const statement of ast.program.body) {
+    const declaration =
+      statement.type === 'ExportNamedDeclaration' && statement.declaration
+        ? statement.declaration
+        : statement;
+    if (
+      (declaration.type === 'VariableDeclaration' ||
+        declaration.type === 'FunctionDeclaration' ||
+        declaration.type === 'ClassDeclaration' ||
+        declaration.type === 'TSEnumDeclaration') &&
+      !declaration.declare
+    ) {
+      walkTemplateDeclaration(
+        declaration,
+        bindings,
+        vueImportAliases,
+        ast.program,
+        source,
+        hoistStatic
+      );
+    }
+  }
+}
+
+type TemplateDeclaration =
+  | t.VariableDeclaration
+  | t.FunctionDeclaration
+  | t.ClassDeclaration
+  | t.TSEnumDeclaration;
+
+/** Mirrors compiler-sfc's binding-type analysis used by component lookup. */
+function walkTemplateDeclaration(
+  declaration: TemplateDeclaration,
+  bindings: Map<string, TemplateBinding>,
+  vueImportAliases: ReadonlyMap<string, string>,
+  owner: t.Program,
+  source: 'script' | 'script-setup',
+  hoistStatic: boolean
+): void {
+  if (declaration.type === 'VariableDeclaration') {
+    const isConst = declaration.kind === 'const';
+    const isAllLiteral =
+      isConst &&
+      declaration.declarations.every(
+        ({ id, init }) =>
+          id.type === 'Identifier' && isStaticTemplateBinding(init)
+      );
+    for (const { id, init: wrappedInitializer } of declaration.declarations) {
+      const initializer = unwrapTemplateBindingExpression(wrappedInitializer);
+      const isConstMacroCall =
+        isConst &&
+        isTemplateCallOf(initializer, [
+          'defineProps',
+          'defineEmits',
+          'defineSlots',
+          'withDefaults',
+        ]);
+      if (id.type === 'Identifier') {
+        let type: TemplateBindingType;
+        const reactiveImport = vueImportAliases.get('reactive');
+        if (
+          (hoistStatic || source === 'script') &&
+          (isAllLiteral || (isConst && isStaticTemplateBinding(initializer)))
+        ) {
+          type = 'literal-const';
+        } else if (isTemplateCallOf(initializer, reactiveImport)) {
+          type = isConst ? 'setup-reactive-const' : 'setup-let';
+        } else if (
+          isConstMacroCall ||
+          (isConst && canNeverBeTemplateRef(initializer, reactiveImport))
+        ) {
+          type = isTemplateCallOf(initializer, 'defineProps')
+            ? 'setup-reactive-const'
+            : 'setup-const';
+        } else if (isConst) {
+          type = isTemplateCallOf(initializer, [
+            vueImportAliases.get('ref'),
+            vueImportAliases.get('computed'),
+            vueImportAliases.get('shallowRef'),
+            vueImportAliases.get('customRef'),
+            vueImportAliases.get('toRef'),
+            vueImportAliases.get('useTemplateRef'),
+            'defineModel',
+          ])
+            ? 'setup-ref'
+            : 'setup-maybe-ref';
+        } else {
+          type = 'setup-let';
+        }
+        setTemplateBinding(bindings, id.name, type, owner);
+        continue;
+      }
+      if (
+        id.type === 'ObjectPattern' &&
+        isTemplateCallOf(initializer, 'defineProps')
+      ) {
+        registerTemplatePropsDestructure(id, bindings, owner);
+      } else {
+        walkTemplateBindingPattern(
+          id,
+          bindings,
+          owner,
+          isConst,
+          isConstMacroCall
+        );
+      }
+    }
+    return;
+  }
+  if (declaration.type === 'TSEnumDeclaration') {
+    const isAllLiteral = declaration.members.every(
+      ({ initializer }) => !initializer || isStaticTemplateBinding(initializer)
+    );
+    setTemplateBinding(
+      bindings,
+      declaration.id.name,
+      isAllLiteral ? 'literal-const' : 'setup-const',
+      owner
+    );
+    return;
+  }
+  if (declaration.id) {
+    setTemplateBinding(bindings, declaration.id.name, 'setup-const', owner);
+  }
+}
+
+/**
+ * Registers the conservative union of reactive and legacy prop destructuring.
+ *
+ * Vue 3.3/3.5 and `propsDestructure: false` disagree about these local binding
+ * types. Compiler configuration cannot be loaded safely before Vue ownership
+ * is established, so a local destructure takes the strongest possible type.
+ * This may defer an ambiguous wrapper-only project, but it cannot make that
+ * ambiguity poison an otherwise valid React extraction.
+ */
+function registerTemplatePropsDestructure(
+  pattern: t.ObjectPattern,
+  bindings: Map<string, TemplateBinding>,
+  owner: t.Program
+): void {
+  for (const property of pattern.properties) {
+    if (property.type === 'RestElement') {
+      for (const identifier of Object.values(
+        t.getBindingIdentifiers(property.argument)
+      )) {
+        setTemplateBinding(
+          bindings,
+          identifier.name,
+          'setup-reactive-const',
+          owner
+        );
+      }
+      continue;
+    }
+    const publicName = readStaticPatternPropertyName(property);
+    if (!publicName) continue;
+    setTemplateBinding(bindings, publicName, 'props', owner);
+    const value =
+      property.value.type === 'AssignmentPattern'
+        ? property.value.left
+        : property.value;
+    if (value.type === 'Identifier') {
+      setTemplateBinding(bindings, value.name, 'setup-const', owner);
+    }
+  }
+}
+
+function readStaticPatternPropertyName(
+  property: t.ObjectProperty
+): string | undefined {
+  if (property.computed) return undefined;
+  if (property.key.type === 'Identifier') return property.key.name;
+  if (
+    property.key.type === 'StringLiteral' ||
+    property.key.type === 'NumericLiteral'
+  ) {
+    return String(property.key.value);
+  }
+  return undefined;
+}
+
+function walkTemplateBindingPattern(
+  pattern: t.VariableDeclarator['id'],
+  bindings: Map<string, TemplateBinding>,
+  owner: t.Program,
+  isConst: boolean,
+  isDefineCall = false
+): void {
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type === 'RestElement') {
+        registerTemplatePatternIdentifiers(
+          property.argument,
+          bindings,
+          owner,
+          isConst ? 'setup-const' : 'setup-let'
+        );
+      } else if (
+        property.key.type === 'Identifier' &&
+        property.shorthand &&
+        property.value.type === 'Identifier'
+      ) {
+        setTemplateBinding(
+          bindings,
+          property.value.name,
+          isDefineCall
+            ? 'setup-const'
+            : isConst
+              ? 'setup-maybe-ref'
+              : 'setup-let',
+          owner
+        );
+      } else {
+        walkTemplatePattern(
+          property.value,
+          bindings,
+          owner,
+          isConst,
+          isDefineCall
+        );
+      }
+    }
+    return;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements) {
+      if (element) {
+        walkTemplatePattern(element, bindings, owner, isConst, isDefineCall);
+      }
+    }
+  }
+}
+
+/** Applies compiler-sfc's recursive destructuring binding classification. */
+function walkTemplatePattern(
+  pattern: t.Node,
+  bindings: Map<string, TemplateBinding>,
+  owner: t.Program,
+  isConst: boolean,
+  isDefineCall = false
+): void {
+  if (pattern.type === 'Identifier') {
+    setTemplateBinding(
+      bindings,
+      pattern.name,
+      isDefineCall ? 'setup-const' : isConst ? 'setup-maybe-ref' : 'setup-let',
+      owner
+    );
+  } else if (pattern.type === 'RestElement') {
+    registerTemplatePatternIdentifiers(
+      pattern.argument,
+      bindings,
+      owner,
+      isConst ? 'setup-const' : 'setup-let'
+    );
+  } else if (
+    pattern.type === 'ObjectPattern' ||
+    pattern.type === 'ArrayPattern'
+  ) {
+    walkTemplateBindingPattern(pattern, bindings, owner, isConst);
+  } else if (pattern.type === 'AssignmentPattern') {
+    walkTemplatePattern(pattern.left, bindings, owner, isConst, isDefineCall);
+  }
+}
+
+function registerTemplatePatternIdentifiers(
+  pattern: t.LVal,
+  bindings: Map<string, TemplateBinding>,
+  owner: t.Program,
+  type: TemplateBindingType
+): void {
+  for (const identifier of Object.values(t.getBindingIdentifiers(pattern))) {
+    setTemplateBinding(bindings, identifier.name, type, owner);
+  }
+}
+
+function setTemplateBinding(
+  bindings: Map<string, TemplateBinding>,
+  name: string,
+  type: TemplateBindingType,
+  owner: t.Program
+): void {
+  bindings.set(name, { owner, type });
+}
+
+function unwrapTemplateBindingExpression(
+  input: t.Node | null | undefined
+): t.Node | undefined {
+  let current = input ?? undefined;
+  while (
+    current &&
+    (current.type === 'TSAsExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSInstantiationExpression' ||
+      current.type === 'TypeCastExpression' ||
+      current.type === 'ParenthesizedExpression')
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** Matches direct compiler macros and locally aliased Vue helper calls. */
+function isTemplateCallOf(
+  node: t.Node | null | undefined,
+  names: string | readonly (string | undefined)[] | undefined
+): boolean {
+  if (!node || !names || node.type !== 'CallExpression') return false;
+  const callee = unwrapTemplateBindingExpression(node.callee);
+  if (callee?.type !== 'Identifier') return false;
+  return typeof names === 'string'
+    ? callee.name === names
+    : names.some((name) => Boolean(name) && name === callee.name);
+}
+
+/** Returns whether compiler-sfc can prove that a value will never be a ref. */
+function canNeverBeTemplateRef(
+  node: t.Node | null | undefined,
+  reactiveImport: string | undefined
+): boolean {
+  const expression = unwrapTemplateBindingExpression(node);
+  if (!expression) return false;
+  if (isTemplateCallOf(expression, reactiveImport)) return true;
+  if (
+    expression.type === 'UnaryExpression' ||
+    expression.type === 'BinaryExpression' ||
+    expression.type === 'ArrayExpression' ||
+    expression.type === 'ObjectExpression' ||
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'UpdateExpression' ||
+    expression.type === 'ClassExpression' ||
+    expression.type === 'TaggedTemplateExpression'
+  ) {
+    return true;
+  }
+  if (expression.type === 'SequenceExpression') {
+    return canNeverBeTemplateRef(expression.expressions.at(-1), reactiveImport);
+  }
+  return expression.type.endsWith('Literal');
+}
+
+/** Reproduces compiler-sfc's static-expression predicate for hoisted bindings. */
+function isStaticTemplateBinding(node: t.Node | null | undefined): boolean {
+  const expression = unwrapTemplateBindingExpression(node);
+  if (!expression) return false;
+  if (expression.type === 'UnaryExpression') {
+    return isStaticTemplateBinding(expression.argument);
+  }
+  if (
+    expression.type === 'LogicalExpression' ||
+    expression.type === 'BinaryExpression'
+  ) {
+    return (
+      isStaticTemplateBinding(expression.left) &&
+      isStaticTemplateBinding(expression.right)
+    );
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return (
+      isStaticTemplateBinding(expression.test) &&
+      isStaticTemplateBinding(expression.consequent) &&
+      isStaticTemplateBinding(expression.alternate)
+    );
+  }
+  if (
+    expression.type === 'SequenceExpression' ||
+    expression.type === 'TemplateLiteral'
+  ) {
+    return expression.expressions.every(isStaticTemplateBinding);
+  }
+  return (
+    expression.type === 'StringLiteral' ||
+    expression.type === 'NumericLiteral' ||
+    expression.type === 'BooleanLiteral' ||
+    expression.type === 'NullLiteral' ||
+    expression.type === 'BigIntLiteral'
+  );
+}
+
+type StaticImportUsageOptions = {
+  externalUsage?: TemplateUsage;
+  templateBindings?: ReadonlyMap<string, TemplateBinding>;
+  templateSource?: string;
+};
 
 function collectStaticImports(
   ast: t.File,
-  templateSource?: string
+  options: StaticImportUsageOptions = {}
 ): ConsumerImport[] {
   let programScope: Scope | undefined;
   traverse(ast, {
@@ -586,9 +1144,13 @@ function collectStaticImports(
     },
   });
   if (!programScope) return [];
-  const templateUsage = templateSource
-    ? readTemplateUsage(templateSource)
-    : undefined;
+  const templateUsage =
+    options.templateSource && options.templateBindings
+      ? readTemplateUsage(options.templateSource, options.templateBindings)
+      : undefined;
+  const runtimeUsages = [templateUsage, options.externalUsage].filter(
+    (usage): usage is TemplateUsage => Boolean(usage)
+  );
 
   const imports: ConsumerImport[] = [];
   for (const statement of ast.program.body) {
@@ -604,7 +1166,8 @@ function collectStaticImports(
             bindingHasRuntimeUsage(
               programScope,
               specifier.local.name,
-              templateUsage
+              runtimeUsages,
+              ast.program
             )
           ) {
             importedNames.add('default');
@@ -613,7 +1176,8 @@ function collectStaticImports(
           for (const name of readUsedNamespaceMembers(
             programScope,
             specifier.local.name,
-            templateUsage
+            runtimeUsages,
+            ast.program
           )) {
             importedNames.add(name);
           }
@@ -623,7 +1187,8 @@ function collectStaticImports(
           bindingHasRuntimeUsage(
             programScope,
             specifier.local.name,
-            templateUsage
+            runtimeUsages,
+            ast.program
           )
         ) {
           importedNames.add(readModuleName(specifier.imported));
@@ -677,13 +1242,17 @@ function readModuleName(node: t.Identifier | t.StringLiteral): string {
 function bindingHasRuntimeUsage(
   scope: Scope,
   localName: string,
-  templateUsage: TemplateUsage | undefined
+  runtimeUsages: readonly TemplateUsage[],
+  owner: t.Program
 ): boolean {
   const binding = scope.getBinding(localName);
   return Boolean(
     binding?.referencePaths.some(
       (reference) => !isTypeOnlyReference(reference)
-    ) || templateUsage?.identifiers.has(localName)
+    ) ||
+    runtimeUsages.some((usage) =>
+      templateUsageMatchesBinding(usage, localName, owner)
+    )
   );
 }
 
@@ -710,7 +1279,8 @@ function isTypeOnlyReference(reference: NodePath<t.Node>): boolean {
 function readUsedNamespaceMembers(
   scope: Scope,
   localName: string,
-  templateUsage?: TemplateUsage
+  runtimeUsages: readonly TemplateUsage[],
+  owner: t.Program
 ): Set<string> {
   const names = new Set<string>();
   const bindings = new Set<Binding>();
@@ -784,9 +1354,12 @@ function readUsedNamespaceMembers(
       }
     }
   }
-  if (templateUsage) {
+  for (const runtimeUsage of runtimeUsages) {
     for (const templateName of templateNames) {
-      for (const name of templateUsage.namespaceMembers.get(templateName) ??
+      if (!templateUsageMatchesBinding(runtimeUsage, templateName, owner)) {
+        continue;
+      }
+      for (const name of runtimeUsage.namespaceMembers.get(templateName) ??
         []) {
         if (!writtenMembers.has(name)) names.add(name);
       }
@@ -824,9 +1397,30 @@ function isMemberWrite(
 }
 
 type TemplateUsage = {
+  bindingOwners?: ReadonlyMap<string, t.Program>;
   identifiers: Set<string>;
   namespaceMembers: Map<string, Set<string>>;
 };
+
+function createTemplateUsage(
+  bindingOwners?: ReadonlyMap<string, t.Program>
+): TemplateUsage {
+  return {
+    bindingOwners,
+    identifiers: new Set(),
+    namespaceMembers: new Map(),
+  };
+}
+
+function templateUsageMatchesBinding(
+  usage: TemplateUsage,
+  name: string,
+  owner: t.Program
+): boolean {
+  if (!usage.identifiers.has(name)) return false;
+  const expectedOwner = usage.bindingOwners?.get(name);
+  return !expectedOwner || expectedOwner === owner;
+}
 
 const VUE_BUILTIN_TEMPLATE_TAGS = new Set([
   'BaseTransition',
@@ -892,11 +1486,13 @@ const VUE_NATIVE_TEMPLATE_TAGS = new Set(
 );
 
 /** Parses component tags and executable expressions without raw-text guesses. */
-function readTemplateUsage(templateSource: string): TemplateUsage {
-  const usage: TemplateUsage = {
-    identifiers: new Set(),
-    namespaceMembers: new Map(),
-  };
+function readTemplateUsage(
+  templateSource: string,
+  scriptBindings: ReadonlyMap<string, TemplateBinding>
+): TemplateUsage {
+  const usage = createTemplateUsage(
+    new Map([...scriptBindings].map(([name, binding]) => [name, binding.owner]))
+  );
   const activeBindings = new Map<string, number>();
   const elementStack: TemplateElementScope[] = [];
   let vPreDepth = 0;
@@ -958,7 +1554,13 @@ function readTemplateUsage(templateSource: string): TemplateUsage {
       for (const binding of directiveUsage.elementBindings) {
         elementBindings.set(binding, (elementBindings.get(binding) ?? 0) + 1);
       }
-      recordTemplateTagUsage(tag.name, usage, elementBindings, attributes);
+      recordTemplateTagUsage(
+        tag.name,
+        usage,
+        elementBindings,
+        attributes,
+        scriptBindings
+      );
     }
     const rawTextClosingTag =
       !tag.selfClosing && VUE_RAW_TEXT_TEMPLATE_TAGS.has(tag.name)
@@ -1106,13 +1708,18 @@ function recordTemplateTagUsage(
   tag: string,
   usage: TemplateUsage,
   shadowedBindings: ReadonlyMap<string, number>,
-  attributes: readonly TemplateAttribute[]
+  attributes: readonly TemplateAttribute[],
+  scriptBindings: ReadonlyMap<string, TemplateBinding>
 ): void {
   if (isDynamicComponentTag(tag, attributes)) return;
   const member = /^([A-Za-z_$][\w$-]*)\.([A-Za-z_$][\w$]*)$/.exec(tag);
   if (member?.[1] && member[2]) {
-    for (const namespace of normalizeTemplateBindingNames(member[1])) {
-      if (shadowedBindings.has(namespace)) continue;
+    const namespace = resolveTemplateTagBinding(
+      member[1],
+      shadowedBindings,
+      scriptBindings
+    );
+    if (namespace) {
       usage.identifiers.add(namespace);
       addTemplateNamespaceMember(usage, namespace, member[2]);
     }
@@ -1121,9 +1728,24 @@ function recordTemplateTagUsage(
   if (VUE_BUILTIN_TEMPLATE_TAGS.has(tag) || VUE_NATIVE_TEMPLATE_TAGS.has(tag)) {
     return;
   }
-  for (const name of normalizeTemplateBindingNames(tag)) {
-    if (!shadowedBindings.has(name)) usage.identifiers.add(name);
+  const name = resolveTemplateTagBinding(tag, shadowedBindings, scriptBindings);
+  if (name) usage.identifiers.add(name);
+}
+
+/** Selects the first lexical or setup binding in Vue's tag lookup order. */
+function resolveTemplateTagBinding(
+  sourceName: string,
+  shadowedBindings: ReadonlyMap<string, number>,
+  scriptBindings: ReadonlyMap<string, TemplateBinding>
+): string | undefined {
+  const candidates = [...normalizeTemplateBindingNames(sourceName)];
+  for (const bindingType of TEMPLATE_BINDING_RESOLUTION_ORDER) {
+    for (const candidate of candidates) {
+      if (scriptBindings.get(candidate)?.type !== bindingType) continue;
+      return shadowedBindings.has(candidate) ? undefined : candidate;
+    }
   }
+  return undefined;
 }
 
 function isDynamicComponentTag(
@@ -1420,6 +2042,19 @@ function collectTemplateAstUsage(
     },
     OptionalMemberExpression(path) {
       collectTemplateMemberUsage(path, usage, shadowedBindings);
+    },
+    JSXMemberExpression(path) {
+      const object = path.node.object;
+      if (
+        object.type !== 'JSXIdentifier' ||
+        shadowedBindings.has(object.name) ||
+        path.scope.getBinding(object.name) ||
+        path.node.property.type !== 'JSXIdentifier'
+      ) {
+        return;
+      }
+      usage.identifiers.add(object.name);
+      addTemplateNamespaceMember(usage, object.name, path.node.property.name);
     },
   });
 }

--- a/packages/vue-extractor/src/internal/project/consumerUsage.ts
+++ b/packages/vue-extractor/src/internal/project/consumerUsage.ts
@@ -17,6 +17,7 @@ import {
   readPublicImportEntries,
   type PublicGTImport,
 } from './wrapperProvenance.js';
+import { classifyVueSource } from './vueSourceClassification.js';
 
 const traverse = traverseModule.default || traverseModule;
 
@@ -36,13 +37,20 @@ const IGNORED_CONSUMER_DIRECTORIES = new Set([
   'build',
   'coverage',
   'dist',
-  'lib',
   'node_modules',
   'out',
   'storybook-static',
   'target',
   'temp',
   'tmp',
+]);
+
+const GENERATED_CONSUMER_ROOT_DIRECTORIES = new Set([
+  'cjs',
+  'esm',
+  'generated',
+  'lib',
+  'lib-esm',
 ]);
 
 /** Prevents wrapper-use detection from walking an unbounded package tree. */
@@ -326,13 +334,17 @@ function isIgnoredConsumerPath(root: string, file: string): boolean {
   if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
     return true;
   }
-  return relative
-    .split(path.sep)
-    .slice(0, -1)
-    .some(
-      (segment) =>
-        segment.startsWith('.') || IGNORED_CONSUMER_DIRECTORIES.has(segment)
-    );
+  const directories = relative.split(path.sep).slice(0, -1);
+  const rootDirectory = directories[0]?.toLowerCase();
+  return Boolean(
+    (rootDirectory && GENERATED_CONSUMER_ROOT_DIRECTORIES.has(rootDirectory)) ||
+    directories.some((segment) => {
+      const normalized = segment.toLowerCase();
+      return (
+        segment.startsWith('.') || IGNORED_CONSUMER_DIRECTORIES.has(normalized)
+      );
+    })
+  );
 }
 
 /** Parses regular modules and the executable script blocks of Vue SFCs. */
@@ -345,6 +357,9 @@ function readConsumerImports(file: string): ConsumerImport[] {
   }
   const extension = path.extname(file).toLowerCase();
   if (extension === '.vue') {
+    if (classifyVueSource(source) === 'non-sfc') {
+      return readScriptImports(source, 'tsx');
+    }
     const { blocks, templateSource } = readVueScriptBlocks(source);
     return blocks.flatMap(({ language, source }) =>
       readScriptImports(source, language, templateSource)
@@ -538,7 +553,11 @@ function readScriptImports(
 ): ConsumerImport[] {
   const languages = new Set<string | undefined>([declaredLanguage]);
   languages.add('tsx');
-  if (declaredLanguage === 'js' || declaredLanguage === 'jsx') {
+  if (
+    declaredLanguage === 'js' ||
+    declaredLanguage === 'jsx' ||
+    declaredLanguage === 'tsx'
+  ) {
     languages.add('flow');
   }
 
@@ -826,12 +845,9 @@ const VUE_BUILTIN_TEMPLATE_TAGS = new Set([
   'transition-group',
 ]);
 
-const VUE_RAW_TEXT_TEMPLATE_TAGS = new Set([
-  'script',
-  'style',
-  'textarea',
-  'title',
-]);
+const VUE_RAW_TEXT_TEMPLATE_TAGS = new Set(['script', 'style']);
+
+const VUE_RCDATA_TEMPLATE_TAGS = new Set(['textarea', 'title']);
 
 const VUE_VOID_TEMPLATE_TAGS = new Set(
   'area,base,br,col,embed,hr,img,input,link,meta,param,source,track,wbr'.split(
@@ -882,7 +898,8 @@ function readTemplateUsage(templateSource: string): TemplateUsage {
     namespaceMembers: new Map(),
   };
   const activeBindings = new Map<string, number>();
-  const elementStack: Array<{ bindings: Set<string>; name: string }> = [];
+  const elementStack: TemplateElementScope[] = [];
+  let vPreDepth = 0;
   let index = 0;
   while (index < templateSource.length) {
     if (templateSource.startsWith('<!--', index)) {
@@ -890,6 +907,10 @@ function readTemplateUsage(templateSource: string): TemplateUsage {
       continue;
     }
     if (templateSource.startsWith('{{', index)) {
+      if (vPreDepth > 0) {
+        index += 2;
+        continue;
+      }
       const interpolation = readTemplateInterpolation(templateSource, index);
       if (interpolation.ast) {
         collectTemplateAstUsage(interpolation.ast, usage, activeBindings);
@@ -906,17 +927,39 @@ function readTemplateUsage(templateSource: string): TemplateUsage {
       index += 1;
       continue;
     }
-    recordTemplateTagUsage(tag.name, usage);
+    const normalizedTagName = tag.name.toLowerCase();
     if (tag.closing) {
-      closeTemplateElementScope(tag.name, elementStack, activeBindings);
+      vPreDepth = Math.max(
+        0,
+        vPreDepth -
+          closeTemplateElementScope(
+            normalizedTagName,
+            elementStack,
+            activeBindings
+          )
+      );
       index = tag.end;
       continue;
     }
-    const declaredBindings = collectTemplateDirectiveUsage(
-      tag.attributes,
-      usage,
-      activeBindings
+    const attributes = readTemplateAttributes(tag.attributes);
+    const introducesVPre = attributes.some(({ name }) =>
+      isTemplateVPreDirective(name)
     );
+    const suppressUsage = vPreDepth > 0 || introducesVPre;
+    let descendantBindings = new Set<string>();
+    if (!suppressUsage) {
+      const directiveUsage = collectTemplateDirectiveUsage(
+        attributes,
+        usage,
+        activeBindings
+      );
+      descendantBindings = directiveUsage.descendantBindings;
+      const elementBindings = new Map(activeBindings);
+      for (const binding of directiveUsage.elementBindings) {
+        elementBindings.set(binding, (elementBindings.get(binding) ?? 0) + 1);
+      }
+      recordTemplateTagUsage(tag.name, usage, elementBindings, attributes);
+    }
     const rawTextClosingTag =
       !tag.selfClosing && VUE_RAW_TEXT_TEMPLATE_TAGS.has(tag.name)
         ? findRawBlockClosingTag(templateSource, tag.name, tag.end)
@@ -925,22 +968,52 @@ function readTemplateUsage(templateSource: string): TemplateUsage {
       index = rawTextClosingTag.end;
       continue;
     }
+    const rcdataClosingTag =
+      !tag.selfClosing && VUE_RCDATA_TEMPLATE_TAGS.has(tag.name)
+        ? findRawBlockClosingTag(templateSource, tag.name, tag.end)
+        : undefined;
+    if (rcdataClosingTag) {
+      if (!suppressUsage) {
+        const rcdataBindings = new Map(activeBindings);
+        for (const binding of descendantBindings) {
+          rcdataBindings.set(binding, (rcdataBindings.get(binding) ?? 0) + 1);
+        }
+        collectTemplateRcdataUsage(
+          templateSource.slice(tag.end, rcdataClosingTag.start),
+          usage,
+          rcdataBindings
+        );
+      }
+      index = rcdataClosingTag.end;
+      continue;
+    }
     if (!tag.selfClosing && !VUE_VOID_TEMPLATE_TAGS.has(tag.name)) {
-      elementStack.push({ bindings: declaredBindings, name: tag.name });
-      for (const binding of declaredBindings) {
+      elementStack.push({
+        bindings: descendantBindings,
+        name: normalizedTagName,
+        vPre: introducesVPre,
+      });
+      for (const binding of descendantBindings) {
         activeBindings.set(binding, (activeBindings.get(binding) ?? 0) + 1);
       }
+      if (introducesVPre) vPreDepth += 1;
     }
     index = tag.end;
   }
   return usage;
 }
 
+type TemplateElementScope = {
+  bindings: Set<string>;
+  name: string;
+  vPre: boolean;
+};
+
 function closeTemplateElementScope(
   name: string,
-  elementStack: Array<{ bindings: Set<string>; name: string }>,
+  elementStack: TemplateElementScope[],
   activeBindings: Map<string, number>
-): void {
+): number {
   let matchingIndex = -1;
   for (let index = elementStack.length - 1; index >= 0; index -= 1) {
     if (elementStack[index]?.name === name) {
@@ -948,14 +1021,34 @@ function closeTemplateElementScope(
       break;
     }
   }
-  if (matchingIndex < 0) return;
+  if (matchingIndex < 0) return 0;
+  let closedVPreScopes = 0;
   while (elementStack.length > matchingIndex) {
     const element = elementStack.pop()!;
+    if (element.vPre) closedVPreScopes += 1;
     for (const binding of element.bindings) {
       const remaining = (activeBindings.get(binding) ?? 1) - 1;
       if (remaining > 0) activeBindings.set(binding, remaining);
       else activeBindings.delete(binding);
     }
+  }
+  return closedVPreScopes;
+}
+
+/** Records executable Vue interpolations while keeping RCDATA tags opaque. */
+function collectTemplateRcdataUsage(
+  source: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>
+): void {
+  let index = source.indexOf('{{');
+  while (index >= 0) {
+    const interpolation = readTemplateInterpolation(source, index);
+    if (interpolation.ast) {
+      collectTemplateAstUsage(interpolation.ast, usage, shadowedBindings);
+    }
+    if (interpolation.end >= source.length) return;
+    index = source.indexOf('{{', interpolation.end);
   }
 }
 
@@ -1009,29 +1102,62 @@ function readTemplateMarkupTag(
   return undefined;
 }
 
-function recordTemplateTagUsage(tag: string, usage: TemplateUsage): void {
-  const member = /^([A-Za-z_$][\w$]*)\.([A-Za-z_$][\w$]*)$/.exec(tag);
+function recordTemplateTagUsage(
+  tag: string,
+  usage: TemplateUsage,
+  shadowedBindings: ReadonlyMap<string, number>,
+  attributes: readonly TemplateAttribute[]
+): void {
+  if (isDynamicComponentTag(tag, attributes)) return;
+  const member = /^([A-Za-z_$][\w$-]*)\.([A-Za-z_$][\w$]*)$/.exec(tag);
   if (member?.[1] && member[2]) {
-    usage.identifiers.add(member[1]);
-    addTemplateNamespaceMember(usage, member[1], member[2]);
+    for (const namespace of normalizeTemplateBindingNames(member[1])) {
+      if (shadowedBindings.has(namespace)) continue;
+      usage.identifiers.add(namespace);
+      addTemplateNamespaceMember(usage, namespace, member[2]);
+    }
     return;
   }
   if (VUE_BUILTIN_TEMPLATE_TAGS.has(tag) || VUE_NATIVE_TEMPLATE_TAGS.has(tag)) {
     return;
   }
   for (const name of normalizeTemplateBindingNames(tag)) {
-    usage.identifiers.add(name);
+    if (!shadowedBindings.has(name)) usage.identifiers.add(name);
   }
+}
+
+function isDynamicComponentTag(
+  tag: string,
+  attributes: readonly TemplateAttribute[]
+): boolean {
+  if (tag !== 'component' && tag !== 'Component') return false;
+  return attributes.some(({ name, value }) => {
+    // No-value bind shorthand resolves differently in Vue 3.3 and 3.5. Keep
+    // the static tag candidate as well as collecting the shorthand expression,
+    // so neither supported runtime can silently lose real wrapper usage.
+    if (value === undefined) return false;
+    const baseName = name.split('.')[0];
+    return (
+      baseName === 'is' ||
+      baseName === ':is' ||
+      baseName === 'v-bind:is' ||
+      name === '.is' ||
+      name.startsWith('.is.')
+    );
+  });
 }
 
 /** Collects dynamic directive arguments and executable directive values. */
 function collectTemplateDirectiveUsage(
-  attributes: string,
+  attributes: readonly TemplateAttribute[],
   usage: TemplateUsage,
   shadowedBindings: ReadonlyMap<string, number>
-): Set<string> {
-  const directives = readTemplateDirectives(attributes);
-  const declaredBindings = new Set<string>();
+): TemplateDirectiveUsage {
+  const directives = attributes.filter(({ name }) =>
+    isTemplateDirectiveName(name)
+  );
+  const elementBindings = new Set<string>();
+  const descendantBindings = new Set<string>();
   for (const directive of directives.filter(({ name }) =>
     isTemplateForDirective(name)
   )) {
@@ -1041,7 +1167,8 @@ function collectTemplateDirectiveUsage(
       usage,
       shadowedBindings
     )) {
-      declaredBindings.add(binding);
+      elementBindings.add(binding);
+      descendantBindings.add(binding);
     }
   }
   for (const directive of directives.filter(({ name }) =>
@@ -1055,7 +1182,7 @@ function collectTemplateDirectiveUsage(
     );
   }
   const loopBindings = new Map(shadowedBindings);
-  for (const binding of declaredBindings) {
+  for (const binding of elementBindings) {
     loopBindings.set(binding, (loopBindings.get(binding) ?? 0) + 1);
   }
   for (const directive of directives) {
@@ -1071,24 +1198,29 @@ function collectTemplateDirectiveUsage(
       usage,
       loopBindings
     )) {
-      declaredBindings.add(binding);
+      descendantBindings.add(binding);
     }
   }
-  return declaredBindings;
+  return { descendantBindings, elementBindings };
 }
 
-type TemplateDirective = {
+type TemplateDirectiveUsage = {
+  descendantBindings: Set<string>;
+  elementBindings: Set<string>;
+};
+
+type TemplateAttribute = {
   name: string;
   value: string | undefined;
 };
 
-function readTemplateDirectives(attributes: string): TemplateDirective[] {
-  const directives: TemplateDirective[] = [];
+function readTemplateAttributes(attributes: string): TemplateAttribute[] {
+  const parsedAttributes: TemplateAttribute[] = [];
   let index = 0;
   while (index < attributes.length) {
     while (/\s/.test(attributes[index] ?? '')) index += 1;
     if (index >= attributes.length || attributes[index] === '/') {
-      return directives;
+      return parsedAttributes;
     }
     const nameStart = index;
     while (index < attributes.length && !/[\s=]/.test(attributes[index]!)) {
@@ -1118,9 +1250,17 @@ function readTemplateDirectives(attributes: string): TemplateDirective[] {
         value = attributes.slice(valueStart, index);
       }
     }
-    if (/^[:@#]|^v-/.test(name)) directives.push({ name, value });
+    parsedAttributes.push({ name, value });
   }
-  return directives;
+  return parsedAttributes;
+}
+
+function isTemplateDirectiveName(name: string): boolean {
+  return /^[.:@#]|^v-/.test(name);
+}
+
+function isTemplateVPreDirective(name: string): boolean {
+  return /^v-pre(?:$|[:.])/.test(name);
 }
 
 function isTemplateForDirective(name: string): boolean {
@@ -1137,13 +1277,13 @@ function collectTemplateDirective(
   usage: TemplateUsage,
   shadowedBindings: ReadonlyMap<string, number>
 ): Set<string> {
-  if (!/^[:@#]|^v-/.test(name)) return new Set();
+  if (!/^[.:@#]|^v-/.test(name)) return new Set();
   const argument = readDynamicDirectiveArgument(name);
   if (argument) {
     collectTemplateExpressionUsage(argument, usage, shadowedBindings);
   }
   if (value === undefined) {
-    if (name.startsWith(':') && !argument) {
+    if ((name.startsWith(':') || name.startsWith('.')) && !argument) {
       collectTemplateExpressionUsage(
         name.slice(1).split('.')[0] ?? '',
         usage,
@@ -1215,7 +1355,13 @@ function collectTemplateForUsage(
   }
   const left = source.slice(0, separator.index).trim();
   const right = source.slice(separator.index + separator[0].length).trim();
-  const bindings = collectTemplateBindingUsage(left, usage, shadowedBindings);
+  const unwrappedLeft =
+    left.startsWith('(') && left.endsWith(')') ? left.slice(1, -1) : left;
+  const bindings = collectTemplateBindingUsage(
+    unwrappedLeft,
+    usage,
+    shadowedBindings
+  );
   collectTemplateExpressionUsage(right, usage, shadowedBindings);
   return bindings;
 }

--- a/packages/vue-extractor/src/internal/project/consumerUsage.ts
+++ b/packages/vue-extractor/src/internal/project/consumerUsage.ts
@@ -1,0 +1,566 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import traverseModule, {
+  type Binding,
+  type NodePath,
+  type Scope,
+} from '@babel/traverse';
+import type * as t from '@babel/types';
+import { parseScriptAst } from '../script/parser.js';
+import {
+  readJavaScriptPackageManifest,
+  type JavaScriptPackageManifest,
+} from './manifest.js';
+import { DEFAULT_VUE_SOURCE_DIRECTORIES } from './sourcePatterns.js';
+import {
+  readPublicGTImports,
+  readPublicImportEntries,
+} from './wrapperProvenance.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+const CONSUMER_SOURCE_EXTENSIONS = new Set([
+  '.cjs',
+  '.cts',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.mts',
+  '.ts',
+  '.tsx',
+  '.vue',
+]);
+
+const IGNORED_CONSUMER_DIRECTORIES = new Set([
+  'build',
+  'coverage',
+  'dist',
+  'node_modules',
+  'out',
+  'storybook-static',
+  'target',
+  'temp',
+  'tmp',
+]);
+
+/** Prevents wrapper-use detection from walking an unbounded package tree. */
+const MAX_CONSUMER_SOURCE_FILES = 20_000;
+
+type ConsumerImport = {
+  importedNames: ReadonlySet<string> | '*';
+  source: string;
+};
+
+/**
+ * Returns whether consumer source actually imports a wrapper's public GT API.
+ *
+ * A dependency can expose separate React and Vue entrypoints. Package
+ * metadata alone cannot tell which one an application uses, so Vue ownership
+ * propagates only through a static value import or re-export of the exact
+ * public subpath and export name. The dependency binding name is kept
+ * separate from the package's declared name so npm/workspace aliases retain
+ * their consumer-visible specifiers.
+ */
+export function packageConsumesPublicGT(
+  consumerDirectory: string,
+  dependencyName: string,
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest
+): boolean {
+  const packageName = readPackageName(manifest);
+  if (!packageName) return false;
+  const publicImports = readPublicGTImports(packageDirectory, manifest).map(
+    ({ entry: _entry, exportNames, specifier }) => ({
+      exportNames,
+      specifier: `${dependencyName}${specifier.slice(packageName.length)}`,
+    })
+  );
+  if (publicImports.length === 0) return false;
+
+  const importsBySpecifier = new Map<string, ReadonlySet<string>>();
+  for (const { exportNames, specifier } of publicImports) {
+    const existing = importsBySpecifier.get(specifier);
+    importsBySpecifier.set(
+      specifier,
+      existing ? new Set([...existing, ...exportNames]) : exportNames
+    );
+  }
+  return consumerSourceUsesGT(consumerDirectory, importsBySpecifier);
+}
+
+/** Scans one package boundary for static imports of its dependency's GT API. */
+function consumerSourceUsesGT(
+  consumerDirectory: string,
+  importsBySpecifier: ReadonlyMap<string, ReadonlySet<string>>
+): boolean {
+  const root = resolveRealPath(consumerDirectory);
+  const pending = DEFAULT_VUE_SOURCE_DIRECTORIES.map((directory) =>
+    path.join(root, directory)
+  )
+    .filter((directory) => isContainedPhysicalDirectory(root, directory))
+    .reverse();
+  const sourceFileQueue = new Set<string>();
+  const consumerManifest = readJavaScriptPackageManifest(
+    path.join(root, 'package.json')
+  );
+  if (consumerManifest) {
+    for (const { entry } of readPublicImportEntries(root, consumerManifest)) {
+      if (!isIgnoredConsumerPath(root, entry)) sourceFileQueue.add(entry);
+    }
+  }
+  try {
+    for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+      if (entry.isFile() && path.extname(entry.name).toLowerCase() === '.vue') {
+        sourceFileQueue.add(path.join(root, entry.name));
+      }
+    }
+  } catch {
+    // Public entries may still establish usage when the root cannot be listed.
+  }
+  let sourceFiles = 0;
+
+  for (const file of sourceFileQueue) {
+    sourceFiles += 1;
+    if (sourceFiles > MAX_CONSUMER_SOURCE_FILES) return false;
+    if (sourceFileUsesGT(file, importsBySpecifier)) return true;
+  }
+
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    if (fs.existsSync(path.join(current, 'package.json'))) {
+      // Nested workspace packages establish their own ownership. Their imports
+      // must never promote an aggregator or sibling package.
+      continue;
+    }
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      if (shouldIgnoreConsumerEntry(entry)) continue;
+      const candidate = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(candidate);
+        continue;
+      }
+      if (
+        !entry.isFile() ||
+        !CONSUMER_SOURCE_EXTENSIONS.has(path.extname(entry.name).toLowerCase())
+      ) {
+        continue;
+      }
+      sourceFiles += 1;
+      if (sourceFiles > MAX_CONSUMER_SOURCE_FILES) return false;
+      if (
+        !sourceFileQueue.has(candidate) &&
+        sourceFileUsesGT(candidate, importsBySpecifier)
+      ) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function sourceFileUsesGT(
+  file: string,
+  importsBySpecifier: ReadonlyMap<string, ReadonlySet<string>>
+): boolean {
+  for (const consumerImport of readConsumerImports(file)) {
+    const gtExportNames = importsBySpecifier.get(consumerImport.source);
+    if (!gtExportNames) continue;
+    if (
+      consumerImport.importedNames === '*' ||
+      [...consumerImport.importedNames].some((name) => gtExportNames.has(name))
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function shouldIgnoreConsumerEntry(entry: fs.Dirent): boolean {
+  return (
+    entry.isSymbolicLink() ||
+    (entry.isDirectory() &&
+      (entry.name.startsWith('.') ||
+        IGNORED_CONSUMER_DIRECTORIES.has(entry.name)))
+  );
+}
+
+/** Rejects public entries that resolve only into generated package output. */
+function isIgnoredConsumerPath(root: string, file: string): boolean {
+  const relative = path.relative(root, file);
+  if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) {
+    return true;
+  }
+  return relative
+    .split(path.sep)
+    .slice(0, -1)
+    .some(
+      (segment) =>
+        segment.startsWith('.') || IGNORED_CONSUMER_DIRECTORIES.has(segment)
+    );
+}
+
+/** Parses regular modules and the executable script blocks of Vue SFCs. */
+function readConsumerImports(file: string): ConsumerImport[] {
+  let source: string;
+  try {
+    source = fs.readFileSync(file, 'utf8');
+  } catch {
+    return [];
+  }
+  const extension = path.extname(file).toLowerCase();
+  if (extension === '.vue') {
+    const { blocks, templateSource } = readVueScriptBlocks(source);
+    return blocks.flatMap(({ language, source }) =>
+      readScriptImports(source, language, templateSource)
+    );
+  }
+  const language =
+    extension === '.mjs' || extension === '.cjs'
+      ? 'js'
+      : extension === '.mts' || extension === '.cts'
+        ? 'ts'
+        : extension.slice(1);
+  return readScriptImports(source, language);
+}
+
+/** Reads SFC script blocks without loading a project Vue compiler. */
+function readVueScriptBlocks(source: string): {
+  blocks: Array<{ language: string | undefined; source: string }>;
+  templateSource: string;
+} {
+  const blocks: Array<{ language: string | undefined; source: string }> = [];
+  const expression = /<script\b([^>]*)>([\s\S]*?)<\/script\s*>/gi;
+  for (const match of source.matchAll(expression)) {
+    const attributes = match[1] ?? '';
+    const quotedLanguage = /\blang\s*=\s*(["'])([^"']+)\1/i.exec(
+      attributes
+    )?.[2];
+    const bareLanguage = /\blang\s*=\s*([^\s>]+)/i.exec(attributes)?.[1];
+    blocks.push({
+      language: quotedLanguage ?? bareLanguage,
+      source: match[2] ?? '',
+    });
+  }
+  const templateSource = [
+    ...source.matchAll(/<template\b[^>]*>([\s\S]*?)<\/template\s*>/gi),
+  ]
+    .map((match) => match[1] ?? '')
+    .join('\n');
+  return { blocks, templateSource };
+}
+
+/** Accepts project-compatible syntax while extracting only static ESM edges. */
+function readScriptImports(
+  source: string,
+  declaredLanguage: string | undefined,
+  templateSource?: string
+): ConsumerImport[] {
+  const languages = new Set<string | undefined>([declaredLanguage]);
+  languages.add('tsx');
+  if (declaredLanguage === 'js' || declaredLanguage === 'jsx') {
+    languages.add('flow');
+  }
+
+  for (const language of languages) {
+    try {
+      return collectStaticImports(
+        parseScriptAst(source, language),
+        templateSource
+      );
+    } catch {
+      // Try the next syntax accepted by source extraction.
+    }
+  }
+  return [];
+}
+
+function collectStaticImports(
+  ast: t.File,
+  templateSource?: string
+): ConsumerImport[] {
+  let programScope: Scope | undefined;
+  traverse(ast, {
+    Program(programPath) {
+      programScope = programPath.scope;
+      programPath.stop();
+    },
+  });
+  if (!programScope) return [];
+
+  const imports: ConsumerImport[] = [];
+  for (const statement of ast.program.body) {
+    if (
+      statement.type === 'ImportDeclaration' &&
+      statement.importKind !== 'type' &&
+      statement.importKind !== 'typeof'
+    ) {
+      const importedNames = new Set<string>();
+      for (const specifier of statement.specifiers) {
+        if (specifier.type === 'ImportDefaultSpecifier') {
+          importedNames.add('default');
+        } else if (specifier.type === 'ImportNamespaceSpecifier') {
+          for (const name of readUsedNamespaceMembers(
+            programScope,
+            specifier.local.name,
+            templateSource
+          )) {
+            importedNames.add(name);
+          }
+        } else if (
+          specifier.importKind !== 'type' &&
+          specifier.importKind !== 'typeof'
+        ) {
+          importedNames.add(readModuleName(specifier.imported));
+        }
+      }
+      if (importedNames.size > 0) {
+        imports.push({ importedNames, source: statement.source.value });
+      }
+      continue;
+    }
+
+    if (
+      statement.type === 'ExportAllDeclaration' &&
+      statement.exportKind !== 'type'
+    ) {
+      imports.push({ importedNames: '*', source: statement.source.value });
+      continue;
+    }
+
+    if (
+      statement.type !== 'ExportNamedDeclaration' ||
+      statement.exportKind === 'type' ||
+      !statement.source
+    ) {
+      continue;
+    }
+    const importedNames = new Set<string>();
+    for (const specifier of statement.specifiers) {
+      if (
+        specifier.type === 'ExportSpecifier' &&
+        specifier.exportKind !== 'type'
+      ) {
+        importedNames.add(readModuleName(specifier.local));
+      }
+    }
+    if (importedNames.size > 0) {
+      imports.push({
+        importedNames,
+        source: statement.source.value,
+      });
+    }
+  }
+  return imports;
+}
+
+function readModuleName(node: t.Identifier | t.StringLiteral): string {
+  return node.type === 'Identifier' ? node.name : node.value;
+}
+
+/** Returns only statically named namespace members used by source or template. */
+function readUsedNamespaceMembers(
+  scope: Scope,
+  localName: string,
+  templateSource?: string
+): Set<string> {
+  const names = new Set<string>();
+  const bindings = new Set<Binding>();
+  const collectImmutableAliases = (binding: Binding | undefined): void => {
+    if (!binding?.constant || bindings.has(binding)) return;
+    bindings.add(binding);
+    for (const reference of binding.referencePaths) {
+      const declarator = reference.parentPath;
+      if (
+        !declarator?.isVariableDeclarator() ||
+        declarator.node.init !== reference.node ||
+        declarator.node.id.type !== 'Identifier' ||
+        !declarator.parentPath?.isVariableDeclaration() ||
+        declarator.parentPath.node.kind !== 'const'
+      ) {
+        continue;
+      }
+      const alias = declarator.scope.getBinding(declarator.node.id.name);
+      if (alias?.path.node === declarator.node) collectImmutableAliases(alias);
+    }
+  };
+  collectImmutableAliases(scope.getBinding(localName));
+
+  const writtenMembers = new Set<string>();
+  for (const binding of bindings) {
+    for (const reference of binding.referencePaths) {
+      const member = readNamespaceMemberPath(reference);
+      if (!member) continue;
+      const name = readStaticPropertyName(member.node);
+      if (name && isMemberWrite(member)) writtenMembers.add(name);
+    }
+  }
+
+  const templateNames = new Set<string>();
+  for (const binding of bindings) {
+    if (binding.scope === scope) templateNames.add(binding.identifier.name);
+    for (const reference of binding.referencePaths) {
+      const member = readNamespaceMemberPath(reference);
+      if (member) {
+        const name = readStaticPropertyName(member.node);
+        if (name && !writtenMembers.has(name)) names.add(name);
+        continue;
+      }
+      const jsxMember = reference.parentPath;
+      if (
+        jsxMember?.isJSXMemberExpression() &&
+        jsxMember.node.object === reference.node &&
+        jsxMember.node.property.type === 'JSXIdentifier' &&
+        !writtenMembers.has(jsxMember.node.property.name)
+      ) {
+        names.add(jsxMember.node.property.name);
+        continue;
+      }
+      const parent = reference.parent;
+      if (
+        parent?.type !== 'VariableDeclarator' ||
+        parent.init !== reference.node ||
+        parent.id.type !== 'ObjectPattern'
+      ) {
+        continue;
+      }
+      for (const property of parent.id.properties) {
+        if (property.type !== 'ObjectProperty' || property.computed) continue;
+        const name =
+          property.key.type === 'Identifier'
+            ? property.key.name
+            : property.key.type === 'StringLiteral'
+              ? property.key.value
+              : undefined;
+        if (name && !writtenMembers.has(name)) names.add(name);
+      }
+    }
+  }
+  if (templateSource) {
+    for (const templateName of templateNames) {
+      for (const name of readTemplateNamespaceMembers(
+        templateSource,
+        templateName
+      )) {
+        if (!writtenMembers.has(name)) names.add(name);
+      }
+    }
+  }
+  return names;
+}
+
+function readNamespaceMemberPath(
+  reference: NodePath<t.Node>
+): NodePath<t.MemberExpression | t.OptionalMemberExpression> | undefined {
+  const member = reference.parentPath;
+  if (
+    (member?.isMemberExpression() || member?.isOptionalMemberExpression()) &&
+    member.node.object === reference.node
+  ) {
+    return member;
+  }
+  return undefined;
+}
+
+function isMemberWrite(
+  member: NodePath<t.MemberExpression | t.OptionalMemberExpression>
+): boolean {
+  const parent = member.parentPath?.node;
+  return Boolean(
+    (parent?.type === 'AssignmentExpression' && parent.left === member.node) ||
+    (parent?.type === 'UpdateExpression' && parent.argument === member.node) ||
+    (parent?.type === 'UnaryExpression' &&
+      parent.operator === 'delete' &&
+      parent.argument === member.node) ||
+    ((parent?.type === 'ForInStatement' || parent?.type === 'ForOfStatement') &&
+      parent.left === member.node)
+  );
+}
+
+/** Reads namespace members only from component tags and executable markup. */
+function readTemplateNamespaceMembers(
+  templateSource: string,
+  localName: string
+): Set<string> {
+  const names = new Set<string>();
+  const source = templateSource.replace(/<!--[\s\S]*?-->/g, '');
+  const memberPattern = `${escapeRegularExpression(localName)}\\s*\\.\\s*([A-Za-z_$][\\w$]*)`;
+  const tagExpression = new RegExp(`<\\/?\\s*${memberPattern}(?=[\\s/>])`, 'g');
+  for (const match of source.matchAll(tagExpression)) {
+    if (match[1]) names.add(match[1]);
+  }
+
+  const executableExpressions = [
+    ...source.matchAll(/{{([\s\S]*?)}}/g),
+    ...source.matchAll(
+      /(?:^|\s)(?:[:@#][^\s=]+|v-[^\s=]+)\s*=\s*(["'])([\s\S]*?)\1/g
+    ),
+  ];
+  const memberExpression = new RegExp(`\\b${memberPattern}`, 'g');
+  for (const executable of executableExpressions) {
+    const value = executable[2] ?? executable[1] ?? '';
+    for (const match of value.matchAll(memberExpression)) {
+      if (match[1]) names.add(match[1]);
+    }
+  }
+  return names;
+}
+
+function readStaticPropertyName(
+  member: t.MemberExpression | t.OptionalMemberExpression
+): string | undefined {
+  if (!member.computed && member.property.type === 'Identifier') {
+    return member.property.name;
+  }
+  if (member.computed && member.property.type === 'StringLiteral') {
+    return member.property.value;
+  }
+  return undefined;
+}
+
+function readPackageName(
+  manifest: JavaScriptPackageManifest
+): string | undefined {
+  return typeof manifest.name === 'string' && manifest.name
+    ? manifest.name
+    : undefined;
+}
+
+function resolveRealPath(file: string): string {
+  try {
+    return fs.realpathSync(file);
+  } catch {
+    return path.resolve(file);
+  }
+}
+
+/** Keeps a package's default source roots from following external symlinks. */
+function isContainedPhysicalDirectory(
+  root: string,
+  directory: string
+): boolean {
+  try {
+    const stat = fs.lstatSync(directory);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    const realDirectory = fs.realpathSync(directory);
+    const relative = path.relative(root, realDirectory);
+    return (
+      relative !== '' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      relative !== '..' &&
+      !path.isAbsolute(relative)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -11,7 +11,11 @@ import {
   type JavaScriptDependencyBinding,
   type JavaScriptPackageManifest,
 } from './manifest.js';
-import { packageConsumesPublicGT } from './consumerUsage.js';
+import {
+  createConsumerUsageCache,
+  packageConsumesPublicGT,
+  type ConsumerUsageCache,
+} from './consumerUsage.js';
 
 /**
  * Returns whether the root package owns gt-vue directly or through local code.
@@ -37,7 +41,11 @@ export function detectVueProject(cwd: string = process.cwd()): boolean {
     ) {
       return true;
     }
-    return localDependencyGraphDeclaresVue(rootManifest, projectRoot);
+    return localDependencyGraphDeclaresVue(
+      rootManifest,
+      projectRoot,
+      createConsumerUsageCache()
+    );
   } catch {
     return false;
   }
@@ -46,7 +54,8 @@ export function detectVueProject(cwd: string = process.cwd()): boolean {
 /** Checks only installed project-local dependency edges for a Vue wrapper. */
 export function localDependencyGraphDeclaresVue(
   rootManifest: JavaScriptPackageManifest,
-  projectRoot: string
+  projectRoot: string,
+  consumerUsageCache: ConsumerUsageCache = createConsumerUsageCache()
 ): boolean {
   for (const binding of readWorkspaceDependencyBindings(
     rootManifest,
@@ -84,7 +93,8 @@ export function localDependencyGraphDeclaresVue(
         projectRoot,
         binding.name,
         sourceDirectory,
-        sourceManifest
+        sourceManifest,
+        consumerUsageCache
       )
     ) {
       return true;

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -1,15 +1,30 @@
-import { discoverVueProject } from './scopes.js';
+import path from 'node:path';
+import {
+  declaresAvailableJavaScriptDependency,
+  GT_VUE_PACKAGE,
+  readJavaScriptPackageManifest,
+} from './manifest.js';
 
 /**
- * Returns whether a project root owns or contains a declared gt-vue app.
+ * Returns whether the current package directly owns a declared gt-vue app.
  *
- * Detection is read-only, synchronous, and fail-safe. It loads no Vue compiler
- * or source parser, making it safe for a host CLI to call before selecting a
- * framework-specific command surface.
+ * Workspace descendants cannot change the root CLI mode. Detection is
+ * read-only, synchronous, and fail-safe, and it loads no Vue compiler, source
+ * parser, workspace globber, or project configuration.
  */
 export function detectVueProject(cwd: string = process.cwd()): boolean {
   try {
-    return discoverVueProject(cwd).scopes.length > 0;
+    const manifest = readJavaScriptPackageManifest(
+      path.join(path.resolve(cwd), 'package.json')
+    );
+    return Boolean(
+      manifest &&
+      declaresAvailableJavaScriptDependency(
+        manifest,
+        GT_VUE_PACKAGE,
+        path.resolve(cwd)
+      )
+    );
   } catch {
     return false;
   }

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -3,22 +3,15 @@ import path from 'node:path';
 import {
   dependencyBindingAcceptsPackageVersion,
   declaresAvailableJavaScriptDependency,
-  declaresPropagatingJavaScriptDependency,
   GT_VUE_PACKAGE,
   parseLocalDependencyPath,
   readJavaScriptPackageManifest,
-  readPropagatingDependencyBindings,
   readWorkspaceDependencyBindings,
   resolveInstalledJavaScriptPackage,
-  type InstalledJavaScriptPackage,
   type JavaScriptDependencyBinding,
   type JavaScriptPackageManifest,
 } from './manifest.js';
-
-type LocalPackage = InstalledJavaScriptPackage & {
-  includeDevelopmentBindings: boolean;
-  sourceDirectory: string;
-};
+import { packagePubliclyExposesGT } from './wrapperProvenance.js';
 
 /**
  * Returns whether the root package owns gt-vue directly or through local code.
@@ -55,65 +48,38 @@ export function localDependencyGraphDeclaresVue(
   rootManifest: JavaScriptPackageManifest,
   projectRoot: string
 ): boolean {
-  const pending: LocalPackage[] = [
-    {
-      directory: projectRoot,
-      includeDevelopmentBindings: true,
-      manifest: rootManifest,
-      sourceDirectory: projectRoot,
-    },
-  ];
-  const visited = new Set<string>([projectRoot]);
-  for (let index = 0; index < pending.length; index += 1) {
-    const current = pending[index]!;
-    const bindings = current.includeDevelopmentBindings
-      ? readWorkspaceDependencyBindings(current.manifest, current.directory)
-      : readPropagatingDependencyBindings(current.manifest, current.directory);
-    for (const binding of bindings) {
-      const installed = resolveInstalledJavaScriptPackage(
-        current.directory,
-        binding.name
-      );
-      if (!installed) continue;
-      const sourceDirectory = findLocalSourceDirectory(
+  for (const binding of readWorkspaceDependencyBindings(
+    rootManifest,
+    projectRoot
+  )) {
+    const installed = resolveInstalledJavaScriptPackage(
+      projectRoot,
+      binding.name
+    );
+    if (!installed) continue;
+    const sourceDirectory = findLocalSourceDirectory(
+      binding,
+      projectRoot,
+      installed.directory,
+      projectRoot
+    );
+    if (!sourceDirectory) continue;
+    const sourceManifest = readJavaScriptPackageManifest(
+      path.join(sourceDirectory, 'package.json')
+    );
+    const packageName = readPackageName(sourceManifest);
+    if (
+      !sourceManifest ||
+      !packageName ||
+      !dependencyBindingAcceptsPackageVersion(
         binding,
-        current.sourceDirectory,
-        installed.directory,
-        projectRoot
-      );
-      if (!sourceDirectory || visited.has(sourceDirectory)) continue;
-      const sourceManifest = readJavaScriptPackageManifest(
-        path.join(sourceDirectory, 'package.json')
-      );
-      const packageName = readPackageName(sourceManifest);
-      if (
-        !sourceManifest ||
-        !packageName ||
-        !dependencyBindingAcceptsPackageVersion(
-          binding,
-          packageName,
-          sourceManifest.version
-        )
-      ) {
-        continue;
-      }
-      if (
-        declaresPropagatingJavaScriptDependency(
-          sourceManifest,
-          GT_VUE_PACKAGE,
-          installed.directory
-        )
-      ) {
-        return true;
-      }
-      visited.add(sourceDirectory);
-      pending.push({
-        directory: installed.directory,
-        includeDevelopmentBindings: false,
-        manifest: sourceManifest,
-        sourceDirectory,
-      });
+        packageName,
+        sourceManifest.version
+      )
+    ) {
+      continue;
     }
+    if (packagePubliclyExposesGT(sourceDirectory, sourceManifest)) return true;
   }
   return false;
 }

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -11,7 +11,7 @@ import {
   type JavaScriptDependencyBinding,
   type JavaScriptPackageManifest,
 } from './manifest.js';
-import { packagePubliclyExposesGT } from './wrapperProvenance.js';
+import { packageConsumesPublicGT } from './consumerUsage.js';
 
 /**
  * Returns whether the root package owns gt-vue directly or through local code.
@@ -79,7 +79,16 @@ export function localDependencyGraphDeclaresVue(
     ) {
       continue;
     }
-    if (packagePubliclyExposesGT(sourceDirectory, sourceManifest)) return true;
+    if (
+      packageConsumesPublicGT(
+        projectRoot,
+        binding.name,
+        sourceDirectory,
+        sourceManifest
+      )
+    ) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -1,31 +1,173 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import {
+  dependencyBindingAcceptsPackageVersion,
   declaresAvailableJavaScriptDependency,
+  declaresPropagatingJavaScriptDependency,
   GT_VUE_PACKAGE,
+  parseLocalDependencyPath,
   readJavaScriptPackageManifest,
+  readPropagatingDependencyBindings,
+  readWorkspaceDependencyBindings,
+  resolveInstalledJavaScriptPackage,
+  type InstalledJavaScriptPackage,
+  type JavaScriptDependencyBinding,
+  type JavaScriptPackageManifest,
 } from './manifest.js';
 
+type LocalPackage = InstalledJavaScriptPackage & {
+  includeDevelopmentBindings: boolean;
+  sourceDirectory: string;
+};
+
 /**
- * Returns whether the current package directly owns a declared gt-vue app.
+ * Returns whether the root package owns gt-vue directly or through local code.
  *
- * Workspace descendants cannot change the root CLI mode. Detection is
- * read-only, synchronous, and fail-safe, and it loads no Vue compiler, source
- * parser, workspace globber, or project configuration.
+ * Only installed bindings proven to originate inside the current project are
+ * traversed. Registry packages and unrelated workspace descendants therefore
+ * cannot change the root CLI mode, and ordinary projects never scan workspace
+ * manifests or eagerly load the Vue parser and project-discovery graph.
  */
 export function detectVueProject(cwd: string = process.cwd()): boolean {
   try {
-    const manifest = readJavaScriptPackageManifest(
-      path.join(path.resolve(cwd), 'package.json')
+    const projectRoot = normalizeDirectory(cwd);
+    const rootManifest = readJavaScriptPackageManifest(
+      path.join(projectRoot, 'package.json')
     );
-    return Boolean(
-      manifest &&
+    if (!rootManifest) return false;
+    if (
       declaresAvailableJavaScriptDependency(
-        manifest,
+        rootManifest,
         GT_VUE_PACKAGE,
-        path.resolve(cwd)
+        projectRoot
       )
-    );
+    ) {
+      return true;
+    }
+    return localDependencyGraphDeclaresVue(rootManifest, projectRoot);
   } catch {
     return false;
   }
+}
+
+/** Checks only installed project-local dependency edges for a Vue wrapper. */
+export function localDependencyGraphDeclaresVue(
+  rootManifest: JavaScriptPackageManifest,
+  projectRoot: string
+): boolean {
+  const pending: LocalPackage[] = [
+    {
+      directory: projectRoot,
+      includeDevelopmentBindings: true,
+      manifest: rootManifest,
+      sourceDirectory: projectRoot,
+    },
+  ];
+  const visited = new Set<string>([projectRoot]);
+  for (let index = 0; index < pending.length; index += 1) {
+    const current = pending[index]!;
+    const bindings = current.includeDevelopmentBindings
+      ? readWorkspaceDependencyBindings(current.manifest, current.directory)
+      : readPropagatingDependencyBindings(current.manifest, current.directory);
+    for (const binding of bindings) {
+      const installed = resolveInstalledJavaScriptPackage(
+        current.directory,
+        binding.name
+      );
+      if (!installed) continue;
+      const sourceDirectory = findLocalSourceDirectory(
+        binding,
+        current.sourceDirectory,
+        installed.directory,
+        projectRoot
+      );
+      if (!sourceDirectory || visited.has(sourceDirectory)) continue;
+      const sourceManifest = readJavaScriptPackageManifest(
+        path.join(sourceDirectory, 'package.json')
+      );
+      const packageName = readPackageName(sourceManifest);
+      if (
+        !sourceManifest ||
+        !packageName ||
+        !dependencyBindingAcceptsPackageVersion(
+          binding,
+          packageName,
+          sourceManifest.version
+        )
+      ) {
+        continue;
+      }
+      if (
+        declaresPropagatingJavaScriptDependency(
+          sourceManifest,
+          GT_VUE_PACKAGE,
+          installed.directory
+        )
+      ) {
+        return true;
+      }
+      visited.add(sourceDirectory);
+      pending.push({
+        directory: installed.directory,
+        includeDevelopmentBindings: false,
+        manifest: sourceManifest,
+        sourceDirectory,
+      });
+    }
+  }
+  return false;
+}
+
+function findLocalSourceDirectory(
+  binding: JavaScriptDependencyBinding,
+  importerSourceDirectory: string,
+  installedDirectory: string,
+  projectRoot: string
+): string | undefined {
+  const localPath = parseLocalDependencyPath(binding.specifier);
+  if (localPath) {
+    const sourceDirectory = normalizeDirectory(
+      path.resolve(importerSourceDirectory, localPath)
+    );
+    if (isLocalSourceDirectory(projectRoot, sourceDirectory)) {
+      return sourceDirectory;
+    }
+  }
+
+  const normalizedInstalled = normalizeDirectory(installedDirectory);
+  if (isLocalSourceDirectory(projectRoot, normalizedInstalled)) {
+    return normalizedInstalled;
+  }
+  return undefined;
+}
+
+function isLocalSourceDirectory(
+  projectRoot: string,
+  candidate: string
+): boolean {
+  const relative = path.relative(projectRoot, candidate);
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative) &&
+    !relative.split(path.sep).includes('node_modules') &&
+    fs.existsSync(path.join(candidate, 'package.json'))
+  );
+}
+
+function normalizeDirectory(directory: string): string {
+  try {
+    return fs.realpathSync(directory);
+  } catch {
+    return path.resolve(directory);
+  }
+}
+
+function readPackageName(
+  manifest: JavaScriptPackageManifest | undefined
+): string | undefined {
+  return typeof manifest?.name === 'string' && manifest.name
+    ? manifest.name
+    : undefined;
 }

--- a/packages/vue-extractor/src/internal/project/detectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/detectVueProject.ts
@@ -1,0 +1,16 @@
+import { discoverVueProject } from './scopes.js';
+
+/**
+ * Returns whether a project root owns or contains a declared gt-vue app.
+ *
+ * Detection is read-only, synchronous, and fail-safe. It loads no Vue compiler
+ * or source parser, making it safe for a host CLI to call before selecting a
+ * framework-specific command surface.
+ */
+export function detectVueProject(cwd: string = process.cwd()): boolean {
+  try {
+    return discoverVueProject(cwd).scopes.length > 0;
+  } catch {
+    return false;
+  }
+}

--- a/packages/vue-extractor/src/internal/project/extractFromVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/extractFromVueProject.ts
@@ -18,16 +18,21 @@ import {
 } from './moduleResolver.js';
 import { resolveVueProjectAliasConfiguration } from './viteAliases.js';
 import {
-  declaresJavaScriptDependency,
+  declaresInstalledJavaScriptDependency,
+  GT_VUE_PACKAGE,
   readJavaScriptPackageManifest,
-} from './workspaces.js';
+} from './manifest.js';
 import {
   discoverVueProject,
   findVueSourceScope,
-  GT_VUE_PACKAGE,
   readDefaultVueSourcePatterns,
+  resolveProjectDirectory,
   type VueSourceScope,
 } from './scopes.js';
+import {
+  isVueSfcSource,
+  readVueProjectInspection,
+} from './inspectVueProject.js';
 import type {
   VueCompilerOptions,
   VueExtractionOutput,
@@ -62,8 +67,12 @@ const JSX_CONFIG_EXTENSIONS = new Set(['.jsx', '.tsx']);
 export async function extractFromVueProject(
   options: VueProjectExtractionOptions = {}
 ): Promise<VueProjectExtractionOutput> {
-  const projectRoot = path.resolve(options.cwd ?? process.cwd());
-  const discovery = discoverVueProject(projectRoot);
+  const projectRoot = resolveProjectDirectory(
+    options.cwd ?? options.inspection?.projectRoot ?? process.cwd()
+  );
+  const discovery =
+    readVueProjectInspection(options.inspection, projectRoot) ??
+    discoverVueProject(projectRoot);
   const discoveryErrors =
     options.filePatterns === undefined
       ? validateNuxtSourceScopes(discovery.scopes, options.vueCompilerOptions)
@@ -94,18 +103,19 @@ export async function extractFromVueProject(
   );
   // Explicit globs can also match files owned by another framework package.
   // They are not Vue inputs unless discovery placed them in a Vue scope.
-  const files = matchedFiles.filter(
+  const ownedFiles = matchedFiles.filter(
     (file) => fileScopes.get(file) !== undefined
   );
+  const files = await filterVueSourceFiles(ownedFiles, sourceByFile);
+  if (files.length === 0) {
+    return { updates: [], errors: [], warnings: [] };
+  }
   const errors: string[] = [];
   const warnings = new Set<string>();
   let explicitCompilerResolution = validateExplicitCompilerConfig(
     projectRoot,
     options,
-    files.some((file) => {
-      const scope = fileScopes.get(file);
-      return scope?.includeByDefault === true || path.extname(file) === '.vue';
-    }),
+    files.some((file) => path.extname(file).toLowerCase() === '.vue'),
     errors
   );
   if (errors.length > 0) {
@@ -130,14 +140,16 @@ export async function extractFromVueProject(
   for (const file of files) {
     const extension = path.extname(file).toLowerCase();
     if (extension !== '.vue' && !SCRIPT_EXTENSIONS.has(extension)) continue;
-    let source: string;
-    try {
-      source = await fs.promises.readFile(file, 'utf8');
-    } catch (error) {
-      errors.push(createReadDiagnostic(projectRoot, file, error));
-      continue;
+    let source = sourceByFile.get(file);
+    if (source === undefined) {
+      try {
+        source = await fs.promises.readFile(file, 'utf8');
+      } catch (error) {
+        errors.push(createReadDiagnostic(projectRoot, file, error));
+        continue;
+      }
+      sourceByFile.set(file, source);
     }
-    sourceByFile.set(file, source);
     if (extension === '.vue') continue;
     standaloneResults.set(
       file,
@@ -246,6 +258,27 @@ export async function extractFromVueProject(
     errors,
     warnings: [...warnings],
   };
+}
+
+/** Excludes script modules whose filename happens to end in `.vue`. */
+async function filterVueSourceFiles(
+  files: readonly string[],
+  sourceByFile: Map<string, string>
+): Promise<string[]> {
+  const included = await Promise.all(
+    files.map(async (file) => {
+      if (path.extname(file).toLowerCase() !== '.vue') return true;
+      try {
+        const source = await fs.promises.readFile(file, 'utf8');
+        sourceByFile.set(file, source);
+        return isVueSfcSource(source);
+      } catch {
+        // Preserve the file so the normal extraction pass reports its I/O error.
+        return true;
+      }
+    })
+  );
+  return files.filter((_file, index) => included[index]);
 }
 
 /** Returns whether a standalone file has observable gt-vue extraction work. */
@@ -425,7 +458,7 @@ function matchProjectFiles(
       errors: [createRootRealpathDiagnostic(cwd, error)],
     };
   }
-  const files: string[] = [];
+  const files = new Set<string>();
   const errors: string[] = [];
   for (const file of matches) {
     let realFile: string;
@@ -445,11 +478,11 @@ function matchProjectFiles(
       // Symlinks outside the project are intentionally outside its catalog.
       continue;
     }
-    files.push(file);
+    files.add(realFile);
   }
   return {
     errors,
-    files: files.sort((left, right) => left.localeCompare(right)),
+    files: [...files].sort((left, right) => left.localeCompare(right)),
   };
 }
 
@@ -517,7 +550,7 @@ function ownsIndependentVueConfiguration(directory: string): boolean {
     path.join(directory, 'package.json')
   );
   return Boolean(
-    manifest && declaresJavaScriptDependency(manifest, GT_VUE_PACKAGE)
+    manifest && declaresInstalledJavaScriptDependency(manifest, GT_VUE_PACKAGE)
   );
 }
 

--- a/packages/vue-extractor/src/internal/project/extractFromVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/extractFromVueProject.ts
@@ -1,0 +1,911 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { hashSource } from 'generaltranslation/id';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import { extractFromVueSource } from '../extractFromVueSource.js';
+import {
+  resolveVueCompilerOptions,
+  type VueCompilerOptionsResolution,
+} from '../config/resolveVueCompilerOptions.js';
+import { NUXT_CONFIG_FILES, VITE_CONFIG_FILES } from '../config/configFiles.js';
+import {
+  createProjectModuleResolver,
+  DEFAULT_RESOLUTION_CONDITIONS,
+} from './moduleResolver.js';
+import { resolveVueProjectAliasConfiguration } from './viteAliases.js';
+import {
+  declaresJavaScriptDependency,
+  readJavaScriptPackageManifest,
+} from './workspaces.js';
+import {
+  discoverVueProject,
+  findVueSourceScope,
+  GT_VUE_PACKAGE,
+  readDefaultVueSourcePatterns,
+  type VueSourceScope,
+} from './scopes.js';
+import type {
+  VueCompilerOptions,
+  VueExtractionOutput,
+  VueExtractionResult,
+  VueProjectExtractionOptions,
+  VueProjectExtractionOutput,
+  VueProjectExtractionResult,
+  VueSourceCode,
+} from '../../types.js';
+
+const SCRIPT_EXTENSIONS = new Set([
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.ts',
+  '.tsx',
+  '.mts',
+  '.cts',
+]);
+
+const JSX_CONFIG_EXTENSIONS = new Set(['.jsx', '.tsx']);
+
+/**
+ * Extracts, hashes, and deduplicates every gt-vue message owned by a project.
+ *
+ * This is the package-level orchestration boundary used by host CLIs. It owns
+ * workspace discovery, source matching, compiler/config resolution, static
+ * module resolution, and catalog hashing so framework hosts do not need Vue
+ * implementation details. Configuration failures return no partial updates.
+ */
+export async function extractFromVueProject(
+  options: VueProjectExtractionOptions = {}
+): Promise<VueProjectExtractionOutput> {
+  const projectRoot = path.resolve(options.cwd ?? process.cwd());
+  const discovery = discoverVueProject(projectRoot);
+  const discoveryErrors =
+    options.filePatterns === undefined
+      ? validateNuxtSourceScopes(discovery.scopes, options.vueCompilerOptions)
+      : [];
+  if (discoveryErrors.length > 0) {
+    return { updates: [], errors: discoveryErrors, warnings: [] };
+  }
+  const patterns =
+    options.filePatterns ?? readDefaultVueSourcePatterns(discovery.scopes);
+  if (patterns.length === 0) {
+    return { updates: [], errors: [], warnings: [] };
+  }
+
+  const fileMatches = matchProjectFiles(projectRoot, patterns);
+  if (fileMatches.errors.length > 0) {
+    return { updates: [], errors: fileMatches.errors, warnings: [] };
+  }
+  const matchedFiles = fileMatches.files;
+  const scopes = addExplicitSourceScopes(
+    projectRoot,
+    discovery.scopes,
+    options.filePatterns === undefined ? [] : matchedFiles
+  );
+  const sourceByFile = new Map<string, string>();
+  const standaloneResults = new Map<string, VueExtractionOutput>();
+  const fileScopes = new Map(
+    matchedFiles.map((file) => [file, findVueSourceScope(file, scopes)])
+  );
+  // Explicit globs can also match files owned by another framework package.
+  // They are not Vue inputs unless discovery placed them in a Vue scope.
+  const files = matchedFiles.filter(
+    (file) => fileScopes.get(file) !== undefined
+  );
+  const errors: string[] = [];
+  const warnings = new Set<string>();
+  let explicitCompilerResolution = validateExplicitCompilerConfig(
+    projectRoot,
+    options,
+    files.some((file) => {
+      const scope = fileScopes.get(file);
+      return scope?.includeByDefault === true || path.extname(file) === '.vue';
+    }),
+    errors
+  );
+  if (errors.length > 0) {
+    return { updates: [], errors, warnings: [] };
+  }
+
+  const moduleResolution = createVueModuleResolver(
+    projectRoot,
+    scopes,
+    fileScopes,
+    options,
+    createProjectModuleResolver(
+      options.conditionNames ?? DEFAULT_RESOLUTION_CONDITIONS
+    )
+  );
+  errors.push(...moduleResolution.errors);
+  if (errors.length > 0) {
+    return { updates: [], errors, warnings: [] };
+  }
+  const resolveModuleForFile = moduleResolution.resolveModuleForFile;
+
+  for (const file of files) {
+    const extension = path.extname(file).toLowerCase();
+    if (extension !== '.vue' && !SCRIPT_EXTENSIONS.has(extension)) continue;
+    let source: string;
+    try {
+      source = await fs.promises.readFile(file, 'utf8');
+    } catch (error) {
+      errors.push(createReadDiagnostic(projectRoot, file, error));
+      continue;
+    }
+    sourceByFile.set(file, source);
+    if (extension === '.vue') continue;
+    standaloneResults.set(
+      file,
+      await extractFromVueSource(source, file, {
+        compilerOptions: {},
+        includeSourceCodeContext: options.includeSourceCodeContext,
+        projectRoot,
+        requireGTProvenance: true,
+        resolveModule: resolveModuleForFile(file),
+        surroundingLineCount: options.surroundingLineCount,
+      })
+    );
+  }
+
+  if (
+    explicitCompilerResolution === undefined &&
+    [...standaloneResults.values()].some(hasExtractionSignal)
+  ) {
+    explicitCompilerResolution = validateExplicitCompilerConfig(
+      projectRoot,
+      options,
+      true,
+      errors
+    );
+  }
+
+  const potentialAliasProvenanceScopes = await probePotentialAliasProvenance(
+    files,
+    sourceByFile,
+    fileScopes,
+    standaloneResults,
+    moduleResolution.resolvePotentialModulesForFile,
+    projectRoot
+  );
+
+  validateIncompleteAliasScopes(
+    files,
+    fileScopes,
+    standaloneResults,
+    moduleResolution.incompleteAliasScopes,
+    potentialAliasProvenanceScopes,
+    errors
+  );
+
+  // I/O failures make project discovery incomplete, so never return a partial
+  // catalog that a caller could mistake for a successful extraction.
+  if (errors.length > 0) {
+    return { updates: [], errors, warnings: [] };
+  }
+
+  const configAffectedFiles = files.filter((file) => {
+    const extension = path.extname(file).toLowerCase();
+    if (extension === '.vue') return true;
+    const standaloneResult = standaloneResults.get(file);
+    return (
+      hasExtractionSignal(standaloneResult) &&
+      (JSX_CONFIG_EXTENSIONS.has(extension) ||
+        standaloneResult?.results.some(
+          ({ dataFormat }) => dataFormat === 'JSX'
+        ) === true)
+    );
+  });
+  const compilerOptionsByScope = resolveCompilerOptionsByScope(
+    projectRoot,
+    configAffectedFiles,
+    fileScopes,
+    scopes,
+    options,
+    explicitCompilerResolution,
+    errors
+  );
+  if (errors.length > 0) {
+    return { updates: [], errors, warnings: [] };
+  }
+
+  const results: VueExtractionResult[] = [];
+  for (const file of files) {
+    const extension = path.extname(file).toLowerCase();
+    if (extension !== '.vue' && !SCRIPT_EXTENSIONS.has(extension)) continue;
+    const source = sourceByFile.get(file);
+    if (source === undefined) continue;
+    const result =
+      extension === '.vue'
+        ? await extractFromVueSource(source, file, {
+            compilerOptions:
+              compilerOptionsByScope.get(
+                fileScopes.get(file)?.directory ?? ''
+              ) ?? {},
+            includeSourceCodeContext: options.includeSourceCodeContext,
+            projectRoot,
+            requireGTProvenance: true,
+            resolveModule: resolveModuleForFile(file),
+            surroundingLineCount: options.surroundingLineCount,
+          })
+        : standaloneResults.get(file);
+    if (!result) continue;
+    results.push(...result.results);
+    errors.push(...result.errors);
+    for (const warning of result.warnings) warnings.add(warning);
+  }
+
+  const updates = results.map(addCatalogHash);
+  deduplicateProjectUpdates(updates);
+  return {
+    updates: errors.length > 0 ? [] : updates,
+    errors,
+    warnings: [...warnings],
+  };
+}
+
+/** Returns whether a standalone file has observable gt-vue extraction work. */
+function hasExtractionSignal(result: VueExtractionOutput | undefined): boolean {
+  return Boolean(
+    result &&
+    (result.results.length > 0 ||
+      result.errors.length > 0 ||
+      result.warnings.length > 0)
+  );
+}
+
+/**
+ * Proves whether a statically observed alias candidate can expose gt-vue.
+ *
+ * Incomplete config candidates are diagnostic evidence only: results from
+ * these probes are never published. Reusing the normal provenance analyzer
+ * avoids treating ordinary React/local helpers with GT-shaped names as Vue.
+ */
+async function probePotentialAliasProvenance(
+  files: readonly string[],
+  sourceByFile: ReadonlyMap<string, string>,
+  fileScopes: ReadonlyMap<string, VueSourceScope | undefined>,
+  standaloneResults: ReadonlyMap<string, VueExtractionOutput>,
+  resolvePotentialModulesForFile: (
+    sourceFile: string
+  ) => Array<(specifier: string, importer: string) => string | undefined>,
+  projectRoot: string
+): Promise<Set<string>> {
+  const provenScopes = new Set<string>();
+  for (const file of files) {
+    if (path.extname(file).toLowerCase() === '.vue') continue;
+    const scope = fileScopes.get(file);
+    const source = sourceByFile.get(file);
+    if (
+      !scope ||
+      source === undefined ||
+      provenScopes.has(scope.directory) ||
+      hasExtractionSignal(standaloneResults.get(file))
+    ) {
+      continue;
+    }
+    for (const resolveModule of resolvePotentialModulesForFile(file)) {
+      const probe = await extractFromVueSource(source, file, {
+        compilerOptions: {},
+        projectRoot,
+        requireGTProvenance: true,
+        resolveModule,
+      });
+      if (!hasExtractionSignal(probe)) continue;
+      provenScopes.add(scope.directory);
+      break;
+    }
+  }
+  return provenScopes;
+}
+
+/** Maximum diagnostic-only alias combinations explored for one application. */
+const MAX_POTENTIAL_ALIAS_CONFIGURATIONS = 128;
+
+/** Builds deterministic candidate maps without trusting any as active config. */
+function createPotentialAliasConfigurations(
+  potentialAliases: ReadonlyMap<string, ReadonlySet<string>> | undefined
+): Map<string, string>[] {
+  if (!potentialAliases || potentialAliases.size === 0) return [];
+  let configurations: Map<string, string>[] = [new Map()];
+  for (const [key, replacements] of potentialAliases) {
+    if (replacements.size === 0) continue;
+    const next: Map<string, string>[] = [];
+    for (const configuration of configurations) {
+      for (const replacement of replacements) {
+        next.push(new Map(configuration).set(key, replacement));
+        if (next.length >= MAX_POTENTIAL_ALIAS_CONFIGURATIONS) break;
+      }
+      if (next.length >= MAX_POTENTIAL_ALIAS_CONFIGURATIONS) break;
+    }
+    configurations = next;
+    if (configurations.length === 0) return [];
+  }
+  return configurations;
+}
+
+function addCatalogHash(
+  result: VueExtractionResult
+): VueProjectExtractionResult {
+  const hash = hashSource({
+    source: result.source,
+    ...(result.metadata.context && { context: result.metadata.context }),
+    dataFormat: result.dataFormat,
+  });
+  return {
+    ...result,
+    metadata: { ...result.metadata, hash },
+  } as VueProjectExtractionResult;
+}
+
+/** Merges duplicate Vue hashes without repeating source-location metadata. */
+function deduplicateProjectUpdates(
+  updates: VueProjectExtractionResult[]
+): void {
+  const byHash = new Map<string, VueProjectExtractionResult>();
+  for (const update of updates) {
+    const existing = byHash.get(update.metadata.hash);
+    if (!existing) {
+      byHash.set(update.metadata.hash, update);
+      continue;
+    }
+    existing.metadata.filePaths = mergeUnique(
+      existing.metadata.filePaths,
+      update.metadata.filePaths
+    );
+    existing.metadata.sourceCode = mergeSourceCode(
+      existing.metadata.sourceCode,
+      update.metadata.sourceCode
+    );
+  }
+  updates.splice(0, updates.length, ...byHash.values());
+}
+
+function mergeUnique(
+  left: string[] | undefined,
+  right: string[] | undefined
+): string[] | undefined {
+  const merged = [...new Set([...(left ?? []), ...(right ?? [])])];
+  return merged.length > 0 ? merged : undefined;
+}
+
+function mergeSourceCode(
+  left: Record<string, VueSourceCode[]> | undefined,
+  right: Record<string, VueSourceCode[]> | undefined
+): Record<string, VueSourceCode[]> | undefined {
+  if (!left && !right) return undefined;
+  const merged: Record<string, VueSourceCode[]> = {};
+  for (const sourceCode of [left, right]) {
+    for (const [file, entries] of Object.entries(sourceCode ?? {})) {
+      const known = new Set(
+        (merged[file] ?? []).map((entry) => JSON.stringify(entry))
+      );
+      for (const entry of entries) {
+        const key = JSON.stringify(entry);
+        if (known.has(key)) continue;
+        (merged[file] ??= []).push(entry);
+        known.add(key);
+      }
+    }
+  }
+  return merged;
+}
+
+/** Matches source patterns without hiding filesystem discovery failures. */
+function matchProjectFiles(
+  cwd: string,
+  patterns: readonly string[]
+): { files: string[]; errors: string[] } {
+  let matches: string[];
+  try {
+    matches = fg.sync([...patterns], {
+      absolute: true,
+      cwd,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**'],
+      onlyFiles: true,
+      unique: true,
+    });
+  } catch (error) {
+    return {
+      files: [],
+      errors: [createGlobDiagnostic(patterns, error)],
+    };
+  }
+  let realRoot: string;
+  try {
+    realRoot = fs.realpathSync(cwd);
+  } catch (error) {
+    return {
+      files: [],
+      errors: [createRootRealpathDiagnostic(cwd, error)],
+    };
+  }
+  const files: string[] = [];
+  const errors: string[] = [];
+  for (const file of matches) {
+    let realFile: string;
+    try {
+      realFile = fs.realpathSync(file);
+    } catch (error) {
+      errors.push(createMatchedFileRealpathDiagnostic(cwd, file, error));
+      continue;
+    }
+    const relative = path.relative(realRoot, realFile);
+    if (
+      relative === '' ||
+      relative === '..' ||
+      relative.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relative)
+    ) {
+      // Symlinks outside the project are intentionally outside its catalog.
+      continue;
+    }
+    files.push(file);
+  }
+  return {
+    errors,
+    files: files.sort((left, right) => left.localeCompare(right)),
+  };
+}
+
+/**
+ * Makes custom Nuxt source layouts fail closed before another scope can make
+ * an incomplete project look successful. Vite config does not influence
+ * source discovery and remains gated on a matched SFC or proven gt-vue JSX.
+ */
+function validateNuxtSourceScopes(
+  scopes: readonly VueSourceScope[],
+  explicitOptions: VueCompilerOptions | undefined
+): string[] {
+  const errors: string[] = [];
+  for (const scope of scopes) {
+    if (
+      !NUXT_CONFIG_FILES.some((file) =>
+        fs.existsSync(path.join(scope.directory, file))
+      )
+    ) {
+      continue;
+    }
+    errors.push(
+      ...resolveVueCompilerOptions(scope.directory, explicitOptions).errors
+    );
+  }
+  return errors;
+}
+
+/** Adds independent package boundaries only for explicit user-selected sources. */
+function addExplicitSourceScopes(
+  projectRoot: string,
+  discoveredScopes: readonly VueSourceScope[],
+  files: readonly string[]
+): VueSourceScope[] {
+  const scopes = [...discoveredScopes];
+  const known = new Set(scopes.map(({ directory }) => directory));
+  for (const file of files) {
+    const directory = findNearestPackageDirectory(file, projectRoot);
+    if (known.has(directory)) continue;
+    const inheritedScope = findVueSourceScope(file, scopes);
+    if (!inheritedScope) continue;
+    if (!ownsIndependentVueConfiguration(directory)) {
+      continue;
+    }
+    known.add(directory);
+    scopes.push({
+      directory,
+      includeByDefault: false,
+      relativeDirectory: toPosixPath(path.relative(projectRoot, directory)),
+    });
+  }
+  return scopes;
+}
+
+/** Returns whether a package must resolve its own Vue build configuration. */
+function ownsIndependentVueConfiguration(directory: string): boolean {
+  if (
+    [...VITE_CONFIG_FILES, ...NUXT_CONFIG_FILES].some((file) =>
+      fs.existsSync(path.join(directory, file))
+    )
+  ) {
+    return true;
+  }
+  const manifest = readJavaScriptPackageManifest(
+    path.join(directory, 'package.json')
+  );
+  return Boolean(
+    manifest && declaresJavaScriptDependency(manifest, GT_VUE_PACKAGE)
+  );
+}
+
+function findNearestPackageDirectory(
+  file: string,
+  projectRoot: string
+): string {
+  let current = path.dirname(file);
+  const root = path.resolve(projectRoot);
+  while (current !== root && isWithin(root, current)) {
+    if (fs.existsSync(path.join(current, 'package.json'))) return current;
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  return root;
+}
+
+/** Applies each Vue app's statically resolved Vite/Nuxt aliases before Node resolution. */
+function createVueModuleResolver(
+  projectRoot: string,
+  scopes: readonly VueSourceScope[],
+  fileScopes: ReadonlyMap<string, VueSourceScope | undefined>,
+  options: VueProjectExtractionOptions,
+  resolveModule: (specifier: string, importer: string) => string | undefined
+): {
+  resolveModuleForFile: (
+    sourceFile: string
+  ) => (specifier: string, importer: string) => string | undefined;
+  resolvePotentialModulesForFile: (
+    sourceFile: string
+  ) => Array<(specifier: string, importer: string) => string | undefined>;
+  errors: string[];
+  incompleteAliasScopes: Set<string>;
+} {
+  const matchedScopes = uniqueSourceScopes(fileScopes.values());
+  const ownedMatchedScopes = matchedScopes.filter(
+    ({ includeByDefault }) => includeByDefault
+  );
+  const candidateExplicitScopes =
+    ownedMatchedScopes.length > 0 ? ownedMatchedScopes : matchedScopes;
+  const aliasesByScope = new Map<string, Map<string, string>>();
+  const errors: string[] = [];
+  const incompleteAliasScopes = new Set<string>();
+  const potentialAliasesByScope = new Map<string, Map<string, Set<string>>>();
+  if (options.viteConfigPath !== undefined) {
+    const explicitConfig = path.resolve(projectRoot, options.viteConfigPath);
+    const explicitScope =
+      candidateExplicitScopes.length === 1
+        ? candidateExplicitScopes[0]
+        : findVueSourceScope(explicitConfig, candidateExplicitScopes);
+    if (!explicitScope) {
+      errors.push(
+        createExplicitConfigOwnershipDiagnostic(options.viteConfigPath)
+      );
+    } else {
+      for (const scope of matchedScopes) {
+        addAliasesForScope(
+          aliasesByScope,
+          incompleteAliasScopes,
+          potentialAliasesByScope,
+          scope,
+          scope.directory === explicitScope.directory
+            ? {
+                directory: projectRoot,
+                viteConfigPath: options.viteConfigPath,
+              }
+            : { directory: scope.directory }
+        );
+      }
+    }
+  } else {
+    for (const scope of matchedScopes) {
+      addAliasesForScope(
+        aliasesByScope,
+        incompleteAliasScopes,
+        potentialAliasesByScope,
+        scope,
+        { directory: scope.directory }
+      );
+    }
+  }
+
+  return {
+    errors,
+    incompleteAliasScopes,
+    resolveModuleForFile(sourceFile) {
+      // Keep aliases attached to the application that initiated traversal.
+      // A local barrel can live in a sibling/linked package and import another
+      // application alias transitively; selecting by that barrel's directory
+      // would either lose the alias or leak a different app's configuration.
+      const sourceScope = findVueSourceScope(sourceFile, scopes);
+      return (specifier, importer) => {
+        const scope = sourceScope ?? findVueSourceScope(importer, scopes);
+        const aliases = scope ? aliasesByScope.get(scope.directory) : undefined;
+        return resolveModule(applyStaticAlias(specifier, aliases), importer);
+      };
+    },
+    resolvePotentialModulesForFile(sourceFile) {
+      const sourceScope = findVueSourceScope(sourceFile, scopes);
+      if (!sourceScope) return [];
+      return createPotentialAliasConfigurations(
+        potentialAliasesByScope.get(sourceScope.directory)
+      ).map(
+        (aliases) => (specifier: string, importer: string) =>
+          resolveModule(applyStaticAlias(specifier, aliases), importer)
+      );
+    },
+  };
+}
+
+function addAliasesForScope(
+  aliasesByScope: Map<string, Map<string, string>>,
+  incompleteAliasScopes: Set<string>,
+  potentialAliasesByScope: Map<string, Map<string, Set<string>>>,
+  scope: VueSourceScope,
+  config: { directory: string; viteConfigPath?: string }
+): void {
+  const resolution = resolveVueProjectAliasConfiguration(config.directory, {
+    viteConfigPath: config.viteConfigPath,
+  });
+  if (!resolution.complete) {
+    incompleteAliasScopes.add(scope.directory);
+    if (resolution.potentialAliases) {
+      potentialAliasesByScope.set(scope.directory, resolution.potentialAliases);
+    }
+    aliasesByScope.set(scope.directory, new Map());
+    return;
+  }
+  aliasesByScope.set(scope.directory, resolution.aliases);
+}
+
+/** Blocks incomplete aliases only after a source proves Vue ownership. */
+function validateIncompleteAliasScopes(
+  files: readonly string[],
+  fileScopes: ReadonlyMap<string, VueSourceScope | undefined>,
+  standaloneResults: ReadonlyMap<string, VueExtractionOutput>,
+  incompleteScopes: ReadonlySet<string>,
+  potentialAliasProvenanceScopes: ReadonlySet<string>,
+  errors: string[]
+): void {
+  const diagnosedScopes = new Set<string>();
+  for (const file of files) {
+    const scope = fileScopes.get(file);
+    if (
+      !scope ||
+      !incompleteScopes.has(scope.directory) ||
+      diagnosedScopes.has(scope.directory)
+    ) {
+      continue;
+    }
+    const isVueSource = path.extname(file).toLowerCase() === '.vue';
+    const hasVueSignal = hasExtractionSignal(standaloneResults.get(file));
+    const hasPotentialAliasProvenance = potentialAliasProvenanceScopes.has(
+      scope.directory
+    );
+    if (!isVueSource && !hasVueSignal && !hasPotentialAliasProvenance) {
+      continue;
+    }
+    diagnosedScopes.add(scope.directory);
+    errors.push(createIncompleteAliasDiagnostic(scope));
+  }
+}
+
+function createIncompleteAliasDiagnostic(scope: VueSourceScope): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened:
+      'Could not statically resolve the Vue application module aliases',
+    why: 'Dynamic alias behavior can hide gt-vue imports and produce an incomplete translation catalog',
+    fix: 'Define Vite or Nuxt aliases with static string values and remove custom alias resolvers',
+    details: scope.relativeDirectory || '.',
+  });
+}
+
+function uniqueSourceScopes(
+  scopes: Iterable<VueSourceScope | undefined>
+): VueSourceScope[] {
+  const unique = new Map<string, VueSourceScope>();
+  for (const scope of scopes) {
+    if (scope) unique.set(scope.directory, scope);
+  }
+  return [...unique.values()];
+}
+
+function applyStaticAlias(
+  specifier: string,
+  aliases: ReadonlyMap<string, string> | undefined
+): string {
+  if (!aliases) return specifier;
+  for (const [find, replacement] of aliases) {
+    const normalized =
+      find.endsWith('/') && replacement.endsWith('/')
+        ? {
+            find: find.slice(0, -1),
+            replacement: replacement.slice(0, -1),
+          }
+        : { find, replacement };
+    if (
+      specifier === normalized.find ||
+      specifier.startsWith(`${normalized.find}/`)
+    ) {
+      return specifier.replace(normalized.find, normalized.replacement);
+    }
+  }
+  return specifier;
+}
+
+/** Resolves every affected scope before parsing any SFC catalog content. */
+function resolveCompilerOptionsByScope(
+  projectRoot: string,
+  files: readonly string[],
+  fileScopes: ReadonlyMap<string, VueSourceScope | undefined>,
+  scopes: readonly VueSourceScope[],
+  options: VueProjectExtractionOptions,
+  explicitCompilerResolution: VueCompilerOptionsResolution | undefined,
+  errors: string[]
+): Map<string, VueCompilerOptions> {
+  const optionsByScope = new Map<string, VueCompilerOptions>();
+  const affectedScopes = new Map<string, VueSourceScope>();
+  for (const file of files) {
+    const scope = fileScopes.get(file);
+    if (scope) affectedScopes.set(scope.directory, scope);
+  }
+  if (affectedScopes.size === 0) return optionsByScope;
+
+  if (options.viteConfigPath !== undefined) {
+    const explicitConfig = path.resolve(projectRoot, options.viteConfigPath);
+    const explicitResolution =
+      explicitCompilerResolution ??
+      resolveVueCompilerOptions(projectRoot, options.vueCompilerOptions, {
+        viteConfigPath: options.viteConfigPath,
+        sourceDiscoveryIsExplicit: options.filePatterns !== undefined,
+      });
+    errors.push(...explicitResolution.errors);
+    if (explicitResolution.errors.length > 0) return optionsByScope;
+    const explicitScope =
+      affectedScopes.size === 1
+        ? [...affectedScopes.values()][0]
+        : findVueSourceScope(explicitConfig, scopes);
+    if (!explicitScope || !affectedScopes.has(explicitScope.directory)) {
+      errors.push(
+        createExplicitConfigOwnershipDiagnostic(options.viteConfigPath)
+      );
+      return optionsByScope;
+    }
+
+    for (const scope of affectedScopes.values()) {
+      const resolution =
+        scope.directory === explicitScope.directory
+          ? explicitResolution
+          : resolveVueCompilerOptions(
+              scope.directory,
+              options.vueCompilerOptions,
+              {
+                sourceDiscoveryIsExplicit: options.filePatterns !== undefined,
+              }
+            );
+      errors.push(...resolution.errors);
+      optionsByScope.set(scope.directory, resolution.compilerOptions);
+    }
+    return optionsByScope;
+  }
+
+  for (const scope of affectedScopes.values()) {
+    const resolution = resolveVueCompilerOptions(
+      scope.directory,
+      options.vueCompilerOptions,
+      {
+        sourceDiscoveryIsExplicit: options.filePatterns !== undefined,
+      }
+    );
+    errors.push(...resolution.errors);
+    optionsByScope.set(scope.directory, resolution.compilerOptions);
+  }
+  return optionsByScope;
+}
+
+/** Validates an explicitly selected config even when every match is STRING. */
+function validateExplicitCompilerConfig(
+  projectRoot: string,
+  options: VueProjectExtractionOptions,
+  hasPotentialVueSource: boolean,
+  errors: string[]
+): VueCompilerOptionsResolution | undefined {
+  if (!hasPotentialVueSource || options.viteConfigPath === undefined) {
+    return undefined;
+  }
+  const resolution = resolveVueCompilerOptions(
+    projectRoot,
+    options.vueCompilerOptions,
+    {
+      viteConfigPath: options.viteConfigPath,
+      sourceDiscoveryIsExplicit: options.filePatterns !== undefined,
+    }
+  );
+  errors.push(...resolution.errors);
+  return resolution;
+}
+
+function createExplicitConfigOwnershipDiagnostic(configPath: string): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened:
+      'The configured Vite config does not own any matched Vue sources',
+    fix: 'Run extraction from that application root, include only one centrally configured Vue application, or remove files.gt.parsingFlags.viteConfigPath',
+    details: configPath,
+  });
+}
+
+function createReadDiagnostic(
+  projectRoot: string,
+  file: string,
+  error: unknown
+): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened: 'Could not read a matched Vue source file',
+    fix: 'Restore read access or exclude the file from the configured source patterns',
+    details: [
+      toPosixPath(path.relative(projectRoot, file)),
+      formatDiagnosticErrorDetails(error) ?? 'Unknown read error',
+    ],
+  });
+}
+
+function createGlobDiagnostic(
+  patterns: readonly string[],
+  error: unknown
+): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened: 'Could not match the configured Vue source patterns',
+    fix: 'Correct the source patterns and rerun extraction',
+    details: [
+      patterns.join(', ') || '(no patterns)',
+      formatDiagnosticErrorDetails(error) ?? 'Unknown glob error',
+    ],
+  });
+}
+
+function createRootRealpathDiagnostic(
+  projectRoot: string,
+  error: unknown
+): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened: 'Could not resolve the Vue project root',
+    fix: 'Restore access to the project directory and rerun extraction',
+    details: [
+      projectRoot,
+      formatDiagnosticErrorDetails(error) ?? 'Unknown filesystem error',
+    ],
+  });
+}
+
+function createMatchedFileRealpathDiagnostic(
+  projectRoot: string,
+  file: string,
+  error: unknown
+): string {
+  return createDiagnosticMessage({
+    source: '@generaltranslation/vue-extractor',
+    severity: 'Error',
+    whatHappened: 'Could not resolve a matched Vue source file',
+    fix: 'Restore the file or exclude it from the configured source patterns',
+    details: [
+      toPosixPath(path.relative(projectRoot, file)),
+      formatDiagnosticErrorDetails(error) ?? 'Unknown filesystem error',
+    ],
+  });
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(path.resolve(root), path.resolve(candidate));
+  return (
+    relative === '' ||
+    (relative !== '..' &&
+      !relative.startsWith(`..${path.sep}`) &&
+      !path.isAbsolute(relative))
+  );
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}

--- a/packages/vue-extractor/src/internal/project/inspectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/inspectVueProject.ts
@@ -72,11 +72,35 @@ export function readVueSfcExclusionPatterns(
   inspection: VueProjectInspection,
   filePatterns: readonly string[]
 ): string[] {
+  return partitionVueSourcePatterns(inspection, filePatterns)
+    .primaryExclusionPatterns;
+}
+
+/**
+ * Partitions explicitly selected `.vue` files between a historical parser and
+ * the companion Vue extractor.
+ *
+ * A lone `<template>`, `<script>`, or `<style>` expression is valid both as a
+ * Vue block and as a Babel JSX module. Those ambiguous files stay with the
+ * historical parser so adding Vue support cannot remove existing messages,
+ * while the companion Vue pass skips them to avoid duplicate or invalid SFC
+ * diagnostics. Vue-primary and default Vue discovery do not use this explicit
+ * mixed-framework partition and continue to accept template-only SFCs.
+ */
+export function partitionVueSourcePatterns(
+  inspection: VueProjectInspection,
+  filePatterns: readonly string[]
+): {
+  primaryExclusionPatterns: string[];
+  vueExclusionPatterns: string[];
+} {
   const discovery = readVueProjectInspection(
     inspection,
     inspection.projectRoot
   );
-  if (!discovery) return [];
+  if (!discovery) {
+    return { primaryExclusionPatterns: [], vueExclusionPatterns: [] };
+  }
 
   let matches: string[];
   try {
@@ -89,32 +113,42 @@ export function readVueSfcExclusionPatterns(
       unique: true,
     });
   } catch {
-    return [];
+    return { primaryExclusionPatterns: [], vueExclusionPatterns: [] };
   }
 
-  const exclusions = matches.flatMap((file) => {
+  const primaryExclusionPatterns: string[] = [];
+  const vueExclusionPatterns: string[] = [];
+  for (const file of matches) {
     let realFile: string;
     try {
       realFile = fs.realpathSync(file);
     } catch {
-      return [];
+      continue;
     }
     if (
       path.extname(realFile).toLowerCase() !== '.vue' ||
       !findVueSourceScope(realFile, discovery.scopes)
     ) {
-      return [];
+      continue;
     }
     let source: string;
     try {
       source = fs.readFileSync(realFile, 'utf8');
     } catch {
-      return [];
+      continue;
     }
-    if (!isVueSfcSource(source)) return [];
-    return [`!${fg.escapePath(toPosixPath(path.resolve(file)))}`];
-  });
-  return [...new Set(exclusions)];
+    const classification = classifyVueSource(source);
+    const exclusion = `!${fg.escapePath(toPosixPath(path.resolve(file)))}`;
+    if (classification === 'definitive-sfc') {
+      primaryExclusionPatterns.push(exclusion);
+    } else if (classification === 'ambiguous-standard-tag-jsx') {
+      vueExclusionPatterns.push(exclusion);
+    }
+  }
+  return {
+    primaryExclusionPatterns: [...new Set(primaryExclusionPatterns)],
+    vueExclusionPatterns: [...new Set(vueExclusionPatterns)],
+  };
 }
 
 /** Returns the package-private discovery carried by a valid inspection. */
@@ -141,31 +175,42 @@ export function readVueProjectInspection(
  * uses a standard SFC tag; lone standard-tag expressions remain Vue blocks.
  */
 export function isVueSfcSource(source: string): boolean {
+  return classifyVueSource(source) !== 'non-sfc';
+}
+
+type VueSourceClassification =
+  | 'definitive-sfc'
+  | 'ambiguous-standard-tag-jsx'
+  | 'non-sfc';
+
+/** Classifies standard-tag JSX separately from unambiguous Vue SFC source. */
+function classifyVueSource(source: string): VueSourceClassification {
   let remainder = source.replace(/^\uFEFF/, '').trimStart();
-  let checkedLegacyModule = false;
+  let javascriptClassification: JavaScriptModuleClassification | undefined;
+  const readJavaScriptClassification = () => {
+    javascriptClassification ??= classifyJavaScriptModule(source);
+    return javascriptClassification;
+  };
   while (remainder) {
     const afterPrelude = stripLeadingSfcPrelude(remainder);
-    if (afterPrelude === undefined) return false;
+    if (afterPrelude === undefined) return 'non-sfc';
     remainder = afterPrelude;
-    if (!remainder) return false;
+    if (!remainder) return 'non-sfc';
 
     const openingTag = readLeadingBlockTag(remainder);
     if (!openingTag) {
-      if (!checkedLegacyModule) {
-        checkedLegacyModule = true;
-        if (isLegacyJavaScriptModule(source)) return false;
-      }
+      if (readJavaScriptClassification() === 'module') return 'non-sfc';
       const nextBlock = findNextBlockStart(remainder);
-      if (nextBlock < 0) return false;
+      if (nextBlock < 0) return 'non-sfc';
       remainder = remainder.slice(nextBlock);
       continue;
     }
     if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) {
-      if (!checkedLegacyModule) {
-        checkedLegacyModule = true;
-        if (isLegacyJavaScriptModule(source)) return false;
-      }
-      return true;
+      const classification = readJavaScriptClassification();
+      if (classification === 'module') return 'non-sfc';
+      return classification === 'ambiguous-standard-tag-jsx'
+        ? 'ambiguous-standard-tag-jsx'
+        : 'definitive-sfc';
     }
 
     if (openingTag.selfClosing) {
@@ -176,12 +221,12 @@ export function isVueSfcSource(source: string): boolean {
       `</${escapeRegularExpression(openingTag.name)}\\s*>`,
       'i'
     ).exec(remainder.slice(openingTag.end));
-    if (!closingTag) return false;
+    if (!closingTag) return 'non-sfc';
     remainder = remainder
       .slice(openingTag.end + closingTag.index + closingTag[0].length)
       .trimStart();
   }
-  return false;
+  return 'non-sfc';
 }
 
 const STANDARD_SFC_BLOCKS = new Set(['template', 'script', 'style']);
@@ -222,14 +267,21 @@ function stripLeadingSfcPrelude(source: string): string | undefined {
   return remainder;
 }
 
-/** Distinguishes complete legacy modules from lone standard-tag JSX blocks. */
-function isLegacyJavaScriptModule(source: string): boolean {
+type JavaScriptModuleClassification =
+  | 'ambiguous-standard-tag-jsx'
+  | 'invalid'
+  | 'module';
+
+/** Distinguishes complete modules from lone standard-tag JSX expressions. */
+function classifyJavaScriptModule(
+  source: string
+): JavaScriptModuleClassification {
   try {
     const ast = parseLegacyModule(source, {
       plugins: ['jsx', 'typescript'],
       sourceType: 'module',
     });
-    if (ast.program.directives.length > 0) return true;
+    if (ast.program.directives.length > 0) return 'module';
 
     let foundStandardBlock = false;
     for (const statement of ast.program.body) {
@@ -246,11 +298,11 @@ function isLegacyJavaScriptModule(source: string): boolean {
         foundStandardBlock = true;
         continue;
       }
-      return true;
+      return 'module';
     }
-    return !foundStandardBlock;
+    return foundStandardBlock ? 'ambiguous-standard-tag-jsx' : 'module';
   } catch {
-    return false;
+    return 'invalid';
   }
 }
 

--- a/packages/vue-extractor/src/internal/project/inspectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/inspectVueProject.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import { createRequire } from 'node:module';
 import path from 'node:path';
+import { parse as parseLegacyModule } from '@babel/parser';
 import fg from 'fast-glob';
 import type { VueProjectInspection } from '../../types.js';
 import {
@@ -9,19 +9,49 @@ import {
   resolveProjectDirectory,
   type VueProjectDiscovery,
 } from './scopes.js';
+import { readJavaScriptPackageManifest } from './manifest.js';
+import {
+  createWorkspaceDiscoveryCache,
+  readDeclaredWorkspacePackagesAsync,
+} from './workspaces.js';
 
 const discoveryByInspection = new WeakMap<
   VueProjectInspection,
   VueProjectDiscovery
 >();
-const requireFromInspection = createRequire(import.meta.url);
-let parseLegacyModule: typeof import('@babel/parser').parse | undefined;
 
 /** Discovers Vue workspace ownership once and returns a reusable opaque plan. */
 export function inspectVueProject(
   cwd: string = process.cwd()
 ): VueProjectInspection {
-  const discovery = discoverVueProject(cwd);
+  return createVueProjectInspection(discoverVueProject(cwd));
+}
+
+/**
+ * Discovers Vue ownership while reading declared workspace manifests with
+ * bounded asynchronous I/O.
+ *
+ * The asynchronous traversal pre-populates the same per-inspection cache used
+ * by `discoverVueProject`, preserving its ownership semantics while allowing a
+ * host framework to continue its existing extraction concurrently.
+ */
+export async function inspectVueProjectAsync(
+  cwd: string = process.cwd()
+): Promise<VueProjectInspection> {
+  const projectRoot = resolveProjectDirectory(cwd);
+  const rootManifest = readJavaScriptPackageManifest(
+    path.join(projectRoot, 'package.json')
+  );
+  const cache = createWorkspaceDiscoveryCache();
+  if (rootManifest) {
+    await readDeclaredWorkspacePackagesAsync(projectRoot, rootManifest, cache);
+  }
+  return createVueProjectInspection(discoverVueProject(projectRoot, cache));
+}
+
+function createVueProjectInspection(
+  discovery: VueProjectDiscovery
+): VueProjectInspection {
   const inspection = Object.freeze({
     projectRoot: discovery.projectRoot,
     rootOwnsVue: discovery.rootOwnsVue,
@@ -107,8 +137,8 @@ export function readVueProjectInspection(
  *
  * Vue tolerates arbitrary text before its first block, but treating every such
  * file as an SFC would hide Babel-valid legacy modules from the existing
- * parser. Common SFC forms stay on the lightweight path. Only an ambiguous
- * text prefix lazily invokes the parser already used by source extraction.
+ * parser. A complete JavaScript module wins even when its first JSX expression
+ * uses a standard SFC tag; lone standard-tag expressions remain Vue blocks.
  */
 export function isVueSfcSource(source: string): boolean {
   let remainder = source.replace(/^\uFEFF/, '').trimStart();
@@ -130,7 +160,13 @@ export function isVueSfcSource(source: string): boolean {
       remainder = remainder.slice(nextBlock);
       continue;
     }
-    if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) return true;
+    if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) {
+      if (!checkedLegacyModule) {
+        checkedLegacyModule = true;
+        if (isLegacyJavaScriptModule(source)) return false;
+      }
+      return true;
+    }
 
     if (openingTag.selfClosing) {
       remainder = remainder.slice(openingTag.end).trimStart();
@@ -186,12 +222,9 @@ function stripLeadingSfcPrelude(source: string): string | undefined {
   return remainder;
 }
 
-/** Uses the historical parser only for ambiguous text-prefixed `.vue` files. */
+/** Distinguishes complete legacy modules from lone standard-tag JSX blocks. */
 function isLegacyJavaScriptModule(source: string): boolean {
   try {
-    parseLegacyModule ??= (
-      requireFromInspection('@babel/parser') as typeof import('@babel/parser')
-    ).parse;
     const ast = parseLegacyModule(source, {
       plugins: ['jsx', 'typescript'],
       sourceType: 'module',

--- a/packages/vue-extractor/src/internal/project/inspectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/inspectVueProject.ts
@@ -1,0 +1,263 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import fg from 'fast-glob';
+import type { VueProjectInspection } from '../../types.js';
+import {
+  discoverVueProject,
+  findVueSourceScope,
+  resolveProjectDirectory,
+  type VueProjectDiscovery,
+} from './scopes.js';
+
+const discoveryByInspection = new WeakMap<
+  VueProjectInspection,
+  VueProjectDiscovery
+>();
+const requireFromInspection = createRequire(import.meta.url);
+let parseLegacyModule: typeof import('@babel/parser').parse | undefined;
+
+/** Discovers Vue workspace ownership once and returns a reusable opaque plan. */
+export function inspectVueProject(
+  cwd: string = process.cwd()
+): VueProjectInspection {
+  const discovery = discoverVueProject(cwd);
+  const inspection = Object.freeze({
+    projectRoot: discovery.projectRoot,
+    rootOwnsVue: discovery.rootOwnsVue,
+    hasVueScopes: discovery.scopes.length > 0,
+  });
+  discoveryByInspection.set(inspection, discovery);
+  return inspection;
+}
+
+/**
+ * Returns exact negative globs for real Vue SFCs selected by explicit input.
+ *
+ * A `.vue` suffix alone is insufficient because the historical React parser
+ * accepts arbitrary JSX modules with that extension. Only files inside a
+ * discovered Vue scope whose source is classified as an SFC are partitioned.
+ */
+export function readVueSfcExclusionPatterns(
+  inspection: VueProjectInspection,
+  filePatterns: readonly string[]
+): string[] {
+  const discovery = readVueProjectInspection(
+    inspection,
+    inspection.projectRoot
+  );
+  if (!discovery) return [];
+
+  let matches: string[];
+  try {
+    matches = fg.sync([...filePatterns], {
+      absolute: true,
+      cwd: discovery.projectRoot,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**'],
+      onlyFiles: true,
+      unique: true,
+    });
+  } catch {
+    return [];
+  }
+
+  const exclusions = matches.flatMap((file) => {
+    let realFile: string;
+    try {
+      realFile = fs.realpathSync(file);
+    } catch {
+      return [];
+    }
+    if (
+      path.extname(realFile).toLowerCase() !== '.vue' ||
+      !findVueSourceScope(realFile, discovery.scopes)
+    ) {
+      return [];
+    }
+    let source: string;
+    try {
+      source = fs.readFileSync(realFile, 'utf8');
+    } catch {
+      return [];
+    }
+    if (!isVueSfcSource(source)) return [];
+    return [`!${fg.escapePath(toPosixPath(path.resolve(file)))}`];
+  });
+  return [...new Set(exclusions)];
+}
+
+/** Returns the package-private discovery carried by a valid inspection. */
+export function readVueProjectInspection(
+  inspection: VueProjectInspection | undefined,
+  projectRoot: string
+): VueProjectDiscovery | undefined {
+  if (
+    !inspection ||
+    resolveProjectDirectory(inspection.projectRoot) !==
+      resolveProjectDirectory(projectRoot)
+  ) {
+    return undefined;
+  }
+  return discoveryByInspection.get(inspection);
+}
+
+/**
+ * Distinguishes a conventional SFC from a script module named with `.vue`.
+ *
+ * Vue tolerates arbitrary text before its first block, but treating every such
+ * file as an SFC would hide Babel-valid legacy modules from the existing
+ * parser. Common SFC forms stay on the lightweight path. Only an ambiguous
+ * text prefix lazily invokes the parser already used by source extraction.
+ */
+export function isVueSfcSource(source: string): boolean {
+  let remainder = source.replace(/^\uFEFF/, '').trimStart();
+  let checkedLegacyModule = false;
+  while (remainder) {
+    const afterPrelude = stripLeadingSfcPrelude(remainder);
+    if (afterPrelude === undefined) return false;
+    remainder = afterPrelude;
+    if (!remainder) return false;
+
+    const openingTag = readLeadingBlockTag(remainder);
+    if (!openingTag) {
+      if (!checkedLegacyModule) {
+        checkedLegacyModule = true;
+        if (isLegacyJavaScriptModule(source)) return false;
+      }
+      const nextBlock = findNextBlockStart(remainder);
+      if (nextBlock < 0) return false;
+      remainder = remainder.slice(nextBlock);
+      continue;
+    }
+    if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) return true;
+
+    if (openingTag.selfClosing) {
+      remainder = remainder.slice(openingTag.end).trimStart();
+      continue;
+    }
+    const closingTag = new RegExp(
+      `</${escapeRegularExpression(openingTag.name)}\\s*>`,
+      'i'
+    ).exec(remainder.slice(openingTag.end));
+    if (!closingTag) return false;
+    remainder = remainder
+      .slice(openingTag.end + closingTag.index + closingTag[0].length)
+      .trimStart();
+  }
+  return false;
+}
+
+const STANDARD_SFC_BLOCKS = new Set(['template', 'script', 'style']);
+
+/** Removes common top-level prelude forms accepted by Vue's SFC compiler. */
+function stripLeadingSfcPrelude(source: string): string | undefined {
+  let remainder = source.trimStart();
+  while (remainder) {
+    if (remainder.startsWith('<!--')) {
+      const end = remainder.indexOf('-->');
+      if (end < 0) return undefined;
+      remainder = remainder.slice(end + 3).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('/*')) {
+      const end = remainder.indexOf('*/', 2);
+      if (end < 0) return undefined;
+      remainder = remainder.slice(end + 2).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('//')) {
+      const end = remainder.search(/[\r\n]/);
+      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('#!')) {
+      const end = remainder.search(/[\r\n]/);
+      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
+      continue;
+    }
+    const doctype = /^<!doctype(?:\s[^>]*)?>/i.exec(remainder);
+    if (doctype) {
+      remainder = remainder.slice(doctype[0].length).trimStart();
+      continue;
+    }
+    break;
+  }
+  return remainder;
+}
+
+/** Uses the historical parser only for ambiguous text-prefixed `.vue` files. */
+function isLegacyJavaScriptModule(source: string): boolean {
+  try {
+    parseLegacyModule ??= (
+      requireFromInspection('@babel/parser') as typeof import('@babel/parser')
+    ).parse;
+    const ast = parseLegacyModule(source, {
+      plugins: ['jsx', 'typescript'],
+      sourceType: 'module',
+    });
+    if (ast.program.directives.length > 0) return true;
+
+    let foundStandardBlock = false;
+    for (const statement of ast.program.body) {
+      if (statement.type === 'EmptyStatement') continue;
+      if (
+        statement.type === 'ExpressionStatement' &&
+        statement.expression.type === 'JSXElement' &&
+        statement.expression.extra?.parenthesized !== true &&
+        statement.expression.openingElement.name.type === 'JSXIdentifier' &&
+        STANDARD_SFC_BLOCKS.has(
+          statement.expression.openingElement.name.name.toLowerCase()
+        )
+      ) {
+        foundStandardBlock = true;
+        continue;
+      }
+      return true;
+    }
+    return !foundStandardBlock;
+  } catch {
+    return false;
+  }
+}
+
+/** Finds the next possible top-level block after compiler-tolerated text. */
+function findNextBlockStart(source: string): number {
+  return source.search(/<[A-Za-z][A-Za-z0-9._-]*(?=[\s/>])/);
+}
+
+/** Reads one complete opening block tag while respecting quoted attributes. */
+function readLeadingBlockTag(
+  source: string
+): { end: number; name: string; selfClosing: boolean } | undefined {
+  const nameMatch = /^<([A-Za-z][A-Za-z0-9._-]*)(?=[\s/>])/.exec(source);
+  if (!nameMatch) return undefined;
+
+  let quote: '"' | "'" | undefined;
+  for (let index = nameMatch[0].length; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character !== '>') continue;
+    return {
+      end: index + 1,
+      name: nameMatch[1]!,
+      selfClosing: source.slice(0, index).trimEnd().endsWith('/'),
+    };
+  }
+  return undefined;
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}

--- a/packages/vue-extractor/src/internal/project/inspectVueProject.ts
+++ b/packages/vue-extractor/src/internal/project/inspectVueProject.ts
@@ -1,6 +1,5 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { parse as parseLegacyModule } from '@babel/parser';
 import fg from 'fast-glob';
 import type { VueProjectInspection } from '../../types.js';
 import {
@@ -14,6 +13,9 @@ import {
   createWorkspaceDiscoveryCache,
   readDeclaredWorkspacePackagesAsync,
 } from './workspaces.js';
+import { classifyVueSource } from './vueSourceClassification.js';
+
+export { isVueSfcSource } from './vueSourceClassification.js';
 
 const discoveryByInspection = new WeakMap<
   VueProjectInspection,
@@ -164,183 +166,6 @@ export function readVueProjectInspection(
     return undefined;
   }
   return discoveryByInspection.get(inspection);
-}
-
-/**
- * Distinguishes a conventional SFC from a script module named with `.vue`.
- *
- * Vue tolerates arbitrary text before its first block, but treating every such
- * file as an SFC would hide Babel-valid legacy modules from the existing
- * parser. A complete JavaScript module wins even when its first JSX expression
- * uses a standard SFC tag; lone standard-tag expressions remain Vue blocks.
- */
-export function isVueSfcSource(source: string): boolean {
-  return classifyVueSource(source) !== 'non-sfc';
-}
-
-type VueSourceClassification =
-  | 'definitive-sfc'
-  | 'ambiguous-standard-tag-jsx'
-  | 'non-sfc';
-
-/** Classifies standard-tag JSX separately from unambiguous Vue SFC source. */
-function classifyVueSource(source: string): VueSourceClassification {
-  let remainder = source.replace(/^\uFEFF/, '').trimStart();
-  let javascriptClassification: JavaScriptModuleClassification | undefined;
-  const readJavaScriptClassification = () => {
-    javascriptClassification ??= classifyJavaScriptModule(source);
-    return javascriptClassification;
-  };
-  while (remainder) {
-    const afterPrelude = stripLeadingSfcPrelude(remainder);
-    if (afterPrelude === undefined) return 'non-sfc';
-    remainder = afterPrelude;
-    if (!remainder) return 'non-sfc';
-
-    const openingTag = readLeadingBlockTag(remainder);
-    if (!openingTag) {
-      if (readJavaScriptClassification() === 'module') return 'non-sfc';
-      const nextBlock = findNextBlockStart(remainder);
-      if (nextBlock < 0) return 'non-sfc';
-      remainder = remainder.slice(nextBlock);
-      continue;
-    }
-    if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) {
-      const classification = readJavaScriptClassification();
-      if (classification === 'module') return 'non-sfc';
-      return classification === 'ambiguous-standard-tag-jsx'
-        ? 'ambiguous-standard-tag-jsx'
-        : 'definitive-sfc';
-    }
-
-    if (openingTag.selfClosing) {
-      remainder = remainder.slice(openingTag.end).trimStart();
-      continue;
-    }
-    const closingTag = new RegExp(
-      `</${escapeRegularExpression(openingTag.name)}\\s*>`,
-      'i'
-    ).exec(remainder.slice(openingTag.end));
-    if (!closingTag) return 'non-sfc';
-    remainder = remainder
-      .slice(openingTag.end + closingTag.index + closingTag[0].length)
-      .trimStart();
-  }
-  return 'non-sfc';
-}
-
-const STANDARD_SFC_BLOCKS = new Set(['template', 'script', 'style']);
-
-/** Removes common top-level prelude forms accepted by Vue's SFC compiler. */
-function stripLeadingSfcPrelude(source: string): string | undefined {
-  let remainder = source.trimStart();
-  while (remainder) {
-    if (remainder.startsWith('<!--')) {
-      const end = remainder.indexOf('-->');
-      if (end < 0) return undefined;
-      remainder = remainder.slice(end + 3).trimStart();
-      continue;
-    }
-    if (remainder.startsWith('/*')) {
-      const end = remainder.indexOf('*/', 2);
-      if (end < 0) return undefined;
-      remainder = remainder.slice(end + 2).trimStart();
-      continue;
-    }
-    if (remainder.startsWith('//')) {
-      const end = remainder.search(/[\r\n]/);
-      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
-      continue;
-    }
-    if (remainder.startsWith('#!')) {
-      const end = remainder.search(/[\r\n]/);
-      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
-      continue;
-    }
-    const doctype = /^<!doctype(?:\s[^>]*)?>/i.exec(remainder);
-    if (doctype) {
-      remainder = remainder.slice(doctype[0].length).trimStart();
-      continue;
-    }
-    break;
-  }
-  return remainder;
-}
-
-type JavaScriptModuleClassification =
-  | 'ambiguous-standard-tag-jsx'
-  | 'invalid'
-  | 'module';
-
-/** Distinguishes complete modules from lone standard-tag JSX expressions. */
-function classifyJavaScriptModule(
-  source: string
-): JavaScriptModuleClassification {
-  try {
-    const ast = parseLegacyModule(source, {
-      plugins: ['jsx', 'typescript'],
-      sourceType: 'module',
-    });
-    if (ast.program.directives.length > 0) return 'module';
-
-    let foundStandardBlock = false;
-    for (const statement of ast.program.body) {
-      if (statement.type === 'EmptyStatement') continue;
-      if (
-        statement.type === 'ExpressionStatement' &&
-        statement.expression.type === 'JSXElement' &&
-        statement.expression.extra?.parenthesized !== true &&
-        statement.expression.openingElement.name.type === 'JSXIdentifier' &&
-        STANDARD_SFC_BLOCKS.has(
-          statement.expression.openingElement.name.name.toLowerCase()
-        )
-      ) {
-        foundStandardBlock = true;
-        continue;
-      }
-      return 'module';
-    }
-    return foundStandardBlock ? 'ambiguous-standard-tag-jsx' : 'module';
-  } catch {
-    return 'invalid';
-  }
-}
-
-/** Finds the next possible top-level block after compiler-tolerated text. */
-function findNextBlockStart(source: string): number {
-  return source.search(/<[A-Za-z][A-Za-z0-9._-]*(?=[\s/>])/);
-}
-
-/** Reads one complete opening block tag while respecting quoted attributes. */
-function readLeadingBlockTag(
-  source: string
-): { end: number; name: string; selfClosing: boolean } | undefined {
-  const nameMatch = /^<([A-Za-z][A-Za-z0-9._-]*)(?=[\s/>])/.exec(source);
-  if (!nameMatch) return undefined;
-
-  let quote: '"' | "'" | undefined;
-  for (let index = nameMatch[0].length; index < source.length; index += 1) {
-    const character = source[index];
-    if (quote) {
-      if (character === quote) quote = undefined;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      quote = character;
-      continue;
-    }
-    if (character !== '>') continue;
-    return {
-      end: index + 1,
-      name: nameMatch[1]!,
-      selfClosing: source.slice(0, index).trimEnd().endsWith('/'),
-    };
-  }
-  return undefined;
-}
-
-function escapeRegularExpression(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 function toPosixPath(filePath: string): string {

--- a/packages/vue-extractor/src/internal/project/manifest.ts
+++ b/packages/vue-extractor/src/internal/project/manifest.ts
@@ -58,7 +58,9 @@ export function declaresInstalledJavaScriptDependency(
   packageName: string
 ): boolean {
   return INSTALLED_DEPENDENCY_FIELDS.some(
-    (field) => manifest[field]?.[packageName] !== undefined
+    (field) =>
+      readEffectiveDependencySpecifier(manifest, field, packageName) !==
+      undefined
   );
 }
 
@@ -68,9 +70,31 @@ export function declaresAvailableJavaScriptDependency(
   packageName: string,
   packageDirectory: string
 ): boolean {
-  if (declaresInstalledJavaScriptDependency(manifest, packageName)) return true;
-  if (manifest.optionalDependencies?.[packageName] !== undefined) {
-    return canResolvePackage(packageDirectory, packageName);
+  if (
+    readEffectiveDependencySpecifier(
+      manifest,
+      'devDependencies',
+      packageName
+    ) !== undefined
+  ) {
+    return true;
+  }
+  const optionalSpecifier = readDependencySpecifier(
+    manifest,
+    'optionalDependencies',
+    packageName
+  );
+  if (optionalSpecifier !== undefined) {
+    return canResolveDependencyBinding(packageDirectory, {
+      name: packageName,
+      specifier: optionalSpecifier,
+    });
+  }
+  if (
+    readEffectiveDependencySpecifier(manifest, 'dependencies', packageName) !==
+    undefined
+  ) {
+    return true;
   }
   return declaresAvailableRequiredPeerDependency(
     manifest,
@@ -87,22 +111,6 @@ export function declaresWorkspaceJavaScriptDependency(
 ): boolean {
   return (
     declaresInstalledJavaScriptDependency(manifest, packageName) ||
-    declaresAvailableRequiredPeerDependency(
-      manifest,
-      packageName,
-      packageDirectory
-    )
-  );
-}
-
-/** Checks dependencies that may propagate wrapper ownership to consumers. */
-export function declaresPropagatingJavaScriptDependency(
-  manifest: JavaScriptPackageManifest,
-  packageName: string,
-  packageDirectory: string
-): boolean {
-  return (
-    manifest.dependencies?.[packageName] !== undefined ||
     declaresAvailableRequiredPeerDependency(
       manifest,
       packageName,
@@ -178,8 +186,9 @@ function readDependencyBindings(
     bindings.push({ name, specifier });
   };
   for (const field of fields) {
-    for (const [name, specifier] of Object.entries(manifest[field] ?? {})) {
-      if (typeof specifier === 'string') addBinding(name, specifier);
+    for (const name of Object.keys(manifest[field] ?? {})) {
+      const specifier = readEffectiveDependencySpecifier(manifest, field, name);
+      if (specifier !== undefined) addBinding(name, specifier);
     }
   }
   for (const [name, specifier] of Object.entries(
@@ -226,7 +235,8 @@ export function resolveInstalledJavaScriptPackage(
       const manifest = readJavaScriptPackageManifest(
         path.join(packageDirectory, 'package.json')
       );
-      if (manifest) return { directory: packageDirectory, manifest };
+      if (!manifest) return undefined;
+      return { directory: packageDirectory, manifest };
     }
     try {
       const resolvedEntry = localRequire.resolve(bindingName);
@@ -234,10 +244,64 @@ export function resolveInstalledJavaScriptPackage(
     } catch {
       // ESM-only packages can omit a `require` export.
     }
+    const pnpLocation = resolvePnpPackageLocation(
+      localRequire,
+      bindingName,
+      path.join(path.resolve(directory), 'package.json')
+    );
+    if (pnpLocation) return readPackageAtLocation(pnpLocation);
   } catch {
     return undefined;
   }
   return undefined;
+}
+
+/** Resolves a package location through Yarn Plug'n'Play when it is active. */
+function resolvePnpPackageLocation(
+  localRequire: ReturnType<typeof createRequire>,
+  bindingName: string,
+  issuer: string
+): string | undefined {
+  if (process.versions.pnp === undefined) return undefined;
+  try {
+    const pnpApi = localRequire('pnpapi') as {
+      resolveToUnqualified?: (request: string, issuer: string) => string | null;
+    };
+    const location = pnpApi.resolveToUnqualified?.(bindingName, issuer);
+    return typeof location === 'string' ? location : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Reads a package whose resolver may return either its root or an entrypoint. */
+function readPackageAtLocation(
+  location: string
+): InstalledJavaScriptPackage | undefined {
+  try {
+    if (fs.statSync(location).isDirectory()) {
+      const packageDirectory = fs.realpathSync(location);
+      const manifest = readJavaScriptPackageManifest(
+        path.join(packageDirectory, 'package.json')
+      );
+      return manifest ? { directory: packageDirectory, manifest } : undefined;
+    }
+  } catch {
+    return undefined;
+  }
+
+  let packageDirectory: string;
+  try {
+    packageDirectory = fs.realpathSync(location);
+  } catch {
+    packageDirectory = path.resolve(location);
+  }
+  const manifest = readJavaScriptPackageManifest(
+    path.join(packageDirectory, 'package.json')
+  );
+  return manifest
+    ? { directory: packageDirectory, manifest }
+    : findPackageBoundary(location);
 }
 
 function findPackageBoundary(
@@ -329,9 +393,28 @@ export function dependencyBindingAcceptsPackageVersion(
   return semverRangeAcceptsVersion(binding.specifier, packageVersion, true);
 }
 
-function canResolvePackage(directory: string, packageName: string): boolean {
-  const installed = resolveInstalledJavaScriptPackage(directory, packageName);
-  return installed?.manifest.name === packageName;
+function canResolveDependencyBinding(
+  directory: string,
+  binding: JavaScriptDependencyBinding
+): boolean {
+  const installed = resolveInstalledJavaScriptPackage(directory, binding.name);
+  const installedName = installed?.manifest.name;
+  if (!installed || typeof installedName !== 'string') return false;
+
+  const expectedName = binding.specifier.startsWith('catalog:')
+    ? installedName
+    : (parseWorkspaceDependencyAlias(binding.specifier)?.packageName ??
+      parseNpmDependencyAlias(binding.specifier)?.packageName ??
+      readLocalDependencyPackageName(binding.specifier, directory) ??
+      binding.name);
+  return (
+    installedName === expectedName &&
+    dependencyBindingAcceptsPackageVersion(
+      binding,
+      installedName,
+      installed.manifest.version
+    )
+  );
 }
 
 function declaresAvailableRequiredPeerDependency(
@@ -346,20 +429,38 @@ function declaresAvailableRequiredPeerDependency(
   ) {
     return false;
   }
-  const installed = resolveInstalledJavaScriptPackage(
-    packageDirectory,
-    packageName
-  );
-  if (!installed) return false;
-  const expectedName =
-    parseWorkspaceDependencyAlias(specifier)?.packageName ??
-    parseNpmDependencyAlias(specifier)?.packageName ??
-    readLocalDependencyPackageName(specifier, packageDirectory);
-  if (expectedName) return installed.manifest.name === expectedName;
-  if (specifier.startsWith('catalog:')) {
-    return typeof installed.manifest.name === 'string';
+  return canResolveDependencyBinding(packageDirectory, {
+    name: packageName,
+    specifier,
+  });
+}
+
+function readDependencySpecifier(
+  manifest: JavaScriptPackageManifest,
+  field: (typeof INSTALLED_DEPENDENCY_FIELDS)[number] | 'optionalDependencies',
+  packageName: string
+): string | undefined {
+  const specifier = manifest[field]?.[packageName];
+  return typeof specifier === 'string' ? specifier : undefined;
+}
+
+/** Applies npm's rule that an optional dependency replaces the same dependency. */
+function readEffectiveDependencySpecifier(
+  manifest: JavaScriptPackageManifest,
+  field: (typeof INSTALLED_DEPENDENCY_FIELDS)[number],
+  packageName: string
+): string | undefined {
+  if (
+    field === 'dependencies' &&
+    manifest.optionalDependencies !== undefined &&
+    Object.prototype.hasOwnProperty.call(
+      manifest.optionalDependencies,
+      packageName
+    )
+  ) {
+    return undefined;
   }
-  return installed.manifest.name === packageName;
+  return readDependencySpecifier(manifest, field, packageName);
 }
 
 function readPackageNameSegments(packageName: string): string[] | undefined {

--- a/packages/vue-extractor/src/internal/project/manifest.ts
+++ b/packages/vue-extractor/src/internal/project/manifest.ts
@@ -1,6 +1,11 @@
 import fs from 'node:fs';
 import { createRequire } from 'node:module';
 import path from 'node:path';
+import {
+  satisfies as satisfiesSemver,
+  valid as validSemver,
+  validRange as validSemverRange,
+} from 'semver';
 
 /** Runtime package whose direct ownership activates Vue extraction. */
 export const GT_VUE_PACKAGE = 'gt-vue';
@@ -21,6 +26,18 @@ export type JavaScriptPackageManifest = {
   peerDependencies?: Record<string, string>;
   peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   workspaces?: string[] | { packages?: string[] };
+};
+
+/** One dependency name and specifier as written by a consuming package. */
+export type JavaScriptDependencyBinding = {
+  name: string;
+  specifier: string;
+};
+
+/** An installed package directory resolved without evaluating its entrypoint. */
+export type InstalledJavaScriptPackage = {
+  directory: string;
+  manifest: JavaScriptPackageManifest;
 };
 
 /** Reads one package manifest without throwing for absent or malformed input. */
@@ -78,64 +95,243 @@ export function declaresWorkspaceJavaScriptDependency(
   );
 }
 
+/** Checks dependencies that may propagate wrapper ownership to consumers. */
+export function declaresPropagatingJavaScriptDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string,
+  packageDirectory: string
+): boolean {
+  return (
+    manifest.dependencies?.[packageName] !== undefined ||
+    declaresAvailableRequiredPeerDependency(
+      manifest,
+      packageName,
+      packageDirectory
+    )
+  );
+}
+
 /** Lists required dependencies that can bind one workspace package to another. */
 export function readWorkspaceDependencyNames(
   manifest: JavaScriptPackageManifest,
   packageDirectory: string
 ): string[] {
   const names = new Set<string>();
-  for (const field of INSTALLED_DEPENDENCY_FIELDS) {
-    for (const packageName of Object.keys(manifest[field] ?? {})) {
-      names.add(packageName);
+  for (const binding of readWorkspaceDependencyBindings(
+    manifest,
+    packageDirectory
+  )) {
+    names.add(binding.name);
+    const workspaceAlias = parseWorkspaceDependencyAlias(binding.specifier);
+    if (workspaceAlias) names.add(workspaceAlias.packageName);
+    const npmAlias = parseNpmDependencyAlias(binding.specifier);
+    if (npmAlias) names.add(npmAlias.packageName);
+    if (binding.specifier.startsWith('catalog:')) {
+      const installed = resolveInstalledJavaScriptPackage(
+        packageDirectory,
+        binding.name
+      );
+      if (typeof installed?.manifest.name === 'string') {
+        names.add(installed.manifest.name);
+      }
     }
-  }
-  for (const packageName of Object.keys(manifest.peerDependencies ?? {})) {
-    if (
-      declaresAvailableRequiredPeerDependency(
-        manifest,
-        packageName,
-        packageDirectory
-      )
-    ) {
-      names.add(packageName);
-    }
+    const localPackageName = readLocalDependencyPackageName(
+      binding.specifier,
+      packageDirectory
+    );
+    if (localPackageName) names.add(localPackageName);
   }
   return [...names];
 }
 
-/** Reads installed and resolvable required-peer ranges for one dependency. */
-export function readWorkspaceDependencySpecifiers(
+/** Reads installed dependencies and resolvable, non-optional required peers. */
+export function readWorkspaceDependencyBindings(
   manifest: JavaScriptPackageManifest,
-  packageName: string,
   packageDirectory: string
-): string[] {
-  const specifiers = new Set<string>();
-  for (const field of INSTALLED_DEPENDENCY_FIELDS) {
-    const specifier = manifest[field]?.[packageName];
-    if (typeof specifier === 'string') specifiers.add(specifier);
+): JavaScriptDependencyBinding[] {
+  return readDependencyBindings(
+    manifest,
+    packageDirectory,
+    INSTALLED_DEPENDENCY_FIELDS
+  );
+}
+
+/** Reads dependency edges that may propagate wrapper ownership to consumers. */
+export function readPropagatingDependencyBindings(
+  manifest: JavaScriptPackageManifest,
+  packageDirectory: string
+): JavaScriptDependencyBinding[] {
+  return readDependencyBindings(manifest, packageDirectory, ['dependencies']);
+}
+
+function readDependencyBindings(
+  manifest: JavaScriptPackageManifest,
+  packageDirectory: string,
+  fields: readonly (typeof INSTALLED_DEPENDENCY_FIELDS)[number][]
+): JavaScriptDependencyBinding[] {
+  const bindings: JavaScriptDependencyBinding[] = [];
+  const seenBindings = new Set<string>();
+  const addBinding = (name: string, specifier: string) => {
+    const key = `${name}\0${specifier}`;
+    if (seenBindings.has(key)) return;
+    seenBindings.add(key);
+    bindings.push({ name, specifier });
+  };
+  for (const field of fields) {
+    for (const [name, specifier] of Object.entries(manifest[field] ?? {})) {
+      if (typeof specifier === 'string') addBinding(name, specifier);
+    }
   }
-  if (
-    declaresAvailableRequiredPeerDependency(
-      manifest,
-      packageName,
-      packageDirectory
-    )
-  ) {
-    const peerSpecifier = manifest.peerDependencies?.[packageName];
-    if (typeof peerSpecifier === 'string') specifiers.add(peerSpecifier);
+  for (const [name, specifier] of Object.entries(
+    manifest.peerDependencies ?? {}
+  )) {
+    if (
+      typeof specifier === 'string' &&
+      declaresAvailableRequiredPeerDependency(manifest, name, packageDirectory)
+    ) {
+      addBinding(name, specifier);
+    }
   }
-  return [...specifiers];
+  return bindings;
+}
+
+/**
+ * Resolves an installed package directory without selecting an export branch.
+ *
+ * `require.resolve()` is insufficient for availability checks because a valid
+ * ESM package may intentionally expose only its `import` condition. Walking
+ * Node's lookup directories finds the package boundary without importing user
+ * code or depending on the package's public subpath exports.
+ */
+export function resolveInstalledJavaScriptPackage(
+  directory: string,
+  bindingName: string
+): InstalledJavaScriptPackage | undefined {
+  const packageSegments = readPackageNameSegments(bindingName);
+  if (!packageSegments) return undefined;
+
+  try {
+    const localRequire = createRequire(
+      path.join(path.resolve(directory), 'package.json')
+    );
+    for (const modulesDirectory of localRequire.resolve.paths(bindingName) ??
+      []) {
+      const candidate = path.join(modulesDirectory, ...packageSegments);
+      let packageDirectory: string;
+      try {
+        packageDirectory = fs.realpathSync(candidate);
+      } catch {
+        continue;
+      }
+      const manifest = readJavaScriptPackageManifest(
+        path.join(packageDirectory, 'package.json')
+      );
+      if (manifest) return { directory: packageDirectory, manifest };
+    }
+    try {
+      const resolvedEntry = localRequire.resolve(bindingName);
+      return findPackageBoundary(resolvedEntry);
+    } catch {
+      // ESM-only packages can omit a `require` export.
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
+function findPackageBoundary(
+  entry: string
+): InstalledJavaScriptPackage | undefined {
+  if (!path.isAbsolute(entry)) return undefined;
+  let directory = path.dirname(entry);
+  while (true) {
+    const manifest = readJavaScriptPackageManifest(
+      path.join(directory, 'package.json')
+    );
+    if (manifest) return { directory, manifest };
+    const parent = path.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+/** Parses pnpm's explicit `workspace:alias@range` dependency syntax. */
+export function parseWorkspaceDependencyAlias(
+  specifier: string
+): { packageName: string; range: string } | undefined {
+  if (!specifier.startsWith('workspace:')) return undefined;
+  const value = specifier.slice('workspace:'.length);
+  const separator = value.lastIndexOf('@');
+  if (separator <= 0) return undefined;
+  const packageName = value.slice(0, separator);
+  const range = value.slice(separator + 1);
+  if (!range || !readPackageNameSegments(packageName)) return undefined;
+  return { packageName, range };
+}
+
+/** Reads the target package name from an npm alias dependency. */
+export function parseNpmDependencyAlias(
+  specifier: string
+): { packageName: string; range?: string } | undefined {
+  if (!specifier.startsWith('npm:')) return undefined;
+  const value = specifier.slice('npm:'.length);
+  const separator = value.lastIndexOf('@');
+  const packageName = separator > 0 ? value.slice(0, separator) : value;
+  if (!readPackageNameSegments(packageName)) return undefined;
+  return {
+    packageName,
+    range: separator > 0 ? value.slice(separator + 1) : undefined,
+  };
+}
+
+/** Reads a relative directory selected by an explicit local protocol. */
+export function parseLocalDependencyPath(
+  specifier: string
+): string | undefined {
+  const localPath = specifier.match(/^(?:file|link|portal):(.+)$/)?.[1];
+  if (localPath) return localPath;
+  return specifier.match(/^workspace:(\.{1,2}(?:\/.*)?)$/)?.[1];
+}
+
+/** Checks whether one binding's declared range accepts a selected package. */
+export function dependencyBindingAcceptsPackageVersion(
+  binding: JavaScriptDependencyBinding,
+  packageName: string,
+  packageVersion: string | undefined
+): boolean {
+  if (parseLocalDependencyPath(binding.specifier)) return true;
+
+  const workspaceAlias = parseWorkspaceDependencyAlias(binding.specifier);
+  if (workspaceAlias) {
+    return (
+      workspaceAlias.packageName === packageName &&
+      workspaceRangeAcceptsVersion(workspaceAlias.range, packageVersion)
+    );
+  }
+
+  const npmAlias = parseNpmDependencyAlias(binding.specifier);
+  if (npmAlias) {
+    return (
+      npmAlias.packageName === packageName &&
+      (npmAlias.range === undefined ||
+        semverRangeAcceptsVersion(npmAlias.range, packageVersion, true))
+    );
+  }
+  if (binding.specifier.startsWith('catalog:')) return true;
+  if (binding.name !== packageName) return false;
+  if (binding.specifier.startsWith('workspace:')) {
+    return workspaceRangeAcceptsVersion(
+      binding.specifier.slice('workspace:'.length),
+      packageVersion
+    );
+  }
+  return semverRangeAcceptsVersion(binding.specifier, packageVersion, true);
 }
 
 function canResolvePackage(directory: string, packageName: string): boolean {
-  try {
-    createRequire(path.join(path.resolve(directory), 'package.json')).resolve(
-      packageName
-    );
-    return true;
-  } catch {
-    return false;
-  }
+  const installed = resolveInstalledJavaScriptPackage(directory, packageName);
+  return installed?.manifest.name === packageName;
 }
 
 function declaresAvailableRequiredPeerDependency(
@@ -143,11 +339,87 @@ function declaresAvailableRequiredPeerDependency(
   packageName: string,
   packageDirectory: string
 ): boolean {
-  return Boolean(
-    manifest.peerDependencies?.[packageName] !== undefined &&
-    manifest.peerDependenciesMeta?.[packageName]?.optional !== true &&
-    canResolvePackage(packageDirectory, packageName)
+  const specifier = manifest.peerDependencies?.[packageName];
+  if (
+    typeof specifier !== 'string' ||
+    manifest.peerDependenciesMeta?.[packageName]?.optional === true
+  ) {
+    return false;
+  }
+  const installed = resolveInstalledJavaScriptPackage(
+    packageDirectory,
+    packageName
   );
+  if (!installed) return false;
+  const expectedName =
+    parseWorkspaceDependencyAlias(specifier)?.packageName ??
+    parseNpmDependencyAlias(specifier)?.packageName ??
+    readLocalDependencyPackageName(specifier, packageDirectory);
+  if (expectedName) return installed.manifest.name === expectedName;
+  if (specifier.startsWith('catalog:')) {
+    return typeof installed.manifest.name === 'string';
+  }
+  return installed.manifest.name === packageName;
+}
+
+function readPackageNameSegments(packageName: string): string[] | undefined {
+  if (!packageName || packageName.includes('\\')) return undefined;
+  const segments = packageName.split('/');
+  const isScoped = packageName.startsWith('@');
+  if (
+    (isScoped && segments.length !== 2) ||
+    (!isScoped && segments.length !== 1)
+  ) {
+    return undefined;
+  }
+  return segments.every(
+    (segment) => segment && segment !== '.' && segment !== '..'
+  )
+    ? segments
+    : undefined;
+}
+
+function readLocalDependencyPackageName(
+  specifier: string,
+  packageDirectory: string
+): string | undefined {
+  const localPath = parseLocalDependencyPath(specifier);
+  if (!localPath) return undefined;
+  const packageName = readJavaScriptPackageManifest(
+    path.join(path.resolve(packageDirectory, localPath), 'package.json')
+  )?.name;
+  return typeof packageName === 'string' && packageName
+    ? packageName
+    : undefined;
+}
+
+function workspaceRangeAcceptsVersion(
+  range: string,
+  version: string | undefined
+): boolean {
+  return (
+    range === '' ||
+    range === '*' ||
+    range === '^' ||
+    range === '~' ||
+    semverRangeAcceptsVersion(range, version, true)
+  );
+}
+
+function semverRangeAcceptsVersion(
+  range: string,
+  version: string | undefined,
+  acceptOpaqueRange = false
+): boolean {
+  const validRange = validSemverRange(range);
+  if (!validRange) return acceptOpaqueRange;
+  if (!version) return false;
+  try {
+    const validVersion = validSemver(version);
+    return Boolean(validVersion && satisfiesSemver(validVersion, validRange));
+  } catch {
+    return false;
+  }
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/vue-extractor/src/internal/project/manifest.ts
+++ b/packages/vue-extractor/src/internal/project/manifest.ts
@@ -1,0 +1,155 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/** Runtime package whose direct ownership activates Vue extraction. */
+export const GT_VUE_PACKAGE = 'gt-vue';
+
+/** Dependency fields that declare a runtime installed for one package. */
+const INSTALLED_DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+] as const;
+
+/** Minimal package manifest shape used by Vue project discovery. */
+export type JavaScriptPackageManifest = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  workspaces?: string[] | { packages?: string[] };
+};
+
+/** Reads one package manifest without throwing for absent or malformed input. */
+export function readJavaScriptPackageManifest(
+  packagePath: string
+): JavaScriptPackageManifest | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packagePath, 'utf8')) as unknown;
+    return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Checks dependency fields that make a runtime available to package code. */
+export function declaresInstalledJavaScriptDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string
+): boolean {
+  return INSTALLED_DEPENDENCY_FIELDS.some(
+    (field) => manifest[field]?.[packageName] !== undefined
+  );
+}
+
+/** Checks direct ownership, requiring optional and peer runtimes to resolve. */
+export function declaresAvailableJavaScriptDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string,
+  packageDirectory: string
+): boolean {
+  if (declaresInstalledJavaScriptDependency(manifest, packageName)) return true;
+  if (manifest.optionalDependencies?.[packageName] !== undefined) {
+    return canResolvePackage(packageDirectory, packageName);
+  }
+  return declaresAvailableRequiredPeerDependency(
+    manifest,
+    packageName,
+    packageDirectory
+  );
+}
+
+/** Checks package ownership without promoting optional workspace integrations. */
+export function declaresWorkspaceJavaScriptDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string,
+  packageDirectory: string
+): boolean {
+  return (
+    declaresInstalledJavaScriptDependency(manifest, packageName) ||
+    declaresAvailableRequiredPeerDependency(
+      manifest,
+      packageName,
+      packageDirectory
+    )
+  );
+}
+
+/** Lists required dependencies that can bind one workspace package to another. */
+export function readWorkspaceDependencyNames(
+  manifest: JavaScriptPackageManifest,
+  packageDirectory: string
+): string[] {
+  const names = new Set<string>();
+  for (const field of INSTALLED_DEPENDENCY_FIELDS) {
+    for (const packageName of Object.keys(manifest[field] ?? {})) {
+      names.add(packageName);
+    }
+  }
+  for (const packageName of Object.keys(manifest.peerDependencies ?? {})) {
+    if (
+      declaresAvailableRequiredPeerDependency(
+        manifest,
+        packageName,
+        packageDirectory
+      )
+    ) {
+      names.add(packageName);
+    }
+  }
+  return [...names];
+}
+
+/** Reads installed and resolvable required-peer ranges for one dependency. */
+export function readWorkspaceDependencySpecifiers(
+  manifest: JavaScriptPackageManifest,
+  packageName: string,
+  packageDirectory: string
+): string[] {
+  const specifiers = new Set<string>();
+  for (const field of INSTALLED_DEPENDENCY_FIELDS) {
+    const specifier = manifest[field]?.[packageName];
+    if (typeof specifier === 'string') specifiers.add(specifier);
+  }
+  if (
+    declaresAvailableRequiredPeerDependency(
+      manifest,
+      packageName,
+      packageDirectory
+    )
+  ) {
+    const peerSpecifier = manifest.peerDependencies?.[packageName];
+    if (typeof peerSpecifier === 'string') specifiers.add(peerSpecifier);
+  }
+  return [...specifiers];
+}
+
+function canResolvePackage(directory: string, packageName: string): boolean {
+  try {
+    createRequire(path.join(path.resolve(directory), 'package.json')).resolve(
+      packageName
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function declaresAvailableRequiredPeerDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string,
+  packageDirectory: string
+): boolean {
+  return Boolean(
+    manifest.peerDependencies?.[packageName] !== undefined &&
+    manifest.peerDependenciesMeta?.[packageName]?.optional !== true &&
+    canResolvePackage(packageDirectory, packageName)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/vue-extractor/src/internal/project/mergeVueProjectExtraction.ts
+++ b/packages/vue-extractor/src/internal/project/mergeVueProjectExtraction.ts
@@ -1,0 +1,105 @@
+import type { Updates } from 'generaltranslation/types';
+import type { VueProjectExtractionOutput } from '../../types.js';
+
+/** Framework-neutral extraction output accepted by the CLI adapter. */
+export type InlineExtractionOutput = {
+  updates: Updates;
+  errors: string[];
+  warnings: string[];
+};
+
+/**
+ * Appends Vue extraction to an existing framework catalog.
+ *
+ * Hash collisions represent one catalog entry. Their paths and source context
+ * are combined without duplicating identical locations, while the primary
+ * framework's ordering and update object remain authoritative.
+ */
+export function mergeVueProjectExtraction(
+  primary: InlineExtractionOutput,
+  vue: VueProjectExtractionOutput
+): InlineExtractionOutput {
+  return {
+    updates: mergeUpdates(primary.updates, vue.updates),
+    errors: [...primary.errors, ...vue.errors],
+    warnings: [...new Set([...primary.warnings, ...vue.warnings])],
+  };
+}
+
+function mergeUpdates(primary: Updates, vue: Updates): Updates {
+  const updates = [...primary];
+  const byHash = new Map(
+    updates.flatMap((update, index) =>
+      update.metadata.hash ? [[update.metadata.hash, index] as const] : []
+    )
+  );
+
+  for (const update of vue) {
+    const hash = update.metadata.hash;
+    const existingIndex = hash ? byHash.get(hash) : undefined;
+    if (existingIndex === undefined) {
+      if (hash) byHash.set(hash, updates.length);
+      updates.push(update);
+      continue;
+    }
+
+    const existing = updates[existingIndex]!;
+    mergeFilePaths(existing, update);
+    mergeSourceCode(existing, update);
+  }
+  return updates;
+}
+
+function mergeFilePaths(
+  existing: Updates[number],
+  incoming: Updates[number]
+): void {
+  const paths = [
+    ...(existing.metadata.filePaths ?? []),
+    ...(incoming.metadata.filePaths ?? []),
+  ];
+  if (paths.length > 0) existing.metadata.filePaths = [...new Set(paths)];
+}
+
+function mergeSourceCode(
+  existing: Updates[number],
+  incoming: Updates[number]
+): void {
+  const incomingSourceCode = asSourceCodeMap(incoming.metadata.sourceCode);
+  if (!incomingSourceCode) return;
+
+  const currentSourceCode = existing.metadata.sourceCode;
+  const existingSourceCode =
+    currentSourceCode === undefined ? {} : asSourceCodeMap(currentSourceCode);
+  if (!existingSourceCode) return;
+  if (currentSourceCode === undefined) {
+    existing.metadata.sourceCode = existingSourceCode;
+  }
+
+  for (const [file, entries] of Object.entries(incomingSourceCode)) {
+    const target = (existingSourceCode[file] ??= []);
+    const known = new Set(target.map(serializeSourceCodeEntry));
+    for (const entry of entries) {
+      const key = serializeSourceCodeEntry(entry);
+      if (known.has(key)) continue;
+      target.push(entry);
+      known.add(key);
+    }
+  }
+}
+
+type SourceCodeMap = Record<string, unknown[]>;
+
+function asSourceCodeMap(value: unknown): SourceCodeMap | undefined {
+  if (!isRecord(value)) return undefined;
+  if (!Object.values(value).every(Array.isArray)) return undefined;
+  return value as SourceCodeMap;
+}
+
+function serializeSourceCodeEntry(entry: unknown): string {
+  return JSON.stringify(entry);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/vue-extractor/src/internal/project/moduleResolver.ts
+++ b/packages/vue-extractor/src/internal/project/moduleResolver.ts
@@ -1,0 +1,441 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import enhancedResolve, { type FileSystem } from 'enhanced-resolve';
+import { createMatchPath, loadConfig } from 'tsconfig-paths';
+
+const { ResolverFactory } = enhancedResolve;
+
+const SOURCE_EXTENSIONS = [
+  '.mjs',
+  '.js',
+  '.mts',
+  '.ts',
+  '.jsx',
+  '.tsx',
+  '.json',
+] as const;
+
+const SOURCE_EXTENSION_ALIASES = {
+  '.cjs': ['.cjs', '.cts'],
+  '.js': ['.js', '.ts', '.tsx'],
+  '.jsx': ['.jsx', '.tsx'],
+  '.mjs': ['.mjs', '.mts'],
+};
+
+const VITE_MAIN_FIELDS = [
+  'browser',
+  'module',
+  'jsnext:main',
+  'jsnext',
+  'main',
+] as const;
+
+const COMMONJS_SOURCE_EXTENSIONS = new Set(['.cjs', '.cts']);
+
+// Keep this in step with Vite's entry-point heuristic. A package may publish
+// a CommonJS browser build alongside an ESM `module` build; Vite deliberately
+// selects the module build for an ESM importer in that case.
+const ESM_SYNTAX =
+  /(?:[\s;]|^)(?:import[\s\w*,{}]*from|import\s*["'*{]|export\b\s*(?:[*{]|default|class|type|function|const|var|let|async function)|import\.meta\b)/m;
+
+/** Conditions used by the CLI when no project override is supplied. */
+export const DEFAULT_RESOLUTION_CONDITIONS = [
+  'module',
+  'browser',
+  'development|production',
+] as const;
+
+/** Creates a deterministic, source-first resolver scoped to one extraction. */
+export function createProjectModuleResolver(
+  conditionNames: readonly string[] = DEFAULT_RESOLUTION_CONDITIONS
+): (specifier: string, importer: string) => string | undefined {
+  const cache = new Map<string, string | undefined>();
+  return (specifier, importer) => {
+    const cacheKey = `${importer}::${specifier}`;
+    if (cache.has(cacheKey)) return cache.get(cacheKey);
+    const result = resolveProjectModule(specifier, importer, conditionNames);
+    cache.set(cacheKey, result);
+    return result;
+  };
+}
+
+/** Resolves local barrels, TypeScript paths, and package export maps. */
+function resolveProjectModule(
+  specifier: string,
+  importer: string,
+  conditionNames: readonly string[]
+): string | undefined {
+  const basedir = path.dirname(importer);
+  const extensions = [...SOURCE_EXTENSIONS];
+  const isRequire = COMMONJS_SOURCE_EXTENSIONS.has(
+    path.extname(importer).toLowerCase()
+  );
+  const mainFields = resolveViteMainFields(specifier, basedir, isRequire);
+  const resolvedConditions = resolveConditionsForImporter(
+    conditionNames,
+    isRequire
+  );
+
+  const tsConfigResult = loadConfig(basedir);
+  if (tsConfigResult.resultType === 'success') {
+    const matchPath = createMatchPath(
+      tsConfigResult.absoluteBaseUrl,
+      tsConfigResult.paths,
+      mainFields
+    );
+    const directMatch = resolveExistingPath(
+      matchPath(specifier, undefined, undefined, extensions),
+      extensions
+    );
+    if (directMatch) return directMatch;
+
+    const baseMatch = matchPath(specifier);
+    for (const extension of extensions) {
+      const explicitMatch = resolveExistingPath(
+        matchPath(`${specifier}${extension}`),
+        extensions
+      );
+      if (explicitMatch) return explicitMatch;
+      const baseWithExtension = resolveExistingPath(
+        baseMatch ? `${baseMatch}${extension}` : undefined,
+        extensions
+      );
+      if (baseWithExtension) return baseWithExtension;
+    }
+  }
+
+  try {
+    const resolver = ResolverFactory.createResolver({
+      useSyncFileSystemCalls: true,
+      fileSystem: fs as unknown as FileSystem,
+      extensions,
+      aliasFields: ['browser'],
+      conditionNames: resolvedConditions,
+      extensionAlias: SOURCE_EXTENSION_ALIASES,
+      exportsFields: ['exports'],
+      mainFields,
+    });
+    const result = resolver.resolveSync({}, basedir, specifier);
+    if (typeof result === 'string') return result;
+  } catch {
+    // Resolution is intentionally final. Falling back to a resolver that
+    // ignores `exports` would expose package-private modules that Vite rejects.
+  }
+  return resolvePackageExportSourceAlternative(
+    specifier,
+    basedir,
+    resolvedConditions
+  );
+}
+
+/** Adds the import kind and expands Vite's mode placeholder deterministically. */
+function resolveConditionsForImporter(
+  conditionNames: readonly string[],
+  isRequire: boolean
+): string[] {
+  const useProduction =
+    conditionNames.includes('production') &&
+    !conditionNames.includes('development');
+  const modeCondition = useProduction ? 'production' : 'development';
+  const conditions = conditionNames
+    .filter((condition) => condition !== 'import' && condition !== 'require')
+    .map((condition) =>
+      condition === 'development|production' ? modeCondition : condition
+    );
+  conditions.push(isRequire ? 'require' : 'import', 'default');
+  return [...new Set(conditions)];
+}
+
+/** Mirrors Vite's browser-entry versus ESM-module compatibility heuristic. */
+function resolveViteMainFields(
+  specifier: string,
+  basedir: string,
+  isRequire: boolean
+): string[] {
+  if (isRequire) return [...VITE_MAIN_FIELDS];
+  const packageData = readImportedPackageData(specifier, basedir);
+  if (!packageData) return [...VITE_MAIN_FIELDS];
+  const { directory, manifest } = packageData;
+  const browserEntry =
+    typeof manifest.browser === 'string'
+      ? manifest.browser
+      : isUnknownRecord(manifest.browser) &&
+          typeof manifest.browser['.'] === 'string'
+        ? manifest.browser['.']
+        : undefined;
+  if (
+    !browserEntry ||
+    typeof manifest.module !== 'string' ||
+    manifest.module === browserEntry
+  ) {
+    return [...VITE_MAIN_FIELDS];
+  }
+  const browserEntryPath = path.resolve(directory, browserEntry);
+  const resolvedBrowserEntry =
+    resolveExistingPath(browserEntryPath, SOURCE_EXTENSIONS) ??
+    resolveSourceOutputPath(browserEntryPath);
+  if (!resolvedBrowserEntry) return [...VITE_MAIN_FIELDS];
+  try {
+    if (ESM_SYNTAX.test(fs.readFileSync(resolvedBrowserEntry, 'utf8'))) {
+      return [...VITE_MAIN_FIELDS];
+    }
+  } catch {
+    return [...VITE_MAIN_FIELDS];
+  }
+  return ['module', 'browser', 'jsnext:main', 'jsnext', 'main'];
+}
+
+type ImportedPackageData = {
+  directory: string;
+  manifest: Record<string, unknown>;
+};
+
+/** Reads the package selected by Node's nearest-node_modules precedence. */
+function readImportedPackageData(
+  specifier: string,
+  basedir: string
+): ImportedPackageData | undefined {
+  const packageName = readPackageName(specifier);
+  if (!packageName) return undefined;
+  let current = path.resolve(basedir);
+  for (;;) {
+    const candidate = path.join(current, 'node_modules', packageName);
+    const packageData = readPackageData(candidate);
+    if (packageData) return packageData;
+
+    // Match Vite's package self-reference behavior without searching outside
+    // the importer's nearest package boundary first.
+    const selfPackage = readPackageData(current);
+    if (selfPackage?.manifest.name === packageName) return selfPackage;
+
+    const parent = path.dirname(current);
+    if (parent === current) return undefined;
+    current = parent;
+  }
+}
+
+/**
+ * Recovers TypeScript source behind a JavaScript package export target.
+ *
+ * This fallback interprets the package's export map instead of probing its
+ * filesystem by subpath. That distinction preserves package encapsulation:
+ * an unexported file remains unresolved even when it physically exists.
+ */
+function resolvePackageExportSourceAlternative(
+  specifier: string,
+  basedir: string,
+  conditions: readonly string[]
+): string | undefined {
+  const packageName = readPackageName(specifier);
+  const packageData = readImportedPackageData(specifier, basedir);
+  if (
+    !packageName ||
+    !packageData ||
+    packageData.manifest.exports === undefined
+  ) {
+    return undefined;
+  }
+  const subpath =
+    specifier === packageName ? '.' : `.${specifier.slice(packageName.length)}`;
+  const target = resolveExportsTarget(
+    packageData.manifest.exports,
+    subpath,
+    new Set(conditions)
+  );
+  if (!target || !target.startsWith('./')) return undefined;
+  const mappedTarget = applyPackageBrowserMap(target, packageData.manifest);
+  if (!mappedTarget || !mappedTarget.startsWith('./')) return undefined;
+  const candidate = path.resolve(packageData.directory, mappedTarget);
+  const relative = path.relative(packageData.directory, candidate);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return undefined;
+  }
+  return resolveSourceOutputPath(candidate);
+}
+
+/** Resolves the exact or best-pattern subpath before evaluating conditions. */
+function resolveExportsTarget(
+  exportsField: unknown,
+  subpath: string,
+  conditions: ReadonlySet<string>
+): string | undefined {
+  if (!isUnknownRecord(exportsField) || isConditionalExports(exportsField)) {
+    return subpath === '.'
+      ? resolveConditionalTarget(exportsField, conditions)
+      : undefined;
+  }
+  if (Object.prototype.hasOwnProperty.call(exportsField, subpath)) {
+    return resolveConditionalTarget(exportsField[subpath], conditions);
+  }
+  const pattern = Object.keys(exportsField)
+    .filter((key) => key.startsWith('./') && key.includes('*'))
+    .map((key) => {
+      const star = key.indexOf('*');
+      const prefix = key.slice(0, star);
+      const suffix = key.slice(star + 1);
+      return subpath.startsWith(prefix) && subpath.endsWith(suffix)
+        ? {
+            key,
+            match: subpath.slice(prefix.length, subpath.length - suffix.length),
+            prefixLength: prefix.length,
+            suffixLength: suffix.length,
+          }
+        : undefined;
+    })
+    .filter((entry): entry is NonNullable<typeof entry> => entry !== undefined)
+    .sort(
+      (left, right) =>
+        right.prefixLength - left.prefixLength ||
+        right.suffixLength - left.suffixLength ||
+        right.key.length - left.key.length
+    )[0];
+  if (!pattern) return undefined;
+  const target = resolveConditionalTarget(
+    exportsField[pattern.key],
+    conditions
+  );
+  return target?.replaceAll('*', pattern.match);
+}
+
+/** Evaluates export conditions in declaration order, matching Node and Vite. */
+function resolveConditionalTarget(
+  target: unknown,
+  conditions: ReadonlySet<string>
+): string | undefined {
+  if (typeof target === 'string') return target;
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const resolved = resolveConditionalTarget(candidate, conditions);
+      if (resolved) return resolved;
+    }
+    return undefined;
+  }
+  if (!isUnknownRecord(target)) return undefined;
+  for (const [condition, candidate] of Object.entries(target)) {
+    if (condition !== 'default' && !conditions.has(condition)) continue;
+    const resolved = resolveConditionalTarget(candidate, conditions);
+    if (resolved) return resolved;
+  }
+  return undefined;
+}
+
+function isConditionalExports(exportsField: Record<string, unknown>): boolean {
+  return Object.keys(exportsField).every((key) => !key.startsWith('.'));
+}
+
+/** Applies the object form of a package browser map to an export target. */
+function applyPackageBrowserMap(
+  target: string,
+  manifest: Record<string, unknown>
+): string | undefined {
+  if (!isUnknownRecord(manifest.browser)) return target;
+  const normalizedTarget = path.posix.normalize(target);
+  for (const [key, mapped] of Object.entries(manifest.browser)) {
+    const normalizedKey = path.posix.normalize(key);
+    if (
+      normalizedTarget !== normalizedKey &&
+      !equalWithoutSuffix(normalizedTarget, normalizedKey, '.js') &&
+      !equalWithoutSuffix(normalizedTarget, normalizedKey, '/index.js')
+    ) {
+      continue;
+    }
+    return typeof mapped === 'string' ? mapped : undefined;
+  }
+  return target;
+}
+
+function equalWithoutSuffix(
+  target: string,
+  key: string,
+  suffix: string
+): boolean {
+  return key.endsWith(suffix) && key.slice(0, -suffix.length) === target;
+}
+
+/** Maps emitted JS-family file names to their source equivalents like Vite. */
+function resolveSourceOutputPath(candidate: string): string | undefined {
+  if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+    return candidate;
+  }
+  const extension = path.extname(candidate).toLowerCase();
+  const alternatives =
+    SOURCE_EXTENSION_ALIASES[
+      extension as keyof typeof SOURCE_EXTENSION_ALIASES
+    ];
+  if (!alternatives) return undefined;
+  const stem = candidate.slice(0, -extension.length);
+  for (const alternative of alternatives.slice(1)) {
+    const source = `${stem}${alternative}`;
+    try {
+      if (fs.statSync(source).isFile()) return source;
+    } catch {
+      // Try the next source extension.
+    }
+  }
+  return undefined;
+}
+
+function readPackageData(directory: string): ImportedPackageData | undefined {
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(directory, 'package.json'), 'utf8')
+    ) as unknown;
+    return isUnknownRecord(manifest) ? { directory, manifest } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readPackageName(specifier: string): string | undefined {
+  if (
+    !specifier ||
+    specifier.startsWith('.') ||
+    specifier.startsWith('/') ||
+    specifier.startsWith('#')
+  ) {
+    return undefined;
+  }
+  const segments = specifier.split('/');
+  if (specifier.startsWith('@')) {
+    return segments.length >= 2 ? `${segments[0]}/${segments[1]}` : undefined;
+  }
+  return segments[0];
+}
+
+function isUnknownRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function resolveExistingPath(
+  filePath: string | undefined,
+  extensions: readonly string[]
+): string | undefined {
+  if (!filePath) return undefined;
+  try {
+    if (fs.existsSync(filePath)) {
+      const stats = fs.statSync(filePath);
+      if (stats.isFile()) return filePath;
+      if (stats.isDirectory()) {
+        for (const extension of extensions) {
+          const indexPath = path.join(filePath, `index${extension}`);
+          if (fs.existsSync(indexPath) && fs.statSync(indexPath).isFile()) {
+            return indexPath;
+          }
+        }
+      }
+    }
+    for (const extension of extensions) {
+      const candidate = `${filePath}${extension}`;
+      if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        return candidate;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}

--- a/packages/vue-extractor/src/internal/project/moduleResolver.ts
+++ b/packages/vue-extractor/src/internal/project/moduleResolver.ts
@@ -2,6 +2,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import enhancedResolve, { type FileSystem } from 'enhanced-resolve';
 import { createMatchPath, loadConfig } from 'tsconfig-paths';
+import {
+  readJavaScriptPackageManifest,
+  resolveInstalledJavaScriptPackage,
+  type JavaScriptPackageManifest,
+} from './manifest.js';
 
 const { ResolverFactory } = enhancedResolve;
 
@@ -45,15 +50,29 @@ export const DEFAULT_RESOLUTION_CONDITIONS = [
   'development|production',
 ] as const;
 
+type ProjectModuleResolverOptions = {
+  /** Package currently being inspected, for standards-compliant self imports. */
+  selfPackage?: {
+    directory: string;
+    manifest: JavaScriptPackageManifest;
+  };
+};
+
 /** Creates a deterministic, source-first resolver scoped to one extraction. */
 export function createProjectModuleResolver(
-  conditionNames: readonly string[] = DEFAULT_RESOLUTION_CONDITIONS
+  conditionNames: readonly string[] = DEFAULT_RESOLUTION_CONDITIONS,
+  options: ProjectModuleResolverOptions = {}
 ): (specifier: string, importer: string) => string | undefined {
   const cache = new Map<string, string | undefined>();
   return (specifier, importer) => {
     const cacheKey = `${importer}::${specifier}`;
     if (cache.has(cacheKey)) return cache.get(cacheKey);
-    const result = resolveProjectModule(specifier, importer, conditionNames);
+    const result = resolveProjectModule(
+      specifier,
+      importer,
+      conditionNames,
+      options
+    );
     cache.set(cacheKey, result);
     return result;
   };
@@ -63,14 +82,20 @@ export function createProjectModuleResolver(
 function resolveProjectModule(
   specifier: string,
   importer: string,
-  conditionNames: readonly string[]
+  conditionNames: readonly string[],
+  options: ProjectModuleResolverOptions
 ): string | undefined {
   const basedir = path.dirname(importer);
   const extensions = [...SOURCE_EXTENSIONS];
   const isRequire = COMMONJS_SOURCE_EXTENSIONS.has(
     path.extname(importer).toLowerCase()
   );
-  const mainFields = resolveViteMainFields(specifier, basedir, isRequire);
+  const mainFields = resolveViteMainFields(
+    specifier,
+    basedir,
+    isRequire,
+    options
+  );
   const resolvedConditions = resolveConditionsForImporter(
     conditionNames,
     isRequire
@@ -124,7 +149,8 @@ function resolveProjectModule(
   return resolvePackageExportSourceAlternative(
     specifier,
     basedir,
-    resolvedConditions
+    resolvedConditions,
+    options
   );
 }
 
@@ -150,10 +176,11 @@ function resolveConditionsForImporter(
 function resolveViteMainFields(
   specifier: string,
   basedir: string,
-  isRequire: boolean
+  isRequire: boolean,
+  options: ProjectModuleResolverOptions
 ): string[] {
   if (isRequire) return [...VITE_MAIN_FIELDS];
-  const packageData = readImportedPackageData(specifier, basedir);
+  const packageData = readImportedPackageData(specifier, basedir, options);
   if (!packageData) return [...VITE_MAIN_FIELDS];
   const { directory, manifest } = packageData;
   const browserEntry =
@@ -193,21 +220,45 @@ type ImportedPackageData = {
 /** Reads the package selected by Node's nearest-node_modules precedence. */
 function readImportedPackageData(
   specifier: string,
-  basedir: string
+  basedir: string,
+  options: ProjectModuleResolverOptions = {}
 ): ImportedPackageData | undefined {
   const packageName = readPackageName(specifier);
   if (!packageName) return undefined;
+  const selfPackage = options.selfPackage;
+  if (
+    selfPackage?.manifest.name === packageName &&
+    isWithinDirectory(selfPackage.directory, basedir)
+  ) {
+    return {
+      directory: selfPackage.directory,
+      manifest: selfPackage.manifest as Record<string, unknown>,
+    };
+  }
+  const nearestPackage = readNearestPackageData(basedir);
+  if (nearestPackage?.manifest.name === packageName) return nearestPackage;
+  const installed = resolveInstalledJavaScriptPackage(basedir, packageName);
+  return installed
+    ? {
+        directory: installed.directory,
+        manifest: installed.manifest as Record<string, unknown>,
+      }
+    : undefined;
+}
+
+/** Reads only the importer's nearest package scope for self-reference lookup. */
+function readNearestPackageData(
+  basedir: string
+): ImportedPackageData | undefined {
   let current = path.resolve(basedir);
-  for (;;) {
-    const candidate = path.join(current, 'node_modules', packageName);
-    const packageData = readPackageData(candidate);
-    if (packageData) return packageData;
-
-    // Match Vite's package self-reference behavior without searching outside
-    // the importer's nearest package boundary first.
-    const selfPackage = readPackageData(current);
-    if (selfPackage?.manifest.name === packageName) return selfPackage;
-
+  while (true) {
+    const manifestPath = path.join(current, 'package.json');
+    if (fs.existsSync(manifestPath)) {
+      const manifest = readJavaScriptPackageManifest(manifestPath);
+      return manifest
+        ? { directory: current, manifest: manifest as Record<string, unknown> }
+        : undefined;
+    }
     const parent = path.dirname(current);
     if (parent === current) return undefined;
     current = parent;
@@ -224,10 +275,11 @@ function readImportedPackageData(
 function resolvePackageExportSourceAlternative(
   specifier: string,
   basedir: string,
-  conditions: readonly string[]
+  conditions: readonly string[],
+  options: ProjectModuleResolverOptions
 ): string | undefined {
   const packageName = readPackageName(specifier);
-  const packageData = readImportedPackageData(specifier, basedir);
+  const packageData = readImportedPackageData(specifier, basedir, options);
   if (
     !packageName ||
     !packageData ||
@@ -255,6 +307,18 @@ function resolvePackageExportSourceAlternative(
     return undefined;
   }
   return resolveSourceOutputPath(candidate);
+}
+
+function isWithinDirectory(directory: string, candidate: string): boolean {
+  const relative = path.relative(
+    path.resolve(directory),
+    path.resolve(candidate)
+  );
+  return (
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
 }
 
 /** Resolves the exact or best-pattern subpath before evaluating conditions. */
@@ -377,17 +441,6 @@ function resolveSourceOutputPath(candidate: string): string | undefined {
     }
   }
   return undefined;
-}
-
-function readPackageData(directory: string): ImportedPackageData | undefined {
-  try {
-    const manifest = JSON.parse(
-      fs.readFileSync(path.join(directory, 'package.json'), 'utf8')
-    ) as unknown;
-    return isUnknownRecord(manifest) ? { directory, manifest } : undefined;
-  } catch {
-    return undefined;
-  }
 }
 
 function readPackageName(specifier: string): string | undefined {

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -1,18 +1,22 @@
+import fs from 'node:fs';
 import path from 'node:path';
 import fg from 'fast-glob';
+import { satisfies as satisfiesSemver, valid as validSemver } from 'semver';
 import {
   createWorkspaceDiscoveryCache,
-  declaresJavaScriptDependency,
-  readDeclaredDependencyNames,
   readDeclaredWorkspacePackages,
-  readJavaScriptPackageManifest,
   type DeclaredWorkspacePackage,
-  type JavaScriptPackageManifest,
   type WorkspaceDiscoveryCache,
 } from './workspaces.js';
-
-/** Runtime package whose ownership selects Vue extraction scopes. */
-export const GT_VUE_PACKAGE = 'gt-vue';
+import {
+  declaresAvailableJavaScriptDependency,
+  declaresWorkspaceJavaScriptDependency,
+  GT_VUE_PACKAGE,
+  readWorkspaceDependencyNames,
+  readWorkspaceDependencySpecifiers,
+  readJavaScriptPackageManifest,
+  type JavaScriptPackageManifest,
+} from './manifest.js';
 
 /** Default Vue source patterns, including conventional Vue and Nuxt folders. */
 export const DEFAULT_VUE_SOURCE_PATTERNS = [
@@ -34,6 +38,7 @@ export type VueSourceScope = {
 /** Project discovery result reused by detection and extraction. */
 export type VueProjectDiscovery = {
   projectRoot: string;
+  rootOwnsVue: boolean;
   rootManifest?: JavaScriptPackageManifest;
   scopes: VueSourceScope[];
 };
@@ -50,12 +55,12 @@ export function discoverVueProject(
   cwd: string,
   cache: WorkspaceDiscoveryCache = createWorkspaceDiscoveryCache()
 ): VueProjectDiscovery {
-  const projectRoot = path.resolve(cwd);
+  const projectRoot = resolveProjectDirectory(cwd);
   const rootManifest = readJavaScriptPackageManifest(
     path.join(projectRoot, 'package.json')
   );
   if (!rootManifest) {
-    return { projectRoot, scopes: [] };
+    return { projectRoot, rootOwnsVue: false, scopes: [] };
   }
 
   const workspacePackages = readDeclaredWorkspacePackages(
@@ -65,14 +70,16 @@ export function discoverVueProject(
   );
   const selectedWorkspacePackages = selectVueWorkspacePackages(
     workspacePackages,
-    rootManifest
-  );
-  const rootOwnsVue = declaresJavaScriptDependency(
     rootManifest,
-    GT_VUE_PACKAGE
+    projectRoot
+  );
+  const rootOwnsVue = declaresAvailableJavaScriptDependency(
+    rootManifest,
+    GT_VUE_PACKAGE,
+    projectRoot
   );
   const rootConsumesVueWrapper = consumesSelectedWorkspace(
-    rootManifest,
+    { directory: projectRoot, manifest: rootManifest },
     selectedWorkspacePackages
   );
   const scopes: VueSourceScope[] = [];
@@ -102,7 +109,16 @@ export function discoverVueProject(
     });
   }
 
-  return { projectRoot, rootManifest, scopes };
+  return { projectRoot, rootManifest, rootOwnsVue, scopes };
+}
+
+/** Canonicalizes existing roots so macOS path aliases share one ownership tree. */
+export function resolveProjectDirectory(directory: string): string {
+  try {
+    return fs.realpathSync(path.resolve(directory));
+  } catch {
+    return path.resolve(directory);
+  }
 }
 
 /** Returns safe project-root-relative default globs for selected Vue scopes. */
@@ -132,36 +148,48 @@ export function findVueSourceScope(
 
 function selectVueWorkspacePackages(
   workspacePackages: readonly DeclaredWorkspacePackage[],
-  rootManifest: JavaScriptPackageManifest
+  rootManifest: JavaScriptPackageManifest,
+  projectRoot: string
 ): DeclaredWorkspacePackage[] {
   const selectedDirectories = new Set(
     workspacePackages
-      .filter(({ manifest }) =>
-        declaresJavaScriptDependency(manifest, GT_VUE_PACKAGE)
+      .filter(({ directory, manifest }) =>
+        declaresWorkspaceJavaScriptDependency(
+          manifest,
+          GT_VUE_PACKAGE,
+          directory
+        )
       )
       .map(({ directory }) => directory)
   );
   const selectedNames = new Set<string>();
-  const pendingNames: string[] = [];
-  const selectName = (manifest: JavaScriptPackageManifest) => {
-    const packageName = readPackageName(manifest);
+  const pendingPackages: DeclaredWorkspacePackage[] = [];
+  const selectPackage = (selectedPackage: DeclaredWorkspacePackage) => {
+    const packageName = readPackageName(selectedPackage.manifest);
     if (!packageName || selectedNames.has(packageName)) return;
     selectedNames.add(packageName);
-    pendingNames.push(packageName);
+    pendingPackages.push(selectedPackage);
   };
-  if (declaresJavaScriptDependency(rootManifest, GT_VUE_PACKAGE)) {
-    selectName(rootManifest);
+  if (
+    declaresAvailableJavaScriptDependency(
+      rootManifest,
+      GT_VUE_PACKAGE,
+      projectRoot
+    )
+  ) {
+    selectPackage({ directory: projectRoot, manifest: rootManifest });
   }
   for (const workspacePackage of workspacePackages) {
     if (selectedDirectories.has(workspacePackage.directory)) {
-      selectName(workspacePackage.manifest);
+      selectPackage(workspacePackage);
     }
   }
 
   const consumersByDependency = new Map<string, DeclaredWorkspacePackage[]>();
   for (const workspacePackage of workspacePackages) {
-    for (const dependencyName of readDeclaredDependencyNames(
-      workspacePackage.manifest
+    for (const dependencyName of readWorkspaceDependencyNames(
+      workspacePackage.manifest,
+      workspacePackage.directory
     )) {
       const consumers = consumersByDependency.get(dependencyName) ?? [];
       consumers.push(workspacePackage);
@@ -169,12 +197,17 @@ function selectVueWorkspacePackages(
     }
   }
 
-  for (let index = 0; index < pendingNames.length; index += 1) {
-    for (const consumer of consumersByDependency.get(pendingNames[index]!) ??
-      []) {
+  for (let index = 0; index < pendingPackages.length; index += 1) {
+    const selectedPackage = pendingPackages[index]!;
+    const selectedName = readPackageName(selectedPackage.manifest);
+    if (!selectedName) continue;
+    for (const consumer of consumersByDependency.get(selectedName) ?? []) {
       if (selectedDirectories.has(consumer.directory)) continue;
+      if (!dependsOnCompatibleWorkspace(consumer, selectedPackage)) {
+        continue;
+      }
       selectedDirectories.add(consumer.directory);
-      selectName(consumer.manifest);
+      selectPackage(consumer);
     }
   }
 
@@ -184,19 +217,83 @@ function selectVueWorkspacePackages(
 }
 
 function consumesSelectedWorkspace(
-  manifest: JavaScriptPackageManifest,
+  consumer: DeclaredWorkspacePackage,
   selectedPackages: readonly DeclaredWorkspacePackage[]
 ): boolean {
-  const selectedNames = new Set(
-    selectedPackages
-      .map(({ manifest: selectedManifest }) =>
-        readPackageName(selectedManifest)
-      )
-      .filter((name): name is string => name !== undefined)
+  return selectedPackages.some((selectedPackage) =>
+    dependsOnCompatibleWorkspace(consumer, selectedPackage)
   );
-  return readDeclaredDependencyNames(manifest).some((name) =>
-    selectedNames.has(name)
+}
+
+/** Checks that a consumer's declared range can resolve to the local package. */
+function dependsOnCompatibleWorkspace(
+  consumer: DeclaredWorkspacePackage,
+  selected: DeclaredWorkspacePackage
+): boolean {
+  const packageName = readPackageName(selected.manifest);
+  if (!packageName) return false;
+  return readWorkspaceDependencySpecifiers(
+    consumer.manifest,
+    packageName,
+    consumer.directory
+  ).some((specifier) =>
+    workspaceSpecifierMatches(
+      specifier,
+      selected.manifest.version,
+      consumer.directory,
+      selected.directory
+    )
   );
+}
+
+function workspaceSpecifierMatches(
+  specifier: string,
+  workspaceVersion: string | undefined,
+  consumerDirectory: string,
+  selectedDirectory: string
+): boolean {
+  const normalized = specifier.trim();
+  if (!normalized) return false;
+  const localPath = normalized.match(/^(?:file|link|portal):(.+)$/)?.[1];
+  if (localPath) {
+    return pathsIdentifySameDirectory(
+      path.resolve(consumerDirectory, localPath),
+      selectedDirectory
+    );
+  }
+
+  const usesWorkspaceProtocol = normalized.startsWith('workspace:');
+  const workspaceRange = usesWorkspaceProtocol
+    ? normalized.slice('workspace:'.length)
+    : normalized;
+  if (usesWorkspaceProtocol && /^\.{1,2}(?:\/|$)/.test(workspaceRange)) {
+    return pathsIdentifySameDirectory(
+      path.resolve(consumerDirectory, workspaceRange),
+      selectedDirectory
+    );
+  }
+  if (
+    usesWorkspaceProtocol &&
+    (workspaceRange === '*' || workspaceRange === '^' || workspaceRange === '~')
+  ) {
+    return true;
+  }
+
+  const version = workspaceVersion ? validSemver(workspaceVersion) : null;
+  if (!version) return false;
+  try {
+    return satisfiesSemver(version, workspaceRange);
+  } catch {
+    return false;
+  }
+}
+
+function pathsIdentifySameDirectory(left: string, right: string): boolean {
+  try {
+    return fs.realpathSync(left) === fs.realpathSync(right);
+  } catch {
+    return path.resolve(left) === path.resolve(right);
+  }
 }
 
 function readPackageName(

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -217,6 +217,18 @@ function selectVueWorkspacePackages(
     selectPackage(workspacePackage, publiclyExposesGT(workspacePackage));
   }
 
+  // A pure non-Vue workspace has no ownership seed to propagate. Avoid
+  // walking every dependency edge after the manifest scan has already proved
+  // that no package directly owns gt-vue.
+  if (pendingPackages.length === 0) {
+    return {
+      packages: workspacePackages.filter(({ directory }) =>
+        selectedDirectories.has(directory)
+      ),
+      propagatingDirectories,
+    };
+  }
+
   const consumersByDependency = new Map<string, DeclaredWorkspacePackage[]>();
   for (const workspacePackage of workspacePackages) {
     for (const dependencyName of readWorkspaceDependencyNames(

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -1,7 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import fg from 'fast-glob';
-import { satisfies as satisfiesSemver, valid as validSemver } from 'semver';
 import {
   createWorkspaceDiscoveryCache,
   readDeclaredWorkspacePackages,
@@ -9,14 +8,23 @@ import {
   type WorkspaceDiscoveryCache,
 } from './workspaces.js';
 import {
+  dependencyBindingAcceptsPackageVersion,
   declaresAvailableJavaScriptDependency,
+  declaresPropagatingJavaScriptDependency,
   declaresWorkspaceJavaScriptDependency,
   GT_VUE_PACKAGE,
+  parseLocalDependencyPath,
+  parseNpmDependencyAlias,
+  parseWorkspaceDependencyAlias,
+  readPropagatingDependencyBindings,
+  readWorkspaceDependencyBindings,
   readWorkspaceDependencyNames,
-  readWorkspaceDependencySpecifiers,
   readJavaScriptPackageManifest,
+  resolveInstalledJavaScriptPackage,
+  type JavaScriptDependencyBinding,
   type JavaScriptPackageManifest,
 } from './manifest.js';
+import { localDependencyGraphDeclaresVue } from './detectVueProject.js';
 
 /** Default Vue source patterns, including conventional Vue and Nuxt folders. */
 export const DEFAULT_VUE_SOURCE_PATTERNS = [
@@ -47,9 +55,9 @@ export type VueProjectDiscovery = {
  * Discovers only packages that own gt-vue or consume a selected local wrapper.
  *
  * An aggregator root is not scanned merely because one child uses Vue. It is
- * included only when it directly declares gt-vue or depends on a selected
- * workspace wrapper. This is the boundary that prevents Vue support from
- * broadening existing React source discovery.
+ * included only when it directly declares gt-vue or depends on a proven local
+ * wrapper. This is the boundary that prevents Vue support from broadening
+ * existing React source discovery.
  */
 export function discoverVueProject(
   cwd: string,
@@ -68,23 +76,32 @@ export function discoverVueProject(
     rootManifest,
     cache
   );
-  const selectedWorkspacePackages = selectVueWorkspacePackages(
+  const workspaceSelection = selectVueWorkspacePackages(
     workspacePackages,
     rootManifest,
     projectRoot
   );
-  const rootOwnsVue = declaresAvailableJavaScriptDependency(
+  const selectedWorkspacePackages = workspaceSelection.packages;
+  const rootDeclaresVue = declaresAvailableJavaScriptDependency(
     rootManifest,
     GT_VUE_PACKAGE,
     projectRoot
   );
   const rootConsumesVueWrapper = consumesSelectedWorkspace(
     { directory: projectRoot, manifest: rootManifest },
-    selectedWorkspacePackages
+    selectedWorkspacePackages.filter(({ directory }) =>
+      workspaceSelection.propagatingDirectories.has(directory)
+    )
+  );
+  const rootConsumesLocalVueWrapper = localDependencyGraphDeclaresVue(
+    rootManifest,
+    projectRoot
   );
   const scopes: VueSourceScope[] = [];
 
-  if (rootOwnsVue || rootConsumesVueWrapper) {
+  const rootOwnsVue =
+    rootDeclaresVue || rootConsumesVueWrapper || rootConsumesLocalVueWrapper;
+  if (rootOwnsVue) {
     scopes.push({
       directory: projectRoot,
       includeByDefault: true,
@@ -150,24 +167,24 @@ function selectVueWorkspacePackages(
   workspacePackages: readonly DeclaredWorkspacePackage[],
   rootManifest: JavaScriptPackageManifest,
   projectRoot: string
-): DeclaredWorkspacePackage[] {
-  const selectedDirectories = new Set(
-    workspacePackages
-      .filter(({ directory, manifest }) =>
-        declaresWorkspaceJavaScriptDependency(
-          manifest,
-          GT_VUE_PACKAGE,
-          directory
-        )
-      )
-      .map(({ directory }) => directory)
-  );
-  const selectedNames = new Set<string>();
+): {
+  packages: DeclaredWorkspacePackage[];
+  propagatingDirectories: Set<string>;
+} {
+  const selectedDirectories = new Set<string>();
+  const propagatingDirectories = new Set<string>();
+  const queuedPropagators = new Set<string>();
   const pendingPackages: DeclaredWorkspacePackage[] = [];
-  const selectPackage = (selectedPackage: DeclaredWorkspacePackage) => {
-    const packageName = readPackageName(selectedPackage.manifest);
-    if (!packageName || selectedNames.has(packageName)) return;
-    selectedNames.add(packageName);
+  const selectPackage = (
+    selectedPackage: DeclaredWorkspacePackage,
+    propagates: boolean
+  ) => {
+    selectedDirectories.add(selectedPackage.directory);
+    if (!propagates || queuedPropagators.has(selectedPackage.directory)) {
+      return;
+    }
+    propagatingDirectories.add(selectedPackage.directory);
+    queuedPropagators.add(selectedPackage.directory);
     pendingPackages.push(selectedPackage);
   };
   if (
@@ -177,12 +194,33 @@ function selectVueWorkspacePackages(
       projectRoot
     )
   ) {
-    selectPackage({ directory: projectRoot, manifest: rootManifest });
+    selectPackage(
+      { directory: projectRoot, manifest: rootManifest },
+      declaresPropagatingJavaScriptDependency(
+        rootManifest,
+        GT_VUE_PACKAGE,
+        projectRoot
+      )
+    );
   }
   for (const workspacePackage of workspacePackages) {
-    if (selectedDirectories.has(workspacePackage.directory)) {
-      selectPackage(workspacePackage);
+    if (
+      !declaresWorkspaceJavaScriptDependency(
+        workspacePackage.manifest,
+        GT_VUE_PACKAGE,
+        workspacePackage.directory
+      )
+    ) {
+      continue;
     }
+    selectPackage(
+      workspacePackage,
+      declaresPropagatingJavaScriptDependency(
+        workspacePackage.manifest,
+        GT_VUE_PACKAGE,
+        workspacePackage.directory
+      )
+    );
   }
 
   const consumersByDependency = new Map<string, DeclaredWorkspacePackage[]>();
@@ -202,18 +240,23 @@ function selectVueWorkspacePackages(
     const selectedName = readPackageName(selectedPackage.manifest);
     if (!selectedName) continue;
     for (const consumer of consumersByDependency.get(selectedName) ?? []) {
-      if (selectedDirectories.has(consumer.directory)) continue;
+      if (propagatingDirectories.has(consumer.directory)) continue;
       if (!dependsOnCompatibleWorkspace(consumer, selectedPackage)) {
         continue;
       }
-      selectedDirectories.add(consumer.directory);
-      selectPackage(consumer);
+      selectPackage(
+        consumer,
+        dependsOnCompatibleWorkspace(consumer, selectedPackage, true)
+      );
     }
   }
 
-  return workspacePackages.filter(({ directory }) =>
-    selectedDirectories.has(directory)
-  );
+  return {
+    packages: workspacePackages.filter(({ directory }) =>
+      selectedDirectories.has(directory)
+    ),
+    propagatingDirectories,
+  };
 }
 
 function consumesSelectedWorkspace(
@@ -228,64 +271,78 @@ function consumesSelectedWorkspace(
 /** Checks that a consumer's declared range can resolve to the local package. */
 function dependsOnCompatibleWorkspace(
   consumer: DeclaredWorkspacePackage,
-  selected: DeclaredWorkspacePackage
+  selected: DeclaredWorkspacePackage,
+  propagatingOnly = false
 ): boolean {
   const packageName = readPackageName(selected.manifest);
   if (!packageName) return false;
-  return readWorkspaceDependencySpecifiers(
-    consumer.manifest,
-    packageName,
-    consumer.directory
-  ).some((specifier) =>
-    workspaceSpecifierMatches(
-      specifier,
-      selected.manifest.version,
-      consumer.directory,
-      selected.directory
+  const bindings = propagatingOnly
+    ? readPropagatingDependencyBindings(consumer.manifest, consumer.directory)
+    : readWorkspaceDependencyBindings(consumer.manifest, consumer.directory);
+  return bindings.some((binding) =>
+    dependencyBindingMatchesWorkspace(
+      binding,
+      packageName,
+      selected,
+      consumer.directory
     )
   );
 }
 
-function workspaceSpecifierMatches(
-  specifier: string,
-  workspaceVersion: string | undefined,
-  consumerDirectory: string,
-  selectedDirectory: string
+function dependencyBindingMatchesWorkspace(
+  binding: JavaScriptDependencyBinding,
+  workspaceName: string,
+  selected: DeclaredWorkspacePackage,
+  consumerDirectory: string
 ): boolean {
-  const normalized = specifier.trim();
-  if (!normalized) return false;
-  const localPath = normalized.match(/^(?:file|link|portal):(.+)$/)?.[1];
+  const workspaceAlias = parseWorkspaceDependencyAlias(binding.specifier);
+  const npmAlias = parseNpmDependencyAlias(binding.specifier);
+  const catalogPackage = binding.specifier.startsWith('catalog:')
+    ? resolveInstalledJavaScriptPackage(consumerDirectory, binding.name)
+    : undefined;
+  const namesWorkspace = binding.name === workspaceName;
+  const aliasesWorkspace =
+    workspaceAlias?.packageName === workspaceName ||
+    npmAlias?.packageName === workspaceName ||
+    catalogPackage?.manifest.name === workspaceName;
+  const localPath = parseLocalDependencyPath(binding.specifier);
+
   if (localPath) {
     return pathsIdentifySameDirectory(
       path.resolve(consumerDirectory, localPath),
-      selectedDirectory
+      selected.directory
     );
+  }
+  if (!namesWorkspace && !aliasesWorkspace) return false;
+  if (
+    !dependencyBindingAcceptsPackageVersion(
+      binding,
+      workspaceName,
+      selected.manifest.version
+    )
+  ) {
+    return false;
   }
 
-  const usesWorkspaceProtocol = normalized.startsWith('workspace:');
-  const workspaceRange = usesWorkspaceProtocol
-    ? normalized.slice('workspace:'.length)
-    : normalized;
-  if (usesWorkspaceProtocol && /^\.{1,2}(?:\/|$)/.test(workspaceRange)) {
-    return pathsIdentifySameDirectory(
-      path.resolve(consumerDirectory, workspaceRange),
-      selectedDirectory
-    );
-  }
+  const installed =
+    catalogPackage ??
+    resolveInstalledJavaScriptPackage(consumerDirectory, binding.name);
   if (
-    usesWorkspaceProtocol &&
-    (workspaceRange === '*' || workspaceRange === '^' || workspaceRange === '~')
+    installed &&
+    pathsIdentifySameDirectory(installed.directory, selected.directory)
   ) {
     return true;
   }
 
-  const version = workspaceVersion ? validSemver(workspaceVersion) : null;
-  if (!version) return false;
-  try {
-    return satisfiesSemver(version, workspaceRange);
-  } catch {
-    return false;
+  if (workspaceAlias?.packageName === workspaceName) {
+    return true;
   }
+  if (namesWorkspace && binding.specifier.startsWith('workspace:')) {
+    return true;
+  }
+  // Bare semver, catalogs, and npm aliases may resolve to a registry package.
+  // They select a local wrapper only when the installed binding proves it.
+  return false;
 }
 
 function pathsIdentifySameDirectory(left: string, right: string): boolean {

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -10,7 +10,6 @@ import {
 import {
   dependencyBindingAcceptsPackageVersion,
   declaresAvailableJavaScriptDependency,
-  declaresPropagatingJavaScriptDependency,
   declaresWorkspaceJavaScriptDependency,
   GT_VUE_PACKAGE,
   parseLocalDependencyPath,
@@ -25,6 +24,7 @@ import {
   type JavaScriptPackageManifest,
 } from './manifest.js';
 import { localDependencyGraphDeclaresVue } from './detectVueProject.js';
+import { packagePubliclyExposesGT } from './wrapperProvenance.js';
 
 /** Default Vue source patterns, including conventional Vue and Nuxt folders. */
 export const DEFAULT_VUE_SOURCE_PATTERNS = [
@@ -175,6 +175,17 @@ function selectVueWorkspacePackages(
   const propagatingDirectories = new Set<string>();
   const queuedPropagators = new Set<string>();
   const pendingPackages: DeclaredWorkspacePackage[] = [];
+  const publicGTByDirectory = new Map<string, boolean>();
+  const publiclyExposesGT = ({
+    directory,
+    manifest,
+  }: DeclaredWorkspacePackage): boolean => {
+    const cached = publicGTByDirectory.get(directory);
+    if (cached !== undefined) return cached;
+    const exposesGT = packagePubliclyExposesGT(directory, manifest);
+    publicGTByDirectory.set(directory, exposesGT);
+    return exposesGT;
+  };
   const selectPackage = (
     selectedPackage: DeclaredWorkspacePackage,
     propagates: boolean
@@ -196,11 +207,7 @@ function selectVueWorkspacePackages(
   ) {
     selectPackage(
       { directory: projectRoot, manifest: rootManifest },
-      declaresPropagatingJavaScriptDependency(
-        rootManifest,
-        GT_VUE_PACKAGE,
-        projectRoot
-      )
+      publiclyExposesGT({ directory: projectRoot, manifest: rootManifest })
     );
   }
   for (const workspacePackage of workspacePackages) {
@@ -213,14 +220,7 @@ function selectVueWorkspacePackages(
     ) {
       continue;
     }
-    selectPackage(
-      workspacePackage,
-      declaresPropagatingJavaScriptDependency(
-        workspacePackage.manifest,
-        GT_VUE_PACKAGE,
-        workspacePackage.directory
-      )
-    );
+    selectPackage(workspacePackage, publiclyExposesGT(workspacePackage));
   }
 
   const consumersByDependency = new Map<string, DeclaredWorkspacePackage[]>();
@@ -246,7 +246,8 @@ function selectVueWorkspacePackages(
       }
       selectPackage(
         consumer,
-        dependsOnCompatibleWorkspace(consumer, selectedPackage, true)
+        dependsOnCompatibleWorkspace(consumer, selectedPackage, true) &&
+          publiclyExposesGT(consumer)
       );
     }
   }

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -1,0 +1,222 @@
+import path from 'node:path';
+import fg from 'fast-glob';
+import {
+  createWorkspaceDiscoveryCache,
+  declaresJavaScriptDependency,
+  readDeclaredDependencyNames,
+  readDeclaredWorkspacePackages,
+  readJavaScriptPackageManifest,
+  type DeclaredWorkspacePackage,
+  type JavaScriptPackageManifest,
+  type WorkspaceDiscoveryCache,
+} from './workspaces.js';
+
+/** Runtime package whose ownership selects Vue extraction scopes. */
+export const GT_VUE_PACKAGE = 'gt-vue';
+
+/** Default Vue source patterns, including conventional Vue and Nuxt folders. */
+export const DEFAULT_VUE_SOURCE_PATTERNS = [
+  '*.vue',
+  'src/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'app/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'pages/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'components/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  '{composables,layers,layouts,middleware,modules,plugins,server,shared,stores,utils,views}/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+] as const;
+
+/** One package boundary whose sources share Vue build configuration. */
+export type VueSourceScope = {
+  directory: string;
+  includeByDefault: boolean;
+  relativeDirectory: string;
+};
+
+/** Project discovery result reused by detection and extraction. */
+export type VueProjectDiscovery = {
+  projectRoot: string;
+  rootManifest?: JavaScriptPackageManifest;
+  scopes: VueSourceScope[];
+};
+
+/**
+ * Discovers only packages that own gt-vue or consume a selected local wrapper.
+ *
+ * An aggregator root is not scanned merely because one child uses Vue. It is
+ * included only when it directly declares gt-vue or depends on a selected
+ * workspace wrapper. This is the boundary that prevents Vue support from
+ * broadening existing React source discovery.
+ */
+export function discoverVueProject(
+  cwd: string,
+  cache: WorkspaceDiscoveryCache = createWorkspaceDiscoveryCache()
+): VueProjectDiscovery {
+  const projectRoot = path.resolve(cwd);
+  const rootManifest = readJavaScriptPackageManifest(
+    path.join(projectRoot, 'package.json')
+  );
+  if (!rootManifest) {
+    return { projectRoot, scopes: [] };
+  }
+
+  const workspacePackages = readDeclaredWorkspacePackages(
+    projectRoot,
+    rootManifest,
+    cache
+  );
+  const selectedWorkspacePackages = selectVueWorkspacePackages(
+    workspacePackages,
+    rootManifest
+  );
+  const rootOwnsVue = declaresJavaScriptDependency(
+    rootManifest,
+    GT_VUE_PACKAGE
+  );
+  const rootConsumesVueWrapper = consumesSelectedWorkspace(
+    rootManifest,
+    selectedWorkspacePackages
+  );
+  const scopes: VueSourceScope[] = [];
+
+  if (rootOwnsVue || rootConsumesVueWrapper) {
+    scopes.push({
+      directory: projectRoot,
+      includeByDefault: true,
+      relativeDirectory: '',
+    });
+  }
+  for (const { directory } of selectedWorkspacePackages) {
+    const relativeDirectory = toPosixPath(
+      path.relative(projectRoot, directory)
+    );
+    if (
+      !relativeDirectory ||
+      relativeDirectory === '..' ||
+      relativeDirectory.startsWith('../')
+    ) {
+      continue;
+    }
+    scopes.push({
+      directory,
+      includeByDefault: true,
+      relativeDirectory,
+    });
+  }
+
+  return { projectRoot, rootManifest, scopes };
+}
+
+/** Returns safe project-root-relative default globs for selected Vue scopes. */
+export function readDefaultVueSourcePatterns(
+  scopes: readonly VueSourceScope[]
+): string[] {
+  const patterns = scopes.flatMap(({ includeByDefault, relativeDirectory }) => {
+    if (!includeByDefault) return [];
+    if (!relativeDirectory) return [...DEFAULT_VUE_SOURCE_PATTERNS];
+    const literalDirectory = fg.escapePath(relativeDirectory);
+    return DEFAULT_VUE_SOURCE_PATTERNS.map(
+      (pattern) => `${literalDirectory}/${pattern}`
+    );
+  });
+  return [...new Set(patterns)];
+}
+
+/** Selects the deepest declared Vue package containing a source file. */
+export function findVueSourceScope(
+  file: string,
+  scopes: readonly VueSourceScope[]
+): VueSourceScope | undefined {
+  return [...scopes]
+    .sort((left, right) => right.directory.length - left.directory.length)
+    .find(({ directory }) => isWithin(directory, file));
+}
+
+function selectVueWorkspacePackages(
+  workspacePackages: readonly DeclaredWorkspacePackage[],
+  rootManifest: JavaScriptPackageManifest
+): DeclaredWorkspacePackage[] {
+  const selectedDirectories = new Set(
+    workspacePackages
+      .filter(({ manifest }) =>
+        declaresJavaScriptDependency(manifest, GT_VUE_PACKAGE)
+      )
+      .map(({ directory }) => directory)
+  );
+  const selectedNames = new Set<string>();
+  const pendingNames: string[] = [];
+  const selectName = (manifest: JavaScriptPackageManifest) => {
+    const packageName = readPackageName(manifest);
+    if (!packageName || selectedNames.has(packageName)) return;
+    selectedNames.add(packageName);
+    pendingNames.push(packageName);
+  };
+  if (declaresJavaScriptDependency(rootManifest, GT_VUE_PACKAGE)) {
+    selectName(rootManifest);
+  }
+  for (const workspacePackage of workspacePackages) {
+    if (selectedDirectories.has(workspacePackage.directory)) {
+      selectName(workspacePackage.manifest);
+    }
+  }
+
+  const consumersByDependency = new Map<string, DeclaredWorkspacePackage[]>();
+  for (const workspacePackage of workspacePackages) {
+    for (const dependencyName of readDeclaredDependencyNames(
+      workspacePackage.manifest
+    )) {
+      const consumers = consumersByDependency.get(dependencyName) ?? [];
+      consumers.push(workspacePackage);
+      consumersByDependency.set(dependencyName, consumers);
+    }
+  }
+
+  for (let index = 0; index < pendingNames.length; index += 1) {
+    for (const consumer of consumersByDependency.get(pendingNames[index]!) ??
+      []) {
+      if (selectedDirectories.has(consumer.directory)) continue;
+      selectedDirectories.add(consumer.directory);
+      selectName(consumer.manifest);
+    }
+  }
+
+  return workspacePackages.filter(({ directory }) =>
+    selectedDirectories.has(directory)
+  );
+}
+
+function consumesSelectedWorkspace(
+  manifest: JavaScriptPackageManifest,
+  selectedPackages: readonly DeclaredWorkspacePackage[]
+): boolean {
+  const selectedNames = new Set(
+    selectedPackages
+      .map(({ manifest: selectedManifest }) =>
+        readPackageName(selectedManifest)
+      )
+      .filter((name): name is string => name !== undefined)
+  );
+  return readDeclaredDependencyNames(manifest).some((name) =>
+    selectedNames.has(name)
+  );
+}
+
+function readPackageName(
+  manifest: JavaScriptPackageManifest
+): string | undefined {
+  return typeof manifest.name === 'string' && manifest.name
+    ? manifest.name
+    : undefined;
+}
+
+function isWithin(directory: string, file: string): boolean {
+  const relative = path.relative(path.resolve(directory), path.resolve(file));
+  return (
+    relative !== '' &&
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -24,17 +24,11 @@ import {
   type JavaScriptPackageManifest,
 } from './manifest.js';
 import { localDependencyGraphDeclaresVue } from './detectVueProject.js';
+import { packageConsumesPublicGT } from './consumerUsage.js';
+import { DEFAULT_VUE_SOURCE_PATTERNS } from './sourcePatterns.js';
 import { packagePubliclyExposesGT } from './wrapperProvenance.js';
 
-/** Default Vue source patterns, including conventional Vue and Nuxt folders. */
-export const DEFAULT_VUE_SOURCE_PATTERNS = [
-  '*.vue',
-  'src/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
-  'app/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
-  'pages/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
-  'components/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
-  '{composables,layers,layouts,middleware,modules,plugins,server,shared,stores,utils,views}/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
-] as const;
+export { DEFAULT_VUE_SOURCE_PATTERNS } from './sourcePatterns.js';
 
 /** One package boundary whose sources share Vue build configuration. */
 export type VueSourceScope = {
@@ -241,12 +235,12 @@ function selectVueWorkspacePackages(
     if (!selectedName) continue;
     for (const consumer of consumersByDependency.get(selectedName) ?? []) {
       if (propagatingDirectories.has(consumer.directory)) continue;
-      if (!dependsOnCompatibleWorkspace(consumer, selectedPackage)) {
+      if (!consumesCompatibleWorkspace(consumer, selectedPackage)) {
         continue;
       }
       selectPackage(
         consumer,
-        dependsOnCompatibleWorkspace(consumer, selectedPackage, true) &&
+        consumesCompatibleWorkspace(consumer, selectedPackage, true) &&
           publiclyExposesGT(consumer)
       );
     }
@@ -265,12 +259,12 @@ function consumesSelectedWorkspace(
   selectedPackages: readonly DeclaredWorkspacePackage[]
 ): boolean {
   return selectedPackages.some((selectedPackage) =>
-    dependsOnCompatibleWorkspace(consumer, selectedPackage)
+    consumesCompatibleWorkspace(consumer, selectedPackage)
   );
 }
 
-/** Checks that a consumer's declared range can resolve to the local package. */
-function dependsOnCompatibleWorkspace(
+/** Checks that a compatible dependency edge is used by consumer source. */
+function consumesCompatibleWorkspace(
   consumer: DeclaredWorkspacePackage,
   selected: DeclaredWorkspacePackage,
   propagatingOnly = false
@@ -280,13 +274,20 @@ function dependsOnCompatibleWorkspace(
   const bindings = propagatingOnly
     ? readPropagatingDependencyBindings(consumer.manifest, consumer.directory)
     : readWorkspaceDependencyBindings(consumer.manifest, consumer.directory);
-  return bindings.some((binding) =>
-    dependencyBindingMatchesWorkspace(
-      binding,
-      packageName,
-      selected,
-      consumer.directory
-    )
+  return bindings.some(
+    (binding) =>
+      dependencyBindingMatchesWorkspace(
+        binding,
+        packageName,
+        selected,
+        consumer.directory
+      ) &&
+      packageConsumesPublicGT(
+        consumer.directory,
+        binding.name,
+        selected.directory,
+        selected.manifest
+      )
   );
 }
 

--- a/packages/vue-extractor/src/internal/project/scopes.ts
+++ b/packages/vue-extractor/src/internal/project/scopes.ts
@@ -24,9 +24,13 @@ import {
   type JavaScriptPackageManifest,
 } from './manifest.js';
 import { localDependencyGraphDeclaresVue } from './detectVueProject.js';
-import { packageConsumesPublicGT } from './consumerUsage.js';
+import {
+  createConsumerUsageCache,
+  packageConsumesPublicGT,
+  packageExposesPublicGT,
+  type ConsumerUsageCache,
+} from './consumerUsage.js';
 import { DEFAULT_VUE_SOURCE_PATTERNS } from './sourcePatterns.js';
-import { packagePubliclyExposesGT } from './wrapperProvenance.js';
 
 export { DEFAULT_VUE_SOURCE_PATTERNS } from './sourcePatterns.js';
 
@@ -70,10 +74,12 @@ export function discoverVueProject(
     rootManifest,
     cache
   );
+  const consumerUsageCache = createConsumerUsageCache();
   const workspaceSelection = selectVueWorkspacePackages(
     workspacePackages,
     rootManifest,
-    projectRoot
+    projectRoot,
+    consumerUsageCache
   );
   const selectedWorkspacePackages = workspaceSelection.packages;
   const rootDeclaresVue = declaresAvailableJavaScriptDependency(
@@ -85,11 +91,13 @@ export function discoverVueProject(
     { directory: projectRoot, manifest: rootManifest },
     selectedWorkspacePackages.filter(({ directory }) =>
       workspaceSelection.propagatingDirectories.has(directory)
-    )
+    ),
+    consumerUsageCache
   );
   const rootConsumesLocalVueWrapper = localDependencyGraphDeclaresVue(
     rootManifest,
-    projectRoot
+    projectRoot,
+    consumerUsageCache
   );
   const scopes: VueSourceScope[] = [];
 
@@ -160,7 +168,8 @@ export function findVueSourceScope(
 function selectVueWorkspacePackages(
   workspacePackages: readonly DeclaredWorkspacePackage[],
   rootManifest: JavaScriptPackageManifest,
-  projectRoot: string
+  projectRoot: string,
+  consumerUsageCache: ConsumerUsageCache
 ): {
   packages: DeclaredWorkspacePackage[];
   propagatingDirectories: Set<string>;
@@ -176,7 +185,11 @@ function selectVueWorkspacePackages(
   }: DeclaredWorkspacePackage): boolean => {
     const cached = publicGTByDirectory.get(directory);
     if (cached !== undefined) return cached;
-    const exposesGT = packagePubliclyExposesGT(directory, manifest);
+    const exposesGT = packageExposesPublicGT(
+      directory,
+      manifest,
+      consumerUsageCache
+    );
     publicGTByDirectory.set(directory, exposesGT);
     return exposesGT;
   };
@@ -247,13 +260,24 @@ function selectVueWorkspacePackages(
     if (!selectedName) continue;
     for (const consumer of consumersByDependency.get(selectedName) ?? []) {
       if (propagatingDirectories.has(consumer.directory)) continue;
-      if (!consumesCompatibleWorkspace(consumer, selectedPackage)) {
+      if (
+        !consumesCompatibleWorkspace(
+          consumer,
+          selectedPackage,
+          false,
+          consumerUsageCache
+        )
+      ) {
         continue;
       }
       selectPackage(
         consumer,
-        consumesCompatibleWorkspace(consumer, selectedPackage, true) &&
-          publiclyExposesGT(consumer)
+        consumesCompatibleWorkspace(
+          consumer,
+          selectedPackage,
+          true,
+          consumerUsageCache
+        ) && publiclyExposesGT(consumer)
       );
     }
   }
@@ -268,10 +292,16 @@ function selectVueWorkspacePackages(
 
 function consumesSelectedWorkspace(
   consumer: DeclaredWorkspacePackage,
-  selectedPackages: readonly DeclaredWorkspacePackage[]
+  selectedPackages: readonly DeclaredWorkspacePackage[],
+  consumerUsageCache: ConsumerUsageCache
 ): boolean {
   return selectedPackages.some((selectedPackage) =>
-    consumesCompatibleWorkspace(consumer, selectedPackage)
+    consumesCompatibleWorkspace(
+      consumer,
+      selectedPackage,
+      false,
+      consumerUsageCache
+    )
   );
 }
 
@@ -279,7 +309,8 @@ function consumesSelectedWorkspace(
 function consumesCompatibleWorkspace(
   consumer: DeclaredWorkspacePackage,
   selected: DeclaredWorkspacePackage,
-  propagatingOnly = false
+  propagatingOnly: boolean,
+  consumerUsageCache: ConsumerUsageCache
 ): boolean {
   const packageName = readPackageName(selected.manifest);
   if (!packageName) return false;
@@ -298,7 +329,8 @@ function consumesCompatibleWorkspace(
         consumer.directory,
         binding.name,
         selected.directory,
-        selected.manifest
+        selected.manifest,
+        consumerUsageCache
       )
   );
 }

--- a/packages/vue-extractor/src/internal/project/sourcePatterns.ts
+++ b/packages/vue-extractor/src/internal/project/sourcePatterns.ts
@@ -1,0 +1,28 @@
+/** Conventional source directories searched by default for Vue applications. */
+export const DEFAULT_VUE_SOURCE_DIRECTORIES = [
+  'src',
+  'app',
+  'pages',
+  'components',
+  'composables',
+  'layers',
+  'layouts',
+  'middleware',
+  'modules',
+  'plugins',
+  'server',
+  'shared',
+  'stores',
+  'utils',
+  'views',
+] as const;
+
+/** Default Vue source patterns, including conventional Vue and Nuxt folders. */
+export const DEFAULT_VUE_SOURCE_PATTERNS = [
+  '*.vue',
+  'src/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'app/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'pages/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  'components/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+  '{composables,layers,layouts,middleware,modules,plugins,server,shared,stores,utils,views}/**/*.{vue,js,jsx,mjs,cjs,ts,tsx,mts,cts}',
+] as const;

--- a/packages/vue-extractor/src/internal/project/viteAliases.ts
+++ b/packages/vue-extractor/src/internal/project/viteAliases.ts
@@ -1,0 +1,1903 @@
+import fs from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { parse, type ParserPlugin } from '@babel/parser';
+import traverseModule, {
+  type Binding,
+  type NodePath,
+  type Scope,
+} from '@babel/traverse';
+import type * as t from '@babel/types';
+import {
+  NUXT_CONFIG_FILES,
+  VITE_CONFIG_EXTENSIONS,
+  VITE_CONFIG_FILES,
+} from '../config/configFiles.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+type StaticEntry = {
+  node: t.Node;
+  scope: Scope;
+};
+
+type StaticObject = Map<string, StaticEntry>;
+
+type ConfigKind = 'vite' | 'nuxt';
+
+type ConfigSource = {
+  file: string;
+  kind: ConfigKind;
+};
+
+type ConfigDiscovery = {
+  complete: boolean;
+  source?: ConfigSource;
+};
+
+type StaticAliases = {
+  entries: Array<readonly [find: string, replacement: string]>;
+  form: 'array' | 'object';
+};
+
+type AliasResolution =
+  | { ok: true; aliases: StaticAliases }
+  | {
+      ok: false;
+      potentialAliasKeys: Set<string>;
+      potentialAliases: Map<string, Set<string>>;
+    };
+
+type BindingSafety = 'alias' | 'config' | 'none';
+
+type HelperBindings = {
+  configFunctions: Set<Binding>;
+  configNamespaces: Set<Binding>;
+  fileURLToPathFunctions: Set<Binding>;
+  pathNamespaces: Set<Binding>;
+  pathResolveFunctions: Set<Binding>;
+  urlConstructors: Set<Binding>;
+  urlNamespaces: Set<Binding>;
+};
+
+type EvaluationContext = {
+  configFile: string;
+  helpers: HelperBindings;
+  nuxtMajorVersion?: number;
+  packageRoot: string;
+  scopes: WeakMap<t.Node, Scope>;
+};
+
+/** Controls static Vite alias discovery for a Vue package. */
+export type VueProjectAliasResolverOptions = {
+  /** A single Vite config path, resolved within the Vue package directory. */
+  viteConfigPath?: string;
+  /** Nuxt major selected by the package, when already known by the caller. */
+  nuxtMajorVersion?: number;
+};
+
+/** Result of proving the active framework alias surface statically. */
+export type VueProjectAliasConfiguration = {
+  /** Ordered string aliases, present only when analysis is complete. */
+  aliases: Map<string, string>;
+  /** Whether every active alias behavior was proven without execution. */
+  complete: boolean;
+  /**
+   * Statically observed key-to-replacement candidates whose precedence remains
+   * uncertain. These mappings are diagnostic evidence only; callers must not
+   * use them to resolve imports or extract translations.
+   */
+  potentialAliases?: Map<string, Set<string>>;
+  /**
+   * Statically observed alias keys whose final behavior remains uncertain.
+   * These keys are diagnostic evidence only and must never be resolved as
+   * trusted aliases while `complete` is false.
+   */
+  potentialAliasKeys?: Set<string>;
+};
+
+/**
+ * Reads string aliases from statically analyzable Vite and Nuxt config.
+ *
+ * Config files are parsed as source and are never imported or executed.
+ * Dynamic aliases, regular-expression find values, and unsupported syntax are
+ * ignored so alias discovery cannot make otherwise valid extraction fatal.
+ */
+export function resolveVueProjectAliases(
+  cwd: string,
+  options: VueProjectAliasResolverOptions = {}
+): Map<string, string> {
+  return resolveVueProjectAliasConfiguration(cwd, options).aliases;
+}
+
+/**
+ * Resolves aliases and reports whether the active alias surface was proven.
+ *
+ * Incomplete analysis never returns partial aliases. This lets project-level
+ * integrations distinguish a project with no configured aliases from one
+ * whose dynamic resolver behavior must block safe static extraction.
+ */
+export function resolveVueProjectAliasConfiguration(
+  cwd: string,
+  options: VueProjectAliasResolverOptions = {}
+): VueProjectAliasConfiguration {
+  const packageRoot = path.resolve(cwd);
+  const hasExplicitConfig = options.viteConfigPath !== undefined;
+  const explicitConfig =
+    options.viteConfigPath !== undefined
+      ? resolveExplicitConfig(packageRoot, options.viteConfigPath)
+      : undefined;
+  const discovery: ConfigDiscovery = hasExplicitConfig
+    ? explicitConfig
+      ? { complete: true, source: { file: explicitConfig, kind: 'vite' } }
+      : { complete: false }
+    : discoverConfigSource(packageRoot);
+  if (!discovery.complete) return incompleteAliasConfiguration();
+  if (!discovery.source) return completeAliasConfiguration();
+  return readConfigAliases(
+    discovery.source,
+    packageRoot,
+    options.nuxtMajorVersion
+  );
+}
+
+function discoverConfigSource(cwd: string): ConfigDiscovery {
+  const viteConfig = findFirstConfig(cwd, VITE_CONFIG_FILES);
+  const nuxtConfig = findFirstConfig(cwd, NUXT_CONFIG_FILES);
+  // Match compiler-option discovery: two active framework configs are
+  // ambiguous, so no alias result is safer than resolving with the wrong one.
+  if (!viteConfig.complete || !nuxtConfig.complete) return { complete: false };
+  if (viteConfig.file && nuxtConfig.file) return { complete: false };
+  if (nuxtConfig.file) {
+    return {
+      complete: true,
+      source: { file: nuxtConfig.file, kind: 'nuxt' },
+    };
+  }
+  if (viteConfig.file) {
+    return {
+      complete: true,
+      source: { file: viteConfig.file, kind: 'vite' },
+    };
+  }
+  return { complete: true };
+}
+
+function findFirstConfig(
+  cwd: string,
+  filenames: readonly string[]
+): { complete: boolean; file?: string } {
+  for (const filename of filenames) {
+    const candidate = path.join(cwd, filename);
+    try {
+      return fs.statSync(candidate).isFile()
+        ? { complete: true, file: candidate }
+        : { complete: false };
+    } catch (error) {
+      if (isMissingPathError(error)) continue;
+      return { complete: false };
+    }
+  }
+  return { complete: true };
+}
+
+function resolveExplicitConfig(
+  cwd: string,
+  configuredPath: string
+): string | undefined {
+  if (!configuredPath.trim()) return undefined;
+  const candidate = path.resolve(cwd, configuredPath);
+  if (!isInsideDirectory(cwd, candidate)) return undefined;
+  if (!VITE_CONFIG_EXTENSIONS.has(path.extname(candidate).toLowerCase())) {
+    return undefined;
+  }
+  try {
+    if (!fs.statSync(candidate).isFile()) return undefined;
+    const realRoot = fs.realpathSync(cwd);
+    const realCandidate = fs.realpathSync(candidate);
+    if (!isInsideDirectory(realRoot, realCandidate)) return undefined;
+    if (
+      path
+        .relative(realRoot, realCandidate)
+        .split(path.sep)
+        .includes('node_modules')
+    ) {
+      return undefined;
+    }
+    return candidate;
+  } catch {
+    return undefined;
+  }
+}
+
+function isInsideDirectory(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return Boolean(
+    error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    (error.code === 'ENOENT' || error.code === 'ENOTDIR')
+  );
+}
+
+function completeAliasConfiguration(
+  aliases: Map<string, string> = new Map()
+): VueProjectAliasConfiguration {
+  return { aliases, complete: true };
+}
+
+function incompleteAliasConfiguration(
+  potentialAliasKeys: Iterable<string> = [],
+  potentialAliases: ReadonlyMap<string, ReadonlySet<string>> = new Map()
+): VueProjectAliasConfiguration {
+  const keys = new Set(potentialAliasKeys);
+  const aliases = clonePotentialAliases(potentialAliases);
+  for (const key of aliases.keys()) keys.add(key);
+  return {
+    aliases: new Map(),
+    complete: false,
+    ...(aliases.size > 0 && { potentialAliases: aliases }),
+    ...(keys.size > 0 && { potentialAliasKeys: keys }),
+  };
+}
+
+function collectAliasResolutionKeys(
+  ...sources: Array<StaticAliases | AliasResolution | undefined>
+): Set<string> {
+  const keys = new Set<string>();
+  for (const source of sources) {
+    if (!source) continue;
+    if ('ok' in source) {
+      addAll(
+        keys,
+        source.ok
+          ? source.aliases.entries.map(([find]) => find)
+          : source.potentialAliasKeys
+      );
+      continue;
+    }
+    for (const [find] of source.entries) keys.add(find);
+  }
+  return keys;
+}
+
+function collectAliasResolutionCandidates(
+  ...sources: Array<StaticAliases | AliasResolution | undefined>
+): Map<string, Set<string>> {
+  const aliases = new Map<string, Set<string>>();
+  for (const source of sources) {
+    if (!source) continue;
+    if ('ok' in source) {
+      if (source.ok) {
+        for (const [find, replacement] of source.aliases.entries) {
+          addPotentialAlias(aliases, find, replacement);
+        }
+      } else {
+        mergePotentialAliases(aliases, source.potentialAliases);
+      }
+      continue;
+    }
+    for (const [find, replacement] of source.entries) {
+      addPotentialAlias(aliases, find, replacement);
+    }
+  }
+  return aliases;
+}
+
+function readConfigAliases(
+  source: ConfigSource,
+  packageRoot: string,
+  configuredNuxtMajor: number | undefined
+): VueProjectAliasConfiguration {
+  const ast = parseConfig(source.file);
+  if (!ast) return incompleteAliasConfiguration();
+  const { helpers, scopes } = collectAnalysisContext(ast);
+  const activeExport = findActiveConfigExport(ast);
+  if (!activeExport) return incompleteAliasConfiguration();
+  const context: EvaluationContext = {
+    configFile: source.file,
+    helpers,
+    nuxtMajorVersion:
+      configuredNuxtMajor ?? readInstalledNuxtMajor(packageRoot),
+    packageRoot,
+    scopes,
+  };
+  const root = resolveConfigRoot(activeExport, context, new Set());
+  const config = root
+    ? resolveStaticObject(root, context, new Set(), 'config')
+    : undefined;
+  if (!config) return incompleteAliasConfiguration();
+
+  if (source.kind === 'vite') {
+    const aliases = readNestedAliasObject(
+      config,
+      ['resolve', 'alias'],
+      context
+    );
+    if (!aliases) return completeAliasConfiguration();
+    return aliases.ok
+      ? completeAliasConfiguration(toFirstMatchMap(aliases.aliases.entries))
+      : incompleteAliasConfiguration(
+          aliases.potentialAliasKeys,
+          aliases.potentialAliases
+        );
+  }
+
+  const builtInAliases = readNuxtBuiltInAliases(config, context);
+  if (!builtInAliases) return incompleteAliasConfiguration();
+  const configuredNuxtAliases = readNestedAliasObject(
+    config,
+    ['alias'],
+    context
+  );
+  const viteAliases = readNestedAliasObject(
+    config,
+    ['vite', 'resolve', 'alias'],
+    context
+  );
+  if (configuredNuxtAliases && !configuredNuxtAliases.ok) {
+    return incompleteAliasConfiguration(
+      collectAliasResolutionKeys(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      ),
+      collectAliasResolutionCandidates(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      )
+    );
+  }
+  if (viteAliases && !viteAliases.ok) {
+    return incompleteAliasConfiguration(
+      collectAliasResolutionKeys(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      ),
+      collectAliasResolutionCandidates(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      )
+    );
+  }
+  if (
+    configuredNuxtAliases?.ok &&
+    configuredNuxtAliases.aliases.form !== 'object'
+  ) {
+    return incompleteAliasConfiguration(
+      collectAliasResolutionKeys(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      ),
+      collectAliasResolutionCandidates(
+        builtInAliases,
+        configuredNuxtAliases,
+        viteAliases
+      )
+    );
+  }
+  const nuxtAliases = mergeObjectAliases(
+    builtInAliases,
+    configuredNuxtAliases?.ok ? configuredNuxtAliases.aliases : undefined
+  );
+  return completeAliasConfiguration(
+    mergeNuxtAliases(
+      nuxtAliases,
+      viteAliases?.ok ? viteAliases.aliases : undefined
+    )
+  );
+}
+
+function readNuxtBuiltInAliases(
+  config: StaticObject,
+  context: EvaluationContext
+): StaticAliases | undefined {
+  const configuredRoot = config.get('rootDir');
+  const rootDirValue = configuredRoot
+    ? resolveStaticString(configuredRoot, context, new Set())
+    : undefined;
+  if (configuredRoot && rootDirValue === undefined) return undefined;
+  const rootDir = resolveSafeNuxtDirectory(
+    context.packageRoot,
+    rootDirValue ?? '.'
+  );
+  if (!rootDir) return undefined;
+
+  const configuredSource = config.get('srcDir');
+  const sourceValue = configuredSource
+    ? resolveStaticString(configuredSource, context, new Set())
+    : undefined;
+  if (configuredSource && sourceValue === undefined) return undefined;
+  const compatibilityMajor = readNuxtCompatibilityMajor(config, context);
+  if (compatibilityMajor === null) return undefined;
+  const effectiveNuxtMajor = compatibilityMajor ?? context.nuxtMajorVersion;
+  const hasExplicitSource = Boolean(configuredSource && sourceValue);
+  if (!hasExplicitSource && effectiveNuxtMajor === undefined) return undefined;
+  const srcDir = hasExplicitSource
+    ? resolveSafeNuxtDirectory(rootDir, sourceValue!)
+    : effectiveNuxtMajor! >= 4
+      ? resolveDefaultNuxt4SourceDirectory(rootDir)
+      : rootDir;
+  if (!srcDir) return undefined;
+
+  const sourceAlias = withTrailingSlash(srcDir);
+  const rootAlias = withTrailingSlash(rootDir);
+  return {
+    entries: [
+      ['~', sourceAlias],
+      ['@', sourceAlias],
+      ['~~', rootAlias],
+      ['@@', rootAlias],
+    ],
+    form: 'object',
+  };
+}
+
+function readNuxtCompatibilityMajor(
+  config: StaticObject,
+  context: EvaluationContext
+): number | null | undefined {
+  const futureEntry = config.get('future');
+  if (!futureEntry) return undefined;
+  const future = resolveStaticObject(futureEntry, context, new Set(), 'config');
+  if (!future) return null;
+  const compatibilityEntry = future.get('compatibilityVersion');
+  if (!compatibilityEntry) return undefined;
+  return resolveStaticInteger(compatibilityEntry, context, new Set()) ?? null;
+}
+
+function resolveStaticInteger(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): number | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    if (
+      unwrapped.node.type === 'NumericLiteral' &&
+      Number.isInteger(unwrapped.node.value)
+    ) {
+      return unwrapped.node.value;
+    }
+    if (
+      unwrapped.node.type === 'StringLiteral' &&
+      /^\d+$/.test(unwrapped.node.value)
+    ) {
+      return Number(unwrapped.node.value);
+    }
+    if (unwrapped.node.type !== 'Identifier') return undefined;
+    const bound = resolveImmutableBinding(unwrapped, context, 'none');
+    return bound ? resolveStaticInteger(bound, context, seen) : undefined;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function resolveSafeNuxtDirectory(
+  root: string,
+  configuredPath: string
+): string | undefined {
+  const candidate = path.resolve(root, configuredPath);
+  if (!isInsideDirectory(root, candidate)) return undefined;
+  if (path.relative(root, candidate).split(path.sep).includes('node_modules')) {
+    return undefined;
+  }
+  try {
+    const realRoot = fs.realpathSync(root);
+    let existingAncestor = candidate;
+    while (!fs.existsSync(existingAncestor)) {
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) return undefined;
+      existingAncestor = parent;
+    }
+    const realAncestor = fs.realpathSync(existingAncestor);
+    const realCandidate = path.resolve(
+      realAncestor,
+      path.relative(existingAncestor, candidate)
+    );
+    return isInsideDirectory(realRoot, realCandidate) ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveDefaultNuxt4SourceDirectory(rootDir: string): string {
+  const appDir = path.join(rootDir, 'app');
+  try {
+    if (!fs.statSync(appDir).isDirectory()) return rootDir;
+    const meaningfulAppEntries = fs
+      .readdirSync(appDir)
+      .filter(
+        (entry) =>
+          entry !== 'spa-loading-template.html' &&
+          !entry.startsWith('router.options')
+      );
+    if (meaningfulAppEntries.length > 0) return appDir;
+    if (
+      [
+        'app.vue',
+        'App.vue',
+        'assets',
+        'layouts',
+        'middleware',
+        'pages',
+        'plugins',
+      ]
+        .map((entry) => path.join(rootDir, entry))
+        .some((entry) => fs.existsSync(entry))
+    ) {
+      return rootDir;
+    }
+    return appDir;
+  } catch {
+    return rootDir;
+  }
+}
+
+function withTrailingSlash(directory: string): string {
+  return `${directory.replaceAll(path.sep, '/')}/`;
+}
+
+function readInstalledNuxtMajor(cwd: string): number | undefined {
+  try {
+    const requireFromProject = createRequire(path.join(cwd, 'package.json'));
+    const manifestPath = requireFromProject.resolve('nuxt/package.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8')) as {
+      version?: unknown;
+    };
+    if (typeof manifest.version !== 'string') return undefined;
+    const major = Number(manifest.version.split('.')[0]);
+    return Number.isInteger(major) ? major : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function parseConfig(configFile: string): t.File | undefined {
+  try {
+    const source = fs.readFileSync(configFile, 'utf8');
+    const plugins: ParserPlugin[] = [
+      'decorators-legacy',
+      'typescript',
+      'jsx',
+      'importAttributes',
+    ];
+    return parse(source, {
+      allowAwaitOutsideFunction: true,
+      plugins,
+      sourceType: 'unambiguous',
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function collectAnalysisContext(ast: t.File): {
+  helpers: HelperBindings;
+  scopes: WeakMap<t.Node, Scope>;
+} {
+  const helpers: HelperBindings = {
+    configFunctions: new Set(),
+    configNamespaces: new Set(),
+    fileURLToPathFunctions: new Set(),
+    pathNamespaces: new Set(),
+    pathResolveFunctions: new Set(),
+    urlConstructors: new Set(),
+    urlNamespaces: new Set(),
+  };
+  const scopes = new WeakMap<t.Node, Scope>();
+
+  traverse(ast, {
+    enter(nodePath) {
+      scopes.set(nodePath.node, nodePath.scope);
+    },
+    ImportDeclaration(importPath) {
+      const source = importPath.node.source.value;
+      for (const specifierPath of importPath.get('specifiers')) {
+        const binding = specifierPath.scope.getBinding(
+          specifierPath.node.local.name
+        );
+        if (!binding || !binding.constant || hasDirectMemberMutation(binding)) {
+          continue;
+        }
+        const importedName =
+          specifierPath.node.type === 'ImportSpecifier'
+            ? specifierPath.node.imported.type === 'Identifier'
+              ? specifierPath.node.imported.name
+              : specifierPath.node.imported.value
+            : specifierPath.node.type === 'ImportDefaultSpecifier'
+              ? 'default'
+              : '*';
+        registerHelperBinding(helpers, source, importedName, binding);
+      }
+    },
+    VariableDeclarator(variablePath) {
+      registerRequireBinding(variablePath, helpers);
+    },
+  });
+
+  return { helpers, scopes };
+}
+
+function registerHelperBinding(
+  helpers: HelperBindings,
+  source: string,
+  importedName: string,
+  binding: Binding
+): void {
+  if (
+    source === 'vite' ||
+    source === 'nuxt/config' ||
+    source === 'nuxt' ||
+    source === '#imports'
+  ) {
+    if (
+      importedName === 'defineConfig' ||
+      importedName === 'defineNuxtConfig'
+    ) {
+      helpers.configFunctions.add(binding);
+    } else if (importedName === '*' || importedName === 'default') {
+      helpers.configNamespaces.add(binding);
+    }
+    return;
+  }
+  if (source === 'node:path' || source === 'path') {
+    if (importedName === 'resolve') {
+      helpers.pathResolveFunctions.add(binding);
+    } else if (importedName === '*' || importedName === 'default') {
+      helpers.pathNamespaces.add(binding);
+    }
+    return;
+  }
+  if (source === 'node:url' || source === 'url') {
+    if (importedName === 'fileURLToPath') {
+      helpers.fileURLToPathFunctions.add(binding);
+    } else if (importedName === 'URL') {
+      helpers.urlConstructors.add(binding);
+    } else if (importedName === '*' || importedName === 'default') {
+      helpers.urlNamespaces.add(binding);
+    }
+  }
+}
+
+function registerRequireBinding(
+  variablePath: NodePath<t.VariableDeclarator>,
+  helpers: HelperBindings
+): void {
+  const source = readRequireSource(variablePath.node.init);
+  if (!source) return;
+  const idPath = variablePath.get('id');
+  if (idPath.isIdentifier()) {
+    const binding = idPath.scope.getBinding(idPath.node.name);
+    if (!binding || !binding.constant || hasDirectMemberMutation(binding)) {
+      return;
+    }
+    registerHelperBinding(helpers, source, '*', binding);
+    return;
+  }
+  if (!idPath.isObjectPattern()) return;
+  for (const propertyPath of idPath.get('properties')) {
+    if (!propertyPath.isObjectProperty()) continue;
+    const importedName = readPropertyKey(propertyPath.node);
+    const valuePath = propertyPath.get('value');
+    const localPath = valuePath.isAssignmentPattern()
+      ? valuePath.get('left')
+      : valuePath;
+    if (!importedName || !localPath.isIdentifier()) continue;
+    const binding = localPath.scope.getBinding(localPath.node.name);
+    if (binding?.constant && !hasDirectMemberMutation(binding)) {
+      registerHelperBinding(helpers, source, importedName, binding);
+    }
+  }
+}
+
+function readRequireSource(
+  node: t.Expression | null | undefined
+): string | undefined {
+  const unwrapped = unwrapNode(node);
+  if (
+    !unwrapped ||
+    unwrapped.type !== 'CallExpression' ||
+    unwrapped.callee.type !== 'Identifier' ||
+    unwrapped.callee.name !== 'require' ||
+    unwrapped.arguments.length !== 1 ||
+    unwrapped.arguments[0]?.type !== 'StringLiteral'
+  ) {
+    return undefined;
+  }
+  return unwrapped.arguments[0].value;
+}
+
+function findActiveConfigExport(ast: t.File): StaticEntry | undefined {
+  const candidates: Array<StaticEntry & { start: number }> = [];
+  traverse(ast, {
+    ExportDefaultDeclaration(exportPath) {
+      candidates.push({
+        node: exportPath.node.declaration,
+        scope: exportPath.scope,
+        start: exportPath.node.start ?? -1,
+      });
+    },
+    ExportNamedDeclaration(exportPath) {
+      for (const specifierPath of exportPath.get('specifiers')) {
+        if (!specifierPath.isExportSpecifier()) continue;
+        const exported = specifierPath.node.exported;
+        const exportedName =
+          exported.type === 'Identifier' ? exported.name : exported.value;
+        if (exportedName !== 'default') continue;
+        candidates.push({
+          node: specifierPath.node.local,
+          scope: specifierPath.scope,
+          start: exportPath.node.start ?? -1,
+        });
+      }
+    },
+    TSExportAssignment(exportPath) {
+      candidates.push({
+        node: exportPath.node.expression,
+        scope: exportPath.scope,
+        start: exportPath.node.start ?? -1,
+      });
+    },
+    AssignmentExpression(assignmentPath) {
+      if (!isCommonJsConfigExport(assignmentPath.node.left)) return;
+      candidates.push({
+        node: assignmentPath.node.right,
+        scope: assignmentPath.scope,
+        start: assignmentPath.node.start ?? -1,
+      });
+    },
+  });
+  candidates.sort((left, right) => left.start - right.start);
+  return candidates.at(-1);
+}
+
+function isCommonJsConfigExport(
+  node: t.LVal | t.OptionalMemberExpression
+): boolean {
+  if (node.type !== 'MemberExpression' || node.computed) return false;
+  if (
+    node.object.type === 'Identifier' &&
+    node.property.type === 'Identifier'
+  ) {
+    return (
+      (node.object.name === 'module' && node.property.name === 'exports') ||
+      (node.object.name === 'exports' && node.property.name === 'default')
+    );
+  }
+  if (
+    node.object.type === 'MemberExpression' &&
+    !node.object.computed &&
+    node.object.object.type === 'Identifier' &&
+    node.object.object.name === 'module' &&
+    node.object.property.type === 'Identifier' &&
+    node.object.property.name === 'exports' &&
+    node.property.type === 'Identifier' &&
+    node.property.name === 'default'
+  ) {
+    return true;
+  }
+  return false;
+}
+
+function resolveConfigRoot(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): StaticEntry | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, 'config');
+      return bound ? resolveConfigRoot(bound, context, seen) : undefined;
+    }
+    if (
+      unwrapped.node.type === 'CallExpression' ||
+      unwrapped.node.type === 'OptionalCallExpression'
+    ) {
+      if (!isConfigHelperCall(unwrapped, context.helpers)) return undefined;
+      const argument = unwrapped.node.arguments[0];
+      if (
+        !argument ||
+        argument.type === 'SpreadElement' ||
+        argument.type === 'ArgumentPlaceholder'
+      ) {
+        return undefined;
+      }
+      return resolveConfigRoot(
+        scopedEntry(argument, unwrapped.scope, context),
+        context,
+        seen
+      );
+    }
+    if (
+      unwrapped.node.type === 'ArrowFunctionExpression' ||
+      unwrapped.node.type === 'FunctionExpression' ||
+      unwrapped.node.type === 'FunctionDeclaration'
+    ) {
+      const returned = readStaticFunctionReturn(unwrapped, context);
+      return returned ? resolveConfigRoot(returned, context, seen) : undefined;
+    }
+    return unwrapped;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function isConfigHelperCall(
+  entry: StaticEntry,
+  helpers: HelperBindings
+): boolean {
+  if (
+    entry.node.type !== 'CallExpression' &&
+    entry.node.type !== 'OptionalCallExpression'
+  ) {
+    return false;
+  }
+  const callee = unwrapNode(entry.node.callee);
+  if (!callee) return false;
+  if (callee.type === 'Identifier') {
+    const binding = entry.scope.getBinding(callee.name);
+    return binding
+      ? helpers.configFunctions.has(binding)
+      : callee.name === 'defineConfig' || callee.name === 'defineNuxtConfig';
+  }
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    callee.property.type === 'Identifier' &&
+    (callee.property.name === 'defineConfig' ||
+      callee.property.name === 'defineNuxtConfig')
+  ) {
+    const binding = entry.scope.getBinding(callee.object.name);
+    return Boolean(binding && helpers.configNamespaces.has(binding));
+  }
+  return false;
+}
+
+function readStaticFunctionReturn(
+  entry: StaticEntry,
+  context: EvaluationContext
+): StaticEntry | undefined {
+  if (
+    entry.node.type !== 'ArrowFunctionExpression' &&
+    entry.node.type !== 'FunctionExpression' &&
+    entry.node.type !== 'FunctionDeclaration'
+  ) {
+    return undefined;
+  }
+  if (entry.node.body.type !== 'BlockStatement') {
+    return scopedEntry(entry.node.body, entry.scope, context);
+  }
+  const returns = entry.node.body.body.filter(
+    (statement): statement is t.ReturnStatement =>
+      statement.type === 'ReturnStatement' && Boolean(statement.argument)
+  );
+  if (returns.length !== 1 || !returns[0]!.argument) return undefined;
+  return scopedEntry(returns[0]!.argument, entry.scope, context);
+}
+
+function readNestedAliasObject(
+  root: StaticObject,
+  keys: readonly string[],
+  context: EvaluationContext
+): AliasResolution | undefined {
+  let entry: StaticEntry | undefined;
+  let object = root;
+  for (const [index, key] of keys.entries()) {
+    entry = object.get(key);
+    if (!entry) return undefined;
+    if (isDefinitelyAbsentAliasValue(entry, context, new Set())) {
+      return undefined;
+    }
+    if (index === keys.length - 1) break;
+    const nested = resolveStaticObject(entry, context, new Set(), 'config');
+    if (!nested) {
+      return {
+        ok: false,
+        potentialAliasKeys: new Set(),
+        potentialAliases: new Map(),
+      };
+    }
+    object = nested;
+  }
+  return entry ? readAliasValue(entry, context) : undefined;
+}
+
+function isDefinitelyAbsentAliasValue(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): boolean {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return false;
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'NullLiteral') return true;
+    if (unwrapped.node.type === 'BooleanLiteral' && !unwrapped.node.value) {
+      return true;
+    }
+    if (
+      unwrapped.node.type === 'Identifier' &&
+      unwrapped.node.name === 'undefined' &&
+      !unwrapped.scope.getBinding('undefined')
+    ) {
+      return true;
+    }
+    if (
+      unwrapped.node.type === 'UnaryExpression' &&
+      unwrapped.node.operator === 'void'
+    ) {
+      return true;
+    }
+    if (unwrapped.node.type !== 'Identifier') return false;
+    const bound = resolveImmutableBinding(unwrapped, context, 'none');
+    return bound ? isDefinitelyAbsentAliasValue(bound, context, seen) : false;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function readAliasValue(
+  entry: StaticEntry,
+  context: EvaluationContext
+): AliasResolution {
+  const potentialAliasKeys = collectPotentialAliasKeys(
+    entry,
+    context,
+    new Set()
+  );
+  const potentialAliases = collectPotentialAliases(entry, context, new Set());
+  const object = resolveStaticObject(entry, context, new Set(), 'alias');
+  if (object) {
+    const entries: Array<readonly [string, string]> = [];
+    for (const [find, replacementEntry] of object) {
+      const replacement = resolveStaticString(
+        replacementEntry,
+        context,
+        new Set()
+      );
+      if (replacement === undefined) {
+        return { ok: false, potentialAliasKeys, potentialAliases };
+      }
+      entries.push([find, replacement]);
+    }
+    return { ok: true, aliases: { entries, form: 'object' } };
+  }
+
+  const entries = resolveStaticArray(entry, context, new Set(), 'alias');
+  if (!entries) {
+    return { ok: false, potentialAliasKeys, potentialAliases };
+  }
+  const arrayAliases = new Map<string, string>();
+  for (const item of entries) {
+    const aliasObject = resolveStaticObject(item, context, new Set(), 'alias');
+    if (!aliasObject || aliasObject.has('customResolver')) {
+      return { ok: false, potentialAliasKeys, potentialAliases };
+    }
+    const findEntry = aliasObject.get('find');
+    const replacementEntry = aliasObject.get('replacement');
+    if (!findEntry || !replacementEntry) {
+      return { ok: false, potentialAliasKeys, potentialAliases };
+    }
+    const find = resolveStaticString(findEntry, context, new Set());
+    const replacement = resolveStaticString(
+      replacementEntry,
+      context,
+      new Set()
+    );
+    if (find === undefined || replacement === undefined) {
+      return { ok: false, potentialAliasKeys, potentialAliases };
+    }
+    if (!arrayAliases.has(find)) arrayAliases.set(find, replacement);
+  }
+  return {
+    ok: true,
+    aliases: { entries: [...arrayAliases], form: 'array' },
+  };
+}
+
+/** Collects only fully static key-to-replacement candidates. */
+function collectPotentialAliases(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): Map<string, Set<string>> {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return new Map();
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, 'none');
+      return bound ? collectPotentialAliases(bound, context, seen) : new Map();
+    }
+    if (unwrapped.node.type === 'ObjectExpression') {
+      const aliases = new Map<string, Set<string>>();
+      for (const property of unwrapped.node.properties) {
+        if (property.type === 'SpreadElement') {
+          mergePotentialAliases(
+            aliases,
+            collectPotentialAliases(
+              scopedEntry(property.argument, unwrapped.scope, context),
+              context,
+              seen
+            )
+          );
+          continue;
+        }
+        if (property.type !== 'ObjectProperty') continue;
+        const find = readPropertyKey(property);
+        if (find === undefined) continue;
+        const replacement = resolveStaticString(
+          scopedEntry(property.value, unwrapped.scope, context),
+          context,
+          new Set()
+        );
+        if (replacement !== undefined) {
+          addPotentialAlias(aliases, find, replacement);
+        }
+      }
+      return aliases;
+    }
+    if (unwrapped.node.type === 'ArrayExpression') {
+      const aliases = new Map<string, Set<string>>();
+      for (const element of unwrapped.node.elements) {
+        if (!element) continue;
+        if (element.type === 'SpreadElement') {
+          mergePotentialAliases(
+            aliases,
+            collectPotentialAliases(
+              scopedEntry(element.argument, unwrapped.scope, context),
+              context,
+              seen
+            )
+          );
+          continue;
+        }
+        const item = scopedEntry(element, unwrapped.scope, context);
+        const aliasObject = resolveStaticObject(
+          item,
+          context,
+          new Set(),
+          'none'
+        );
+        const findEntry = aliasObject?.get('find');
+        const replacementEntry = aliasObject?.get('replacement');
+        if (!findEntry || !replacementEntry) continue;
+        const find = resolveStaticString(findEntry, context, new Set());
+        const replacement = resolveStaticString(
+          replacementEntry,
+          context,
+          new Set()
+        );
+        if (find !== undefined && replacement !== undefined) {
+          addPotentialAlias(aliases, find, replacement);
+        }
+      }
+      return aliases;
+    }
+    return new Map();
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+/**
+ * Collects statically visible alias keys without claiming that their final
+ * replacement or precedence is known. Dynamic spreads and overrides can make
+ * the full alias surface incomplete, but the observed keys remain useful as
+ * narrowly scoped evidence that an import may belong to the Vue project.
+ */
+function collectPotentialAliasKeys(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): Set<string> {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return new Set();
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, 'none');
+      return bound
+        ? collectPotentialAliasKeys(bound, context, seen)
+        : new Set();
+    }
+    if (unwrapped.node.type === 'ObjectExpression') {
+      const keys = new Set<string>();
+      for (const property of unwrapped.node.properties) {
+        if (property.type === 'SpreadElement') {
+          addAll(
+            keys,
+            collectPotentialAliasKeys(
+              scopedEntry(property.argument, unwrapped.scope, context),
+              context,
+              seen
+            )
+          );
+          continue;
+        }
+        if (
+          property.type !== 'ObjectProperty' &&
+          property.type !== 'ObjectMethod'
+        ) {
+          continue;
+        }
+        const key = readPropertyKey(property);
+        if (key !== undefined) keys.add(key);
+      }
+      return keys;
+    }
+    if (unwrapped.node.type === 'ArrayExpression') {
+      const keys = new Set<string>();
+      for (const element of unwrapped.node.elements) {
+        if (!element) continue;
+        if (element.type === 'SpreadElement') {
+          addAll(
+            keys,
+            collectPotentialAliasKeys(
+              scopedEntry(element.argument, unwrapped.scope, context),
+              context,
+              seen
+            )
+          );
+          continue;
+        }
+        addAll(
+          keys,
+          collectPotentialArrayAliasKeys(
+            scopedEntry(element, unwrapped.scope, context),
+            context,
+            seen
+          )
+        );
+      }
+      return keys;
+    }
+    return new Set();
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function collectPotentialArrayAliasKeys(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): Set<string> {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return new Set();
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, 'none');
+      return bound
+        ? collectPotentialArrayAliasKeys(bound, context, seen)
+        : new Set();
+    }
+    if (unwrapped.node.type !== 'ObjectExpression') return new Set();
+    const keys = new Set<string>();
+    for (const property of unwrapped.node.properties) {
+      if (property.type === 'SpreadElement') {
+        addAll(
+          keys,
+          collectPotentialArrayAliasKeys(
+            scopedEntry(property.argument, unwrapped.scope, context),
+            context,
+            seen
+          )
+        );
+        continue;
+      }
+      if (
+        property.type !== 'ObjectProperty' ||
+        readPropertyKey(property) !== 'find'
+      ) {
+        continue;
+      }
+      const find = resolveStaticString(
+        scopedEntry(property.value, unwrapped.scope, context),
+        context,
+        new Set()
+      );
+      if (find !== undefined) keys.add(find);
+    }
+    return keys;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function addAll(target: Set<string>, values: Iterable<string>): void {
+  for (const value of values) target.add(value);
+}
+
+function addPotentialAlias(
+  target: Map<string, Set<string>>,
+  find: string,
+  replacement: string
+): void {
+  const replacements = target.get(find) ?? new Set<string>();
+  replacements.add(replacement);
+  target.set(find, replacements);
+}
+
+function mergePotentialAliases(
+  target: Map<string, Set<string>>,
+  source: ReadonlyMap<string, ReadonlySet<string>>
+): void {
+  for (const [find, replacements] of source) {
+    for (const replacement of replacements) {
+      addPotentialAlias(target, find, replacement);
+    }
+  }
+}
+
+function clonePotentialAliases(
+  aliases: ReadonlyMap<string, ReadonlySet<string>>
+): Map<string, Set<string>> {
+  const clone = new Map<string, Set<string>>();
+  mergePotentialAliases(clone, aliases);
+  return clone;
+}
+
+function resolveStaticObject(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>,
+  bindingSafety: BindingSafety
+): StaticObject | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, bindingSafety);
+      return bound
+        ? resolveStaticObject(bound, context, seen, bindingSafety)
+        : undefined;
+    }
+    if (unwrapped.node.type !== 'ObjectExpression') return undefined;
+    const object: StaticObject = new Map();
+    for (const property of unwrapped.node.properties) {
+      if (property.type === 'SpreadElement') {
+        const spread = resolveStaticObject(
+          scopedEntry(property.argument, unwrapped.scope, context),
+          context,
+          seen,
+          bindingSafety
+        );
+        if (!spread) return undefined;
+        for (const pair of spread) object.set(...pair);
+        continue;
+      }
+      if (
+        property.type !== 'ObjectProperty' &&
+        property.type !== 'ObjectMethod'
+      ) {
+        continue;
+      }
+      const key = readPropertyKey(property);
+      if (key === undefined) return undefined;
+      object.set(
+        key,
+        scopedEntry(
+          property.type === 'ObjectProperty' ? property.value : property,
+          unwrapped.scope,
+          context
+        )
+      );
+    }
+    return object;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function resolveStaticArray(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>,
+  bindingSafety: BindingSafety
+): StaticEntry[] | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, bindingSafety);
+      return bound
+        ? resolveStaticArray(bound, context, seen, bindingSafety)
+        : undefined;
+    }
+    if (unwrapped.node.type !== 'ArrayExpression') return undefined;
+    const result: StaticEntry[] = [];
+    for (const element of unwrapped.node.elements) {
+      if (!element) continue;
+      if (element.type === 'SpreadElement') {
+        const spread = resolveStaticArray(
+          scopedEntry(element.argument, unwrapped.scope, context),
+          context,
+          seen,
+          bindingSafety
+        );
+        if (!spread) return undefined;
+        result.push(...spread);
+        continue;
+      }
+      result.push(scopedEntry(element, unwrapped.scope, context));
+    }
+    return result;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function resolveStaticString(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): string | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    const node = unwrapped.node;
+    if (node.type === 'StringLiteral') return node.value;
+    if (node.type === 'Identifier') {
+      if (node.name === '__dirname' && !unwrapped.scope.getBinding(node.name)) {
+        return path.dirname(context.configFile);
+      }
+      const bound = resolveImmutableBinding(unwrapped, context, 'none');
+      return bound ? resolveStaticString(bound, context, seen) : undefined;
+    }
+    if (node.type === 'TemplateLiteral') {
+      let value = node.quasis[0]?.value.cooked ?? '';
+      for (const [index, expression] of node.expressions.entries()) {
+        const resolved = resolveStaticString(
+          scopedEntry(expression, unwrapped.scope, context),
+          context,
+          seen
+        );
+        if (resolved === undefined) return undefined;
+        value += resolved + (node.quasis[index + 1]?.value.cooked ?? '');
+      }
+      return value;
+    }
+    if (node.type === 'BinaryExpression' && node.operator === '+') {
+      const left = resolveStaticString(
+        scopedEntry(node.left, unwrapped.scope, context),
+        context,
+        seen
+      );
+      const right = resolveStaticString(
+        scopedEntry(node.right, unwrapped.scope, context),
+        context,
+        seen
+      );
+      return left === undefined || right === undefined
+        ? undefined
+        : left + right;
+    }
+    if (
+      node.type === 'CallExpression' ||
+      node.type === 'OptionalCallExpression'
+    ) {
+      if (isPathResolveCall(unwrapped, context.helpers)) {
+        const parts: string[] = [];
+        for (const argument of node.arguments) {
+          if (
+            argument.type === 'SpreadElement' ||
+            argument.type === 'ArgumentPlaceholder'
+          ) {
+            return undefined;
+          }
+          const part = resolveStaticString(
+            scopedEntry(argument, unwrapped.scope, context),
+            context,
+            seen
+          );
+          if (part === undefined) return undefined;
+          parts.push(part);
+        }
+        if (parts.length === 0 || !path.isAbsolute(parts[0]!)) {
+          return undefined;
+        }
+        return path.resolve(...parts);
+      }
+      if (isFileURLToPathCall(unwrapped, context.helpers)) {
+        const argument = node.arguments[0];
+        if (
+          !argument ||
+          argument.type === 'SpreadElement' ||
+          argument.type === 'ArgumentPlaceholder'
+        ) {
+          return undefined;
+        }
+        const url = resolveStaticUrl(
+          scopedEntry(argument, unwrapped.scope, context),
+          context,
+          seen
+        );
+        if (!url || url.protocol !== 'file:') return undefined;
+        return fileURLToPath(url);
+      }
+    }
+    if (
+      node.type === 'MemberExpression' &&
+      !node.computed &&
+      node.object.type === 'MetaProperty' &&
+      node.object.meta.name === 'import' &&
+      node.object.property.name === 'meta' &&
+      node.property.type === 'Identifier' &&
+      node.property.name === 'dirname'
+    ) {
+      return path.dirname(context.configFile);
+    }
+    return undefined;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+function resolveStaticUrl(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  seen: Set<t.Node>
+): URL | undefined {
+  const unwrapped = unwrapEntry(entry);
+  if (seen.has(unwrapped.node)) return undefined;
+  seen.add(unwrapped.node);
+  try {
+    if (unwrapped.node.type === 'Identifier') {
+      const bound = resolveImmutableBinding(unwrapped, context, 'none');
+      return bound ? resolveStaticUrl(bound, context, seen) : undefined;
+    }
+    if (
+      unwrapped.node.type !== 'NewExpression' ||
+      unwrapped.node.callee.type !== 'Identifier' ||
+      unwrapped.node.callee.name !== 'URL' ||
+      !isTrustedUrlConstructor(unwrapped, context.helpers) ||
+      unwrapped.node.arguments.length !== 2
+    ) {
+      return undefined;
+    }
+    const [relativeArgument, baseArgument] = unwrapped.node.arguments;
+    if (
+      !relativeArgument ||
+      relativeArgument.type === 'SpreadElement' ||
+      relativeArgument.type === 'ArgumentPlaceholder' ||
+      !baseArgument ||
+      baseArgument.type === 'SpreadElement' ||
+      baseArgument.type === 'ArgumentPlaceholder' ||
+      !isImportMetaUrl(baseArgument)
+    ) {
+      return undefined;
+    }
+    const relative = resolveStaticString(
+      scopedEntry(relativeArgument, unwrapped.scope, context),
+      context,
+      seen
+    );
+    if (relative === undefined) return undefined;
+    return new URL(relative, pathToFileURL(context.configFile));
+  } catch {
+    return undefined;
+  } finally {
+    seen.delete(unwrapped.node);
+  }
+}
+
+/** Accepts the global URL constructor and immutable imports from node:url. */
+function isTrustedUrlConstructor(
+  entry: StaticEntry,
+  helpers: HelperBindings
+): boolean {
+  if (
+    entry.node.type !== 'NewExpression' ||
+    entry.node.callee.type !== 'Identifier' ||
+    entry.node.callee.name !== 'URL'
+  ) {
+    return false;
+  }
+  const binding = entry.scope.getBinding(entry.node.callee.name);
+  return binding === undefined || helpers.urlConstructors.has(binding);
+}
+
+function isPathResolveCall(
+  entry: StaticEntry,
+  helpers: HelperBindings
+): boolean {
+  if (
+    entry.node.type !== 'CallExpression' &&
+    entry.node.type !== 'OptionalCallExpression'
+  ) {
+    return false;
+  }
+  const callee = unwrapNode(entry.node.callee);
+  if (!callee) return false;
+  if (callee.type === 'Identifier') {
+    const binding = entry.scope.getBinding(callee.name);
+    return Boolean(binding && helpers.pathResolveFunctions.has(binding));
+  }
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'resolve'
+  ) {
+    const binding = entry.scope.getBinding(callee.object.name);
+    return Boolean(binding && helpers.pathNamespaces.has(binding));
+  }
+  return false;
+}
+
+function isFileURLToPathCall(
+  entry: StaticEntry,
+  helpers: HelperBindings
+): boolean {
+  if (
+    entry.node.type !== 'CallExpression' &&
+    entry.node.type !== 'OptionalCallExpression'
+  ) {
+    return false;
+  }
+  const callee = unwrapNode(entry.node.callee);
+  if (!callee) return false;
+  if (callee.type === 'Identifier') {
+    const binding = entry.scope.getBinding(callee.name);
+    return Boolean(binding && helpers.fileURLToPathFunctions.has(binding));
+  }
+  if (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'fileURLToPath'
+  ) {
+    const binding = entry.scope.getBinding(callee.object.name);
+    return Boolean(binding && helpers.urlNamespaces.has(binding));
+  }
+  return false;
+}
+
+function isImportMetaUrl(node: t.Node): boolean {
+  const unwrapped = unwrapNode(node);
+  return Boolean(
+    unwrapped &&
+    unwrapped.type === 'MemberExpression' &&
+    !unwrapped.computed &&
+    unwrapped.object.type === 'MetaProperty' &&
+    unwrapped.object.meta.name === 'import' &&
+    unwrapped.object.property.name === 'meta' &&
+    unwrapped.property.type === 'Identifier' &&
+    unwrapped.property.name === 'url'
+  );
+}
+
+function resolveImmutableBinding(
+  entry: StaticEntry,
+  context: EvaluationContext,
+  safety: BindingSafety
+): StaticEntry | undefined {
+  if (entry.node.type !== 'Identifier') return undefined;
+  const binding = entry.scope.getBinding(entry.node.name);
+  if (
+    !binding ||
+    binding.kind !== 'const' ||
+    !binding.constant ||
+    binding.constantViolations.length > 0 ||
+    !binding.path.isVariableDeclarator() ||
+    hasDirectMemberMutation(binding) ||
+    (safety === 'alias' &&
+      hasUnsafeAliasBindingUse(binding, context, new Set())) ||
+    (safety === 'config' &&
+      !isSafeConfigBinding(binding, context, new Set())) ||
+    !binding.path.node.init
+  ) {
+    return undefined;
+  }
+  return scopedEntry(binding.path.node.init, binding.path.scope, context);
+}
+
+function hasUnsafeAliasBindingUse(
+  binding: Binding,
+  context: EvaluationContext,
+  seen: Set<Binding>
+): boolean {
+  if (seen.has(binding)) return false;
+  seen.add(binding);
+  try {
+    return binding.referencePaths.some((referencePath) => {
+      let targetPath = unwrapReferencePath(referencePath);
+      while (
+        (targetPath.parentPath?.isMemberExpression() ||
+          targetPath.parentPath?.isOptionalMemberExpression()) &&
+        targetPath.parentPath.node.object === targetPath.node
+      ) {
+        targetPath = targetPath.parentPath;
+      }
+      const parentPath = targetPath.parentPath;
+      if (!parentPath) return true;
+      if (parentPath.isAssignmentExpression()) return true;
+      if (parentPath.isUpdateExpression()) return true;
+      if (parentPath.isUnaryExpression({ operator: 'delete' })) return true;
+      if (
+        parentPath.isCallExpression() ||
+        parentPath.isOptionalCallExpression()
+      ) {
+        if (parentPath.node.callee === targetPath.node) return true;
+        return !isConfigHelperCall(
+          { node: parentPath.node, scope: parentPath.scope },
+          context.helpers
+        );
+      }
+      if (parentPath.isSpreadElement()) {
+        return !isSafeConfigValuePath(parentPath.parentPath, context, seen);
+      }
+      if (parentPath.isObjectProperty()) {
+        return !(
+          parentPath.node.value === targetPath.node &&
+          readPropertyKey(parentPath.node) === 'alias' &&
+          isSafeConfigValuePath(parentPath.parentPath, context, seen)
+        );
+      }
+      if (parentPath.isArrayExpression()) {
+        return !isSafeConfigValuePath(parentPath, context, seen);
+      }
+      if (parentPath.isVariableDeclarator()) {
+        if (
+          parentPath.node.init !== targetPath.node ||
+          parentPath.node.id.type !== 'Identifier' ||
+          !parentPath.parentPath?.isVariableDeclaration({ kind: 'const' })
+        ) {
+          return true;
+        }
+        const aliasBinding = parentPath.scope.getBinding(
+          parentPath.node.id.name
+        );
+        return (
+          !aliasBinding || hasUnsafeAliasBindingUse(aliasBinding, context, seen)
+        );
+      }
+      return true;
+    });
+  } finally {
+    seen.delete(binding);
+  }
+}
+
+function hasDirectMemberMutation(binding: Binding): boolean {
+  return binding.referencePaths.some((referencePath) => {
+    let targetPath = unwrapReferencePath(referencePath);
+    while (
+      (targetPath.parentPath?.isMemberExpression() ||
+        targetPath.parentPath?.isOptionalMemberExpression()) &&
+      targetPath.parentPath.node.object === targetPath.node
+    ) {
+      targetPath = targetPath.parentPath;
+    }
+    const parentPath = targetPath.parentPath;
+    return Boolean(
+      parentPath &&
+      (parentPath.isAssignmentExpression() ||
+        parentPath.isUpdateExpression() ||
+        parentPath.isUnaryExpression({ operator: 'delete' }))
+    );
+  });
+}
+
+function isSafeConfigValuePath(
+  inputPath: NodePath | null,
+  context: EvaluationContext,
+  seen: Set<Binding>
+): boolean {
+  if (!inputPath) return false;
+  const targetPath = unwrapReferencePath(inputPath);
+  const parentPath = targetPath.parentPath;
+  if (!parentPath) return false;
+  if (parentPath.isObjectProperty()) {
+    if (parentPath.node.value !== targetPath.node) return false;
+    return isSafeConfigValuePath(parentPath.parentPath, context, seen);
+  }
+  if (parentPath.isSpreadElement()) {
+    return isSafeConfigValuePath(parentPath.parentPath, context, seen);
+  }
+  if (parentPath.isArrowFunctionExpression()) {
+    if (parentPath.node.body !== targetPath.node) return false;
+    return isSafeConfigValuePath(parentPath, context, seen);
+  }
+  if (parentPath.isReturnStatement()) {
+    const functionScope = parentPath.scope.getFunctionParent();
+    return functionScope
+      ? isSafeConfigValuePath(functionScope.path, context, seen)
+      : false;
+  }
+  if (parentPath.isVariableDeclarator()) {
+    if (
+      parentPath.node.init !== targetPath.node ||
+      parentPath.node.id.type !== 'Identifier' ||
+      !parentPath.parentPath?.isVariableDeclaration({ kind: 'const' })
+    ) {
+      return false;
+    }
+    const binding = parentPath.scope.getBinding(parentPath.node.id.name);
+    return binding ? isSafeConfigBinding(binding, context, seen) : false;
+  }
+  if (parentPath.isCallExpression() || parentPath.isOptionalCallExpression()) {
+    if (!parentPath.node.arguments.includes(targetPath.node as t.Expression)) {
+      return false;
+    }
+    return isConfigHelperCall(
+      { node: parentPath.node, scope: parentPath.scope },
+      context.helpers
+    );
+  }
+  if (parentPath.isExportDefaultDeclaration()) return true;
+  if (parentPath.isExportSpecifier()) {
+    const exported = parentPath.node.exported;
+    return (
+      (exported.type === 'Identifier' ? exported.name : exported.value) ===
+      'default'
+    );
+  }
+  if (parentPath.isAssignmentExpression()) {
+    return (
+      parentPath.node.right === targetPath.node &&
+      isCommonJsConfigExport(parentPath.node.left)
+    );
+  }
+  return false;
+}
+
+function isSafeConfigBinding(
+  binding: Binding,
+  context: EvaluationContext,
+  seen: Set<Binding>
+): boolean {
+  if (seen.has(binding)) return true;
+  if (
+    binding.kind !== 'const' ||
+    !binding.constant ||
+    binding.constantViolations.length > 0
+  ) {
+    return false;
+  }
+  seen.add(binding);
+  try {
+    return binding.referencePaths.every((referencePath) =>
+      isSafeConfigValuePath(referencePath, context, seen)
+    );
+  } finally {
+    seen.delete(binding);
+  }
+}
+
+function unwrapReferencePath(referencePath: NodePath): NodePath {
+  let targetPath = referencePath;
+  while (
+    targetPath.parentPath &&
+    isTransparentExpression(targetPath.parentPath.node) &&
+    targetPath.parentPath.node.expression === targetPath.node
+  ) {
+    targetPath = targetPath.parentPath;
+  }
+  return targetPath;
+}
+
+function isTransparentExpression(
+  node: t.Node
+): node is
+  | t.TSAsExpression
+  | t.TSSatisfiesExpression
+  | t.TSNonNullExpression
+  | t.TypeCastExpression
+  | t.ParenthesizedExpression
+  | t.TSInstantiationExpression {
+  return (
+    node.type === 'TSAsExpression' ||
+    node.type === 'TSSatisfiesExpression' ||
+    node.type === 'TSNonNullExpression' ||
+    node.type === 'TypeCastExpression' ||
+    node.type === 'ParenthesizedExpression' ||
+    node.type === 'TSInstantiationExpression'
+  );
+}
+
+function scopedEntry(
+  node: t.Node,
+  fallbackScope: Scope,
+  context: EvaluationContext
+): StaticEntry {
+  return { node, scope: context.scopes.get(node) ?? fallbackScope };
+}
+
+function toFirstMatchMap(
+  entries: readonly (readonly [string, string])[]
+): Map<string, string> {
+  const aliases = new Map<string, string>();
+  for (const [find, replacement] of entries) {
+    if (!aliases.has(find)) aliases.set(find, replacement);
+  }
+  return aliases;
+}
+
+function mergeObjectAliases(
+  defaults: StaticAliases,
+  overrides: StaticAliases | undefined
+): StaticAliases {
+  if (!overrides) return defaults;
+  const entries = new Map(defaults.entries);
+  for (const [find, replacement] of overrides.entries) {
+    entries.set(find, replacement);
+  }
+  return { entries: [...entries], form: 'object' };
+}
+
+/**
+ * Mirrors Vite's mergeAlias behavior used by Nuxt. Two object forms merge in
+ * property order with nested `vite.resolve.alias` values overriding duplicate
+ * Nuxt aliases. If either side is an array, nested Vite aliases are prepended
+ * because Vite resolves array aliases from first to last.
+ */
+function mergeNuxtAliases(
+  nuxtAliases: StaticAliases | undefined,
+  viteAliases: StaticAliases | undefined
+): Map<string, string> {
+  if (!nuxtAliases) return toFirstMatchMap(viteAliases?.entries ?? []);
+  if (!viteAliases) return toFirstMatchMap(nuxtAliases.entries);
+  if (nuxtAliases.form === 'object' && viteAliases.form === 'object') {
+    const merged = new Map(nuxtAliases.entries);
+    for (const [find, replacement] of viteAliases.entries) {
+      merged.set(find, replacement);
+    }
+    return merged;
+  }
+  return toFirstMatchMap([...viteAliases.entries, ...nuxtAliases.entries]);
+}
+
+function readPropertyKey(
+  property: t.ObjectMethod | t.ObjectProperty
+): string | undefined {
+  if (!property.computed && property.key.type === 'Identifier') {
+    return property.key.name;
+  }
+  if (property.key.type === 'StringLiteral') return property.key.value;
+  if (property.key.type === 'NumericLiteral') return String(property.key.value);
+  return undefined;
+}
+
+function unwrapEntry(entry: StaticEntry): StaticEntry {
+  return { node: unwrapNode(entry.node) ?? entry.node, scope: entry.scope };
+}
+
+function unwrapNode(node: t.Node | null | undefined): t.Node | undefined {
+  let current = node;
+  while (current) {
+    if (isTransparentExpression(current)) {
+      current = current.expression;
+      continue;
+    }
+    break;
+  }
+  return current ?? undefined;
+}

--- a/packages/vue-extractor/src/internal/project/vueSourceClassification.ts
+++ b/packages/vue-extractor/src/internal/project/vueSourceClassification.ts
@@ -1,0 +1,180 @@
+import { parseScriptAst } from '../script/parser.js';
+
+/** Classification shared by source partitioning and lightweight ownership. */
+export type VueSourceClassification =
+  | 'definitive-sfc'
+  | 'ambiguous-standard-tag-jsx'
+  | 'non-sfc';
+
+const STANDARD_SFC_BLOCKS = new Set(['template', 'script', 'style']);
+
+/**
+ * Distinguishes a conventional SFC from a script module named with `.vue`.
+ *
+ * Vue tolerates arbitrary text before its first block, but treating every such
+ * file as an SFC would hide Babel-valid legacy modules from the existing
+ * parser. A complete JavaScript module wins even when its first JSX expression
+ * uses a standard SFC tag; lone standard-tag expressions remain Vue blocks.
+ */
+export function isVueSfcSource(source: string): boolean {
+  return classifyVueSource(source) !== 'non-sfc';
+}
+
+/** Classifies standard-tag JSX separately from unambiguous Vue SFC source. */
+export function classifyVueSource(source: string): VueSourceClassification {
+  let remainder = source.replace(/^\uFEFF/, '').trimStart();
+  let javascriptClassification: JavaScriptModuleClassification | undefined;
+  const readJavaScriptClassification = () => {
+    javascriptClassification ??= classifyJavaScriptModule(source);
+    return javascriptClassification;
+  };
+  while (remainder) {
+    const afterPrelude = stripLeadingSfcPrelude(remainder);
+    if (afterPrelude === undefined) return 'non-sfc';
+    remainder = afterPrelude;
+    if (!remainder) return 'non-sfc';
+
+    const openingTag = readLeadingBlockTag(remainder);
+    if (!openingTag) {
+      if (readJavaScriptClassification() === 'module') return 'non-sfc';
+      const nextBlock = findNextBlockStart(remainder);
+      if (nextBlock < 0) return 'non-sfc';
+      remainder = remainder.slice(nextBlock);
+      continue;
+    }
+    if (STANDARD_SFC_BLOCKS.has(openingTag.name.toLowerCase())) {
+      const classification = readJavaScriptClassification();
+      if (classification === 'module') return 'non-sfc';
+      return classification === 'ambiguous-standard-tag-jsx'
+        ? 'ambiguous-standard-tag-jsx'
+        : 'definitive-sfc';
+    }
+
+    if (openingTag.selfClosing) {
+      remainder = remainder.slice(openingTag.end).trimStart();
+      continue;
+    }
+    const closingTag = new RegExp(
+      `</${escapeRegularExpression(openingTag.name)}\\s*>`,
+      'i'
+    ).exec(remainder.slice(openingTag.end));
+    if (!closingTag) return 'non-sfc';
+    remainder = remainder
+      .slice(openingTag.end + closingTag.index + closingTag[0].length)
+      .trimStart();
+  }
+  return 'non-sfc';
+}
+
+/** Removes common top-level prelude forms accepted by Vue's SFC compiler. */
+function stripLeadingSfcPrelude(source: string): string | undefined {
+  let remainder = source.trimStart();
+  while (remainder) {
+    if (remainder.startsWith('<!--')) {
+      const end = remainder.indexOf('-->');
+      if (end < 0) return undefined;
+      remainder = remainder.slice(end + 3).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('/*')) {
+      const end = remainder.indexOf('*/', 2);
+      if (end < 0) return undefined;
+      remainder = remainder.slice(end + 2).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('//')) {
+      const end = remainder.search(/[\r\n]/);
+      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
+      continue;
+    }
+    if (remainder.startsWith('#!')) {
+      const end = remainder.search(/[\r\n]/);
+      remainder = end < 0 ? '' : remainder.slice(end + 1).trimStart();
+      continue;
+    }
+    const doctype = /^<!doctype(?:\s[^>]*)?>/i.exec(remainder);
+    if (doctype) {
+      remainder = remainder.slice(doctype[0].length).trimStart();
+      continue;
+    }
+    break;
+  }
+  return remainder;
+}
+
+type JavaScriptModuleClassification =
+  | 'ambiguous-standard-tag-jsx'
+  | 'invalid'
+  | 'module';
+
+/** Distinguishes complete modules from lone standard-tag JSX expressions. */
+function classifyJavaScriptModule(
+  source: string
+): JavaScriptModuleClassification {
+  for (const language of ['tsx', 'flow']) {
+    let ast: ReturnType<typeof parseScriptAst>;
+    try {
+      ast = parseScriptAst(source, language);
+    } catch {
+      continue;
+    }
+    if (ast.program.directives.length > 0) return 'module';
+
+    let foundStandardBlock = false;
+    for (const statement of ast.program.body) {
+      if (statement.type === 'EmptyStatement') continue;
+      if (
+        statement.type === 'ExpressionStatement' &&
+        statement.expression.type === 'JSXElement' &&
+        statement.expression.extra?.parenthesized !== true &&
+        statement.expression.openingElement.name.type === 'JSXIdentifier' &&
+        STANDARD_SFC_BLOCKS.has(
+          statement.expression.openingElement.name.name.toLowerCase()
+        )
+      ) {
+        foundStandardBlock = true;
+        continue;
+      }
+      return 'module';
+    }
+    return foundStandardBlock ? 'ambiguous-standard-tag-jsx' : 'module';
+  }
+  return 'invalid';
+}
+
+/** Finds the next possible top-level block after compiler-tolerated text. */
+function findNextBlockStart(source: string): number {
+  return source.search(/<[A-Za-z][A-Za-z0-9._-]*(?=[\s/>])/);
+}
+
+/** Reads one complete opening block tag while respecting quoted attributes. */
+function readLeadingBlockTag(
+  source: string
+): { end: number; name: string; selfClosing: boolean } | undefined {
+  const nameMatch = /^<([A-Za-z][A-Za-z0-9._-]*)(?=[\s/>])/.exec(source);
+  if (!nameMatch) return undefined;
+
+  let quote: '"' | "'" | undefined;
+  for (let index = nameMatch[0].length; index < source.length; index += 1) {
+    const character = source[index];
+    if (quote) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      continue;
+    }
+    if (character !== '>') continue;
+    return {
+      end: index + 1,
+      name: nameMatch[1]!,
+      selfClosing: source.slice(0, index).trimEnd().endsWith('/'),
+    };
+  }
+  return undefined;
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/vue-extractor/src/internal/project/workspaces.ts
+++ b/packages/vue-extractor/src/internal/project/workspaces.ts
@@ -7,6 +7,8 @@ import {
   type JavaScriptPackageManifest,
 } from './manifest.js';
 
+const ASYNC_WORKSPACE_READ_CONCURRENCY = 64;
+
 /** A validated workspace package and its parsed manifest. */
 export type DeclaredWorkspacePackage = {
   directory: string;
@@ -72,6 +74,7 @@ export function readDeclaredWorkspacePackages(
   } catch {
     return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
   }
+  packagePaths.sort(comparePaths);
 
   const rootPackagePath = path.resolve(cwd, 'package.json');
   const packages = packagePaths.flatMap((packagePath) => {
@@ -97,6 +100,92 @@ export function readDeclaredWorkspacePackages(
       ? [{ directory: path.dirname(absolutePath), manifest }]
       : [];
   });
+  return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, packages);
+}
+
+/**
+ * Reads declared workspace packages without blocking on every manifest.
+ *
+ * The returned packages and cache entry are identical to the synchronous
+ * implementation. Project inspection can populate this cache concurrently
+ * with a host framework's existing extraction, then reuse the established
+ * synchronous ownership logic without traversing the workspace twice.
+ */
+export async function readDeclaredWorkspacePackagesAsync(
+  cwd: string,
+  rootManifest: JavaScriptPackageManifest,
+  cache: WorkspaceDiscoveryCache
+): Promise<DeclaredWorkspacePackage[]> {
+  const cacheKey = path.resolve(cwd);
+  const manifestWorkspaces = JSON.stringify(rootManifest.workspaces ?? null);
+  const cached = cache.get(cacheKey);
+  if (cached?.manifestWorkspaces === manifestWorkspaces) {
+    return cached.packages;
+  }
+
+  const pnpmPatterns = await getPnpmWorkspacePatternsAsync(cwd);
+  const patterns =
+    pnpmPatterns ?? getPackageJsonWorkspacePatterns(rootManifest);
+  const manifestPatterns = [...new Set(patterns.map(toManifestPattern))].filter(
+    (pattern): pattern is string => pattern !== null
+  );
+  if (!manifestPatterns.some((pattern) => !pattern.startsWith('!'))) {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+
+  const realRoot = await readRealPathAsync(cwd);
+  if (!realRoot) {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+
+  let packagePaths: string[];
+  try {
+    packagePaths = await fg(manifestPatterns, {
+      absolute: true,
+      cwd,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**'],
+      onlyFiles: true,
+      unique: true,
+    });
+  } catch {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+  packagePaths.sort(comparePaths);
+
+  const rootPackagePath = path.resolve(cwd, 'package.json');
+  const packageResults = await mapWithConcurrency(
+    packagePaths,
+    ASYNC_WORKSPACE_READ_CONCURRENCY,
+    async (packagePath) => {
+      const absolutePath = path.resolve(packagePath);
+      if (
+        absolutePath === rootPackagePath ||
+        !isWithinRoot(cwd, absolutePath) ||
+        absolutePath.split(path.sep).includes('node_modules')
+      ) {
+        return undefined;
+      }
+
+      const realPackagePath = await readRealPathAsync(absolutePath);
+      if (
+        !realPackagePath ||
+        !isWithinRoot(realRoot, realPackagePath) ||
+        realPackagePath.split(path.sep).includes('node_modules')
+      ) {
+        return undefined;
+      }
+      const manifest =
+        await readJavaScriptPackageManifestAsync(realPackagePath);
+      return manifest
+        ? { directory: path.dirname(absolutePath), manifest }
+        : undefined;
+    }
+  );
+  const packages = packageResults.filter(
+    (workspacePackage): workspacePackage is DeclaredWorkspacePackage =>
+      workspacePackage !== undefined
+  );
   return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, packages);
 }
 
@@ -148,6 +237,28 @@ function getPnpmWorkspacePatterns(cwd: string): string[] | undefined {
   }
 }
 
+async function getPnpmWorkspacePatternsAsync(
+  cwd: string
+): Promise<string[] | undefined> {
+  const workspacePath = path.join(cwd, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(workspacePath)) return undefined;
+
+  try {
+    const parsed = parseYaml(
+      await fs.promises.readFile(workspacePath, 'utf8')
+    ) as unknown;
+    if (parsed == null) return [];
+    if (!isRecord(parsed)) return [];
+    if (parsed.packages == null) return [];
+    if (!Array.isArray(parsed.packages)) return [];
+    return parsed.packages.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
 function toManifestPattern(pattern: string): string | null {
   const trimmed = pattern.trim();
   const negated = trimmed.startsWith('!');
@@ -186,6 +297,50 @@ function readRealPath(filePath: string): string | undefined {
   }
 }
 
+async function readRealPathAsync(
+  filePath: string
+): Promise<string | undefined> {
+  try {
+    return await fs.promises.realpath(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+async function readJavaScriptPackageManifestAsync(
+  packagePath: string
+): Promise<JavaScriptPackageManifest | undefined> {
+  try {
+    const parsed = JSON.parse(
+      await fs.promises.readFile(packagePath, 'utf8')
+    ) as unknown;
+    return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Maps filesystem work concurrently without exhausting file descriptors. */
+async function mapWithConcurrency<Input, Output>(
+  values: readonly Input[],
+  concurrency: number,
+  mapper: (value: Input) => Promise<Output>
+): Promise<Output[]> {
+  const results = Array.from({ length: values.length }) as Output[];
+  let nextIndex = 0;
+  const worker = async () => {
+    while (nextIndex < values.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await mapper(values[index]!);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, values.length) }, () => worker())
+  );
+  return results;
+}
+
 function isWithinRoot(root: string, candidate: string): boolean {
   const relativePath = path.relative(path.resolve(root), candidate);
   return (
@@ -198,4 +353,8 @@ function isWithinRoot(root: string, candidate: string): boolean {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function comparePaths(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }

--- a/packages/vue-extractor/src/internal/project/workspaces.ts
+++ b/packages/vue-extractor/src/internal/project/workspaces.ts
@@ -1,0 +1,250 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import fg from 'fast-glob';
+import { parse as parseYaml } from 'yaml';
+
+/** Dependency fields that can declare a runtime available to one package. */
+const DEPENDENCY_FIELDS = [
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
+/** Minimal package manifest shape used by project discovery. */
+export type JavaScriptPackageManifest = {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  workspaces?: string[] | { packages?: string[] };
+};
+
+/** A validated workspace package and its parsed manifest. */
+export type DeclaredWorkspacePackage = {
+  directory: string;
+  manifest: JavaScriptPackageManifest;
+};
+
+/** Per-extraction cache that avoids traversing the same workspace repeatedly. */
+export type WorkspaceDiscoveryCache = Map<
+  string,
+  { manifestWorkspaces: string; packages: DeclaredWorkspacePackage[] }
+>;
+
+/** Creates an isolated workspace cache for one detection or extraction call. */
+export function createWorkspaceDiscoveryCache(): WorkspaceDiscoveryCache {
+  return new Map();
+}
+
+/**
+ * Reads declared workspace packages without following paths outside the root.
+ *
+ * A valid `pnpm-workspace.yaml` is authoritative over `package.json` because
+ * pnpm uses that file to include and exclude packages. Malformed workspace
+ * metadata is treated as no optional workspaces; it never hides a known root
+ * application or causes extraction to traverse the filesystem recursively.
+ */
+export function readDeclaredWorkspacePackages(
+  cwd: string,
+  rootManifest: JavaScriptPackageManifest,
+  cache: WorkspaceDiscoveryCache
+): DeclaredWorkspacePackage[] {
+  const cacheKey = path.resolve(cwd);
+  const manifestWorkspaces = JSON.stringify(rootManifest.workspaces ?? null);
+  const cached = cache.get(cacheKey);
+  if (cached?.manifestWorkspaces === manifestWorkspaces) {
+    return cached.packages;
+  }
+
+  const pnpmPatterns = getPnpmWorkspacePatterns(cwd);
+  const patterns =
+    pnpmPatterns ?? getPackageJsonWorkspacePatterns(rootManifest);
+  const manifestPatterns = [...new Set(patterns.map(toManifestPattern))].filter(
+    (pattern): pattern is string => pattern !== null
+  );
+  if (!manifestPatterns.some((pattern) => !pattern.startsWith('!'))) {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+
+  const realRoot = readRealPath(cwd);
+  if (!realRoot) {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+
+  let packagePaths: string[];
+  try {
+    packagePaths = fg.sync(manifestPatterns, {
+      absolute: true,
+      cwd,
+      followSymbolicLinks: false,
+      ignore: ['**/node_modules/**'],
+      onlyFiles: true,
+      unique: true,
+    });
+  } catch {
+    return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
+  }
+
+  const rootPackagePath = path.resolve(cwd, 'package.json');
+  const packages = packagePaths.flatMap((packagePath) => {
+    const absolutePath = path.resolve(packagePath);
+    if (
+      absolutePath === rootPackagePath ||
+      !isWithinRoot(cwd, absolutePath) ||
+      absolutePath.split(path.sep).includes('node_modules')
+    ) {
+      return [];
+    }
+
+    const realPackagePath = readRealPath(absolutePath);
+    if (
+      !realPackagePath ||
+      !isWithinRoot(realRoot, realPackagePath) ||
+      realPackagePath.split(path.sep).includes('node_modules')
+    ) {
+      return [];
+    }
+    const manifest = readJavaScriptPackageManifest(realPackagePath);
+    return manifest
+      ? [{ directory: path.dirname(absolutePath), manifest }]
+      : [];
+  });
+  return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, packages);
+}
+
+/** Reads one package manifest without throwing for absent or malformed input. */
+export function readJavaScriptPackageManifest(
+  packagePath: string
+): JavaScriptPackageManifest | undefined {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(packagePath, 'utf8')) as unknown;
+    return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Checks every dependency field used for Vue project ownership. */
+export function declaresJavaScriptDependency(
+  manifest: JavaScriptPackageManifest,
+  packageName: string
+): boolean {
+  return DEPENDENCY_FIELDS.some(
+    (field) => manifest[field]?.[packageName] !== undefined
+  );
+}
+
+/** Lists dependency names across every supported manifest field. */
+export function readDeclaredDependencyNames(
+  manifest: JavaScriptPackageManifest
+): string[] {
+  const names = new Set<string>();
+  for (const field of DEPENDENCY_FIELDS) {
+    for (const packageName of Object.keys(manifest[field] ?? {})) {
+      names.add(packageName);
+    }
+  }
+  return [...names];
+}
+
+function cacheWorkspacePackages(
+  cache: WorkspaceDiscoveryCache,
+  cacheKey: string,
+  manifestWorkspaces: string,
+  packages: DeclaredWorkspacePackage[]
+): DeclaredWorkspacePackage[] {
+  cache.set(cacheKey, { manifestWorkspaces, packages });
+  return packages;
+}
+
+function getPackageJsonWorkspacePatterns(
+  manifest: JavaScriptPackageManifest
+): string[] {
+  if (Array.isArray(manifest.workspaces)) {
+    return manifest.workspaces.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+  if (
+    manifest.workspaces &&
+    typeof manifest.workspaces === 'object' &&
+    Array.isArray(manifest.workspaces.packages)
+  ) {
+    return manifest.workspaces.packages.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  }
+  return [];
+}
+
+function getPnpmWorkspacePatterns(cwd: string): string[] | undefined {
+  const workspacePath = path.join(cwd, 'pnpm-workspace.yaml');
+  if (!fs.existsSync(workspacePath)) return undefined;
+
+  try {
+    const parsed = parseYaml(fs.readFileSync(workspacePath, 'utf8')) as unknown;
+    if (parsed == null) return [];
+    if (!isRecord(parsed)) return [];
+    if (parsed.packages == null) return [];
+    if (!Array.isArray(parsed.packages)) return [];
+    return parsed.packages.filter(
+      (pattern): pattern is string => typeof pattern === 'string'
+    );
+  } catch {
+    return [];
+  }
+}
+
+function toManifestPattern(pattern: string): string | null {
+  const trimmed = pattern.trim();
+  const negated = trimmed.startsWith('!');
+  const rawPattern = negated ? trimmed.slice(1) : trimmed;
+  if (!rawPattern) return null;
+
+  const normalized = path.posix.normalize(rawPattern.replaceAll('\\', '/'));
+  if (
+    path.posix.isAbsolute(normalized) ||
+    path.win32.isAbsolute(normalized) ||
+    /^[A-Za-z]:/.test(normalized) ||
+    containsParentTraversal(normalized) ||
+    normalized === '..' ||
+    normalized.startsWith('../')
+  ) {
+    return null;
+  }
+
+  const withoutTrailingSlash = normalized.replace(/\/+$/, '');
+  const manifestPattern = withoutTrailingSlash.endsWith('/package.json')
+    ? withoutTrailingSlash
+    : `${withoutTrailingSlash}/package.json`;
+  return negated ? `!${manifestPattern}` : manifestPattern;
+}
+
+/** Rejects parent segments, including those hidden in glob alternatives. */
+function containsParentTraversal(pattern: string): boolean {
+  return /(^|[/{,(|])\.\.(?=$|[/},)|])/.test(pattern);
+}
+
+function readRealPath(filePath: string): string | undefined {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return undefined;
+  }
+}
+
+function isWithinRoot(root: string, candidate: string): boolean {
+  const relativePath = path.relative(path.resolve(root), candidate);
+  return (
+    relativePath !== '' &&
+    relativePath !== '..' &&
+    !relativePath.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relativePath)
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}

--- a/packages/vue-extractor/src/internal/project/workspaces.ts
+++ b/packages/vue-extractor/src/internal/project/workspaces.ts
@@ -2,24 +2,10 @@ import fs from 'node:fs';
 import path from 'node:path';
 import fg from 'fast-glob';
 import { parse as parseYaml } from 'yaml';
-
-/** Dependency fields that can declare a runtime available to one package. */
-const DEPENDENCY_FIELDS = [
-  'dependencies',
-  'devDependencies',
-  'optionalDependencies',
-  'peerDependencies',
-] as const;
-
-/** Minimal package manifest shape used by project discovery. */
-export type JavaScriptPackageManifest = {
-  name?: string;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  workspaces?: string[] | { packages?: string[] };
-};
+import {
+  readJavaScriptPackageManifest,
+  type JavaScriptPackageManifest,
+} from './manifest.js';
 
 /** A validated workspace package and its parsed manifest. */
 export type DeclaredWorkspacePackage = {
@@ -112,41 +98,6 @@ export function readDeclaredWorkspacePackages(
       : [];
   });
   return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, packages);
-}
-
-/** Reads one package manifest without throwing for absent or malformed input. */
-export function readJavaScriptPackageManifest(
-  packagePath: string
-): JavaScriptPackageManifest | undefined {
-  try {
-    const parsed = JSON.parse(fs.readFileSync(packagePath, 'utf8')) as unknown;
-    return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/** Checks every dependency field used for Vue project ownership. */
-export function declaresJavaScriptDependency(
-  manifest: JavaScriptPackageManifest,
-  packageName: string
-): boolean {
-  return DEPENDENCY_FIELDS.some(
-    (field) => manifest[field]?.[packageName] !== undefined
-  );
-}
-
-/** Lists dependency names across every supported manifest field. */
-export function readDeclaredDependencyNames(
-  manifest: JavaScriptPackageManifest
-): string[] {
-  const names = new Set<string>();
-  for (const field of DEPENDENCY_FIELDS) {
-    for (const packageName of Object.keys(manifest[field] ?? {})) {
-      names.add(packageName);
-    }
-  }
-  return [...names];
 }
 
 function cacheWorkspacePackages(

--- a/packages/vue-extractor/src/internal/project/workspaces.ts
+++ b/packages/vue-extractor/src/internal/project/workspaces.ts
@@ -2,10 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import fg from 'fast-glob';
 import { parse as parseYaml } from 'yaml';
-import {
-  readJavaScriptPackageManifest,
-  type JavaScriptPackageManifest,
-} from './manifest.js';
+import type { JavaScriptPackageManifest } from './manifest.js';
 
 const ASYNC_WORKSPACE_READ_CONCURRENCY = 64;
 
@@ -61,17 +58,15 @@ export function readDeclaredWorkspacePackages(
     return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
   }
 
-  let packagePaths: string[];
-  try {
-    packagePaths = fg.sync(manifestPatterns, {
-      absolute: true,
-      cwd,
-      followSymbolicLinks: false,
-      ignore: ['**/node_modules/**'],
-      onlyFiles: true,
-      unique: true,
-    });
-  } catch {
+  const shallowPackagePaths = readShallowWorkspaceManifestPaths(
+    cwd,
+    realRoot,
+    manifestPatterns
+  );
+  const packagePaths =
+    shallowPackagePaths ??
+    readWorkspaceManifestPathsWithGlob(cwd, manifestPatterns);
+  if (!packagePaths) {
     return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
   }
   packagePaths.sort(comparePaths);
@@ -87,15 +82,11 @@ export function readDeclaredWorkspacePackages(
       return [];
     }
 
-    const realPackagePath = readRealPath(absolutePath);
-    if (
-      !realPackagePath ||
-      !isWithinRoot(realRoot, realPackagePath) ||
-      realPackagePath.split(path.sep).includes('node_modules')
-    ) {
-      return [];
-    }
-    const manifest = readJavaScriptPackageManifest(realPackagePath);
+    const manifestPath = shallowPackagePaths
+      ? absolutePath
+      : readValidatedManifestPath(realRoot, absolutePath);
+    if (!manifestPath) return [];
+    const manifest = readWorkspacePackageManifest(manifestPath);
     return manifest
       ? [{ directory: path.dirname(absolutePath), manifest }]
       : [];
@@ -138,17 +129,22 @@ export async function readDeclaredWorkspacePackagesAsync(
     return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
   }
 
-  let packagePaths: string[];
-  try {
-    packagePaths = await fg(manifestPatterns, {
-      absolute: true,
-      cwd,
-      followSymbolicLinks: false,
-      ignore: ['**/node_modules/**'],
-      onlyFiles: true,
-      unique: true,
-    });
-  } catch {
+  const shallowPackagePaths = await readShallowWorkspaceManifestPathsAsync(
+    cwd,
+    realRoot,
+    manifestPatterns
+  );
+  let packagePaths: string[] | undefined;
+  if (shallowPackagePaths) {
+    packagePaths = shallowPackagePaths;
+  } else {
+    try {
+      packagePaths = await fg([...manifestPatterns], workspaceGlobOptions(cwd));
+    } catch {
+      packagePaths = undefined;
+    }
+  }
+  if (!packagePaths) {
     return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, []);
   }
   packagePaths.sort(comparePaths);
@@ -167,16 +163,11 @@ export async function readDeclaredWorkspacePackagesAsync(
         return undefined;
       }
 
-      const realPackagePath = await readRealPathAsync(absolutePath);
-      if (
-        !realPackagePath ||
-        !isWithinRoot(realRoot, realPackagePath) ||
-        realPackagePath.split(path.sep).includes('node_modules')
-      ) {
-        return undefined;
-      }
-      const manifest =
-        await readJavaScriptPackageManifestAsync(realPackagePath);
+      const manifestPath = shallowPackagePaths
+        ? absolutePath
+        : await readValidatedManifestPathAsync(realRoot, absolutePath);
+      if (!manifestPath) return undefined;
+      const manifest = await readJavaScriptPackageManifestAsync(manifestPath);
       return manifest
         ? { directory: path.dirname(absolutePath), manifest }
         : undefined;
@@ -187,6 +178,147 @@ export async function readDeclaredWorkspacePackagesAsync(
       workspacePackage !== undefined
   );
   return cacheWorkspacePackages(cache, cacheKey, manifestWorkspaces, packages);
+}
+
+/**
+ * Finds workspace manifests, optimizing only the common shallow-positive form.
+ *
+ * A pattern such as `packages/<child>/package.json` can be resolved with one
+ * directory read instead of traversing every child directory. All negative,
+ * nested, or otherwise dynamic patterns keep fast-glob's existing behavior.
+ */
+function readShallowWorkspaceManifestPaths(
+  cwd: string,
+  realRoot: string,
+  manifestPatterns: readonly string[]
+): string[] | undefined {
+  const shallowBases = readShallowPositiveBases(manifestPatterns);
+  if (!shallowBases) return undefined;
+
+  try {
+    const paths = shallowBases.flatMap((base) => {
+      const baseDirectory = path.resolve(cwd, base);
+      if (!isSafeShallowBase(realRoot, readRealPath(baseDirectory))) return [];
+      try {
+        return fs
+          .readdirSync(baseDirectory, { withFileTypes: true })
+          .filter(isVisibleDirectoryEntry)
+          .map((entry) => path.join(baseDirectory, entry.name, 'package.json'));
+      } catch {
+        return [];
+      }
+    });
+    return [...new Set(paths)];
+  } catch {
+    return undefined;
+  }
+}
+
+/** Asynchronous counterpart to {@link readShallowWorkspaceManifestPaths}. */
+async function readShallowWorkspaceManifestPathsAsync(
+  cwd: string,
+  realRoot: string,
+  manifestPatterns: readonly string[]
+): Promise<string[] | undefined> {
+  const shallowBases = readShallowPositiveBases(manifestPatterns);
+  if (!shallowBases) return undefined;
+
+  try {
+    const entriesByBase = await Promise.all(
+      shallowBases.map(async (base) => {
+        const baseDirectory = path.resolve(cwd, base);
+        const realBase = await readRealPathAsync(baseDirectory);
+        if (!isSafeShallowBase(realRoot, realBase)) {
+          return { baseDirectory, entries: [] };
+        }
+        try {
+          return {
+            baseDirectory,
+            entries: await fs.promises.readdir(baseDirectory, {
+              withFileTypes: true,
+            }),
+          };
+        } catch {
+          return { baseDirectory, entries: [] };
+        }
+      })
+    );
+    const paths = entriesByBase.flatMap(({ baseDirectory, entries }) =>
+      entries
+        .filter(isVisibleDirectoryEntry)
+        .map((entry) => path.join(baseDirectory, entry.name, 'package.json'))
+    );
+    return [...new Set(paths)];
+  } catch {
+    return undefined;
+  }
+}
+
+/** Uses fast-glob for workspace layouts outside the bounded shallow form. */
+function readWorkspaceManifestPathsWithGlob(
+  cwd: string,
+  manifestPatterns: readonly string[]
+): string[] | undefined {
+  try {
+    return fg.sync([...manifestPatterns], workspaceGlobOptions(cwd));
+  } catch {
+    return undefined;
+  }
+}
+
+/** Shared options preserve the historical fast-glob matching semantics. */
+function workspaceGlobOptions(
+  cwd: string
+): NonNullable<Parameters<typeof fg.sync>[1]> {
+  return {
+    absolute: true,
+    cwd,
+    followSymbolicLinks: false,
+    ignore: ['**/node_modules/**'],
+    onlyFiles: true,
+    unique: true,
+  };
+}
+
+/**
+ * Reads literal bases from patterns shaped like `<base>/<child>/package.json`.
+ * Hidden child directories are intentionally excluded to match fast-glob's
+ * default `dot: false` behavior.
+ */
+function readShallowPositiveBases(
+  manifestPatterns: readonly string[]
+): string[] | undefined {
+  const bases: string[] = [];
+  for (const pattern of manifestPatterns) {
+    if (pattern.startsWith('!')) return undefined;
+    const segments = pattern.split('/');
+    if (
+      segments.length < 2 ||
+      segments.at(-1) !== 'package.json' ||
+      segments.at(-2) !== '*'
+    ) {
+      return undefined;
+    }
+    const base = segments.slice(0, -2).join('/') || '.';
+    if (fg.isDynamicPattern(base)) return undefined;
+    bases.push(base);
+  }
+  return [...new Set(bases)];
+}
+
+/** Matches only visible physical directories, excluding symlinked workspaces. */
+function isVisibleDirectoryEntry(entry: fs.Dirent): boolean {
+  return !entry.name.startsWith('.') && entry.isDirectory();
+}
+
+/** Validates one physical shallow base before skipping per-manifest realpath. */
+function isSafeShallowBase(
+  realRoot: string,
+  realBase: string | undefined
+): boolean {
+  if (!realBase || !isWithinOrEqualRoot(realRoot, realBase)) return false;
+  const relative = path.relative(realRoot, realBase);
+  return !relative.split(path.sep).includes('node_modules');
 }
 
 function cacheWorkspacePackages(
@@ -307,17 +439,69 @@ async function readRealPathAsync(
   }
 }
 
+/** Preserves the historical physical containment check for glob fallbacks. */
+function readValidatedManifestPath(
+  realRoot: string,
+  packagePath: string
+): string | undefined {
+  const realPackagePath = readRealPath(packagePath);
+  return realPackagePath &&
+    isWithinRoot(realRoot, realPackagePath) &&
+    !realPackagePath.split(path.sep).includes('node_modules')
+    ? realPackagePath
+    : undefined;
+}
+
+/** Asynchronous counterpart to {@link readValidatedManifestPath}. */
+async function readValidatedManifestPathAsync(
+  realRoot: string,
+  packagePath: string
+): Promise<string | undefined> {
+  const realPackagePath = await readRealPathAsync(packagePath);
+  return realPackagePath &&
+    isWithinRoot(realRoot, realPackagePath) &&
+    !realPackagePath.split(path.sep).includes('node_modules')
+    ? realPackagePath
+    : undefined;
+}
+
 async function readJavaScriptPackageManifestAsync(
   packagePath: string
 ): Promise<JavaScriptPackageManifest | undefined> {
+  let file: fs.promises.FileHandle | undefined;
   try {
-    const parsed = JSON.parse(
-      await fs.promises.readFile(packagePath, 'utf8')
-    ) as unknown;
+    const stats = await fs.promises.lstat(packagePath);
+    if (!stats.isFile()) return undefined;
+    file = await fs.promises.open(packagePath, workspaceManifestOpenFlags());
+    const parsed = JSON.parse(await file.readFile('utf8')) as unknown;
     return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
   } catch {
     return undefined;
+  } finally {
+    await file?.close();
   }
+}
+
+/** Reads a workspace manifest without following a manifest-file symlink. */
+function readWorkspacePackageManifest(
+  packagePath: string
+): JavaScriptPackageManifest | undefined {
+  let descriptor: number | undefined;
+  try {
+    if (!fs.lstatSync(packagePath).isFile()) return undefined;
+    descriptor = fs.openSync(packagePath, workspaceManifestOpenFlags());
+    const parsed = JSON.parse(fs.readFileSync(descriptor, 'utf8')) as unknown;
+    return isRecord(parsed) ? (parsed as JavaScriptPackageManifest) : undefined;
+  } catch {
+    return undefined;
+  } finally {
+    if (descriptor !== undefined) fs.closeSync(descriptor);
+  }
+}
+
+/** Prevents a shallow workspace candidate from redirecting its manifest. */
+function workspaceManifestOpenFlags(): number {
+  return fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0);
 }
 
 /** Maps filesystem work concurrently without exhausting file descriptors. */
@@ -348,6 +532,14 @@ function isWithinRoot(root: string, candidate: string): boolean {
     relativePath !== '..' &&
     !relativePath.startsWith(`..${path.sep}`) &&
     !path.isAbsolute(relativePath)
+  );
+}
+
+/** Checks physical containment while allowing the project root itself. */
+function isWithinOrEqualRoot(root: string, candidate: string): boolean {
+  return (
+    path.resolve(root) === path.resolve(candidate) ||
+    isWithinRoot(root, candidate)
   );
 }
 

--- a/packages/vue-extractor/src/internal/project/wrapperProvenance.ts
+++ b/packages/vue-extractor/src/internal/project/wrapperProvenance.ts
@@ -1,0 +1,428 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createLocalModuleResolver } from '../script/localModules.js';
+import type { JavaScriptPackageManifest } from './manifest.js';
+import { createProjectModuleResolver } from './moduleResolver.js';
+
+const SOURCE_EXTENSIONS = [
+  '.mjs',
+  '.js',
+  '.mts',
+  '.ts',
+  '.jsx',
+  '.tsx',
+] as const;
+
+/** Prevents a pathological export pattern from turning detection into a crawl. */
+const MAX_PATTERN_FILES = 2_000;
+
+/** Conditions used by the package's default ESM/Vite resolver. */
+const IMPORT_CONDITIONS = new Set([
+  'module',
+  'browser',
+  'development',
+  'import',
+  'default',
+]);
+
+type PublicPackageManifest = JavaScriptPackageManifest & {
+  browser?: string | { '.'?: string };
+  exports?: unknown;
+  'jsnext:main'?: string;
+  jsnext?: string;
+  main?: string;
+  module?: string;
+};
+
+/**
+ * Returns whether a local package publicly exposes a gt-vue-derived value.
+ *
+ * Merely using gt-vue inside a package does not make every consumer a Vue
+ * application. This check starts at public import entrypoints and follows the
+ * same local ESM provenance graph as source extraction, so only an API that a
+ * consumer can actually import propagates Vue ownership.
+ */
+export function packagePubliclyExposesGT(
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest
+): boolean {
+  const resolveModule = createProjectModuleResolver(undefined, {
+    selfPackage: { directory: packageDirectory, manifest },
+  });
+  const entries = resolvePublicImportEntries(
+    packageDirectory,
+    manifest,
+    resolveModule
+  );
+  if (entries.length === 0) return false;
+
+  const localModules = createLocalModuleResolver(resolveModule, {
+    recognizeAllGTRuntimeExports: true,
+  });
+  return entries.some((entry) => {
+    // Invalid entrypoints fail closed. The source analyzer can recover enough
+    // provenance from malformed modules to emit diagnostics, but malformed
+    // package code must not establish project ownership by itself.
+    if (!localModules.getRecord(entry)) return false;
+    return localModules
+      .listExportNames(entry)
+      .some((name) => localModules.hasGTExportReference(entry, name));
+  });
+}
+
+/** Resolves root and exact-subpath import entrypoints without executing code. */
+function resolvePublicImportEntries(
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest,
+  resolveModule: ReturnType<typeof createProjectModuleResolver>
+): string[] {
+  const publicManifest = manifest as PublicPackageManifest;
+  const packageName = readPackageName(manifest);
+  const importer = path.join(packageDirectory, '__gt_vue_entry_probe__.mjs');
+  const entries = new Set<string>();
+
+  if (packageName && publicManifest.exports !== undefined) {
+    for (const specifier of readExactPublicSpecifiers(
+      packageName,
+      publicManifest.exports
+    )) {
+      const entry = resolveModule(specifier, importer);
+      if (entry && isWithinPackage(packageDirectory, entry)) {
+        entries.add(resolveRealPath(entry));
+      }
+    }
+    for (const entry of resolveWildcardPublicEntries(
+      packageDirectory,
+      packageName,
+      publicManifest.exports,
+      importer,
+      resolveModule
+    )) {
+      entries.add(entry);
+    }
+    // An exports map encapsulates the package. Never fall back to private main
+    // fields when none of its public import conditions can be resolved.
+    return [...entries];
+  }
+
+  const browserEntry =
+    typeof publicManifest.browser === 'string'
+      ? publicManifest.browser
+      : typeof publicManifest.browser === 'object' &&
+          publicManifest.browser !== null &&
+          typeof publicManifest.browser['.'] === 'string'
+        ? publicManifest.browser['.']
+        : undefined;
+  for (const candidate of [
+    browserEntry,
+    publicManifest.module,
+    publicManifest['jsnext:main'],
+    publicManifest.jsnext,
+    publicManifest.main,
+    'index',
+  ]) {
+    if (typeof candidate !== 'string') continue;
+    const entry = resolveSourceEntry(packageDirectory, candidate);
+    if (entry) {
+      entries.add(entry);
+      // Match package entry selection: the first resolvable main field wins.
+      break;
+    }
+  }
+  return [...entries];
+}
+
+/**
+ * Expands finite package-export patterns and verifies each generated subpath.
+ *
+ * The project resolver remains authoritative for conditions and export-key
+ * precedence. Files discovered from inactive `require` or `types` branches,
+ * shadowed patterns, and targets outside the package therefore cannot prove
+ * public runtime provenance.
+ */
+function resolveWildcardPublicEntries(
+  packageDirectory: string,
+  packageName: string,
+  exportsField: unknown,
+  importer: string,
+  resolveModule: ReturnType<typeof createProjectModuleResolver>
+): string[] {
+  if (!isRecord(exportsField) || isConditionalExports(exportsField)) return [];
+  const entries = new Set<string>();
+  const fileBudget = { remaining: MAX_PATTERN_FILES };
+  for (const [subpath, target] of Object.entries(exportsField)) {
+    if (!subpath.startsWith('./') || !subpath.includes('*')) continue;
+    for (const targetPattern of collectImportTargets(target)) {
+      const candidates = expandTargetPattern(
+        packageDirectory,
+        targetPattern,
+        fileBudget
+      );
+      for (const { capture, file } of candidates) {
+        const publicSubpath = subpath.replaceAll('*', capture);
+        if (!isSafePublicSubpath(publicSubpath)) continue;
+        const resolved = resolveModule(
+          `${packageName}${publicSubpath.slice(1)}`,
+          importer
+        );
+        if (
+          !resolved ||
+          !isWithinPackage(packageDirectory, resolved) ||
+          resolveRealPath(resolved) !== resolveRealPath(file)
+        ) {
+          continue;
+        }
+        entries.add(resolveRealPath(resolved));
+      }
+    }
+  }
+  return [...entries];
+}
+
+/** Selects conditional targets using the same default ESM conditions. */
+function collectImportTargets(target: unknown): string[] {
+  if (typeof target === 'string') return [target];
+  if (Array.isArray(target)) return target.flatMap(collectImportTargets);
+  if (!isRecord(target)) return [];
+  for (const [condition, conditionalTarget] of Object.entries(target)) {
+    if (!IMPORT_CONDITIONS.has(condition)) continue;
+    const targets = collectImportTargets(conditionalTarget);
+    if (targets.length > 0) return targets;
+  }
+  return [];
+}
+
+type ExpandedTarget = { capture: string; file: string };
+
+/** Expands one target pattern beneath its longest literal directory prefix. */
+function expandTargetPattern(
+  packageDirectory: string,
+  targetPattern: string,
+  fileBudget: { remaining: number }
+): ExpandedTarget[] {
+  if (!targetPattern.startsWith('./')) return [];
+  const patterns = readSourceTargetPatterns(targetPattern);
+  const expanded = new Map<string, ExpandedTarget>();
+  for (const pattern of patterns) {
+    if (!pattern.includes('*')) {
+      const file = resolveSourceEntry(packageDirectory, pattern);
+      if (file && isWithinPackage(packageDirectory, file)) {
+        expanded.set(`\0${file}`, { capture: '__gt_vue_probe__', file });
+      }
+      continue;
+    }
+
+    const searchDirectory = resolvePatternSearchDirectory(
+      packageDirectory,
+      pattern
+    );
+    if (!searchDirectory) continue;
+    const files = readFiniteFiles(searchDirectory, fileBudget);
+    if (!files) continue;
+    for (const file of files) {
+      if (!isWithinPackage(packageDirectory, file)) continue;
+      const packageRelative = `./${toPosixPath(
+        path.relative(packageDirectory, file)
+      )}`;
+      const capture = matchPatternCapture(pattern, packageRelative);
+      if (capture === undefined || !isSafePatternCapture(capture)) continue;
+      expanded.set(`${capture}\0${file}`, { capture, file });
+    }
+  }
+  return [...expanded.values()];
+}
+
+/** Includes source equivalents for export maps that name emitted JS files. */
+function readSourceTargetPatterns(targetPattern: string): string[] {
+  const extension = path.posix.extname(targetPattern).toLowerCase();
+  const stem = targetPattern.slice(0, -extension.length);
+  if (extension === '.js') {
+    return [targetPattern, `${stem}.ts`, `${stem}.tsx`];
+  }
+  if (extension === '.jsx') return [targetPattern, `${stem}.tsx`];
+  if (extension === '.mjs') return [targetPattern, `${stem}.mts`];
+  return [targetPattern];
+}
+
+function resolvePatternSearchDirectory(
+  packageDirectory: string,
+  targetPattern: string
+): string | undefined {
+  const literalPrefix = targetPattern.slice(2, targetPattern.indexOf('*'));
+  const directoryPrefix = literalPrefix.endsWith('/')
+    ? literalPrefix
+    : literalPrefix.slice(0, literalPrefix.lastIndexOf('/') + 1);
+  const candidate = path.resolve(packageDirectory, directoryPrefix);
+  if (!isWithinPackage(packageDirectory, candidate)) return undefined;
+  try {
+    return fs.statSync(candidate).isDirectory() ? candidate : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Reads regular files without following symlinked directories or node_modules. */
+function readFiniteFiles(
+  directory: string,
+  fileBudget: { remaining: number }
+): string[] | undefined {
+  const files: string[] = [];
+  const pending = [directory];
+  while (pending.length > 0) {
+    const current = pending.pop()!;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(current, { withFileTypes: true });
+    } catch {
+      return undefined;
+    }
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '.git') continue;
+      const candidate = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(candidate);
+      } else if (entry.isFile()) {
+        files.push(candidate);
+        fileBudget.remaining -= 1;
+        if (fileBudget.remaining < 0) return undefined;
+      }
+    }
+  }
+  return files;
+}
+
+/** Returns the wildcard capture when a package-relative target matches. */
+function matchPatternCapture(
+  targetPattern: string,
+  candidate: string
+): string | undefined {
+  const parts = targetPattern.split('*');
+  if (parts.length < 2) return targetPattern === candidate ? '' : undefined;
+  const expression = new RegExp(
+    `^${escapeRegularExpression(parts[0]!)}(.*)${parts
+      .slice(1)
+      .map(
+        (part, index) =>
+          `${index === 0 ? '' : '\\1'}${escapeRegularExpression(part)}`
+      )
+      .join('')}$`
+  );
+  return expression.exec(candidate)?.[1];
+}
+
+function isSafePatternCapture(capture: string): boolean {
+  return (
+    capture.length > 0 &&
+    !capture.includes('\\') &&
+    !capture.split('/').some((segment) => segment === '..')
+  );
+}
+
+function isSafePublicSubpath(subpath: string): boolean {
+  return (
+    subpath.startsWith('./') &&
+    !subpath.includes('\\') &&
+    !subpath.split('/').some((segment) => segment === '..')
+  );
+}
+
+function escapeRegularExpression(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join(path.posix.sep);
+}
+
+/** Lists the package root and exact subpaths that an import may request. */
+function readExactPublicSpecifiers(
+  packageName: string,
+  exportsField: unknown
+): string[] {
+  if (!isRecord(exportsField) || isConditionalExports(exportsField)) {
+    return [packageName];
+  }
+  return Object.keys(exportsField)
+    .filter(
+      (subpath) =>
+        (subpath === '.' || subpath.startsWith('./')) && !subpath.includes('*')
+    )
+    .map((subpath) =>
+      subpath === '.' ? packageName : `${packageName}${subpath.slice(1)}`
+    );
+}
+
+function isConditionalExports(exportsField: Record<string, unknown>): boolean {
+  return Object.keys(exportsField).every((key) => !key.startsWith('.'));
+}
+
+/** Resolves a legacy package entry while preferring emitted files when present. */
+function resolveSourceEntry(
+  packageDirectory: string,
+  requestedEntry: string
+): string | undefined {
+  const requested = path.resolve(packageDirectory, requestedEntry);
+  const relative = path.relative(packageDirectory, requested);
+  if (
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    return undefined;
+  }
+
+  const candidates = [requested];
+  const extension = path.extname(requested).toLowerCase();
+  if (!extension) {
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(`${requested}${sourceExtension}`);
+    }
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(path.join(requested, `index${sourceExtension}`));
+    }
+  } else if (extension === '.js' || extension === '.jsx') {
+    const stem = requested.slice(0, -extension.length);
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(`${stem}${sourceExtension}`);
+    }
+  }
+  for (const candidate of candidates) {
+    try {
+      if (fs.statSync(candidate).isFile()) return resolveRealPath(candidate);
+    } catch {
+      // Try the next public source candidate.
+    }
+  }
+  return undefined;
+}
+
+function isWithinPackage(packageDirectory: string, file: string): boolean {
+  const root = resolveRealPath(packageDirectory);
+  const candidate = resolveRealPath(file);
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== '..' &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+function resolveRealPath(file: string): string {
+  try {
+    return fs.realpathSync(file);
+  } catch {
+    return path.resolve(file);
+  }
+}
+
+function readPackageName(
+  manifest: JavaScriptPackageManifest
+): string | undefined {
+  return typeof manifest.name === 'string' && manifest.name
+    ? manifest.name
+    : undefined;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/packages/vue-extractor/src/internal/project/wrapperProvenance.ts
+++ b/packages/vue-extractor/src/internal/project/wrapperProvenance.ts
@@ -34,6 +34,15 @@ type PublicPackageManifest = JavaScriptPackageManifest & {
   module?: string;
 };
 
+export type PublicImportEntry = {
+  entry: string;
+  specifier: string;
+};
+
+export type PublicGTImport = PublicImportEntry & {
+  exportNames: ReadonlySet<string>;
+};
+
 /**
  * Returns whether a local package publicly exposes a gt-vue-derived value.
  *
@@ -46,6 +55,14 @@ export function packagePubliclyExposesGT(
   packageDirectory: string,
   manifest: JavaScriptPackageManifest
 ): boolean {
+  return readPublicGTImports(packageDirectory, manifest).length > 0;
+}
+
+/** Resolves every public import entry and retains its GT-derived export names. */
+export function readPublicGTImports(
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest
+): PublicGTImport[] {
   const resolveModule = createProjectModuleResolver(undefined, {
     selfPackage: { directory: packageDirectory, manifest },
   });
@@ -54,20 +71,39 @@ export function packagePubliclyExposesGT(
     manifest,
     resolveModule
   );
-  if (entries.length === 0) return false;
+  if (entries.length === 0) return [];
 
   const localModules = createLocalModuleResolver(resolveModule, {
     recognizeAllGTRuntimeExports: true,
   });
-  return entries.some((entry) => {
+  return entries.flatMap(({ entry, specifier }) => {
     // Invalid entrypoints fail closed. The source analyzer can recover enough
     // provenance from malformed modules to emit diagnostics, but malformed
     // package code must not establish project ownership by itself.
-    if (!localModules.getRecord(entry)) return false;
-    return localModules
+    if (!localModules.getRecord(entry)) return [];
+    const exportNames = localModules
       .listExportNames(entry)
-      .some((name) => localModules.hasGTExportReference(entry, name));
+      .filter(
+        (name) => localModules.getGTExportName(entry, name) !== undefined
+      );
+    return exportNames.length > 0
+      ? [{ entry, exportNames: new Set(exportNames), specifier }]
+      : [];
   });
+}
+
+/** Resolves a package's public ESM import entries without executing code. */
+export function readPublicImportEntries(
+  packageDirectory: string,
+  manifest: JavaScriptPackageManifest
+): PublicImportEntry[] {
+  return resolvePublicImportEntries(
+    packageDirectory,
+    manifest,
+    createProjectModuleResolver(undefined, {
+      selfPackage: { directory: packageDirectory, manifest },
+    })
+  );
 }
 
 /** Resolves root and exact-subpath import entrypoints without executing code. */
@@ -75,11 +111,11 @@ function resolvePublicImportEntries(
   packageDirectory: string,
   manifest: JavaScriptPackageManifest,
   resolveModule: ReturnType<typeof createProjectModuleResolver>
-): string[] {
+): PublicImportEntry[] {
   const publicManifest = manifest as PublicPackageManifest;
   const packageName = readPackageName(manifest);
   const importer = path.join(packageDirectory, '__gt_vue_entry_probe__.mjs');
-  const entries = new Set<string>();
+  const entries = new Map<string, PublicImportEntry>();
 
   if (packageName && publicManifest.exports !== undefined) {
     for (const specifier of readExactPublicSpecifiers(
@@ -88,7 +124,7 @@ function resolvePublicImportEntries(
     )) {
       const entry = resolveModule(specifier, importer);
       if (entry && isWithinPackage(packageDirectory, entry)) {
-        entries.add(resolveRealPath(entry));
+        entries.set(specifier, { entry: resolveRealPath(entry), specifier });
       }
     }
     for (const entry of resolveWildcardPublicEntries(
@@ -98,11 +134,11 @@ function resolvePublicImportEntries(
       importer,
       resolveModule
     )) {
-      entries.add(entry);
+      entries.set(entry.specifier, entry);
     }
     // An exports map encapsulates the package. Never fall back to private main
     // fields when none of its public import conditions can be resolved.
-    return [...entries];
+    return [...entries.values()];
   }
 
   const browserEntry =
@@ -124,12 +160,14 @@ function resolvePublicImportEntries(
     if (typeof candidate !== 'string') continue;
     const entry = resolveSourceEntry(packageDirectory, candidate);
     if (entry) {
-      entries.add(entry);
+      if (packageName) {
+        entries.set(packageName, { entry, specifier: packageName });
+      }
       // Match package entry selection: the first resolvable main field wins.
       break;
     }
   }
-  return [...entries];
+  return [...entries.values()];
 }
 
 /**
@@ -146,9 +184,9 @@ function resolveWildcardPublicEntries(
   exportsField: unknown,
   importer: string,
   resolveModule: ReturnType<typeof createProjectModuleResolver>
-): string[] {
+): PublicImportEntry[] {
   if (!isRecord(exportsField) || isConditionalExports(exportsField)) return [];
-  const entries = new Set<string>();
+  const entries = new Map<string, PublicImportEntry>();
   const fileBudget = { remaining: MAX_PATTERN_FILES };
   for (const [subpath, target] of Object.entries(exportsField)) {
     if (!subpath.startsWith('./') || !subpath.includes('*')) continue;
@@ -172,11 +210,15 @@ function resolveWildcardPublicEntries(
         ) {
           continue;
         }
-        entries.add(resolveRealPath(resolved));
+        const specifier = `${packageName}${publicSubpath.slice(1)}`;
+        entries.set(specifier, {
+          entry: resolveRealPath(resolved),
+          specifier,
+        });
       }
     }
   }
-  return [...entries];
+  return [...entries.values()];
 }
 
 /** Selects conditional targets using the same default ESM conditions. */

--- a/packages/vue-extractor/src/internal/script.ts
+++ b/packages/vue-extractor/src/internal/script.ts
@@ -1,0 +1,11 @@
+export {
+  collectVueScriptImports,
+  createVueScriptAnalysis,
+  createVueScriptAnalysisStats,
+  exposeVueScriptImportsToTemplate,
+  parseVueScript,
+} from './script/analyze.js';
+export type {
+  VueScriptAnalysis,
+  VueScriptAnalysisStats,
+} from './script/model.js';

--- a/packages/vue-extractor/src/internal/script/analyze.ts
+++ b/packages/vue-extractor/src/internal/script/analyze.ts
@@ -1,0 +1,12987 @@
+import traverseModule, {
+  type Binding,
+  type NodePath,
+  type Scope,
+} from '@babel/traverse';
+import type * as t from '@babel/types';
+import { processVueStringCall } from '../stringCalls.js';
+import {
+  appendTemplatePath,
+  unknownTemplatePathSegment,
+} from '../templatePath.js';
+import type {
+  TemplateBindings,
+  TemplateContainerKind,
+  VueExtractionContext,
+} from '../types.js';
+import {
+  addVueError,
+  babelLocation,
+  readStaticPrimitive,
+  type StaticPrimitiveResult,
+  unwrapExpression,
+} from '../utils.js';
+import type {
+  CollectedObjectEntries,
+  ComponentFactoryCandidate,
+  ComponentKind,
+  ComponentMemberCandidate,
+  ContainerWrapperKind,
+  ContainerWritePolicy,
+  GTContainerExposure,
+  KnownValue,
+  ObjectEntryResult,
+  ScopedExpression,
+  ScriptState,
+  TemplateExposure,
+  TemplateKnownValue,
+  VueScriptAnalysis,
+  VueScriptAnalysisStats,
+} from './model.js';
+import { createReplayAnalysis } from './replay.js';
+import { createSnapshotAnalysis } from './snapshot.js';
+import {
+  COMPONENT_IMPORTS,
+  knownExport,
+  knownValueKey,
+  ORDINARY_GLOBAL_VALUES,
+  READONLY_ARRAY_TRANSFORMS,
+  VUE_BUILTIN_IMPORTS,
+} from './knownValues.js';
+import {
+  extractVueJSXTranslation,
+  isNestedInVueJSXTranslation,
+  resolveVueJSXElementIdentity,
+  validateVueJSXVariableComponent,
+  type VueJSXAnalysis,
+} from './jsx.js';
+import type {
+  LocalExportResolution,
+  LocalExportTarget,
+  LocalModuleRecord,
+} from './localModules.js';
+import { parseScriptAst } from './parser.js';
+import { isKnownNonVueGTRuntime } from './runtimeModules.js';
+import {
+  isAssignmentTargetWrapper,
+  isBindingPattern,
+  isStaticallyUndefined,
+  patternContains,
+  readMemberProperty,
+  readPatternIdentifier,
+  readPropertyKey,
+} from './syntax.js';
+
+export type { VueScriptAnalysis, VueScriptAnalysisStats } from './model.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+const staticBindingResults = new WeakMap<
+  VueScriptAnalysis,
+  Map<Binding, Map<boolean, StaticPrimitiveResult>>
+>();
+const staticBindingsInProgress = new WeakMap<
+  VueScriptAnalysis,
+  Map<Binding, Set<boolean>>
+>();
+
+/** Creates opt-in counters for deterministic analyzer complexity tests. */
+export function createVueScriptAnalysisStats(): VueScriptAnalysisStats {
+  return {
+    arrayEntryVisits: 0,
+    containerKindVisits: 0,
+    finalContainerSnapshotReads: 0,
+    knownExpressionVisits: 0,
+    stringFunctionVisits: 0,
+    transformArrayEntryVisits: 0,
+  };
+}
+
+/** Creates the per-SFC state used to resolve cross-block imports safely. */
+export function createVueScriptAnalysis(
+  stats?: VueScriptAnalysisStats
+): VueScriptAnalysis {
+  return {
+    ...(stats && { stats }),
+    arrayLengths: new Map(),
+    componentFactories: new Set(),
+    containerKinds: new Map(),
+    directBindings: new Set(),
+    gtComponentFactories: new Set(),
+    gtContainerFactories: new Set(),
+    hasGTSourceReference: false,
+    possibleGTContainers: new Set(),
+    possibleStaticStrings: new Map(),
+    staticValues: new Map(),
+    templateValues: new Map(),
+    uncertainComponents: new Set(),
+    uncertainGTComponents: new Set(),
+    uncertainStringFunctions: new Set(),
+    uncertainTranslationHelpers: new Set(),
+    values: new Map(),
+  };
+}
+
+/** Exposes imports from a normal script when the SFC also has script setup. */
+export function exposeVueScriptImportsToTemplate(
+  analysis: VueScriptAnalysis,
+  templateBindings: TemplateBindings
+): void {
+  for (const localName of analysis.directBindings) {
+    templateBindings.directBindings.add(localName);
+  }
+  for (const [localName, value] of analysis.values) {
+    templateBindings.directBindings.add(localName);
+    exposeKnownValue(localName, value, templateBindings, analysis);
+  }
+  for (const [localName, value] of analysis.templateValues) {
+    templateBindings.directBindings.add(localName);
+    exposeKnownValue(localName, value, templateBindings, analysis);
+  }
+  for (const [localName, value] of analysis.staticValues) {
+    templateBindings.directBindings.add(localName);
+    templateBindings.staticValues.set(localName, value);
+  }
+  for (const localName of analysis.componentFactories) {
+    templateBindings.componentFactories.add(localName);
+  }
+  for (const [localName, kind] of analysis.containerKinds) {
+    templateBindings.containerKinds.set(localName, kind);
+  }
+  for (const [localName, length] of analysis.arrayLengths) {
+    templateBindings.arrayLengths.set(localName, length);
+  }
+  for (const [localName, values] of analysis.possibleStaticStrings) {
+    templateBindings.possibleStaticStrings.set(localName, new Set(values));
+  }
+  for (const localName of analysis.possibleGTContainers) {
+    templateBindings.possibleGTContainers.add(localName);
+  }
+  for (const localName of analysis.gtContainerFactories) {
+    templateBindings.gtContainerFactories.add(localName);
+  }
+  for (const localName of analysis.gtComponentFactories) {
+    templateBindings.gtComponentFactories.add(localName);
+  }
+  for (const localName of analysis.uncertainComponents) {
+    templateBindings.uncertainComponents.add(localName);
+  }
+  for (const localName of analysis.uncertainGTComponents) {
+    templateBindings.uncertainGTComponents.add(localName);
+  }
+  for (const localName of analysis.uncertainStringFunctions) {
+    templateBindings.uncertainStringFunctions.add(localName);
+  }
+}
+
+/** Collects imports before either SFC script block is fully analyzed. */
+export function collectVueScriptImports(
+  source: string,
+  language: string | undefined,
+  analysis: VueScriptAnalysis
+): void {
+  if (!source.trim()) return;
+  try {
+    const ast = parseScriptAst(source, language);
+    const state = createScriptState(ast, analysis);
+    collectImports(ast, state);
+  } catch {
+    // The full analysis pass reports the parser diagnostic once.
+  }
+}
+
+/** Extracts calls and component bindings from one padded Vue script block. */
+export function parseVueScript(
+  source: string,
+  language: string | undefined,
+  context: VueExtractionContext,
+  templateBindings: TemplateBindings,
+  exposeToTemplate: boolean,
+  analysis: VueScriptAnalysis = createVueScriptAnalysis(),
+  analyzeOptionsApi = true
+): boolean {
+  if (!source.trim()) return true;
+  const initialErrorCount = context.errors.length;
+
+  let ast: t.File;
+  try {
+    ast = parseScriptAst(source, language);
+  } catch (error) {
+    const syntaxError = error as SyntaxError & {
+      loc?: { column: number; line: number };
+    };
+    addVueError(
+      context,
+      syntaxError.loc
+        ? {
+            start: {
+              column: syntaxError.loc.column + 1,
+              line: syntaxError.loc.line,
+              offset: 0,
+            },
+            end: {
+              column: syntaxError.loc.column + 1,
+              line: syntaxError.loc.line,
+              offset: 0,
+            },
+          }
+        : undefined,
+      `Could not parse a gt-vue script block: ${syntaxError.message}`,
+      'Fix the script syntax before extracting translations'
+    );
+    return false;
+  }
+
+  const state = createScriptState(ast, analysis);
+  collectImports(ast, state);
+  analyzeMutableNamespaceSafety(ast, state);
+
+  const jsxAnalysis: VueJSXAnalysis = {
+    customPragma: ast.comments?.find((comment) =>
+      /\*?\s*@jsx\s+([^\s]+)/.test(comment.value)
+    ),
+    readStaticPrimitive: (expression, scope) =>
+      readStaticFromScope(
+        expression,
+        scope,
+        new Set(),
+        expression.start ?? Number.POSITIVE_INFINITY,
+        state.analysis
+      ),
+    resolveKnownValue: (expression, scope) =>
+      resolveKnownExpression(expression, scope, state, new Set()),
+    resolveStaticObject: (expression, scope) =>
+      resolveObjectExpression(
+        expression,
+        scope,
+        new Set(),
+        expression.start ?? Number.POSITIVE_INFINITY
+      ),
+    scopeForNode: (node, fallback) => state.scopes.get(node) ?? fallback,
+  };
+
+  if (exposeToTemplate) {
+    recordCrossBlockWrites(ast, state, templateBindings);
+    exposeProgramBindings(ast, state, templateBindings);
+  } else {
+    recordProgramAnalysis(ast, state);
+    if (analyzeOptionsApi) {
+      exposeOptionsApiBindings(ast, state, templateBindings, context);
+    }
+  }
+  type StringCallPath = {
+    node: t.CallExpression | t.OptionalCallExpression;
+    scope: Scope;
+  };
+
+  const processCallAtLocation = (
+    path: StringCallPath,
+    consumerLocation = babelLocation(path.node.loc)
+  ): void => {
+    if (
+      state.activeTranslationFunctions.size > 0 &&
+      resolveKnownCallTargetWithoutParameterSubstitutions(
+        path.node.callee,
+        path.scope,
+        path.node.start ?? Number.POSITIVE_INFINITY,
+        state
+      ).value?.type === 'string'
+    ) {
+      return;
+    }
+    const vueHelper = readImportedFunctionName(
+      path.node.callee,
+      path.scope,
+      'vue',
+      state
+    );
+    const firstArgument = path.node.arguments[0];
+    if (
+      vueHelper &&
+      ['createVNode', 'h'].includes(vueHelper) &&
+      firstArgument &&
+      firstArgument.type !== 'ArgumentPlaceholder' &&
+      firstArgument.type !== 'SpreadElement' &&
+      expressionContainsGTReference(firstArgument, path.scope, state)
+    ) {
+      state.analysis.hasGTSourceReference = true;
+      addVueError(
+        context,
+        consumerLocation,
+        'Found an unsupported gt-vue <T> component in a Vue render function',
+        'Move the rich translation into a Vue single-file component template'
+      );
+    }
+    if (
+      vueHelper === 'defineAsyncComponent' &&
+      firstArgument &&
+      firstArgument.type !== 'ArgumentPlaceholder' &&
+      firstArgument.type !== 'SpreadElement' &&
+      expressionContainsGTReference(firstArgument, path.scope, state)
+    ) {
+      state.analysis.hasGTSourceReference = true;
+      addVueError(
+        context,
+        consumerLocation,
+        'Could not statically extract a gt-vue <T> component behind defineAsyncComponent()',
+        'Use a direct gt-vue component binding in the Vue template'
+      );
+    }
+    const callTarget = resolveKnownCallTargetAtPosition(
+      path.node.callee,
+      path.scope,
+      path.node.start ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    const value = callTarget.value;
+    if (value?.type !== 'string') {
+      const localCallable = resolveCalledFunction(
+        path.node.callee,
+        path.scope,
+        state,
+        new Set()
+      );
+      const calleePath = readResolvedMemberPath(
+        path.node.callee,
+        path.scope,
+        state
+      );
+      const uncertainTranslationHelper = Boolean(
+        calleePath &&
+        pathMayReferenceUncertainTranslationHelper(
+          path.node.callee,
+          calleePath,
+          path.scope,
+          state
+        ) &&
+        callArgumentsMayProvideTranslationFunction(path.node, path.scope, state)
+      );
+      if (
+        !callTarget.definitelyOrdinary &&
+        !localCallable &&
+        calleePath &&
+        (callTarget.possibleStringFunction ||
+          uncertainTranslationHelper ||
+          templateBindings.uncertainStringFunctions.has(calleePath) ||
+          state.analysis.uncertainStringFunctions.has(calleePath) ||
+          (calleePath.endsWith('.value') &&
+            templateBindings.uncertainStringFunctions.has(
+              calleePath.slice(0, -'.value'.length)
+            )))
+      ) {
+        addVueError(
+          context,
+          consumerLocation,
+          `Could not statically resolve possible gt-vue string function alias "${calleePath}"`,
+          'Use a direct, immutable alias of useGT(), useMessages(), or msg()'
+        );
+      }
+      processForwardedTranslationCalls(path, consumerLocation);
+      return;
+    }
+    state.analysis.hasGTSourceReference = true;
+    processVueStringCall(
+      path.node,
+      value.kind,
+      consumerLocation,
+      context,
+      (node) => {
+        if (!node) return { ok: false };
+        const materialized = materializeParameterExpression(
+          node,
+          path.scope,
+          state
+        );
+        return readStaticFromScope(
+          materialized.node,
+          materialized.scope,
+          new Set(),
+          materialized.node.end ?? Number.POSITIVE_INFINITY,
+          state.analysis
+        );
+      }
+    );
+    processForwardedTranslationCalls(path, consumerLocation);
+  };
+
+  const processForwardedTranslationCalls = (
+    path: StringCallPath,
+    consumerLocation: ReturnType<typeof babelLocation>
+  ): void => {
+    const called = resolveCalledFunction(
+      path.node.callee,
+      path.scope,
+      state,
+      new Set()
+    );
+    if (
+      !called ||
+      state.activeTranslationFunctions.has(called.node) ||
+      !callMayCarryTranslationFunction(path.node, path.scope, state)
+    )
+      return;
+    const functionPath = state.paths.get(called.node);
+    if (!functionPath) return;
+    state.activeTranslationFunctions.add(called.node);
+    try {
+      withCallParameterSubstitutions(
+        path.node,
+        called,
+        path.scope,
+        state,
+        () => {
+          functionPath.traverse({
+            Function(nestedPath) {
+              nestedPath.skip();
+            },
+            CallExpression(callPath) {
+              processCallAtLocation(callPath, consumerLocation);
+            },
+            OptionalCallExpression(callPath) {
+              processCallAtLocation(callPath, consumerLocation);
+            },
+          });
+        }
+      );
+    } finally {
+      state.activeTranslationFunctions.delete(called.node);
+    }
+  };
+
+  const processCall = (path: StringCallPath): void => {
+    processCallAtLocation(path);
+  };
+
+  traverse(ast, {
+    CallExpression: processCall,
+    OptionalCallExpression: processCall,
+    TaggedTemplateExpression(path) {
+      const value = resolveKnownExpression(
+        path.node.tag,
+        path.scope,
+        state,
+        new Set()
+      );
+      if (value?.type !== 'string') return;
+      state.analysis.hasGTSourceReference = true;
+      addVueError(
+        context,
+        babelLocation(path.node.loc),
+        'Found an unsupported tagged template translation in gt-vue',
+        'Call the translation function with a string literal instead'
+      );
+    },
+    JSXElement(path) {
+      const value = resolveVueJSXElementIdentity(
+        path.node.openingElement.name,
+        path.scope,
+        jsxAnalysis
+      );
+      if (value?.type === 'component') {
+        state.analysis.hasGTSourceReference = true;
+      }
+      if (
+        value?.type === 'component' &&
+        (value.name === 'Var' ||
+          value.name === 'Num' ||
+          value.name === 'DateTime' ||
+          value.name === 'Currency')
+      ) {
+        validateVueJSXVariableComponent(path.node, value.name, context);
+      }
+      if (value?.type !== 'component' || value.name !== 'T') return;
+      if (isNestedInVueJSXTranslation(path, jsxAnalysis)) return;
+      extractVueJSXTranslation(path, context, jsxAnalysis);
+    },
+  });
+  if (
+    state.unsupportedDynamicGTReference &&
+    context.errors.length === initialErrorCount
+  ) {
+    addVueError(
+      context,
+      undefined,
+      'Could not statically resolve possible gt-vue string function alias from a dynamic import',
+      'Use a static gt-vue import so translation ownership can be extracted deterministically'
+    );
+  }
+  if (
+    state.unsupportedMalformedGTReference &&
+    context.errors.length === initialErrorCount
+  ) {
+    addVueError(
+      context,
+      undefined,
+      'Could not statically resolve a gt-vue reference imported through a malformed local module',
+      'Fix the local module syntax so translation ownership can be extracted deterministically'
+    );
+  }
+  return true;
+}
+
+/** Indexes Babel's lexical scopes so deferred function analysis stays exact. */
+function createScriptState(
+  ast: t.File,
+  analysis: VueScriptAnalysis
+): ScriptState {
+  const state: ScriptState = {
+    activeComponentFunctions: new Set(),
+    activeReplayFunctions: new Set(),
+    activeStringFunctions: new Set(),
+    activeTranslationFunctions: new Set(),
+    analysis,
+    attachedLocalModules: new Set(),
+    arrayEntries: new Map(),
+    arrayEntriesInProgress: new Set(),
+    componentPossibilities: new Map(),
+    componentFactoryCandidates: new Map(),
+    componentFactoryCandidatesInProgress: new Set(),
+    bindings: new Map(),
+    containerKindSnapshots: new Map(),
+    containerKindSnapshotsInProgress: new Set(),
+    containerIdentityReplays: new WeakMap(),
+    containerWritePolicies: new Map(),
+    definiteNonStringFunctionBindings: new Set(),
+    definiteNonStringFunctionBindingsInProgress: new Set(),
+    entryProgram: ast.program,
+    finalContainerSnapshots: new Map(),
+    finalContainerSnapshotsInProgress: new Set(),
+    gtContainerPossibilities: new Map(),
+    gtContainerPossibilitiesInProgress: new Set(),
+    gtContainerPaths: new Map(),
+    gtContainerPathsInProgress: new Set(),
+    localCallableBindings: new Map(),
+    mutationGTContainerPaths: new Map(),
+    mutationGTContainerPathsInProgress: new Set(),
+    mutationPossibleStaticStrings: new Map(),
+    mutationPossibleStaticStringsInProgress: new Set(),
+    mutableImportSources: new Map(),
+    nextReplayIdentityKey: 0,
+    parameterSubstitutions: [],
+    paths: new WeakMap(),
+    possibleStaticStrings: new Map(),
+    possibleStaticStringsInProgress: new Set(),
+    possibleStaticStringMembers: new Map(),
+    possibleStaticStringMembersInProgress: new Set(),
+    readonlyContainerUses: new Map(),
+    readonlyContainerUsesInProgress: new Set(),
+    replayIdentityKeys: new WeakMap(),
+    resolvedBindings: new Set(),
+    scopes: new WeakMap(),
+    thisSubstitutions: [],
+    transformArrayEntries: new Map(),
+    transformArrayEntriesInProgress: new Set(),
+    uncertainTranslationHelperBindings: new Set(),
+    unsupportedDynamicGTReference: false,
+    unsupportedMalformedGTReference: false,
+    unsafeMutableNamespaceSources: new Set(),
+  };
+  traverse(ast, {
+    enter(path) {
+      state.paths.set(path.node, path as NodePath<t.Node>);
+      state.scopes.set(path.node, path.scope);
+    },
+  });
+  return state;
+}
+
+/** Marks a CommonJS module unsafe when any retained alias mutates or escapes it. */
+function analyzeMutableNamespaceSafety(ast: t.File, state: ScriptState): void {
+  for (const [binding, value] of state.bindings) {
+    if (
+      value.type === 'namespace' &&
+      value.mutable &&
+      !isSafeMutableNamespaceBinding(binding)
+    ) {
+      state.unsafeMutableNamespaceSources.add(value.source);
+    }
+  }
+  traverse(ast, {
+    CallExpression(path) {
+      const namespace = readRequireNamespace(path.node, path.scope);
+      if (namespace && directRequireCanMutate(path)) {
+        state.unsafeMutableNamespaceSources.add(namespace.source);
+      }
+    },
+    OptionalCallExpression(path) {
+      const namespace = readRequireNamespace(path.node, path.scope);
+      if (namespace && directRequireCanMutate(path)) {
+        state.unsafeMutableNamespaceSources.add(namespace.source);
+      }
+    },
+  });
+}
+
+/** Distinguishes a fresh export read from mutation of the require result. */
+function directRequireCanMutate(
+  path: NodePath<t.CallExpression | t.OptionalCallExpression>
+): boolean {
+  const parent = path.parentPath;
+  if (!parent) return true;
+  if (parent.isVariableDeclarator() && parent.node.init === path.node) {
+    return false;
+  }
+  if (
+    (parent.isMemberExpression() || parent.isOptionalMemberExpression()) &&
+    parent.node.object === path.node
+  ) {
+    return memberChainWrites(parent);
+  }
+  return true;
+}
+
+/** Allows export reads while rejecting writes or escape of the namespace object. */
+function isSafeMutableNamespaceBinding(binding: Binding): boolean {
+  return (
+    binding.constant &&
+    binding.referencePaths.every((reference) => {
+      const parent = reference.parentPath;
+      return Boolean(
+        parent &&
+        (parent.isMemberExpression() || parent.isOptionalMemberExpression()) &&
+        parent.node.object === reference.node &&
+        !memberChainWrites(parent)
+      );
+    })
+  );
+}
+
+/** Detects writes through a member chain rooted in a namespace object. */
+function memberChainWrites(
+  memberPath: NodePath<t.MemberExpression | t.OptionalMemberExpression>
+): boolean {
+  let current: NodePath<t.Node> = memberPath;
+  while (
+    current.parentPath &&
+    (current.parentPath.isMemberExpression() ||
+      current.parentPath.isOptionalMemberExpression()) &&
+    current.parentPath.node.object === current.node
+  ) {
+    current = current.parentPath;
+  }
+  const parent = current.parentPath;
+  return Boolean(
+    parent &&
+    ((parent.isAssignmentExpression() && parent.node.left === current.node) ||
+      (parent.isUpdateExpression() && parent.node.argument === current.node) ||
+      (parent.isUnaryExpression({ operator: 'delete' }) &&
+        parent.node.argument === current.node) ||
+      ((parent.isForInStatement() || parent.isForOfStatement()) &&
+        parent.node.left === current.node))
+  );
+}
+
+function collectImports(
+  ast: t.File,
+  state: ScriptState,
+  importerFile = state.analysis.entryFile
+): void {
+  traverse(ast, {
+    ImportDeclaration(path) {
+      if (isTypeOnlyImportKind(path.node.importKind)) return;
+      const source = path.node.source.value;
+      if (
+        source === 'gt-vue' &&
+        hasRuntimeImport(path.node) &&
+        importerFile === state.analysis.entryFile
+      ) {
+        state.analysis.hasGTSourceReference = true;
+      }
+      if (source !== 'gt-vue' && source !== 'vue') {
+        registerLocalImportDeclaration(
+          path.node,
+          path.scope,
+          importerFile,
+          state
+        );
+        return;
+      }
+
+      for (const specifierPath of path.get('specifiers')) {
+        const specifier = specifierPath.node;
+        if (specifier.type === 'ImportNamespaceSpecifier') {
+          registerImport(
+            specifier.local.name,
+            { type: 'namespace', source, mutable: false },
+            specifierPath.scope,
+            state
+          );
+          continue;
+        }
+        if (
+          specifier.type !== 'ImportSpecifier' ||
+          isTypeOnlyImportKind(specifier.importKind)
+        ) {
+          continue;
+        }
+        const importedName =
+          specifier.imported.type === 'Identifier'
+            ? specifier.imported.name
+            : specifier.imported.value;
+        const value = knownExport(source, importedName);
+        if (value) {
+          registerImport(
+            specifier.local.name,
+            value,
+            specifierPath.scope,
+            state
+          );
+        }
+      }
+    },
+    ExportNamedDeclaration(path) {
+      if (
+        path.node.exportKind === 'type' ||
+        !path.node.source ||
+        importerFile !== state.analysis.entryFile
+      ) {
+        return;
+      }
+      const exportNames = path.node.specifiers.flatMap((specifier) => {
+        if (
+          specifier.type === 'ExportSpecifier' &&
+          isTypeOnlyImportKind(specifier.exportKind)
+        ) {
+          return [];
+        }
+        if (specifier.type === 'ExportNamespaceSpecifier') return ['*'];
+        if (specifier.type !== 'ExportSpecifier') return [];
+        return [specifier.local.name];
+      });
+      recordRuntimeReexport(
+        path.node.source.value,
+        exportNames,
+        importerFile,
+        state
+      );
+    },
+    ExportAllDeclaration(path) {
+      if (
+        path.node.exportKind === 'type' ||
+        importerFile !== state.analysis.entryFile
+      ) {
+        return;
+      }
+      recordRuntimeReexport(path.node.source.value, ['*'], importerFile, state);
+    },
+    TSImportEqualsDeclaration(path) {
+      if (path.node.importKind === 'type') return;
+      const reference = path.node.moduleReference;
+      if (
+        reference.type !== 'TSExternalModuleReference' ||
+        reference.expression.type !== 'StringLiteral'
+      ) {
+        return;
+      }
+      const source = reference.expression.value;
+      if (source !== 'gt-vue' && source !== 'vue') return;
+      if (source === 'gt-vue' && importerFile === state.analysis.entryFile) {
+        state.analysis.hasGTSourceReference = true;
+      }
+      registerImport(
+        path.node.id.name,
+        { type: 'namespace', source, mutable: true },
+        path.scope,
+        state
+      );
+    },
+    VariableDeclarator(path) {
+      const dynamicImport = readDynamicImport(path.node.init);
+      if (dynamicImport) {
+        recordDynamicImportPattern(
+          path.node.id,
+          dynamicImport.source,
+          path.scope,
+          importerFile,
+          state
+        );
+        return;
+      }
+      const namespace = readRequireNamespace(path.node.init, path.scope);
+      if (!namespace) return;
+      if (
+        namespace.source === 'gt-vue' &&
+        importerFile === state.analysis.entryFile
+      ) {
+        state.analysis.hasGTSourceReference = true;
+      }
+      registerRequirePattern(path.node.id, namespace, path.scope, state);
+    },
+  });
+  propagateUncertainTranslationHelperAliases(ast, state);
+}
+
+/** Marks only runtime re-exports statically connected to gt-vue. */
+function recordRuntimeReexport(
+  source: string,
+  exportNames: string[],
+  importerFile: string | undefined,
+  state: ScriptState
+): void {
+  if (!importerFile || exportNames.length === 0) return;
+  if (source === 'gt-vue') {
+    state.analysis.hasGTSourceReference = true;
+    return;
+  }
+  if (source === 'vue' || isKnownNonVueGTRuntime(source)) return;
+  const resolver = state.analysis.localModules;
+  const modulePath = resolver?.resolveModule(importerFile, source);
+  if (!resolver || !modulePath || !resolver.isProjectModule(modulePath)) {
+    return;
+  }
+  const candidateNames = exportNames.includes('*')
+    ? [...COMPONENT_IMPORTS, 'msg', 'useGT', 'useMessages']
+    : exportNames;
+  if (
+    candidateNames.some((name) =>
+      resolver.hasGTExportReference(modulePath, name)
+    )
+  ) {
+    state.analysis.hasGTSourceReference = true;
+  }
+}
+
+/** Returns whether an import causes a runtime module reference. */
+function hasRuntimeImport(declaration: t.ImportDeclaration): boolean {
+  return (
+    declaration.specifiers.length === 0 ||
+    declaration.specifiers.some(
+      (specifier) =>
+        specifier.type !== 'ImportSpecifier' ||
+        !isTypeOnlyImportKind(specifier.importKind)
+    )
+  );
+}
+
+/** Returns whether Babel classified an ESM binding as type-only. */
+function isTypeOnlyImportKind(kind: string | null | undefined): boolean {
+  return kind === 'type' || kind === 'typeof';
+}
+
+/** Retains unresolved-helper provenance through simple immutable aliases. */
+function propagateUncertainTranslationHelperAliases(
+  ast: t.File,
+  state: ScriptState
+): void {
+  const candidates: Array<{
+    binding: Binding;
+    source: t.Node;
+    sourcePath: string;
+    sourceScope: Scope;
+    targetName: string;
+  }> = [];
+  traverse(ast, {
+    VariableDeclarator(path) {
+      if (!path.node.init) return;
+      const sourcePath = readResolvedMemberPath(
+        path.node.init,
+        path.scope,
+        state
+      );
+      if (!sourcePath) return;
+      for (const targetName of collectPatternBindingNames(path.node.id)) {
+        const binding = path.scope.getBinding(targetName);
+        if (binding?.constant) {
+          candidates.push({
+            binding,
+            source: path.node.init,
+            sourcePath,
+            sourceScope: path.scope,
+            targetName,
+          });
+        }
+      }
+    },
+  });
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const candidate of candidates) {
+      if (
+        state.uncertainTranslationHelperBindings.has(candidate.binding) ||
+        !pathMayReferenceUncertainTranslationHelper(
+          candidate.source,
+          candidate.sourcePath,
+          candidate.sourceScope,
+          state
+        )
+      ) {
+        continue;
+      }
+      state.analysis.uncertainTranslationHelpers.add(candidate.targetName);
+      state.uncertainTranslationHelperBindings.add(candidate.binding);
+      changed = true;
+    }
+  }
+}
+
+/** Reads an import() source, including a single surrounding await. */
+function readDynamicImport(
+  node: t.Node | null | undefined
+): { source?: string } | undefined {
+  let expression = unwrapExpression(node);
+  if (expression?.type === 'AwaitExpression') {
+    expression = unwrapExpression(expression.argument);
+  }
+  if (!expression) return undefined;
+  if (expression.type === 'ImportExpression') {
+    const source = unwrapExpression(expression.source);
+    return {
+      source: source?.type === 'StringLiteral' ? source.value : undefined,
+    };
+  }
+  if (
+    expression.type !== 'CallExpression' ||
+    expression.callee.type !== 'Import'
+  ) {
+    return undefined;
+  }
+  const source = unwrapExpression(expression.arguments[0]);
+  return {
+    source: source?.type === 'StringLiteral' ? source.value : undefined,
+  };
+}
+
+/** Marks GT-shaped values selected from a dynamic namespace as unresolved. */
+function recordDynamicImportPattern(
+  pattern: t.LVal | t.VoidPattern,
+  source: string | undefined,
+  scope: Scope,
+  importerFile: string | undefined,
+  state: ScriptState
+): void {
+  if (pattern.type === 'VoidPattern') return;
+  if (source && isKnownNonVueGTRuntime(source)) return;
+  if (source === 'gt-vue' && importerFile === state.analysis.entryFile) {
+    state.analysis.hasGTSourceReference = true;
+    state.unsupportedDynamicGTReference = true;
+  }
+  const resolver = state.analysis.localModules;
+  const modulePath =
+    source && source !== 'gt-vue' && source !== 'vue' && importerFile
+      ? resolver?.resolveModule(importerFile, source)
+      : undefined;
+  if (source === 'vue') return;
+  if (source && source !== 'gt-vue' && !modulePath) return;
+  if (modulePath && resolver && !resolver.isProjectModule(modulePath)) {
+    return;
+  }
+  if (pattern.type === 'Identifier') {
+    if (modulePath && resolver) {
+      const binding = scope.getBinding(pattern.name);
+      for (const exportName of [
+        ...COMPONENT_IMPORTS,
+        'msg',
+        'useGT',
+        'useMessages',
+      ]) {
+        recordDynamicImportBinding(
+          appendTemplatePath(pattern.name, exportName),
+          exportName,
+          modulePath,
+          state,
+          bindingReferencesNamespaceMember(binding, exportName, state)
+        );
+      }
+    } else {
+      for (const component of COMPONENT_IMPORTS) {
+        const path = appendTemplatePath(pattern.name, component);
+        state.analysis.uncertainComponents.add(path);
+        state.analysis.uncertainGTComponents.add(path);
+      }
+      for (const name of ['msg', 'useGT', 'useMessages']) {
+        state.analysis.uncertainStringFunctions.add(
+          appendTemplatePath(pattern.name, name)
+        );
+      }
+    }
+    return;
+  }
+  if (pattern.type !== 'ObjectPattern') return;
+  for (const property of pattern.properties) {
+    if (property.type !== 'ObjectProperty') continue;
+    const exportedName = readPropertyKey(property);
+    const localName = readPatternIdentifier(property.value);
+    if (exportedName && localName) {
+      if (modulePath) {
+        recordDynamicImportBinding(
+          localName,
+          exportedName,
+          modulePath,
+          state,
+          importerFile === state.analysis.entryFile
+        );
+      } else {
+        recordUnresolvedGTShapedBinding(localName, exportedName, state);
+      }
+    }
+  }
+  // Resolve computed destructuring only when its key is static. Dynamic keys
+  // and object-rest aliases intentionally remain unusable for GT extraction.
+  for (const property of pattern.properties) {
+    if (property.type !== 'ObjectProperty' || !property.computed) continue;
+    const exportedName = readResolvedPropertyKey(property, scope, state);
+    const localName = readPatternIdentifier(property.value);
+    if (exportedName && localName) {
+      if (modulePath) {
+        recordDynamicImportBinding(
+          localName,
+          exportedName,
+          modulePath,
+          state,
+          importerFile === state.analysis.entryFile
+        );
+      } else {
+        recordUnresolvedGTShapedBinding(localName, exportedName, state);
+      }
+    }
+  }
+}
+
+/** Returns whether one namespace binding is used through a static member. */
+function bindingReferencesNamespaceMember(
+  binding: Binding | undefined,
+  memberName: string,
+  state: ScriptState,
+  seen: Set<Binding> = new Set()
+): boolean {
+  if (!binding || seen.has(binding)) return false;
+  const nextSeen = new Set(seen).add(binding);
+  return Boolean(
+    binding.referencePaths.some((referencePath) => {
+      let reference: NodePath<t.Node> = referencePath;
+      while (
+        reference.parentPath &&
+        unwrapExpression(reference.parentPath.node) === reference.node
+      ) {
+        reference = reference.parentPath;
+      }
+      const parent = reference.parentPath;
+      if (
+        parent?.isMemberExpression() ||
+        parent?.isOptionalMemberExpression()
+      ) {
+        return (
+          parent.node.object === reference.node &&
+          readResolvedMemberProperty(parent.node, parent.scope, state) ===
+            memberName
+        );
+      }
+      if (parent?.isJSXMemberExpression()) {
+        return (
+          parent.node.object === reference.node &&
+          parent.node.property.name === memberName
+        );
+      }
+      if (
+        parent?.isVariableDeclarator() &&
+        parent.node.init === reference.node
+      ) {
+        if (parent.node.id.type === 'Identifier') {
+          return bindingReferencesNamespaceMember(
+            parent.scope.getBinding(parent.node.id.name),
+            memberName,
+            state,
+            nextSeen
+          );
+        }
+        if (parent.node.id.type === 'ObjectPattern') {
+          return parent.node.id.properties.some(
+            (property) =>
+              property.type === 'RestElement' ||
+              (property.type === 'ObjectProperty' &&
+                readResolvedPropertyKey(property, parent.scope, state) ===
+                  memberName)
+          );
+        }
+      }
+      if (
+        parent?.isCallExpression() ||
+        parent?.isNewExpression() ||
+        parent?.isReturnStatement() ||
+        parent?.isSpreadElement() ||
+        parent?.isArrayExpression() ||
+        parent?.isObjectProperty()
+      ) {
+        return true;
+      }
+      return false;
+    })
+  );
+}
+
+/** Marks only GT roles proven reachable from one static dynamic import. */
+function recordDynamicImportBinding(
+  localName: string,
+  exportName: string,
+  modulePath: string,
+  state: ScriptState,
+  establishesEntryProvenance: boolean
+): void {
+  const resolution = state.analysis.localModules?.resolveExport(
+    modulePath,
+    exportName
+  );
+  if (!resolution || resolution.status === 'absent') return;
+  if (resolution.status !== 'resolved') {
+    if (
+      resolution.status === 'invalid' &&
+      materializeRecoveredOrdinaryResolution(resolution, state) !== undefined
+    ) {
+      return;
+    }
+    if (
+      establishesEntryProvenance &&
+      resolution.status === 'invalid' &&
+      resolution.hasGTSourceReference
+    ) {
+      state.analysis.hasGTSourceReference = true;
+      state.unsupportedDynamicGTReference = true;
+      state.unsupportedMalformedGTReference = true;
+    }
+    if (resolution.status === 'invalid' && resolution.hasGTSourceReference) {
+      recordInvalidGTResolution(localName, resolution, state);
+    } else {
+      recordUnresolvedGTShapedBinding(localName, exportName, state);
+    }
+    return;
+  }
+  const materialized = materializeLocalExport(resolution.target, state);
+  if (establishesEntryProvenance && materialized.hasGTSourceReference) {
+    state.analysis.hasGTSourceReference = true;
+    state.unsupportedDynamicGTReference = true;
+  }
+  recordMaterializedLocalUncertainty(localName, materialized, state, true);
+}
+
+/** Resolves one ESM import through a local, read-only source module graph. */
+function registerLocalImportDeclaration(
+  declaration: t.ImportDeclaration,
+  scope: Scope,
+  importerFile: string | undefined,
+  state: ScriptState
+): void {
+  const resolver = state.analysis.localModules;
+  const source = declaration.source.value;
+  if (isKnownNonVueGTRuntime(source)) return;
+  const modulePath =
+    resolver && importerFile
+      ? resolver.resolveModule(importerFile, source)
+      : undefined;
+  if (modulePath && resolver && !resolver.isProjectModule(modulePath)) return;
+  if (!resolver || !modulePath) {
+    recordUnresolvedTranslationHelperImports(declaration, scope, state);
+    if (
+      source.startsWith('.') ||
+      source.startsWith('/') ||
+      resolver?.hasCustomResolver
+    ) {
+      recordUnresolvedGTShapedImports(declaration, state);
+    }
+    return;
+  }
+
+  for (const specifier of declaration.specifiers) {
+    if (
+      specifier.type === 'ImportSpecifier' &&
+      isTypeOnlyImportKind(specifier.importKind)
+    ) {
+      continue;
+    }
+    if (specifier.type === 'ImportNamespaceSpecifier') {
+      const value: KnownValue = { type: 'local-namespace', modulePath };
+      registerImport(specifier.local.name, value, scope, state);
+      if (importerFile === state.analysis.entryFile) {
+        recordLocalNamespaceMembers(
+          specifier.local.name,
+          modulePath,
+          state,
+          scope.getBinding(specifier.local.name)
+        );
+      }
+      continue;
+    }
+    const exportName =
+      specifier.type === 'ImportDefaultSpecifier'
+        ? 'default'
+        : specifier.imported.type === 'Identifier'
+          ? specifier.imported.name
+          : specifier.imported.value;
+    const resolution = resolver.resolveExport(modulePath, exportName);
+    let materialized: MaterializedLocalExport | undefined;
+    if (resolution.status !== 'resolved') {
+      if (resolution.status === 'invalid') {
+        materialized = materializeRecoveredOrdinaryResolution(
+          resolution,
+          state,
+          true
+        );
+      }
+      if (!materialized) {
+        if (
+          importerFile === state.analysis.entryFile &&
+          resolution.status === 'invalid' &&
+          resolution.hasGTSourceReference
+        ) {
+          state.analysis.hasGTSourceReference = true;
+          state.unsupportedMalformedGTReference = true;
+        }
+        recordUncertainTranslationHelperBinding(
+          specifier.local.name,
+          scope,
+          state
+        );
+        if (resolution.status === 'ambiguous') {
+          recordAmbiguousLocalBinding(specifier.local.name, state);
+        } else if (
+          resolution.status === 'invalid' &&
+          resolution.hasGTSourceReference
+        ) {
+          recordInvalidGTResolution(specifier.local.name, resolution, state);
+        } else {
+          recordUnresolvedGTShapedBinding(
+            specifier.local.name,
+            exportName,
+            state
+          );
+        }
+        continue;
+      }
+    } else {
+      materialized = materializeLocalExport(resolution.target, state);
+    }
+    if (
+      importerFile === state.analysis.entryFile &&
+      materialized.hasGTSourceReference
+    ) {
+      state.analysis.hasGTSourceReference = true;
+    }
+    const binding = scope.getBinding(specifier.local.name);
+    if (materialized.value) {
+      registerImport(specifier.local.name, materialized.value, scope, state);
+      if (
+        materialized.value.type === 'local-namespace' &&
+        importerFile === state.analysis.entryFile
+      ) {
+        recordLocalNamespaceMembers(
+          specifier.local.name,
+          materialized.value.modulePath,
+          state,
+          binding
+        );
+      }
+    }
+    if (binding && materialized.callable) {
+      state.localCallableBindings.set(binding, materialized.callable);
+    }
+    recordMaterializedLocalUncertainty(
+      specifier.local.name,
+      materialized,
+      state
+    );
+    if (binding && materialized.unsafeCallable) {
+      state.uncertainTranslationHelperBindings.add(binding);
+    }
+  }
+}
+
+/** Indexes an imported module's scopes and its own static imports once. */
+function attachLocalModule(
+  record: LocalModuleRecord,
+  state: ScriptState
+): void {
+  if (state.attachedLocalModules.has(record.filePath)) return;
+  state.attachedLocalModules.add(record.filePath);
+  traverse(record.ast, {
+    enter(path) {
+      state.paths.set(path.node, path as NodePath<t.Node>);
+      state.scopes.set(path.node, path.scope);
+    },
+  });
+  collectImports(record.ast, state, record.filePath);
+}
+
+/** Converts a graph export into an analyzer identity or callable. */
+type MaterializedLocalExport = {
+  callable?: ScopedExpression & { node: t.Function };
+  hasGTSourceReference?: boolean;
+  possibleGTComponent?: boolean;
+  possibleStringFunction?: boolean;
+  unsafeCallable?: boolean;
+  value?: KnownValue;
+};
+
+function materializeLocalExport(
+  target: LocalExportTarget,
+  state: ScriptState
+): MaterializedLocalExport {
+  if (target.type === 'ordinary-external') return {};
+  if (target.type === 'external') {
+    return {
+      hasGTSourceReference: target.source === 'gt-vue',
+      value: knownExport(target.source, target.exportName),
+    };
+  }
+  if (target.type === 'external-namespace') {
+    return {
+      hasGTSourceReference: target.source === 'gt-vue',
+      value: { mutable: false, source: target.source, type: 'namespace' },
+    };
+  }
+  if (target.type === 'namespace') {
+    return {
+      value: { type: 'local-namespace', modulePath: target.modulePath },
+    };
+  }
+  attachLocalModule(target.record, state);
+  if (target.type === 'expression') {
+    const materialized: MaterializedLocalExport = {
+      callable: resolveCalledFunction(
+        target.node,
+        target.record.programScope,
+        state,
+        new Set()
+      ),
+      value: resolveKnownExpression(
+        target.node,
+        target.record.programScope,
+        state,
+        new Set()
+      ),
+      possibleGTComponent: expressionMayProduceComponent(
+        target.node,
+        target.record.programScope,
+        state,
+        new Set(),
+        'translation'
+      ),
+      possibleStringFunction: expressionMayProduceStringFunction(
+        target.node,
+        target.record.programScope,
+        state,
+        new Set()
+      ),
+    };
+    materialized.hasGTSourceReference = isKnownGTValue(materialized.value);
+    return materialized;
+  }
+  const binding = target.record.programScope.getBinding(target.exportName);
+  if (!binding) return {};
+  const possibleGTComponent = expressionMayProduceComponent(
+    binding.identifier,
+    target.record.programScope,
+    state,
+    new Set(),
+    'translation'
+  );
+  const possibleStringFunction = expressionMayProduceStringFunction(
+    binding.identifier,
+    target.record.programScope,
+    state,
+    new Set()
+  );
+  if (!binding.constant) {
+    return {
+      possibleGTComponent,
+      possibleStringFunction,
+      unsafeCallable: bindingMayReferenceLocalCallable(binding, state),
+    };
+  }
+  const materialized: MaterializedLocalExport = {
+    callable: resolveCalledFunction(
+      binding.identifier,
+      target.record.programScope,
+      state,
+      new Set()
+    ),
+    possibleGTComponent,
+    possibleStringFunction,
+    value: resolveKnownBinding(binding, state, new Set()),
+  };
+  materialized.hasGTSourceReference = isKnownGTValue(materialized.value);
+  return materialized;
+}
+
+/** Returns whether an exact analyzer identity came from gt-vue. */
+function isKnownGTValue(value: KnownValue | undefined): boolean {
+  return (
+    value?.type === 'component' ||
+    value?.type === 'hook' ||
+    value?.type === 'string' ||
+    (value?.type === 'namespace' && value.source === 'gt-vue')
+  );
+}
+
+/** Materializes the one ordinary origin proven through a malformed module. */
+function materializeRecoveredOrdinaryResolution(
+  resolution: Extract<LocalExportResolution, { status: 'invalid' }>,
+  state: ScriptState,
+  preserveLocalIdentity = false
+): MaterializedLocalExport | undefined {
+  if (
+    resolution.hasGTSourceReference ||
+    resolution.gtExportName ||
+    resolution.recoveredTargets?.length !== 1
+  ) {
+    return undefined;
+  }
+  const target = resolution.recoveredTargets[0];
+  if (target.type === 'ordinary-external') return {};
+  if (target.type === 'external' || target.type === 'external-namespace') {
+    return target.source === 'vue'
+      ? materializeLocalExport(target, state)
+      : undefined;
+  }
+  // A recovered local namespace can hide renamed GT exports. The resolver
+  // cannot enumerate that shape exhaustively after syntax recovery, so keep
+  // the whole namespace fail-closed rather than proving selected names only.
+  if (target.type === 'namespace') return undefined;
+
+  const materialized = materializeLocalExport(target, state);
+  if (
+    materialized.hasGTSourceReference ||
+    materialized.possibleGTComponent ||
+    materialized.possibleStringFunction ||
+    materialized.unsafeCallable ||
+    isKnownGTValue(materialized.value)
+  ) {
+    return undefined;
+  }
+  if (localTargetAliasesKnownNonVueRuntime(target)) return materialized;
+  return preserveLocalIdentity &&
+    materialized.callable &&
+    isOrdinaryIdentityFunction(materialized.callable.node)
+    ? materialized
+    : undefined;
+}
+
+/** Proves a direct immutable alias back to an official non-Vue GT runtime. */
+function localTargetAliasesKnownNonVueRuntime(
+  target: Extract<LocalExportTarget, { type: 'expression' | 'local' }>
+): boolean {
+  if (target.type === 'expression') {
+    return expressionAliasesKnownNonVueRuntime(
+      target.node,
+      target.record.programScope,
+      new Set()
+    );
+  }
+  const binding = target.record.programScope.getBinding(target.exportName);
+  if (!binding) return false;
+  const source = getBindingSource(binding);
+  if (!source || source.pattern.type !== 'Identifier') return false;
+  return expressionAliasesKnownNonVueRuntime(
+    source.expression.node,
+    source.expression.scope,
+    new Set([binding])
+  );
+}
+
+/** Follows only immutable identifier aliases to named or default imports. */
+function expressionAliasesKnownNonVueRuntime(
+  node: t.Node,
+  scope: Scope,
+  seen: Set<Binding>
+): boolean {
+  const expression = unwrapExpression(node);
+  if (expression?.type !== 'Identifier') return false;
+  const binding = scope.getBinding(expression.name);
+  if (!binding || seen.has(binding)) return false;
+  const declaration = binding.path.parentPath;
+  if (
+    declaration?.isImportDeclaration() &&
+    isKnownNonVueGTRuntime(declaration.node.source.value)
+  ) {
+    return true;
+  }
+  const source = getBindingSource(binding);
+  return Boolean(
+    source &&
+    source.pattern.type === 'Identifier' &&
+    expressionAliasesKnownNonVueRuntime(
+      source.expression.node,
+      source.expression.scope,
+      new Set(seen).add(binding)
+    )
+  );
+}
+
+/** Proves the narrow local helper form without following unknown dependencies. */
+function isOrdinaryIdentityFunction(node: t.Function): boolean {
+  if (
+    node.async ||
+    node.generator ||
+    node.params.length !== 1 ||
+    node.params[0]?.type !== 'Identifier'
+  ) {
+    return false;
+  }
+  const returned =
+    node.body.type === 'BlockStatement'
+      ? node.body.body.length === 1 &&
+        node.body.body[0]?.type === 'ReturnStatement'
+        ? node.body.body[0].argument
+        : undefined
+      : node.body;
+  const expression = unwrapExpression(returned);
+  return (
+    expression?.type === 'Identifier' && expression.name === node.params[0].name
+  );
+}
+
+/** Makes statically known members of a local namespace visible to templates. */
+function recordLocalNamespaceMembers(
+  localName: string,
+  modulePath: string,
+  state: ScriptState,
+  binding?: Binding
+): void {
+  const resolver = state.analysis.localModules;
+  if (!resolver) return;
+  const exportNames = new Set<string>([
+    ...resolver.listExportNames(modulePath),
+    ...COMPONENT_IMPORTS,
+    'msg',
+    'useGT',
+    'useMessages',
+  ]);
+  for (const exportName of exportNames) {
+    const memberPath = appendTemplatePath(localName, exportName);
+    const resolution = resolver.resolveExport(modulePath, exportName);
+    if (resolution.status === 'absent') continue;
+    if (resolution.status !== 'resolved') {
+      if (
+        resolution.status === 'invalid' &&
+        materializeRecoveredOrdinaryResolution(resolution, state) !== undefined
+      ) {
+        continue;
+      }
+      if (
+        resolution.status === 'invalid' &&
+        resolution.hasGTSourceReference &&
+        bindingReferencesNamespaceMember(binding, exportName, state)
+      ) {
+        state.analysis.hasGTSourceReference = true;
+        state.unsupportedMalformedGTReference = true;
+      }
+      state.analysis.uncertainTranslationHelpers.add(memberPath);
+      if (resolution.status === 'ambiguous') {
+        recordAmbiguousLocalBinding(memberPath, state);
+      } else if (
+        resolution.status === 'invalid' &&
+        resolution.hasGTSourceReference
+      ) {
+        recordInvalidGTResolution(memberPath, resolution, state);
+      } else {
+        recordUnresolvedGTShapedBinding(memberPath, exportName, state);
+      }
+      continue;
+    }
+    const materialized = materializeLocalExport(resolution.target, state);
+    if (materialized.value) {
+      state.analysis.values.set(memberPath, materialized.value);
+    }
+    recordMaterializedLocalUncertainty(memberPath, materialized, state);
+  }
+}
+
+/** Retains the original gt-vue role hidden by a malformed re-export alias. */
+function recordInvalidGTResolution(
+  localName: string,
+  resolution: Extract<LocalExportResolution, { status: 'invalid' }>,
+  state: ScriptState
+): void {
+  if (resolution.gtExportName === '*') {
+    recordUnresolvedGTNamespace(localName, state);
+    return;
+  }
+  if (resolution.gtExportName) {
+    recordUnresolvedGTShapedBinding(localName, resolution.gtExportName, state);
+    return;
+  }
+  state.analysis.uncertainTranslationHelpers.add(localName);
+}
+
+/** Marks the GT-shaped members of one unresolved namespace path. */
+function recordUnresolvedGTNamespace(
+  localName: string,
+  state: ScriptState
+): void {
+  for (const component of COMPONENT_IMPORTS) {
+    const componentPath = appendTemplatePath(localName, component);
+    state.analysis.uncertainComponents.add(componentPath);
+    state.analysis.uncertainGTComponents.add(componentPath);
+  }
+  for (const name of ['msg', 'useGT', 'useMessages']) {
+    state.analysis.uncertainStringFunctions.add(
+      appendTemplatePath(localName, name)
+    );
+  }
+}
+
+/** Records unresolved roles only when a local export can actually be GT. */
+function recordMaterializedLocalUncertainty(
+  localName: string,
+  materialized: ReturnType<typeof materializeLocalExport>,
+  state: ScriptState,
+  forceKnownValues = false
+): void {
+  if (
+    materialized.possibleGTComponent ||
+    (forceKnownValues && materialized.value?.type === 'component')
+  ) {
+    state.analysis.uncertainComponents.add(localName);
+    state.analysis.uncertainGTComponents.add(localName);
+  }
+  if (
+    materialized.possibleStringFunction ||
+    (forceKnownValues && materialized.value?.type === 'string')
+  ) {
+    state.analysis.uncertainStringFunctions.add(localName);
+  }
+  if (materialized.unsafeCallable) {
+    state.analysis.uncertainTranslationHelpers.add(localName);
+  }
+}
+
+/** Detects a mutable export that may still be invoked as a local helper. */
+function bindingMayReferenceLocalCallable(
+  binding: Binding,
+  state: ScriptState
+): boolean {
+  const declaration = binding.path.node;
+  if (
+    declaration.type === 'VariableDeclarator' &&
+    declaration.init &&
+    resolveCalledFunction(
+      declaration.init,
+      binding.path.scope,
+      state,
+      new Set()
+    )
+  ) {
+    return true;
+  }
+  return binding.constantViolations.some(
+    (violation) =>
+      violation.isAssignmentExpression() &&
+      patternContains(violation.node.left, binding.identifier.name) &&
+      resolveCalledFunction(
+        violation.node.right,
+        violation.scope,
+        state,
+        new Set()
+      ) !== undefined
+  );
+}
+
+/** Marks only GT-shaped imports when a custom or bare module is unresolved. */
+function recordUnresolvedGTShapedImports(
+  declaration: t.ImportDeclaration,
+  state: ScriptState
+): void {
+  for (const specifier of declaration.specifiers) {
+    if (specifier.type === 'ImportNamespaceSpecifier') {
+      recordUnresolvedGTNamespace(specifier.local.name, state);
+      continue;
+    }
+    if (
+      specifier.type === 'ImportSpecifier' &&
+      isTypeOnlyImportKind(specifier.importKind)
+    ) {
+      continue;
+    }
+    const importedName =
+      specifier.type === 'ImportDefaultSpecifier'
+        ? specifier.local.name
+        : specifier.imported.type === 'Identifier'
+          ? specifier.imported.name
+          : specifier.imported.value;
+    recordUnresolvedGTShapedBinding(specifier.local.name, importedName, state);
+  }
+}
+
+/** Marks unresolved imports only when a call later passes a translator. */
+function recordUnresolvedTranslationHelperImports(
+  declaration: t.ImportDeclaration,
+  scope: Scope,
+  state: ScriptState
+): void {
+  for (const specifier of declaration.specifiers) {
+    if (
+      specifier.type === 'ImportSpecifier' &&
+      isTypeOnlyImportKind(specifier.importKind)
+    ) {
+      continue;
+    }
+    recordUncertainTranslationHelperBinding(specifier.local.name, scope, state);
+  }
+}
+
+/** Records one unresolved helper name together with its lexical binding. */
+function recordUncertainTranslationHelperBinding(
+  localName: string,
+  scope: Scope,
+  state: ScriptState
+): void {
+  state.analysis.uncertainTranslationHelpers.add(localName);
+  const binding = scope.getBinding(localName);
+  if (binding) state.uncertainTranslationHelperBindings.add(binding);
+}
+
+/** Records the conservative GT roles implied by an unresolved export name. */
+function recordUnresolvedGTShapedBinding(
+  localName: string,
+  exportName: string,
+  state: ScriptState
+): void {
+  if (COMPONENT_IMPORTS.has(exportName as never)) {
+    state.analysis.uncertainComponents.add(localName);
+    state.analysis.uncertainGTComponents.add(localName);
+  }
+  if (
+    exportName === 'msg' ||
+    exportName === 'useGT' ||
+    exportName === 'useMessages'
+  ) {
+    state.analysis.uncertainStringFunctions.add(localName);
+  }
+}
+
+/** Fails closed when a resolved local export is ambiguous or mutable. */
+function recordAmbiguousLocalBinding(
+  localName: string,
+  state: ScriptState
+): void {
+  state.analysis.uncertainComponents.add(localName);
+  state.analysis.uncertainGTComponents.add(localName);
+  state.analysis.uncertainStringFunctions.add(localName);
+}
+
+/** Reads the original name of one direct or namespace ESM import. */
+function readImportedFunctionName(
+  node: t.Node,
+  scope: Scope,
+  source: 'gt-vue' | 'vue',
+  state: ScriptState
+): string | undefined {
+  const known = resolveKnownExpression(node, scope, state, new Set());
+  if (source === 'vue' && known?.type === 'vue-call') return known.name;
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    const importPath = binding?.path;
+    const declaration = importPath?.parentPath;
+    if (
+      !importPath?.isImportSpecifier() ||
+      !declaration?.isImportDeclaration() ||
+      declaration.node.source.value !== source
+    ) {
+      return undefined;
+    }
+    return importPath.node.imported.type === 'Identifier'
+      ? importPath.node.imported.name
+      : importPath.node.imported.value;
+  }
+  if (
+    expression.type !== 'MemberExpression' &&
+    expression.type !== 'OptionalMemberExpression'
+  ) {
+    return undefined;
+  }
+  const property = readMemberProperty(expression);
+  const object = unwrapExpression(expression.object);
+  if (!property || object?.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(object.name);
+  const importPath = binding?.path;
+  const declaration = importPath?.parentPath;
+  return importPath?.isImportNamespaceSpecifier() &&
+    declaration?.isImportDeclaration() &&
+    declaration.node.source.value === source
+    ? property
+    : undefined;
+}
+
+/** Detects an imported T anywhere inside an unsupported wrapper expression. */
+function expressionContainsGTReference(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): boolean {
+  const direct = resolveKnownExpression(node, scope, state, new Set());
+  if (direct?.type === 'component' && direct.name === 'T') return true;
+  const path = state.paths.get(node);
+  if (!path) return false;
+  let found = false;
+  path.traverse({
+    Identifier(identifierPath) {
+      const value = resolveKnownExpression(
+        identifierPath.node,
+        identifierPath.scope,
+        state,
+        new Set()
+      );
+      if (value?.type === 'component' && value.name === 'T') {
+        found = true;
+        identifierPath.stop();
+      }
+    },
+  });
+  return found;
+}
+
+function registerImport(
+  localName: string,
+  value: KnownValue,
+  scope: Scope,
+  state: ScriptState
+): void {
+  const binding = scope.getBinding(localName);
+  if (!binding || binding.constant) {
+    if (binding) state.bindings.set(binding, value);
+    if (
+      binding?.scope.block === state.entryProgram &&
+      (value.type !== 'namespace' || !value.mutable)
+    ) {
+      state.analysis.values.set(localName, value);
+    }
+  }
+}
+
+function registerRequirePattern(
+  pattern: t.Node,
+  namespace: Extract<KnownValue, { type: 'namespace' }>,
+  scope: Scope,
+  state: ScriptState
+): void {
+  if (pattern.type === 'Identifier') {
+    registerImport(pattern.name, namespace, scope, state);
+    const binding = scope.getBinding(pattern.name);
+    if (binding) state.mutableImportSources.set(binding, namespace.source);
+    return;
+  }
+  if (pattern.type !== 'ObjectPattern') return;
+  for (const property of pattern.properties) {
+    if (property.type !== 'ObjectProperty') continue;
+    const importedName = readResolvedPropertyKey(property, scope, state);
+    const localName = readPatternIdentifier(property.value);
+    const value = importedName
+      ? knownExport(namespace.source, importedName)
+      : undefined;
+    if (localName && value) {
+      registerImport(localName, value, scope, state);
+      const binding = scope.getBinding(localName);
+      if (binding) state.mutableImportSources.set(binding, namespace.source);
+    }
+  }
+}
+
+function exposeProgramBindings(
+  ast: t.File,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  for (const name of state.analysis.uncertainComponents) {
+    templateBindings.uncertainComponents.add(name);
+  }
+  for (const name of state.analysis.uncertainGTComponents) {
+    templateBindings.uncertainGTComponents.add(name);
+  }
+  for (const name of state.analysis.uncertainStringFunctions) {
+    templateBindings.uncertainStringFunctions.add(name);
+  }
+  traverse(ast, {
+    Program(path) {
+      for (const [name, binding] of Object.entries(path.scope.bindings)) {
+        clearTemplateBinding(name, templateBindings);
+        templateBindings.directBindings.add(name);
+        if (state.analysis.uncertainComponents.has(name)) {
+          templateBindings.uncertainComponents.add(name);
+        }
+        if (state.analysis.uncertainGTComponents.has(name)) {
+          templateBindings.uncertainGTComponents.add(name);
+        }
+        if (state.analysis.uncertainStringFunctions.has(name)) {
+          templateBindings.uncertainStringFunctions.add(name);
+        }
+        const replayLeaf = readReplayLeafState(binding, state);
+        const exactReplayLeaf = readSafeReplayLeafOverride(
+          binding,
+          replayLeaf,
+          state
+        );
+        const value = exactReplayLeaf
+          ? exactReplayLeaf.value.knownValue
+          : resolveTemplateKnownBinding(binding, state);
+        const unsafeMutableImport = readUnsafeMutableImport(binding, state);
+        const unsafeReplaySource = bindingReadsUnsafeMutableImport(
+          binding,
+          state
+        );
+        const exactReplayComponents =
+          Boolean(exactReplayLeaf) ||
+          (!unsafeReplaySource &&
+            readReplayComponentCandidates(binding, name, state) !== undefined);
+        if (value && !unsafeMutableImport) {
+          exposeKnownValue(name, value, templateBindings, state.analysis);
+        } else if (replayLeaf?.status === 'unsafe') {
+          templateBindings.uncertainComponents.add(name);
+          templateBindings.uncertainGTComponents.add(name);
+          templateBindings.uncertainStringFunctions.add(name);
+        } else if (unsafeMutableImport) {
+          exposeUncertainKnownValue(
+            name,
+            unsafeMutableImport,
+            templateBindings.uncertainComponents,
+            templateBindings.uncertainGTComponents,
+            templateBindings.uncertainStringFunctions
+          );
+        } else if (
+          !exactReplayComponents &&
+          bindingMayReferenceComponent(binding, state)
+        ) {
+          templateBindings.uncertainComponents.add(name);
+        }
+        if (
+          replayLeaf?.status !== 'unsafe' &&
+          !exactReplayComponents &&
+          bindingMayReferenceComponent(binding, state, 'translation')
+        ) {
+          templateBindings.uncertainGTComponents.add(name);
+        }
+        if (
+          !value &&
+          !exactReplayLeaf &&
+          replayLeaf?.status !== 'unsafe' &&
+          bindingMayReferenceStringFunction(binding, state)
+        ) {
+          templateBindings.uncertainStringFunctions.add(name);
+        }
+        exposeProgramComponentMembers(name, binding, state, templateBindings);
+        exposeProgramComponentFactory(name, binding, state, templateBindings);
+        exposeProgramContainerKinds(name, binding, state, templateBindings);
+        const gtContainer = readBindingGTContainerExposure(binding, state);
+        for (const path of gtContainer.containers) {
+          templateBindings.possibleGTContainers.add(path);
+        }
+        for (const path of gtContainer.factories) {
+          templateBindings.gtContainerFactories.add(path);
+        }
+        exposeProgramStaticMembers(name, binding, state, templateBindings);
+        exposeProgramPossibleStaticStrings(
+          name,
+          binding,
+          state,
+          templateBindings
+        );
+        const staticValue = readStaticFromScope(
+          binding.identifier,
+          path.scope,
+          new Set(),
+          Number.POSITIVE_INFINITY,
+          state.analysis
+        );
+        if (staticValue.ok) {
+          templateBindings.staticValues.set(name, staticValue.value);
+        }
+      }
+      path.stop();
+    },
+  });
+}
+
+/** Invalidates normal-script values written from the script-setup block. */
+function recordCrossBlockWrites(
+  ast: t.File,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  const applyWrite = (target: t.Node, scope: Scope, value?: t.Node): void => {
+    for (const path of collectCrossBlockWritePaths(target, scope, state)) {
+      const existingValues = [...readAnalysisPathValues(path, state.analysis)];
+      const hadComponent =
+        existingValues.some(
+          (entry) => entry.type === 'component' || entry.type === 'vue-builtin'
+        ) || setHasPath(state.analysis.uncertainComponents, path);
+      const hadGTComponent =
+        existingValues.some((entry) => entry.type === 'component') ||
+        setHasPath(state.analysis.uncertainGTComponents, path);
+      const hadString =
+        existingValues.some((entry) => entry.type === 'string') ||
+        setHasPath(state.analysis.uncertainStringFunctions, path);
+      invalidateAnalysisPath(path, state.analysis);
+      clearTemplateBinding(path, templateBindings);
+
+      const valueHasComponent = Boolean(
+        value &&
+        (expressionMayProduceComponent(value, scope, state, new Set()) ||
+          containerMayContainComponent(value, scope, state, new Set()))
+      );
+      const valueHasGTComponent = Boolean(
+        value &&
+        (expressionMayProduceComponent(
+          value,
+          scope,
+          state,
+          new Set(),
+          'translation'
+        ) ||
+          containerMayContainComponent(
+            value,
+            scope,
+            state,
+            new Set(),
+            'translation'
+          ))
+      );
+      const valueHasString = Boolean(
+        value &&
+        (expressionMayProduceStringFunction(value, scope, state, new Set()) ||
+          containerMayContainStringFunction(value, scope, state, new Set()))
+      );
+      if (hadComponent || valueHasComponent) {
+        state.analysis.uncertainComponents.add(path);
+        templateBindings.uncertainComponents.add(path);
+      }
+      if (hadGTComponent || valueHasGTComponent) {
+        state.analysis.uncertainGTComponents.add(path);
+        templateBindings.uncertainGTComponents.add(path);
+      }
+      if (hadString || valueHasString) {
+        state.analysis.uncertainStringFunctions.add(path);
+        templateBindings.uncertainStringFunctions.add(path);
+      }
+    }
+  };
+
+  traverse(ast, {
+    AssignmentExpression(path) {
+      applyWrite(path.node.left, path.scope, path.node.right);
+    },
+    UpdateExpression(path) {
+      applyWrite(path.node.argument, path.scope);
+    },
+    UnaryExpression(path) {
+      if (path.node.operator === 'delete') {
+        applyWrite(path.node.argument, path.scope);
+      }
+    },
+    ForInStatement(path) {
+      applyWrite(path.node.left, path.scope, path.node.right);
+    },
+    ForOfStatement(path) {
+      applyWrite(path.node.left, path.scope, path.node.right);
+    },
+  });
+}
+
+function collectCrossBlockWritePaths(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): string[] {
+  const expression = unwrapExpression(node);
+  if (!expression) return [];
+  if (expression.type === 'Identifier') {
+    return !scope.getBinding(expression.name) &&
+      state.analysis.directBindings.has(expression.name)
+      ? [expression.name]
+      : [];
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const root = readMemberRootName(expression);
+    if (
+      !root ||
+      scope.getBinding(root) ||
+      !state.analysis.directBindings.has(root)
+    ) {
+      return [];
+    }
+    return [readResolvedMemberPath(expression, scope, state) ?? root];
+  }
+  if (expression.type === 'ObjectPattern') {
+    return expression.properties.flatMap((property) =>
+      collectCrossBlockWritePaths(
+        property.type === 'RestElement' ? property.argument : property.value,
+        scope,
+        state
+      )
+    );
+  }
+  if (expression.type === 'ArrayPattern') {
+    return expression.elements.flatMap((element) =>
+      element ? collectCrossBlockWritePaths(element, scope, state) : []
+    );
+  }
+  if (expression.type === 'RestElement') {
+    return collectCrossBlockWritePaths(expression.argument, scope, state);
+  }
+  if (expression.type === 'AssignmentPattern') {
+    return collectCrossBlockWritePaths(expression.left, scope, state);
+  }
+  return [];
+}
+
+function readMemberRootName(node: t.Node): string | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (expression.type === 'Identifier') return expression.name;
+  return expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+    ? readMemberRootName(expression.object)
+    : undefined;
+}
+
+function readAnalysisPathValues(
+  path: string,
+  analysis: VueScriptAnalysis
+): KnownValue[] {
+  const values: KnownValue[] = [];
+  for (const source of [analysis.values, analysis.templateValues]) {
+    for (const [name, value] of source) {
+      if (name === path || name.startsWith(`${path}.`)) values.push(value);
+    }
+  }
+  return values;
+}
+
+function setHasPath(values: Set<string>, path: string): boolean {
+  return [...values].some(
+    (name) => name === path || name.startsWith(`${path}.`)
+  );
+}
+
+/** Checks whether a dotted path is nested under one retained set entry. */
+function pathHasSetPrefix(values: Set<string>, path: string): boolean {
+  return [...values].some(
+    (name) => name === path || path.startsWith(`${name}.`)
+  );
+}
+
+/** Checks helper uncertainty against the active lexical binding when present. */
+function pathMayReferenceUncertainTranslationHelper(
+  node: t.Node,
+  path: string,
+  scope: Scope,
+  state: ScriptState
+): boolean {
+  const rootName = readMemberRootName(node);
+  const binding = rootName ? scope.getBinding(rootName) : undefined;
+  if (!binding) {
+    return pathHasSetPrefix(state.analysis.uncertainTranslationHelpers, path);
+  }
+  if (state.uncertainTranslationHelperBindings.has(binding)) return true;
+
+  const known = state.bindings.get(binding);
+  const isLocalNamespace = known?.type === 'local-namespace';
+  return (
+    (binding.path.isImportNamespaceSpecifier() || isLocalNamespace) &&
+    pathHasSetPrefix(state.analysis.uncertainTranslationHelpers, path)
+  );
+}
+
+function invalidateAnalysisPath(
+  path: string,
+  analysis: VueScriptAnalysis
+): void {
+  for (const map of [
+    analysis.arrayLengths,
+    analysis.possibleStaticStrings,
+    analysis.values,
+    analysis.templateValues,
+    analysis.staticValues,
+    analysis.containerKinds,
+  ]) {
+    for (const name of map.keys()) {
+      if (name === path || name.startsWith(`${path}.`)) map.delete(name);
+    }
+  }
+  for (const values of [
+    analysis.componentFactories,
+    analysis.gtComponentFactories,
+    analysis.gtContainerFactories,
+    analysis.possibleGTContainers,
+    analysis.uncertainComponents,
+    analysis.uncertainGTComponents,
+    analysis.uncertainStringFunctions,
+  ]) {
+    for (const name of values) {
+      if (name === path || name.startsWith(`${path}.`)) values.delete(name);
+    }
+  }
+}
+
+/** Removes a normal-script exposure shadowed by a script-setup binding. */
+function clearTemplateBinding(
+  localName: string,
+  templateBindings: TemplateBindings
+): void {
+  for (const bindings of [
+    templateBindings.arrayLengths,
+    templateBindings.possibleStaticStrings,
+    templateBindings.staticValues,
+    templateBindings.containerKinds,
+  ]) {
+    for (const name of bindings.keys()) {
+      if (name === localName || name.startsWith(`${localName}.`)) {
+        bindings.delete(name);
+      }
+    }
+  }
+  templateBindings.uncertainComponents.delete(localName);
+  templateBindings.uncertainGTComponents.delete(localName);
+  templateBindings.uncertainStringFunctions.delete(localName);
+  for (const bindings of [
+    templateBindings.components,
+    templateBindings.stringFunctions,
+    templateBindings.vueBuiltins,
+  ]) {
+    for (const name of bindings.keys()) {
+      if (name === localName || name.startsWith(`${localName}.`)) {
+        bindings.delete(name);
+      }
+    }
+  }
+  for (const bindings of [
+    templateBindings.componentFactories,
+    templateBindings.gtComponentFactories,
+    templateBindings.gtContainerFactories,
+    templateBindings.identityFunctions,
+    templateBindings.possibleGTContainers,
+  ]) {
+    for (const name of bindings) {
+      if (name === localName || name.startsWith(`${localName}.`)) {
+        bindings.delete(name);
+      }
+    }
+  }
+  for (const name of templateBindings.uncertainComponents) {
+    if (name.startsWith(`${localName}.`)) {
+      templateBindings.uncertainComponents.delete(name);
+    }
+  }
+  for (const name of templateBindings.uncertainGTComponents) {
+    if (name.startsWith(`${localName}.`)) {
+      templateBindings.uncertainGTComponents.delete(name);
+    }
+  }
+  for (const name of templateBindings.uncertainStringFunctions) {
+    if (name.startsWith(`${localName}.`)) {
+      templateBindings.uncertainStringFunctions.delete(name);
+    }
+  }
+}
+
+/** Records normal-script module bindings that script setup can reference. */
+function recordProgramAnalysis(ast: t.File, state: ScriptState): void {
+  traverse(ast, {
+    Program(path) {
+      for (const [name, binding] of Object.entries(path.scope.bindings)) {
+        state.analysis.directBindings.add(name);
+        const replayLeaf = readReplayLeafState(binding, state);
+        const exactReplayLeaf = readSafeReplayLeafOverride(
+          binding,
+          replayLeaf,
+          state
+        );
+        const replayKnownValue = exactReplayLeaf
+          ? exactReplayLeaf.value.knownValue
+          : undefined;
+        const value = exactReplayLeaf
+          ? replayKnownValue
+          : resolveKnownBinding(binding, state, new Set());
+        const templateValue = exactReplayLeaf
+          ? replayKnownValue
+          : resolveTemplateKnownBinding(binding, state);
+        const unsafeMutableImport = readUnsafeMutableImport(binding, state);
+        const unsafeReplaySource = bindingReadsUnsafeMutableImport(
+          binding,
+          state
+        );
+        const exactReplayComponents =
+          Boolean(exactReplayLeaf) ||
+          (!unsafeReplaySource &&
+            readReplayComponentCandidates(binding, name, state) !== undefined);
+        if (value && !unsafeMutableImport) {
+          state.analysis.values.set(name, value);
+        } else if (replayLeaf?.status === 'unsafe') {
+          state.analysis.uncertainComponents.add(name);
+          state.analysis.uncertainGTComponents.add(name);
+          state.analysis.uncertainStringFunctions.add(name);
+        } else if (unsafeMutableImport) {
+          exposeUncertainKnownValue(
+            name,
+            unsafeMutableImport,
+            state.analysis.uncertainComponents,
+            state.analysis.uncertainGTComponents,
+            state.analysis.uncertainStringFunctions
+          );
+        } else if (
+          !exactReplayComponents &&
+          bindingMayReferenceComponent(binding, state)
+        ) {
+          state.analysis.uncertainComponents.add(name);
+        }
+        if (
+          replayLeaf?.status !== 'unsafe' &&
+          !exactReplayComponents &&
+          bindingMayReferenceComponent(binding, state, 'translation')
+        ) {
+          state.analysis.uncertainGTComponents.add(name);
+        }
+        if (
+          !templateValue &&
+          !exactReplayLeaf &&
+          replayLeaf?.status !== 'unsafe' &&
+          bindingMayReferenceStringFunction(binding, state)
+        ) {
+          state.analysis.uncertainStringFunctions.add(name);
+        }
+        if (
+          templateValue &&
+          (!value || knownValueKey(value) !== knownValueKey(templateValue))
+        ) {
+          state.analysis.templateValues.set(name, templateValue);
+        }
+        recordProgramComponentMembers(name, binding, state);
+        recordProgramComponentFactory(name, binding, state);
+        recordProgramContainerKinds(name, binding, state);
+        const gtContainer = readBindingGTContainerExposure(binding, state);
+        for (const path of gtContainer.containers) {
+          state.analysis.possibleGTContainers.add(path);
+        }
+        for (const path of gtContainer.factories) {
+          state.analysis.gtContainerFactories.add(path);
+        }
+        recordProgramStaticMembers(name, binding, state);
+        recordProgramPossibleStaticStrings(name, binding, state);
+        const staticValue = readStaticFromScope(
+          binding.identifier,
+          path.scope,
+          new Set(),
+          Number.POSITIVE_INFINITY,
+          state.analysis
+        );
+        if (staticValue.ok) {
+          state.analysis.staticValues.set(name, staticValue.value);
+        }
+      }
+      path.stop();
+    },
+  });
+}
+
+function exposeKnownValue(
+  localName: string,
+  value: KnownValue,
+  templateBindings: TemplateBindings,
+  analysis?: VueScriptAnalysis
+): void {
+  if (value.type === 'component') {
+    templateBindings.components.set(localName, value.name);
+  } else if (value.type === 'string') {
+    templateBindings.stringFunctions.set(localName, value.kind);
+  } else if (value.type === 'namespace' && value.source === 'gt-vue') {
+    for (const component of COMPONENT_IMPORTS) {
+      templateBindings.components.set(
+        appendTemplatePath(localName, component),
+        component
+      );
+    }
+    templateBindings.stringFunctions.set(
+      appendTemplatePath(localName, 'msg'),
+      'msg'
+    );
+  } else if (value.type === 'namespace' && value.source === 'vue') {
+    for (const builtin of VUE_BUILTIN_IMPORTS) {
+      templateBindings.vueBuiltins.set(
+        appendTemplatePath(localName, builtin),
+        builtin
+      );
+    }
+    templateBindings.identityFunctions.add(
+      appendTemplatePath(localName, 'markRaw')
+    );
+  } else if (value.type === 'local-namespace' && analysis) {
+    const prefix = `${localName}.`;
+    for (const [path, member] of analysis.values) {
+      if (path.startsWith(prefix) && path !== localName) {
+        exposeKnownValue(path, member, templateBindings, analysis);
+      }
+    }
+    for (const path of analysis.uncertainComponents) {
+      if (path.startsWith(prefix)) {
+        templateBindings.uncertainComponents.add(path);
+      }
+    }
+    for (const path of analysis.uncertainGTComponents) {
+      if (path.startsWith(prefix)) {
+        templateBindings.uncertainGTComponents.add(path);
+      }
+    }
+    for (const path of analysis.uncertainStringFunctions) {
+      if (path.startsWith(prefix)) {
+        templateBindings.uncertainStringFunctions.add(path);
+      }
+    }
+  } else if (value.type === 'vue-builtin') {
+    templateBindings.vueBuiltins.set(localName, value.name);
+  } else if (value.type === 'identity') {
+    templateBindings.identityFunctions.add(localName);
+  }
+}
+
+/** Reads the original export identity for an unsafe CommonJS import binding. */
+function readUnsafeMutableImport(
+  binding: Binding,
+  state: ScriptState
+): KnownValue | undefined {
+  const source = state.mutableImportSources.get(binding);
+  const value = state.bindings.get(binding);
+  if (!source || !value) return undefined;
+  const unsafe =
+    state.unsafeMutableNamespaceSources.has(source) ||
+    (value.type === 'namespace' &&
+      value.mutable &&
+      !isSafeMutableNamespaceBinding(binding));
+  return unsafe ? value : undefined;
+}
+
+/** Detects a derived binding whose root still comes from mutable CommonJS. */
+function bindingReadsUnsafeMutableImport(
+  binding: Binding,
+  state: ScriptState
+): boolean {
+  const source = getBindingSource(binding);
+  if (!source) return false;
+  let expression = unwrapExpression(source.expression.node);
+  while (
+    expression?.type === 'MemberExpression' ||
+    expression?.type === 'OptionalMemberExpression'
+  ) {
+    expression = unwrapExpression(expression.object);
+  }
+  if (expression?.type !== 'Identifier') return false;
+  const rootBinding = source.expression.scope.getBinding(expression.name);
+  if (!rootBinding) return false;
+  const mutableSource = state.mutableImportSources.get(rootBinding);
+  return Boolean(
+    mutableSource &&
+    (state.unsafeMutableNamespaceSources.has(mutableSource) ||
+      !isSafeMutableNamespaceBinding(rootBinding))
+  );
+}
+
+/** Records only the exact component names reachable from an unsafe import. */
+function exposeUncertainKnownValue(
+  localName: string,
+  value: KnownValue,
+  uncertainComponents: Set<string>,
+  uncertainGTComponents: Set<string>,
+  uncertainStringFunctions: Set<string>
+): void {
+  if (value.type === 'component') {
+    uncertainComponents.add(localName);
+    uncertainGTComponents.add(localName);
+  } else if (value.type === 'vue-builtin') {
+    uncertainComponents.add(localName);
+  } else if (value.type === 'string' || value.type === 'hook') {
+    uncertainStringFunctions.add(localName);
+  } else if (value.type === 'namespace' && value.source === 'gt-vue') {
+    for (const component of COMPONENT_IMPORTS) {
+      uncertainComponents.add(appendTemplatePath(localName, component));
+      uncertainGTComponents.add(appendTemplatePath(localName, component));
+    }
+    uncertainStringFunctions.add(appendTemplatePath(localName, 'msg'));
+  } else if (value.type === 'namespace' && value.source === 'vue') {
+    for (const builtin of VUE_BUILTIN_IMPORTS) {
+      uncertainComponents.add(appendTemplatePath(localName, builtin));
+    }
+  }
+}
+
+/** Exposes a callable whose return can affect template component identity. */
+function exposeProgramComponentFactory(
+  localName: string,
+  binding: Binding,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  const replay = readReplayComponentFactoryCandidates(
+    binding,
+    localName,
+    state
+  );
+  if (replay) {
+    for (const candidate of replay) {
+      templateBindings.componentFactories.add(candidate.name);
+      if (candidate.gt) {
+        templateBindings.gtComponentFactories.add(candidate.name);
+      }
+    }
+    return;
+  }
+  const factory = readProgramComponentFactory(binding, state);
+  if (factory) {
+    templateBindings.componentFactories.add(localName);
+    if (factory.gt) templateBindings.gtComponentFactories.add(localName);
+  }
+  for (const candidate of collectProgramComponentFactoryMembers(
+    localName,
+    binding,
+    state
+  )) {
+    templateBindings.componentFactories.add(candidate.name);
+    if (candidate.gt) {
+      templateBindings.gtComponentFactories.add(candidate.name);
+    }
+  }
+}
+
+/** Records a normal-script component factory for script-setup templates. */
+function recordProgramComponentFactory(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): void {
+  const replay = readReplayComponentFactoryCandidates(
+    binding,
+    localName,
+    state
+  );
+  if (replay) {
+    for (const candidate of replay) {
+      state.analysis.componentFactories.add(candidate.name);
+      if (candidate.gt) {
+        state.analysis.gtComponentFactories.add(candidate.name);
+      }
+    }
+    return;
+  }
+  const factory = readProgramComponentFactory(binding, state);
+  if (factory) {
+    state.analysis.componentFactories.add(localName);
+    if (factory.gt) state.analysis.gtComponentFactories.add(localName);
+  }
+  for (const candidate of collectProgramComponentFactoryMembers(
+    localName,
+    binding,
+    state
+  )) {
+    state.analysis.componentFactories.add(candidate.name);
+    if (candidate.gt) state.analysis.gtComponentFactories.add(candidate.name);
+  }
+}
+
+/** Determines whether a local callable may return GT and/or Vue identity. */
+function readProgramComponentFactory(
+  binding: Binding,
+  state: ScriptState
+): { gt: boolean } | undefined {
+  return readComponentFactoryExpression(
+    binding.identifier,
+    binding.path.scope,
+    state
+  );
+}
+
+function readComponentFactoryExpression(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): { gt: boolean } | undefined {
+  const called = resolveCalledFunction(node, scope, state, new Set());
+  if (!called) return undefined;
+  const gt = functionMayReturnComponent(
+    called.node,
+    called.scope,
+    state,
+    new Set(),
+    'translation'
+  );
+  const vue = functionMayReturnComponent(
+    called.node,
+    called.scope,
+    state,
+    new Set(),
+    'vue'
+  );
+  return gt || vue ? { gt } : undefined;
+}
+
+/** Finds callable component-producing members of an object or array binding. */
+function collectProgramComponentFactoryMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): ComponentFactoryCandidate[] {
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    declaration.id.type !== 'Identifier' ||
+    !declaration.init
+  ) {
+    return [];
+  }
+  return collectComponentFactoryCandidates(
+    declaration.init,
+    binding.path.scope,
+    localName,
+    state,
+    new Set(),
+    new Set([binding])
+  ).filter((candidate) => candidate.name !== localName);
+}
+
+function collectComponentFactoryCandidates(
+  node: t.Node,
+  scope: Scope,
+  name: string,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>
+): ComponentFactoryCandidate[] {
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return [];
+  const nextNodes = new Set(seenNodes).add(expression);
+  const called = resolveCalledFunction(expression, scope, state, new Set());
+  if (called) {
+    const gt = functionMayReturnComponent(
+      called.node,
+      called.scope,
+      state,
+      new Set(),
+      'translation'
+    );
+    const vue = functionMayReturnComponent(
+      called.node,
+      called.scope,
+      state,
+      new Set(),
+      'vue'
+    );
+    return gt || vue ? [{ gt, name }] : [];
+  }
+  if (expression.type === 'Identifier') {
+    const source = scope.getBinding(expression.name);
+    if (!source || seenBindings.has(source)) return [];
+    const bindingSource = getBindingSource(source);
+    if (bindingSource?.pattern.type !== 'Identifier') return [];
+    const cacheable = state.parameterSubstitutions.length === 0;
+    const remap = (candidate: ComponentFactoryCandidate) => ({
+      ...candidate,
+      name:
+        candidate.name === source.identifier.name
+          ? name
+          : `${name}${candidate.name.slice(source.identifier.name.length)}`,
+    });
+    const cached = cacheable
+      ? state.componentFactoryCandidates.get(source)
+      : undefined;
+    if (cached) return cached.map(remap);
+    if (cacheable && state.componentFactoryCandidatesInProgress.has(source)) {
+      return [];
+    }
+    if (cacheable) state.componentFactoryCandidatesInProgress.add(source);
+    try {
+      const candidates = collectComponentFactoryCandidates(
+        bindingSource.expression.node,
+        bindingSource.expression.scope,
+        cacheable ? source.identifier.name : name,
+        state,
+        nextNodes,
+        new Set(seenBindings).add(source)
+      );
+      if (!cacheable) return candidates;
+      state.componentFactoryCandidates.set(source, candidates);
+      return candidates.map(remap);
+    } finally {
+      if (cacheable) {
+        state.componentFactoryCandidatesInProgress.delete(source);
+      }
+    }
+  }
+  if (expression.type === 'ObjectExpression') {
+    return expression.properties.flatMap((property) => {
+      if (property.type === 'SpreadElement') {
+        return collectComponentFactoryCandidates(
+          property.argument,
+          scope,
+          name,
+          state,
+          nextNodes,
+          seenBindings
+        );
+      }
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) return [];
+      return collectComponentFactoryCandidates(
+        property.type === 'ObjectProperty' ? property.value : property,
+        scope,
+        appendTemplatePath(name, key),
+        state,
+        nextNodes,
+        seenBindings
+      );
+    });
+  }
+  if (expression.type === 'ArrayExpression') {
+    return expression.elements.flatMap((element, index) =>
+      element
+        ? collectComponentFactoryCandidates(
+            element.type === 'SpreadElement' ? element.argument : element,
+            scope,
+            appendTemplatePath(name, String(index)),
+            state,
+            nextNodes,
+            seenBindings
+          )
+        : []
+    );
+  }
+  return [];
+}
+
+/** Exposes exact component-valued object members from one script-setup binding. */
+function exposeProgramComponentMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  for (const candidate of collectProgramComponentMembers(
+    localName,
+    binding,
+    state
+  )) {
+    if (candidate.certain) {
+      exposeKnownValue(
+        candidate.name,
+        candidate.value,
+        templateBindings,
+        state.analysis
+      );
+      continue;
+    }
+    if (candidate.value.type === 'component') {
+      templateBindings.uncertainComponents.add(candidate.name);
+      templateBindings.uncertainGTComponents.add(candidate.name);
+    } else if (candidate.value.type === 'string') {
+      templateBindings.uncertainStringFunctions.add(candidate.name);
+    } else {
+      templateBindings.uncertainComponents.add(candidate.name);
+    }
+  }
+}
+
+/** Records exact cross-block member names without a container-wide wildcard. */
+function recordProgramComponentMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): void {
+  for (const candidate of collectProgramComponentMembers(
+    localName,
+    binding,
+    state
+  )) {
+    if (candidate.certain) {
+      state.analysis.values.set(candidate.name, candidate.value);
+      continue;
+    }
+    if (candidate.value.type === 'component') {
+      state.analysis.uncertainComponents.add(candidate.name);
+      state.analysis.uncertainGTComponents.add(candidate.name);
+    } else if (candidate.value.type === 'string') {
+      state.analysis.uncertainStringFunctions.add(candidate.name);
+    } else {
+      state.analysis.uncertainComponents.add(candidate.name);
+    }
+  }
+}
+
+/** Finds statically named component leaves in an object or array binding. */
+function collectProgramComponentMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): ComponentMemberCandidate[] {
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) return [];
+  if (declaration.id.type !== 'Identifier') {
+    return [
+      ...collectNamespaceRestMemberCandidates(
+        localName,
+        binding,
+        declaration.id,
+        declaration.init,
+        state
+      ),
+      ...collectRestPatternMemberCandidates(
+        localName,
+        binding,
+        declaration.id,
+        declaration.init,
+        state
+      ),
+    ];
+  }
+  const replayCandidates = readReplayComponentCandidates(
+    binding,
+    localName,
+    state
+  );
+  if (replayCandidates) return replayCandidates;
+  const finalSnapshot = readDefiniteFinalContainerSnapshot(binding, state);
+  if (finalSnapshot) {
+    const entries =
+      finalSnapshot.kind === 'array'
+        ? finalSnapshot.entries.map(
+            (value, index) => [String(index), value] as const
+          )
+        : [...finalSnapshot.entries];
+    return entries.flatMap(([key, value]) =>
+      value
+        ? collectComponentMemberCandidates(
+            value.node,
+            value.scope,
+            appendTemplatePath(localName, key),
+            state,
+            true,
+            new Set(),
+            new Set([binding])
+          )
+        : []
+    );
+  }
+  const certain = isSafelyReadContainerBinding(
+    binding,
+    binding.identifier,
+    Number.POSITIVE_INFINITY,
+    false,
+    state
+  );
+  const candidates = collectComponentMemberCandidates(
+    declaration.init,
+    binding.path.scope,
+    localName,
+    state,
+    certain,
+    new Set(),
+    new Set([binding])
+  );
+  candidates.push(...collectMemberWriteCandidates(localName, binding, state));
+  const byName = new Map<string, ComponentMemberCandidate>();
+  for (const candidate of candidates) {
+    if (candidate.name !== localName) byName.set(candidate.name, candidate);
+  }
+  return [...byName.values()];
+}
+
+type DirectRestPattern =
+  | { type: 'array'; start: number }
+  | { type: 'object'; excluded: Set<string>; hasDynamicExclusion: boolean };
+
+/** Remaps flattened source paths to the indices/keys created by rest syntax. */
+function remapDirectRestPaths<T>(
+  localName: string,
+  rest: DirectRestPattern,
+  source: Map<string, T>
+): Map<string, T> {
+  const result = new Map<string, T>();
+  for (const [path, value] of source) {
+    if (path === localName || !path.startsWith(`${localName}.`)) continue;
+    const suffix = path.slice(localName.length + 1);
+    const [first, ...restPath] = suffix.split('.');
+    if (rest.type === 'object') {
+      if (!rest.excluded.has(first) && !rest.hasDynamicExclusion) {
+        result.set(path, value);
+      }
+      continue;
+    }
+    const index = first.match(/^(0|[1-9]\d*)$/) ? Number(first) : undefined;
+    if (index === undefined || index < rest.start) continue;
+    result.set(
+      `${appendTemplatePath(localName, String(index - rest.start))}${
+        restPath.length > 0 ? `.${restPath.join('.')}` : ''
+      }`,
+      value
+    );
+  }
+  return result;
+}
+
+/** Reads a direct object/array rest target for one bound identifier. */
+function readDirectRestPattern(
+  pattern: t.Node,
+  localName: string,
+  scope: Scope,
+  state: ScriptState
+): DirectRestPattern | undefined {
+  if (pattern.type === 'ArrayPattern') {
+    const start = pattern.elements.findIndex(
+      (element) =>
+        element?.type === 'RestElement' &&
+        element.argument.type === 'Identifier' &&
+        element.argument.name === localName
+    );
+    return start >= 0 ? { type: 'array', start } : undefined;
+  }
+  if (pattern.type !== 'ObjectPattern') return undefined;
+  const hasRest = pattern.properties.some(
+    (property) =>
+      property.type === 'RestElement' &&
+      property.argument.type === 'Identifier' &&
+      property.argument.name === localName
+  );
+  if (!hasRest) return undefined;
+  const excluded = new Set<string>();
+  let hasDynamicExclusion = false;
+  for (const property of pattern.properties) {
+    if (property.type !== 'ObjectProperty') continue;
+    const key = readResolvedPropertyKey(property, scope, state);
+    if (key !== undefined) excluded.add(appendTemplatePath('', key).slice(1));
+    else hasDynamicExclusion = true;
+  }
+  return { type: 'object', excluded, hasDynamicExclusion };
+}
+
+/** Maps component/string leaves copied into a direct rest binding. */
+function collectRestPatternMemberCandidates(
+  localName: string,
+  binding: Binding,
+  pattern: t.Node,
+  value: t.Expression,
+  state: ScriptState
+): ComponentMemberCandidate[] {
+  const rest = readDirectRestPattern(
+    pattern,
+    localName,
+    binding.path.scope,
+    state
+  );
+  if (!rest) return [];
+  const sourceIsKnown = componentContainerShapeIsKnown(
+    value,
+    binding.path.scope,
+    state,
+    new Set(),
+    value.end ?? Number.POSITIVE_INFINITY
+  );
+  const certain =
+    sourceIsKnown &&
+    isSafelyReadContainerBinding(
+      binding,
+      binding.identifier,
+      Number.POSITIVE_INFINITY,
+      true,
+      state
+    );
+  const candidates = collectComponentMemberCandidates(
+    value,
+    binding.path.scope,
+    localName,
+    state,
+    certain,
+    new Set(),
+    new Set(),
+    Number.POSITIVE_INFINITY
+  );
+  return candidates.flatMap((candidate) => {
+    const suffix = candidate.name.slice(localName.length + 1);
+    const [first, ...restPath] = suffix.split('.');
+    if (rest.type === 'object') {
+      return rest.excluded.has(first)
+        ? []
+        : [
+            {
+              ...candidate,
+              certain: candidate.certain && !rest.hasDynamicExclusion,
+            },
+          ];
+    }
+    const index = first.match(/^(0|[1-9]\d*)$/) ? Number(first) : undefined;
+    if (index === undefined || index < rest.start) return [];
+    return [
+      {
+        ...candidate,
+        name: `${appendTemplatePath(localName, String(index - rest.start))}${
+          restPath.length > 0 ? `.${restPath.join('.')}` : ''
+        }`,
+      },
+    ];
+  });
+}
+
+/** Exposes statically named exports copied by an object-rest namespace binding. */
+function collectNamespaceRestMemberCandidates(
+  localName: string,
+  binding: Binding,
+  pattern: t.Node,
+  value: t.Expression,
+  state: ScriptState
+): ComponentMemberCandidate[] {
+  if (pattern.type !== 'ObjectPattern') return [];
+  const rest = pattern.properties.find(
+    (property): property is t.RestElement =>
+      property.type === 'RestElement' &&
+      property.argument.type === 'Identifier' &&
+      property.argument.name === localName
+  );
+  if (!rest) return [];
+  const namespace = resolveNamespaceOrigin(
+    value,
+    binding.path.scope,
+    state,
+    new Set()
+  );
+  if (!namespace) return [];
+  const excluded = new Set(
+    pattern.properties.flatMap((property) => {
+      if (property.type !== 'ObjectProperty') return [];
+      const key = readResolvedPropertyKey(property, binding.path.scope, state);
+      return key !== undefined ? [key] : [];
+    })
+  );
+  const certain = isSafelyReadContainerBinding(
+    binding,
+    binding.identifier,
+    Number.POSITIVE_INFINITY,
+    true,
+    state
+  );
+  const exports: TemplateKnownValue[] =
+    namespace.source === 'gt-vue'
+      ? [
+          ...[...COMPONENT_IMPORTS].map(
+            (name): TemplateKnownValue => ({ type: 'component', name })
+          ),
+          { type: 'string', kind: 'msg' },
+        ]
+      : [...VUE_BUILTIN_IMPORTS].map(
+          (name): TemplateKnownValue => ({ type: 'vue-builtin', name })
+        );
+  return exports
+    .filter((entry) => {
+      const name =
+        entry.type === 'component'
+          ? entry.name
+          : entry.type === 'string'
+            ? 'msg'
+            : entry.name;
+      return !excluded.has(name);
+    })
+    .map((entry) => ({
+      certain,
+      name: appendTemplatePath(
+        localName,
+        entry.type === 'component'
+          ? entry.name
+          : entry.type === 'string'
+            ? 'msg'
+            : entry.name
+      ),
+      value: entry,
+    }));
+}
+
+/** Exposes the static array/object shape of one script-setup binding. */
+function exposeProgramContainerKinds(
+  localName: string,
+  binding: Binding,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  for (const [name, kind] of collectProgramContainerKinds(
+    localName,
+    binding,
+    state
+  )) {
+    templateBindings.containerKinds.set(name, kind);
+  }
+  for (const [name, length] of collectProgramArrayLengths(
+    localName,
+    binding,
+    state
+  )) {
+    templateBindings.arrayLengths.set(name, length);
+  }
+}
+
+/** Records normal-script container shapes for a combined script-setup SFC. */
+function recordProgramContainerKinds(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): void {
+  for (const [name, kind] of collectProgramContainerKinds(
+    localName,
+    binding,
+    state
+  )) {
+    state.analysis.containerKinds.set(name, kind);
+  }
+  for (const [name, length] of collectProgramArrayLengths(
+    localName,
+    binding,
+    state
+  )) {
+    state.analysis.arrayLengths.set(name, length);
+  }
+}
+
+function collectProgramContainerKinds(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): Map<string, TemplateContainerKind> {
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return new Map();
+  }
+  if (declaration.id.type !== 'Identifier') {
+    const namespace = collectNamespaceRestContainerKind(
+      localName,
+      binding,
+      declaration.id,
+      declaration.init,
+      state
+    );
+    return namespace.size > 0
+      ? namespace
+      : collectRestPatternContainerKinds(
+          localName,
+          binding,
+          declaration.id,
+          declaration.init,
+          state
+        );
+  }
+  const replay = readReplayContainerMetadata(binding, localName, state);
+  if (replay) return replay.kinds;
+  const result = collectContainerKinds(
+    declaration.init,
+    binding.path.scope,
+    localName,
+    state,
+    new Set(),
+    new Set([binding]),
+    Number.POSITIVE_INFINITY
+  );
+  if (
+    isSafelyReadContainerBinding(
+      binding,
+      binding.identifier,
+      Number.POSITIVE_INFINITY,
+      false,
+      state
+    )
+  ) {
+    return result;
+  }
+  const rootKind = result.get(localName);
+  return rootKind ? new Map([[localName, rootKind]]) : new Map();
+}
+
+/** Maps statically known container paths copied by a direct rest binding. */
+function collectRestPatternContainerKinds(
+  localName: string,
+  binding: Binding,
+  pattern: t.Node,
+  value: t.Expression,
+  state: ScriptState
+): Map<string, TemplateContainerKind> {
+  const rest = readDirectRestPattern(
+    pattern,
+    localName,
+    binding.path.scope,
+    state
+  );
+  if (!rest) return new Map();
+  const sourceKinds = collectContainerKinds(
+    value,
+    binding.path.scope,
+    localName,
+    state,
+    new Set(),
+    new Set(),
+    Number.POSITIVE_INFINITY
+  );
+  const result = remapDirectRestPaths(localName, rest, sourceKinds);
+  result.set(localName, rest.type);
+  return result;
+}
+
+/** Records the object shape created by a namespace rest destructuring. */
+function collectNamespaceRestContainerKind(
+  localName: string,
+  binding: Binding,
+  pattern: t.Node,
+  value: t.Expression,
+  state: ScriptState
+): Map<string, TemplateContainerKind> {
+  if (
+    pattern.type !== 'ObjectPattern' ||
+    !pattern.properties.some(
+      (property) =>
+        property.type === 'RestElement' &&
+        property.argument.type === 'Identifier' &&
+        property.argument.name === localName
+    ) ||
+    !resolveNamespaceOrigin(value, binding.path.scope, state, new Set())
+  ) {
+    return new Map();
+  }
+  return new Map([[localName, 'object']]);
+}
+
+function collectProgramArrayLengths(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): Map<string, number> {
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator' || !declaration.init) {
+    return new Map();
+  }
+  if (declaration.id.type === 'Identifier') {
+    const replay = readReplayContainerMetadata(binding, localName, state);
+    if (replay) return replay.arrayLengths;
+  }
+  if (
+    !isSafelyReadContainerBinding(
+      binding,
+      binding.identifier,
+      Number.POSITIVE_INFINITY,
+      false,
+      state
+    )
+  ) {
+    return new Map();
+  }
+  if (declaration.id.type !== 'Identifier') {
+    const rest = readDirectRestPattern(
+      declaration.id,
+      localName,
+      binding.path.scope,
+      state
+    );
+    if (rest?.type !== 'array') return new Map();
+    const sourceLengths = new Map<string, number>();
+    collectContainerKinds(
+      declaration.init,
+      binding.path.scope,
+      localName,
+      state,
+      new Set(),
+      new Set(),
+      Number.POSITIVE_INFINITY,
+      sourceLengths
+    );
+    const length = sourceLengths.get(localName);
+    return length === undefined
+      ? new Map()
+      : new Map([[localName, Math.max(0, length - rest.start)]]);
+  }
+  const lengths = new Map<string, number>();
+  collectContainerKinds(
+    declaration.init,
+    binding.path.scope,
+    localName,
+    state,
+    new Set(),
+    new Set([binding]),
+    Number.POSITIVE_INFINITY,
+    lengths
+  );
+  return lengths;
+}
+
+/** Exposes primitive leaves selected through a static container path. */
+function exposeProgramStaticMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  for (const [name, value] of collectProgramStaticMembers(
+    localName,
+    binding,
+    state
+  )) {
+    if (name !== localName) templateBindings.staticValues.set(name, value);
+  }
+}
+
+/** Records primitive normal-script leaves for a combined SFC template. */
+function recordProgramStaticMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): void {
+  for (const [name, value] of collectProgramStaticMembers(
+    localName,
+    binding,
+    state
+  )) {
+    if (name !== localName) state.analysis.staticValues.set(name, value);
+  }
+}
+
+function collectProgramStaticMembers(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): Map<string, string | number | bigint | boolean | null> {
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    !declaration.init ||
+    !isSafelyReadContainerBinding(
+      binding,
+      binding.identifier,
+      Number.POSITIVE_INFINITY,
+      false,
+      state
+    )
+  ) {
+    return new Map();
+  }
+  if (declaration.id.type !== 'Identifier') {
+    const rest = readDirectRestPattern(
+      declaration.id,
+      localName,
+      binding.path.scope,
+      state
+    );
+    if (!rest) return new Map();
+    return remapDirectRestPaths(
+      localName,
+      rest,
+      collectStaticMemberValues(
+        declaration.init,
+        binding.path.scope,
+        localName,
+        state,
+        new Set(),
+        new Set(),
+        Number.POSITIVE_INFINITY
+      )
+    );
+  }
+  return collectStaticMemberValues(
+    declaration.init,
+    binding.path.scope,
+    localName,
+    state,
+    new Set(),
+    new Set([binding]),
+    Number.POSITIVE_INFINITY
+  );
+}
+
+/** Exposes statically visible string alternatives for template selectors. */
+function exposeProgramPossibleStaticStrings(
+  localName: string,
+  binding: Binding,
+  state: ScriptState,
+  templateBindings: TemplateBindings
+): void {
+  const collected = collectProgramPossibleStaticStrings(
+    localName,
+    binding,
+    state
+  );
+  for (const [name, values] of collected) {
+    templateBindings.possibleStaticStrings.set(name, values);
+  }
+}
+
+/** Records normal-script string alternatives for a combined SFC template. */
+function recordProgramPossibleStaticStrings(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): void {
+  for (const [name, values] of collectProgramPossibleStaticStrings(
+    localName,
+    binding,
+    state
+  )) {
+    state.analysis.possibleStaticStrings.set(name, values);
+  }
+}
+
+function collectProgramPossibleStaticStrings(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  const merge = (values: Map<string, Set<string>>): void => {
+    for (const [path, strings] of values) {
+      const existing = result.get(path) ?? new Set<string>();
+      for (const value of strings) existing.add(value);
+      result.set(path, existing);
+    }
+  };
+  const source = getBindingSource(binding);
+  const finalAssignment = source
+    ? undefined
+    : readDefiniteFinalBindingAssignment(binding);
+  const selected = source
+    ? selectPatternExpression(
+        source.pattern,
+        source.expression.node,
+        localName,
+        source.expression.scope,
+        source.expression.node.end ?? Number.POSITIVE_INFINITY,
+        state
+      )
+    : finalAssignment;
+  if (selected) {
+    merge(
+      collectPossibleStaticStringMembers(
+        selected.node,
+        selected.scope,
+        localName,
+        state,
+        new Set(),
+        new Set([binding]),
+        Number.POSITIVE_INFINITY
+      )
+    );
+  }
+  merge(bindingMutationPossibleStaticStrings(binding, state));
+  return result;
+}
+
+/** Flattens possible string results while preserving their exact member path. */
+function collectPossibleStaticStringMembers(
+  node: t.Node,
+  scope: Scope,
+  name: string,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>,
+  atPosition: number
+): Map<string, Set<string>> {
+  const result = new Map<string, Set<string>>();
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return result;
+  const possible = collectPossibleStaticStrings(
+    expression,
+    scope,
+    state,
+    new Set()
+  );
+  if (possible.size > 0) result.set(name, possible);
+  const nextNodes = new Set(seenNodes).add(expression);
+  const mergeValues = (values: Map<string, Set<string>>): void => {
+    for (const [path, strings] of values) {
+      const existing = result.get(path) ?? new Set<string>();
+      for (const value of strings) existing.add(value);
+      result.set(path, existing);
+    }
+  };
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      const prefix = `${expression.name}.`;
+      for (const [path, values] of state.analysis.possibleStaticStrings) {
+        if (path === expression.name || path.startsWith(prefix)) {
+          result.set(`${name}${path.slice(expression.name.length)}`, values);
+        }
+      }
+      return result;
+    }
+    const substitution = readParameterSubstitution(binding, state);
+    if (substitution) {
+      mergeValues(
+        collectPossibleStaticStringMembers(
+          substitution.node,
+          substitution.scope,
+          name,
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )
+      );
+      return result;
+    }
+    if (seenBindings.has(binding)) return result;
+    const cacheable =
+      binding.constant && state.parameterSubstitutions.length === 0;
+    const remapValues = (
+      values: Map<string, Set<string>>,
+      from: string,
+      to: string
+    ): Map<string, Set<string>> =>
+      new Map(
+        [...values].map(([path, strings]) => [
+          path === from ? to : `${to}${path.slice(from.length)}`,
+          new Set(strings),
+        ])
+      );
+    const cached = cacheable
+      ? state.possibleStaticStringMembers.get(binding)
+      : undefined;
+    if (cached) {
+      mergeValues(remapValues(cached, binding.identifier.name, name));
+      return result;
+    }
+    if (cacheable && state.possibleStaticStringMembersInProgress.has(binding)) {
+      return result;
+    }
+    if (cacheable) state.possibleStaticStringMembersInProgress.add(binding);
+    const source = getBindingSource(binding);
+    const finalAssignment = source
+      ? undefined
+      : readDefiniteFinalBindingAssignment(binding);
+    const selected = source
+      ? selectPatternExpression(
+          source.pattern,
+          source.expression.node,
+          binding.identifier.name,
+          source.expression.scope,
+          source.expression.node.end ?? atPosition,
+          state
+        )
+      : finalAssignment;
+    try {
+      const canonicalName = cacheable ? binding.identifier.name : name;
+      const canonical = new Map<string, Set<string>>();
+      const mergeCanonical = (path: string, values: Set<string>): void => {
+        const existing = canonical.get(path) ?? new Set<string>();
+        for (const value of values) existing.add(value);
+        canonical.set(path, existing);
+      };
+      if (possible.size > 0) mergeCanonical(canonicalName, possible);
+      if (selected) {
+        for (const [path, values] of collectPossibleStaticStringMembers(
+          selected.node,
+          selected.scope,
+          canonicalName,
+          state,
+          nextNodes,
+          new Set(seenBindings).add(binding),
+          atPosition
+        )) {
+          mergeCanonical(path, values);
+        }
+      }
+      for (const [path, values] of bindingMutationPossibleStaticStrings(
+        binding,
+        state
+      )) {
+        const targetPath = cacheable
+          ? path
+          : path === binding.identifier.name
+            ? name
+            : `${name}${path.slice(binding.identifier.name.length)}`;
+        mergeCanonical(targetPath, values);
+      }
+      if (cacheable) {
+        state.possibleStaticStringMembers.set(binding, canonical);
+        mergeValues(remapValues(canonical, binding.identifier.name, name));
+      } else {
+        mergeValues(canonical);
+      }
+      return result;
+    } finally {
+      if (cacheable) {
+        state.possibleStaticStringMembersInProgress.delete(binding);
+      }
+    }
+  }
+  if (expression.type === 'ObjectExpression') {
+    const clearMember = (key: string) => {
+      const member = appendTemplatePath(name, key);
+      for (const path of result.keys()) {
+        if (path === member || path.startsWith(`${member}.`)) {
+          result.delete(path);
+        }
+      }
+    };
+    const replaceProperty = (
+      key: string,
+      property: t.ObjectProperty | t.ObjectMethod,
+      propertyScope: Scope
+    ) => {
+      clearMember(key);
+      if (property.type === 'ObjectProperty') {
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            property.value,
+            propertyScope,
+            appendTemplatePath(name, key),
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      } else if (property.kind === 'get') {
+        const strings = collectFunctionPossibleStaticStrings(
+          property,
+          propertyScope,
+          state
+        );
+        if (strings.size > 0) {
+          result.set(appendTemplatePath(name, key), strings);
+        }
+      }
+    };
+
+    for (const property of expression.properties) {
+      if (property.type !== 'SpreadElement') {
+        const key = readResolvedPropertyKey(property, scope, state);
+        if (key !== undefined) {
+          replaceProperty(key, property, scope);
+          continue;
+        }
+        const unknownValues =
+          property.type === 'ObjectProperty'
+            ? collectPossibleStaticStringMembers(
+                property.value,
+                scope,
+                appendTemplatePath(name, unknownTemplatePathSegment),
+                state,
+                nextNodes,
+                seenBindings,
+                atPosition
+              )
+            : property.kind === 'get'
+              ? new Map([
+                  [
+                    appendTemplatePath(name, unknownTemplatePathSegment),
+                    collectFunctionPossibleStaticStrings(
+                      property,
+                      scope,
+                      state
+                    ),
+                  ],
+                ])
+              : new Map<string, Set<string>>();
+        const knownMembers = new Set(
+          [...result.keys()]
+            .filter((path) => path.startsWith(`${name}.`))
+            .map((path) => path.slice(name.length + 1).split('.', 1)[0])
+        );
+        for (const key of knownMembers) {
+          const remapped = new Map<string, Set<string>>();
+          for (const [path, strings] of unknownValues) {
+            remapped.set(
+              path.replace(
+                appendTemplatePath(name, unknownTemplatePathSegment),
+                appendTemplatePath(name, key)
+              ),
+              strings
+            );
+          }
+          mergeValues(remapped);
+        }
+        continue;
+      }
+
+      const spreadEntries = collectObjectEntries(
+        property.argument,
+        scope,
+        new Set(seenNodes),
+        property.argument.end ?? atPosition,
+        state
+      );
+      const spreadValues = collectPossibleStaticStringMembers(
+        property.argument,
+        scope,
+        name,
+        state,
+        nextNodes,
+        seenBindings,
+        property.argument.end ?? atPosition
+      );
+      const definiteKeys = new Set([
+        ...spreadEntries.entries.keys(),
+        ...spreadEntries.unknownNames,
+      ]);
+      for (const key of definiteKeys) clearMember(key);
+      for (const [path, strings] of spreadValues) {
+        const key = path.startsWith(`${name}.`)
+          ? path.slice(name.length + 1).split('.', 1)[0]
+          : undefined;
+        if (!key || !spreadEntries.unknownAll || definiteKeys.has(key)) {
+          result.set(path, strings);
+        } else {
+          mergeValues(new Map([[path, strings]]));
+        }
+      }
+    }
+    return result;
+  }
+  if (expression.type === 'ConditionalExpression') {
+    const test = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? atPosition,
+      state.analysis
+    );
+    const alternatives = test.ok
+      ? [test.value ? expression.consequent : expression.alternate]
+      : [expression.consequent, expression.alternate];
+    for (const alternative of alternatives) {
+      mergeValues(
+        collectPossibleStaticStringMembers(
+          alternative,
+          scope,
+          name,
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )
+      );
+    }
+    return result;
+  }
+  if (expression.type === 'LogicalExpression') {
+    for (const alternative of [expression.left, expression.right]) {
+      mergeValues(
+        collectPossibleStaticStringMembers(
+          alternative,
+          scope,
+          name,
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )
+      );
+    }
+    return result;
+  }
+  if (expression.type === 'SequenceExpression') {
+    const last = expression.expressions.at(-1);
+    if (last) {
+      mergeValues(
+        collectPossibleStaticStringMembers(
+          last,
+          scope,
+          name,
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )
+      );
+    }
+    return result;
+  }
+  if (expression.type === 'AssignmentExpression') {
+    mergeValues(
+      collectPossibleStaticStringMembers(
+        expression.right,
+        scope,
+        name,
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition
+      )
+    );
+    return result;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const sources = resolveVueTemplateContainerSources(
+      expression,
+      scope,
+      state
+    );
+    if (sources && sources.length > 0) {
+      for (const source of sources) {
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            source.node,
+            source.scope,
+            name,
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      }
+      return result;
+    }
+    const transformedEntries = collectTransformArrayEntries(
+      expression,
+      scope,
+      state,
+      new Set(),
+      atPosition
+    );
+    if (transformedEntries) {
+      transformedEntries.forEach((entry, index) => {
+        if (!entry) return;
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            entry.node,
+            entry.scope,
+            appendTemplatePath(name, String(index)),
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      });
+      return result;
+    }
+    const callee = unwrapExpression(expression.callee);
+    if (
+      callee &&
+      (callee.type === 'MemberExpression' ||
+        callee.type === 'OptionalMemberExpression')
+    ) {
+      const method = readResolvedMemberProperty(callee, scope, state);
+      const receiver = readResolvedMemberPath(callee.object, scope, state);
+      const collectReceiver = (): void => {
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            callee.object,
+            scope,
+            name,
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      };
+      if (
+        receiver === 'Object' &&
+        method === 'assign' &&
+        !scope.getBinding('Object')
+      ) {
+        for (const argument of expression.arguments) {
+          if (argument.type === 'ArgumentPlaceholder') continue;
+          mergeValues(
+            collectPossibleStaticStringMembers(
+              argument.type === 'SpreadElement' ? argument.argument : argument,
+              scope,
+              name,
+              state,
+              nextNodes,
+              seenBindings,
+              atPosition
+            )
+          );
+        }
+        return result;
+      }
+      if (
+        method &&
+        [
+          'filter',
+          'map',
+          'reverse',
+          'slice',
+          'sort',
+          'splice',
+          'toReversed',
+          'toSorted',
+        ].includes(method)
+      ) {
+        collectReceiver();
+      }
+      if (method === 'concat') {
+        collectReceiver();
+        for (const argument of expression.arguments) {
+          if (argument.type === 'ArgumentPlaceholder') continue;
+          const values = collectPossibleStaticStringMembers(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            name,
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          );
+          for (const [path, strings] of values) {
+            const suffix = path === name ? '' : path.slice(name.length + 1);
+            const separator = suffix.indexOf('.');
+            const remaining = separator === -1 ? '' : suffix.slice(separator);
+            const target = `${appendTemplatePath(
+              name,
+              unknownTemplatePathSegment
+            )}${remaining}`;
+            mergeValues(new Map([[target, strings]]));
+          }
+        }
+      }
+      if (
+        receiver === 'Array' &&
+        method === 'from' &&
+        !scope.getBinding('Array')
+      ) {
+        const source = expression.arguments[0];
+        if (source && source.type !== 'ArgumentPlaceholder') {
+          mergeValues(
+            collectPossibleStaticStringMembers(
+              source.type === 'SpreadElement' ? source.argument : source,
+              scope,
+              name,
+              state,
+              nextNodes,
+              seenBindings,
+              atPosition
+            )
+          );
+        }
+      }
+    }
+    const called = resolveCalledFunction(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (called) {
+      withCallParameterSubstitutions(expression, called, scope, state, () => {
+        for (const returned of collectFunctionReturnExpressions(
+          called.node,
+          called.scope,
+          state
+        )) {
+          mergeValues(
+            collectPossibleStaticStringMembers(
+              returned.node,
+              returned.scope,
+              name,
+              state,
+              nextNodes,
+              seenBindings,
+              atPosition
+            )
+          );
+        }
+      });
+    } else if (callTargetsUnknownImport(expression.callee, scope)) {
+      for (const argument of expression.arguments) {
+        if (argument.type === 'ArgumentPlaceholder') continue;
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            name,
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      }
+    }
+    return result;
+  }
+  if (expression.type === 'ArrayExpression') {
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? atPosition,
+      state
+    );
+    if (entries) {
+      entries.forEach((entry, index) => {
+        if (!entry) return;
+        for (const [path, values] of collectPossibleStaticStringMembers(
+          entry.node,
+          entry.scope,
+          appendTemplatePath(name, String(index)),
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )) {
+          result.set(path, values);
+        }
+      });
+    } else {
+      expression.elements.forEach((element, index) => {
+        if (!element) return;
+        mergeValues(
+          collectPossibleStaticStringMembers(
+            element.type === 'SpreadElement' ? element.argument : element,
+            scope,
+            element.type === 'SpreadElement'
+              ? name
+              : appendTemplatePath(name, String(index)),
+            state,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        );
+      });
+    }
+  }
+  return result;
+}
+
+/** Collects static string leaves introduced through container mutations. */
+function bindingMutationPossibleStaticStrings(
+  binding: Binding,
+  state: ScriptState,
+  seenAliases: Set<Binding> = new Set([binding])
+): Map<string, Set<string>> {
+  const cached = state.mutationPossibleStaticStrings.get(binding);
+  if (cached) {
+    return new Map(
+      [...cached].map(([path, values]) => [path, new Set(values)])
+    );
+  }
+  if (state.mutationPossibleStaticStringsInProgress.has(binding)) {
+    return new Map();
+  }
+  state.mutationPossibleStaticStringsInProgress.add(binding);
+  const result = new Map<string, Set<string>>();
+  const writePolicy = readBindingContainerWritePolicy(binding, state);
+  const blocksWriteAtDepth = (depth: number): boolean =>
+    writePolicy === 'readonly-deep' ||
+    (writePolicy === 'readonly-shallow' && depth <= 1);
+  const appendProperties = (properties: string[]): string =>
+    properties.reduce(appendTemplatePath, binding.identifier.name);
+  const merge = (values: Map<string, Set<string>>): void => {
+    for (const [path, strings] of values) {
+      const existing = result.get(path) ?? new Set<string>();
+      for (const value of strings) existing.add(value);
+      result.set(path, existing);
+    }
+  };
+  const collectValue = (
+    value: t.Node,
+    scope: Scope,
+    properties: string[]
+  ): void => {
+    merge(
+      collectPossibleStaticStringMembers(
+        value,
+        scope,
+        appendProperties(properties),
+        state,
+        new Set(),
+        new Set([binding]),
+        Number.POSITIVE_INFINITY
+      )
+    );
+  };
+
+  for (const reference of binding.referencePaths) {
+    let current: NodePath<t.Node> = reference;
+    const properties: string[] = [];
+    while (
+      current.parentPath &&
+      (current.parentPath.isMemberExpression() ||
+        current.parentPath.isOptionalMemberExpression()) &&
+      current.parentPath.node.object === current.node
+    ) {
+      properties.push(
+        readResolvedMemberProperty(
+          current.parentPath.node,
+          current.parentPath.scope,
+          state
+        ) ?? unknownTemplatePathSegment
+      );
+      current = current.parentPath;
+    }
+    const parent = current.parentPath;
+    if (parent?.isAssignmentExpression() && parent.node.left === current.node) {
+      const target =
+        properties[0] === 'value' ? properties.slice(1) : properties;
+      if (blocksWriteAtDepth(target.length)) continue;
+      collectValue(parent.node.right, parent.scope, target);
+      continue;
+    }
+    if (!parent?.isCallExpression() || parent.node.callee !== current.node) {
+      continue;
+    }
+    const method = properties.at(-1);
+    const target = properties
+      .slice(0, -1)
+      .filter((property, index) => !(index === 0 && property === 'value'));
+    if (blocksWriteAtDepth(target.length + 1)) continue;
+    const argumentsToCheck =
+      method === 'splice'
+        ? parent.node.arguments.slice(2)
+        : method === 'fill'
+          ? parent.node.arguments.slice(0, 1)
+          : method === 'push' || method === 'unshift'
+            ? parent.node.arguments
+            : [];
+    for (const argument of argumentsToCheck) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      collectValue(
+        argument.type === 'SpreadElement' ? argument.argument : argument,
+        parent.scope,
+        [...target, unknownTemplatePathSegment]
+      );
+    }
+  }
+
+  for (const reference of binding.referencePaths) {
+    const declarator = reference.parentPath;
+    if (
+      !declarator?.isVariableDeclarator() ||
+      declarator.node.init !== reference.node ||
+      declarator.node.id.type !== 'Identifier'
+    ) {
+      continue;
+    }
+    const alias = declarator.scope.getBinding(declarator.node.id.name);
+    if (!alias || seenAliases.has(alias)) continue;
+    const aliasValues = bindingMutationPossibleStaticStrings(
+      alias,
+      state,
+      new Set(seenAliases).add(alias)
+    );
+    for (const [path, values] of aliasValues) {
+      const remapped =
+        path === alias.identifier.name
+          ? binding.identifier.name
+          : `${binding.identifier.name}${path.slice(alias.identifier.name.length)}`;
+      merge(new Map([[remapped, values]]));
+    }
+  }
+  state.mutationPossibleStaticStrings.set(
+    binding,
+    new Map([...result].map(([path, values]) => [path, new Set(values)]))
+  );
+  state.mutationPossibleStaticStringsInProgress.delete(binding);
+  return result;
+}
+
+/** Collects statically visible string alternatives without executing code. */
+function collectPossibleStaticStrings(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>
+): Set<string> {
+  const result = new Set<string>();
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return result;
+  const nextSeen = new Set(seen).add(expression);
+  if (
+    expression.type === 'Identifier' &&
+    state.parameterSubstitutions.length === 0
+  ) {
+    const binding = scope.getBinding(expression.name);
+    if (binding) {
+      const cached = state.possibleStaticStrings.get(binding);
+      if (cached) return new Set(cached);
+      if (state.possibleStaticStringsInProgress.has(binding)) return result;
+      state.possibleStaticStringsInProgress.add(binding);
+      try {
+        const source = getBindingSource(binding);
+        if (source && binding.constant) {
+          for (const value of collectPossibleStaticStrings(
+            source.expression.node,
+            source.expression.scope,
+            state,
+            nextSeen
+          )) {
+            result.add(value);
+          }
+        } else {
+          const exposed = state.analysis.possibleStaticStrings.get(
+            expression.name
+          );
+          if (exposed) {
+            for (const value of exposed) result.add(value);
+          }
+        }
+        state.possibleStaticStrings.set(binding, new Set(result));
+        return result;
+      } finally {
+        state.possibleStaticStringsInProgress.delete(binding);
+      }
+    }
+  }
+  const staticValue = readStaticFromScope(
+    expression,
+    scope,
+    new Set(),
+    expression.end ?? Number.POSITIVE_INFINITY,
+    state.analysis
+  );
+  if (staticValue.ok) {
+    if (typeof staticValue.value === 'string') result.add(staticValue.value);
+    return result;
+  }
+  const add = (values: Set<string>) => {
+    for (const value of values) result.add(value);
+  };
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    const substitution = binding
+      ? readParameterSubstitution(binding, state)
+      : undefined;
+    if (substitution) {
+      return collectPossibleStaticStrings(
+        substitution.node,
+        substitution.scope,
+        state,
+        nextSeen
+      );
+    }
+    const source = binding ? getBindingSource(binding) : undefined;
+    if (source && binding?.constant) {
+      add(
+        collectPossibleStaticStrings(
+          source.expression.node,
+          source.expression.scope,
+          state,
+          nextSeen
+        )
+      );
+    } else {
+      const values = state.analysis.possibleStaticStrings.get(expression.name);
+      if (values) add(values);
+    }
+    return result;
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const path = readExposedMemberPath(expression, scope, state);
+    const exposed = path
+      ? state.analysis.possibleStaticStrings.get(path)
+      : undefined;
+    if (exposed) add(exposed);
+    const property = readResolvedMemberProperty(expression, scope, state);
+    const selected = property
+      ? selectStaticMemberExpression(
+          expression.object,
+          property,
+          scope,
+          state,
+          expression.end ?? Number.POSITIVE_INFINITY,
+          new Set()
+        )
+      : undefined;
+    if (selected) {
+      add(
+        collectPossibleStaticStrings(
+          selected.node,
+          selected.scope,
+          state,
+          nextSeen
+        )
+      );
+    } else if (!property) {
+      for (const values of collectPossibleStaticStringMembers(
+        expression.object,
+        scope,
+        '',
+        state,
+        new Set(),
+        new Set(),
+        expression.end ?? Number.POSITIVE_INFINITY
+      ).values()) {
+        add(values);
+      }
+    }
+    return result;
+  }
+  if (expression.type === 'ConditionalExpression') {
+    const test = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (test.ok) {
+      return collectPossibleStaticStrings(
+        test.value ? expression.consequent : expression.alternate,
+        scope,
+        state,
+        nextSeen
+      );
+    }
+    add(
+      collectPossibleStaticStrings(
+        expression.consequent,
+        scope,
+        state,
+        nextSeen
+      )
+    );
+    add(
+      collectPossibleStaticStrings(expression.alternate, scope, state, nextSeen)
+    );
+    return result;
+  }
+  if (expression.type === 'LogicalExpression') {
+    add(collectPossibleStaticStrings(expression.left, scope, state, nextSeen));
+    add(collectPossibleStaticStrings(expression.right, scope, state, nextSeen));
+    return result;
+  }
+  if (expression.type === 'SequenceExpression') {
+    return collectPossibleStaticStrings(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return collectPossibleStaticStrings(
+      expression.right,
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return collectPossibleStaticStrings(
+      expression.argument,
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const wrapper = resolveKnownExpression(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    const first = expression.arguments[0];
+    if (
+      wrapper?.type === 'vue-wrapper' &&
+      first &&
+      first.type !== 'ArgumentPlaceholder' &&
+      first.type !== 'SpreadElement'
+    ) {
+      if (wrapper.kind === 'ref') {
+        return collectPossibleStaticStrings(first, scope, state, nextSeen);
+      }
+      const getter = resolveComputedGetter(first, scope, state);
+      return getter
+        ? collectFunctionPossibleStaticStrings(getter.node, getter.scope, state)
+        : result;
+    }
+    const called = resolveCalledFunction(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (called) {
+      withCallParameterSubstitutions(expression, called, scope, state, () => {
+        for (const returned of collectFunctionReturnExpressions(
+          called.node,
+          called.scope,
+          state
+        )) {
+          add(
+            collectPossibleStaticStrings(
+              returned.node,
+              returned.scope,
+              state,
+              nextSeen
+            )
+          );
+        }
+      });
+    }
+  }
+  return result;
+}
+
+/** Collects all statically visible strings returned by one local function. */
+function collectFunctionPossibleStaticStrings(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState
+): Set<string> {
+  const functionScope = state.scopes.get(fn) ?? scope;
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return collectPossibleStaticStrings(
+      fn.body,
+      functionScope,
+      state,
+      new Set()
+    );
+  }
+  const result = new Set<string>();
+  const functionPath = state.paths.get(fn);
+  if (!functionPath || fn.body.type !== 'BlockStatement') return result;
+  functionPath.traverse({
+    Function(path) {
+      path.skip();
+    },
+    ReturnStatement(path) {
+      for (const value of collectPossibleStaticStrings(
+        path.node.argument,
+        path.scope,
+        state,
+        new Set()
+      )) {
+        result.add(value);
+      }
+    },
+  });
+  return result;
+}
+
+function collectStaticMemberValues(
+  node: t.Node,
+  scope: Scope,
+  name: string,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>,
+  atPosition: number
+): Map<string, string | number | bigint | boolean | null> {
+  const result = new Map<string, string | number | bigint | boolean | null>();
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return result;
+  const staticValue = readStaticFromScope(
+    expression,
+    scope,
+    new Set(),
+    atPosition,
+    state.analysis
+  );
+  if (staticValue.ok) {
+    result.set(name, staticValue.value);
+    return result;
+  }
+  const nextNodes = new Set(seenNodes).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (
+      !binding ||
+      seenBindings.has(binding) ||
+      !isSafelyReadContainerBinding(
+        binding,
+        expression,
+        atPosition,
+        false,
+        state
+      )
+    ) {
+      return result;
+    }
+    const source = getBindingSource(binding);
+    return source?.pattern.type === 'Identifier'
+      ? collectStaticMemberValues(
+          source.expression.node,
+          source.expression.scope,
+          name,
+          state,
+          nextNodes,
+          new Set(seenBindings).add(binding),
+          atPosition
+        )
+      : result;
+  }
+  if (expression.type === 'ObjectExpression') {
+    const entries = collectObjectEntries(
+      expression,
+      scope,
+      new Set(seenNodes),
+      atPosition,
+      state
+    );
+    for (const [key, entry] of entries.entries) {
+      for (const [path, value] of collectStaticMemberValues(
+        entry.node,
+        entry.scope,
+        appendTemplatePath(name, key),
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition
+      )) {
+        result.set(path, value);
+      }
+    }
+    return result;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const sources = resolveVueTemplateContainerSources(
+      expression,
+      scope,
+      state
+    );
+    if (!sources || sources.length === 0) return result;
+    const sourceValues = sources.map((source) =>
+      collectStaticMemberValues(
+        source.node,
+        source.scope,
+        name,
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition
+      )
+    );
+    for (const [path, value] of sourceValues[0] ?? []) {
+      if (
+        sourceValues.every(
+          (values) => values.has(path) && Object.is(values.get(path), value)
+        )
+      ) {
+        result.set(path, value);
+      }
+    }
+    return result;
+  }
+  if (expression.type === 'ArrayExpression') {
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? atPosition,
+      state
+    );
+    entries?.forEach((entry, index) => {
+      if (!entry) return;
+      for (const [path, value] of collectStaticMemberValues(
+        entry.node,
+        entry.scope,
+        appendTemplatePath(name, String(index)),
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition
+      )) {
+        result.set(path, value);
+      }
+    });
+  }
+  return result;
+}
+
+/** Flattens statically known container paths without executing user code. */
+function collectContainerKinds(
+  node: t.Node,
+  scope: Scope,
+  name: string,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>,
+  atPosition: number,
+  arrayLengths?: Map<string, number>
+): Map<string, TemplateContainerKind> {
+  if (state.analysis.stats) state.analysis.stats.containerKindVisits += 1;
+  const result = new Map<string, TemplateContainerKind>();
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return result;
+  // Exact GT/Vue identities and string functions are scalar values. Direct
+  // aliases can legitimately be inserted into a mutable container, which
+  // makes the conservative container-use cache ineligible; resolving the
+  // already memoized scalar identity avoids re-walking the full alias prefix.
+  if (resolveKnownExpression(expression, scope, state, new Set())) {
+    return result;
+  }
+  const nextNodes = new Set(seenNodes).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    const readonlyUses = binding
+      ? bindingHasOnlyReadonlyContainerUses(binding, state, new Set())
+      : false;
+    if (
+      !binding ||
+      seenBindings.has(binding) ||
+      !isSafelyReadContainerBinding(
+        binding,
+        expression,
+        atPosition,
+        false,
+        state
+      )
+    ) {
+      return result;
+    }
+    const source = getBindingSource(binding);
+    if (source?.pattern.type !== 'Identifier') return result;
+    const cacheable = readonlyUses && state.parameterSubstitutions.length === 0;
+    const applySnapshot = (snapshot: {
+      arrayLengths: Map<string, number>;
+      kinds: Map<string, TemplateContainerKind>;
+    }): void => {
+      const root = binding.identifier.name;
+      for (const [path, kind] of snapshot.kinds) {
+        result.set(
+          path === root ? name : `${name}${path.slice(root.length)}`,
+          kind
+        );
+      }
+      if (arrayLengths) {
+        for (const [path, length] of snapshot.arrayLengths) {
+          arrayLengths.set(
+            path === root ? name : `${name}${path.slice(root.length)}`,
+            length
+          );
+        }
+      }
+    };
+    const cached = cacheable
+      ? state.containerKindSnapshots.get(binding)
+      : undefined;
+    if (cached) {
+      applySnapshot(cached);
+      return result;
+    }
+    if (cacheable && state.containerKindSnapshotsInProgress.has(binding)) {
+      return result;
+    }
+    if (cacheable) state.containerKindSnapshotsInProgress.add(binding);
+    try {
+      const canonicalLengths = new Map<string, number>();
+      const kinds = collectContainerKinds(
+        source.expression.node,
+        source.expression.scope,
+        cacheable ? binding.identifier.name : name,
+        state,
+        nextNodes,
+        new Set(seenBindings).add(binding),
+        atPosition,
+        cacheable ? canonicalLengths : arrayLengths
+      );
+      if (!cacheable) return kinds;
+      const snapshot = {
+        arrayLengths: canonicalLengths,
+        kinds,
+      };
+      state.containerKindSnapshots.set(binding, snapshot);
+      applySnapshot(snapshot);
+      return result;
+    } finally {
+      if (cacheable) state.containerKindSnapshotsInProgress.delete(binding);
+    }
+  }
+  if (expression.type === 'ObjectExpression') {
+    result.set(name, 'object');
+    const entries = collectObjectEntries(
+      expression,
+      scope,
+      new Set(seenNodes),
+      atPosition,
+      state
+    );
+    for (const [key, entry] of entries.entries) {
+      for (const [path, kind] of collectContainerKinds(
+        entry.node,
+        entry.scope,
+        appendTemplatePath(name, key),
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition,
+        arrayLengths
+      )) {
+        result.set(path, kind);
+      }
+    }
+    return result;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const transformedEntries = collectTransformArrayEntries(
+      expression,
+      scope,
+      state,
+      new Set(),
+      atPosition
+    );
+    if (transformedEntries) {
+      result.set(name, 'array');
+      arrayLengths?.set(name, transformedEntries.length);
+      transformedEntries.forEach((entry, index) => {
+        if (!entry) return;
+        for (const [path, kind] of collectContainerKinds(
+          entry.node,
+          entry.scope,
+          appendTemplatePath(name, String(index)),
+          state,
+          nextNodes,
+          seenBindings,
+          atPosition,
+          arrayLengths
+        )) {
+          result.set(path, kind);
+        }
+      });
+      return result;
+    }
+    const sources = resolveVueTemplateContainerSources(
+      expression,
+      scope,
+      state
+    );
+    if (!sources || sources.length === 0) return result;
+    const sourceLengths = sources.map(() => new Map<string, number>());
+    const sourceKinds = sources.map((source, index) =>
+      collectContainerKinds(
+        source.node,
+        source.scope,
+        name,
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition,
+        sourceLengths[index]
+      )
+    );
+    for (const [path, kind] of sourceKinds[0] ?? []) {
+      if (sourceKinds.every((kinds) => kinds.get(path) === kind)) {
+        result.set(path, kind);
+      }
+    }
+    for (const [path, length] of sourceLengths[0] ?? []) {
+      if (sourceLengths.every((lengths) => lengths.get(path) === length)) {
+        arrayLengths?.set(path, length);
+      }
+    }
+    return result;
+  }
+  if (expression.type === 'ArrayExpression') {
+    result.set(name, 'array');
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? atPosition,
+      state
+    );
+    if (!entries) return result;
+    arrayLengths?.set(name, entries.length);
+    entries.forEach((entry, index) => {
+      if (!entry) return;
+      for (const [path, kind] of collectContainerKinds(
+        entry.node,
+        entry.scope,
+        appendTemplatePath(name, String(index)),
+        state,
+        nextNodes,
+        seenBindings,
+        atPosition,
+        arrayLengths
+      )) {
+        result.set(path, kind);
+      }
+    });
+  }
+  return result;
+}
+
+/** Records values assigned through a statically named member path. */
+function collectMemberWriteCandidates(
+  localName: string,
+  binding: Binding,
+  state: ScriptState
+): ComponentMemberCandidate[] {
+  const candidates: ComponentMemberCandidate[] = [];
+  for (const reference of binding.referencePaths) {
+    let current: NodePath<t.Node> = reference;
+    const properties: string[] = [];
+    let dynamic = false;
+    while (
+      current.parentPath &&
+      (current.parentPath.isMemberExpression() ||
+        current.parentPath.isOptionalMemberExpression()) &&
+      current.parentPath.node.object === current.node
+    ) {
+      const property = readResolvedMemberProperty(
+        current.parentPath.node,
+        current.parentPath.scope,
+        state
+      );
+      if (property === undefined) dynamic = true;
+      else properties.push(property);
+      current = current.parentPath;
+    }
+    const assignment = current.parentPath;
+    if (
+      !assignment?.isAssignmentExpression() ||
+      assignment.node.left !== current.node
+    ) {
+      continue;
+    }
+    const name =
+      !dynamic && properties.length > 0
+        ? properties.reduce(appendTemplatePath, localName)
+        : localName;
+    for (const value of collectPossibleTemplateValues(
+      assignment.node.right,
+      assignment.scope,
+      state,
+      new Set()
+    )) {
+      candidates.push({ certain: false, name, value });
+    }
+  }
+  return candidates;
+}
+
+/** Collects known GT-relevant leaves without claiming one definite result. */
+function collectPossibleTemplateValues(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>
+): Array<TemplateKnownValue> {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return [];
+  const nextSeen = new Set(seen).add(expression);
+  const known = resolveKnownExpression(expression, scope, state, new Set());
+  if (
+    known?.type === 'component' ||
+    known?.type === 'string' ||
+    known?.type === 'vue-builtin'
+  ) {
+    return [known];
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return [
+      ...collectPossibleTemplateValues(
+        expression.consequent,
+        scope,
+        state,
+        nextSeen
+      ),
+      ...collectPossibleTemplateValues(
+        expression.alternate,
+        scope,
+        state,
+        nextSeen
+      ),
+    ];
+  }
+  if (expression.type === 'LogicalExpression') {
+    return [
+      ...collectPossibleTemplateValues(expression.left, scope, state, nextSeen),
+      ...collectPossibleTemplateValues(
+        expression.right,
+        scope,
+        state,
+        nextSeen
+      ),
+    ];
+  }
+  if (expression.type === 'SequenceExpression') {
+    return collectPossibleTemplateValues(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return collectPossibleTemplateValues(
+      expression.right,
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return collectPossibleTemplateValues(
+      expression.argument,
+      scope,
+      state,
+      nextSeen
+    );
+  }
+  return [];
+}
+
+/** Collects GT-relevant values returned by one getter or computed source. */
+function collectFunctionTemplateValues(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState
+): Array<TemplateKnownValue> {
+  const functionScope = state.scopes.get(fn) ?? scope;
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return collectPossibleTemplateValues(
+      fn.body,
+      functionScope,
+      state,
+      new Set()
+    );
+  }
+  const functionPath = state.paths.get(fn);
+  if (!functionPath || fn.body.type !== 'BlockStatement') return [];
+  const values: TemplateKnownValue[] = [];
+  functionPath.traverse({
+    Function(path) {
+      path.skip();
+    },
+    ReturnStatement(path) {
+      values.push(
+        ...collectPossibleTemplateValues(
+          path.node.argument,
+          path.scope,
+          state,
+          new Set()
+        )
+      );
+    },
+  });
+  return values;
+}
+
+function collectComponentMemberCandidates(
+  node: t.Node,
+  scope: Scope,
+  name: string,
+  state: ScriptState,
+  certain: boolean,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>,
+  atPosition = Number.POSITIVE_INFINITY
+): ComponentMemberCandidate[] {
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return [];
+  const nextNodes = new Set(seenNodes).add(expression);
+  const value = resolveKnownExpression(expression, scope, state, new Set());
+  if (
+    value?.type === 'component' ||
+    value?.type === 'string' ||
+    value?.type === 'vue-builtin'
+  ) {
+    return [{ certain, name, value }];
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding || seenBindings.has(binding)) return [];
+    const source = getBindingSource(binding);
+    if (!source || source.pattern.type !== 'Identifier') return [];
+    return collectComponentMemberCandidates(
+      source.expression.node,
+      source.expression.scope,
+      name,
+      state,
+      certain &&
+        isSafelyReadContainerBinding(
+          binding,
+          expression,
+          atPosition,
+          false,
+          state
+        ),
+      nextNodes,
+      new Set(seenBindings).add(binding),
+      atPosition
+    );
+  }
+  if (expression.type === 'ObjectExpression') {
+    const candidates = new Map<string, ComponentMemberCandidate>();
+    for (const property of expression.properties) {
+      if (property.type === 'SpreadElement') {
+        const spreadIsKnown = componentContainerShapeIsKnown(
+          property.argument,
+          scope,
+          state,
+          new Set(),
+          property.argument.end ?? atPosition
+        );
+        if (!spreadIsKnown) {
+          for (const [candidateName, candidate] of candidates) {
+            candidates.set(candidateName, { ...candidate, certain: false });
+          }
+        }
+        for (const candidate of collectComponentMemberCandidates(
+          property.argument,
+          scope,
+          name,
+          state,
+          certain && spreadIsKnown,
+          nextNodes,
+          seenBindings,
+          property.argument.end ?? atPosition
+        )) {
+          candidates.set(candidate.name, candidate);
+        }
+        continue;
+      }
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) {
+        for (const [candidateName, candidate] of candidates) {
+          candidates.set(candidateName, { ...candidate, certain: false });
+        }
+        continue;
+      }
+      const memberName = appendTemplatePath(name, key);
+      for (const candidateName of candidates.keys()) {
+        if (
+          candidateName === memberName ||
+          candidateName.startsWith(`${memberName}.`)
+        ) {
+          candidates.delete(candidateName);
+        }
+      }
+      if (property.type === 'ObjectMethod' && property.kind === 'get') {
+        let foundStringFunction = false;
+        for (const getterValue of collectFunctionTemplateValues(
+          property,
+          scope,
+          state
+        )) {
+          if (getterValue.type === 'string') foundStringFunction = true;
+          candidates.set(memberName, {
+            certain: false,
+            name: memberName,
+            value: getterValue,
+          });
+        }
+        if (
+          !foundStringFunction &&
+          functionMayReturnStringFunction(property, scope, state, new Set())
+        ) {
+          candidates.set(memberName, {
+            certain: false,
+            name: memberName,
+            value: { type: 'string', kind: 'msg' },
+          });
+        }
+        continue;
+      }
+      if (property.type !== 'ObjectProperty') continue;
+      for (const candidate of collectComponentMemberCandidates(
+        property.value,
+        scope,
+        memberName,
+        state,
+        certain,
+        nextNodes,
+        seenBindings,
+        atPosition
+      )) {
+        candidates.set(candidate.name, candidate);
+      }
+    }
+    return [...candidates.values()];
+  }
+  if (expression.type === 'ArrayExpression') {
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (entries) {
+      return entries.flatMap((entry, index) =>
+        entry
+          ? collectComponentMemberCandidates(
+              entry.node,
+              entry.scope,
+              appendTemplatePath(name, String(index)),
+              state,
+              certain,
+              nextNodes,
+              seenBindings,
+              atPosition
+            )
+          : []
+      );
+    }
+    const firstSpread = expression.elements.findIndex(
+      (element) => element?.type === 'SpreadElement'
+    );
+    return expression.elements.flatMap((element, index) =>
+      element &&
+      element.type !== 'SpreadElement' &&
+      (firstSpread === -1 || index < firstSpread)
+        ? collectComponentMemberCandidates(
+            element,
+            scope,
+            appendTemplatePath(name, String(index)),
+            state,
+            certain,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+        : []
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const transformedEntries = collectTransformArrayEntries(
+      expression,
+      scope,
+      state,
+      new Set(),
+      atPosition
+    );
+    if (transformedEntries) {
+      return transformedEntries.flatMap((entry, index) =>
+        entry
+          ? collectComponentMemberCandidates(
+              entry.node,
+              entry.scope,
+              appendTemplatePath(name, String(index)),
+              state,
+              certain,
+              nextNodes,
+              seenBindings,
+              atPosition
+            )
+          : []
+      );
+    }
+    const containerSources = resolveVueTemplateContainerSources(
+      expression,
+      scope,
+      state
+    );
+    if (containerSources) {
+      return containerSources.flatMap((source) =>
+        collectComponentMemberCandidates(
+          source.node,
+          source.scope,
+          name,
+          state,
+          certain && containerSources.length === 1,
+          nextNodes,
+          seenBindings,
+          atPosition
+        )
+      );
+    }
+    if (
+      readResolvedMemberPath(expression.callee, scope, state) ===
+      'Object.entries'
+    ) {
+      return [];
+    }
+    return expression.arguments.flatMap((argument) =>
+      argument.type === 'ArgumentPlaceholder'
+        ? []
+        : collectComponentMemberCandidates(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            name,
+            state,
+            false,
+            nextNodes,
+            seenBindings,
+            atPosition
+          )
+    );
+  }
+  return [];
+}
+
+/** Returns whether every key and spread position in a container is known. */
+function componentContainerShapeIsKnown(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>,
+  atPosition: number
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return false;
+  const nextSeen = new Set(seen).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (
+      !binding ||
+      !isSafelyReadContainerBinding(
+        binding,
+        expression,
+        atPosition,
+        false,
+        state
+      )
+    ) {
+      return false;
+    }
+    const source = getBindingSource(binding);
+    return Boolean(
+      source?.pattern.type === 'Identifier' &&
+      componentContainerShapeIsKnown(
+        source.expression.node,
+        source.expression.scope,
+        state,
+        nextSeen,
+        atPosition
+      )
+    );
+  }
+  if (expression.type === 'ObjectExpression') {
+    return expression.properties.every((property) =>
+      property.type === 'SpreadElement'
+        ? componentContainerShapeIsKnown(
+            property.argument,
+            scope,
+            state,
+            nextSeen,
+            property.argument.end ?? atPosition
+          )
+        : readResolvedPropertyKey(property, scope, state) !== undefined
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    return (
+      collectTransformArrayEntries(
+        expression,
+        scope,
+        state,
+        new Set(seen),
+        atPosition
+      ) !== undefined
+    );
+  }
+  return (
+    expression.type === 'ArrayExpression' &&
+    collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    ) !== undefined
+  );
+}
+
+/** Resolves a mutable string-call binding at the call's source position. */
+function resolveKnownCallTargetAtPosition(
+  node: t.Node,
+  scope: Scope,
+  atPosition: number,
+  state: ScriptState
+): {
+  definitelyOrdinary: boolean;
+  possibleStringFunction?: boolean;
+  value: KnownValue | undefined;
+} {
+  const expression = unwrapExpression(node);
+  const replayed = evaluateReplayAtPosition(node, scope, atPosition, state);
+  if (replayed?.type === 'leaf') {
+    if (isReplayGetterStringLeaf(replayed)) {
+      return {
+        definitelyOrdinary: false,
+        possibleStringFunction: true,
+        value: undefined,
+      };
+    }
+    if (replayed.knownValue?.type === 'string') {
+      return { definitelyOrdinary: false, value: replayed.knownValue };
+    }
+    if (
+      replayed.hasGT === false ||
+      replayed.knownValue?.type === 'component' ||
+      replayed.knownValue?.type === 'vue-builtin'
+    ) {
+      return { definitelyOrdinary: true, value: undefined };
+    }
+  }
+  if (replayed?.type === 'unsafe') {
+    return { definitelyOrdinary: false, value: undefined };
+  }
+  if (expression?.type !== 'Identifier') {
+    return {
+      definitelyOrdinary: false,
+      value: resolveKnownExpression(node, scope, state, new Set()),
+    };
+  }
+  const binding = scope.getBinding(expression.name);
+  if (!binding || binding.constantViolations.length === 0) {
+    return {
+      definitelyOrdinary: false,
+      value: resolveKnownExpression(expression, scope, state, new Set()),
+    };
+  }
+  const candidates = readPossibleBindingValuesAtPosition(
+    binding,
+    atPosition,
+    state
+  );
+  if (candidates.length !== 1) {
+    return { definitelyOrdinary: false, value: undefined };
+  }
+  const candidate = candidates[0]!;
+  const value = resolveKnownExpression(
+    candidate.node,
+    candidate.scope,
+    state,
+    new Set([binding])
+  );
+  if (value) return { definitelyOrdinary: value.type !== 'string', value };
+  const materialized = unwrapExpression(candidate.node);
+  const definitelyOrdinary = Boolean(
+    materialized?.type === 'Identifier' &&
+    !candidate.scope.getBinding(materialized.name) &&
+    ORDINARY_GLOBAL_VALUES.has(materialized.name)
+  );
+  return { definitelyOrdinary, value: undefined };
+}
+
+/** Resolves a call using only lexical identities, ignoring active callbacks. */
+function resolveKnownCallTargetWithoutParameterSubstitutions(
+  node: t.Node,
+  scope: Scope,
+  atPosition: number,
+  state: ScriptState
+): ReturnType<typeof resolveKnownCallTargetAtPosition> {
+  if (state.parameterSubstitutions.length === 0) {
+    return resolveKnownCallTargetAtPosition(node, scope, atPosition, state);
+  }
+  const substitutions = state.parameterSubstitutions;
+  state.parameterSubstitutions = [];
+  try {
+    return resolveKnownCallTargetAtPosition(node, scope, atPosition, state);
+  } finally {
+    state.parameterSubstitutions = substitutions;
+  }
+}
+
+function resolveKnownExpression(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): KnownValue | undefined {
+  if (state.analysis.stats) state.analysis.stats.knownExpressionVisits += 1;
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    const substitution = binding
+      ? readParameterSubstitution(binding, state)
+      : undefined;
+    if (substitution) {
+      return resolveKnownExpression(
+        substitution.node,
+        substitution.scope,
+        state,
+        seen
+      );
+    }
+    const value = binding
+      ? resolveKnownBinding(binding, state, seen)
+      : state.analysis.values.get(expression.name);
+    if (
+      binding &&
+      value?.type === 'namespace' &&
+      value.mutable &&
+      (state.unsafeMutableNamespaceSources.has(value.source) ||
+        !isSafeMutableNamespaceBinding(binding))
+    ) {
+      return undefined;
+    }
+    return value;
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const memberPath = readExposedMemberPath(expression, scope, state);
+    const exposed = memberPath
+      ? state.analysis.values.get(memberPath)
+      : undefined;
+    if (exposed) return exposed;
+    const object = resolveKnownExpression(
+      expression.object,
+      scope,
+      state,
+      seen
+    );
+    const property = readResolvedMemberProperty(expression, scope, state);
+    const wrappedValue =
+      property === 'value'
+        ? resolveVueWrappedMemberValue(expression.object, scope, state)
+        : undefined;
+    if (wrappedValue) return wrappedValue;
+    if (object?.type === 'namespace' && property) {
+      return knownExport(object.source, property);
+    }
+    if (object?.type === 'local-namespace' && property) {
+      const resolution = state.analysis.localModules?.resolveExport(
+        object.modulePath,
+        property
+      );
+      return resolution?.status === 'resolved'
+        ? materializeLocalExport(resolution.target, state).value
+        : undefined;
+    }
+    const selected = property
+      ? selectStaticMemberExpression(
+          expression.object,
+          property,
+          scope,
+          state,
+          expression.end ?? Number.POSITIVE_INFINITY,
+          new Set()
+        )
+      : undefined;
+    if (selected) {
+      return resolveKnownExpression(selected.node, selected.scope, state, seen);
+    }
+    return undefined;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const namespace = readRequireNamespace(expression, scope);
+    if (
+      namespace &&
+      !state.unsafeMutableNamespaceSources.has(namespace.source)
+    ) {
+      return namespace;
+    }
+    const callee = resolveKnownExpression(
+      expression.callee,
+      scope,
+      state,
+      seen
+    );
+    if (callee?.type === 'hook') {
+      return { type: 'string', kind: callee.kind };
+    }
+    const argument = expression.arguments[0];
+    return callee?.type === 'identity' &&
+      expression.arguments.length === 1 &&
+      argument &&
+      argument.type !== 'SpreadElement' &&
+      argument.type !== 'ArgumentPlaceholder'
+      ? resolveKnownExpression(argument, scope, state, new Set(seen))
+      : undefined;
+  }
+  if (expression.type === 'LogicalExpression') {
+    const left = resolveKnownExpression(
+      expression.left,
+      scope,
+      state,
+      new Set(seen)
+    );
+    if (left) {
+      return expression.operator === '&&'
+        ? resolveKnownExpression(expression.right, scope, state, new Set(seen))
+        : left;
+    }
+    const staticLeft = readStaticFromScope(
+      expression.left,
+      scope,
+      new Set(),
+      expression.left.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (!staticLeft.ok) return undefined;
+    const selectsRight =
+      expression.operator === '??'
+        ? staticLeft.value == null
+        : expression.operator === '||'
+          ? !staticLeft.value
+          : Boolean(staticLeft.value);
+    return selectsRight
+      ? resolveKnownExpression(expression.right, scope, state, new Set(seen))
+      : undefined;
+  }
+  if (expression.type === 'ConditionalExpression') {
+    const condition = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (condition.ok) {
+      return resolveKnownExpression(
+        condition.value ? expression.consequent : expression.alternate,
+        scope,
+        state,
+        new Set(seen)
+      );
+    }
+    const consequent = resolveKnownExpression(
+      expression.consequent,
+      scope,
+      state,
+      new Set(seen)
+    );
+    const alternate = resolveKnownExpression(
+      expression.alternate,
+      scope,
+      state,
+      new Set(seen)
+    );
+    return consequent &&
+      alternate &&
+      knownValueKey(consequent) === knownValueKey(alternate)
+      ? consequent
+      : undefined;
+  }
+  if (expression.type === 'SequenceExpression') {
+    return resolveKnownExpression(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      new Set(seen)
+    );
+  }
+  return undefined;
+}
+
+/** Resolves a safely read `.value` from a local Vue ref or computed ref. */
+function resolveVueWrappedMemberValue(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): KnownValue | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      return state.analysis.templateValues.get(expression.name);
+    }
+    if (
+      !isSafelyReadContainerBinding(
+        binding,
+        expression,
+        expression.end ?? Number.POSITIVE_INFINITY,
+        true,
+        state
+      )
+    ) {
+      return undefined;
+    }
+    const source = getBindingSource(binding);
+    return source?.pattern.type === 'Identifier'
+      ? resolveTemplateKnownExpression(
+          source.expression.node,
+          source.expression.scope,
+          state
+        )
+      : undefined;
+  }
+  return resolveTemplateKnownExpression(expression, scope, state);
+}
+
+/** Reads a statically keyed member path for an exposed cross-block value. */
+function readResolvedMemberPath(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): string | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (expression.type === 'Identifier') return expression.name;
+  if (
+    expression.type !== 'MemberExpression' &&
+    expression.type !== 'OptionalMemberExpression'
+  ) {
+    return undefined;
+  }
+  const object = readResolvedMemberPath(expression.object, scope, state);
+  const property = readResolvedMemberProperty(expression, scope, state);
+  return object && property !== undefined
+    ? appendTemplatePath(object, property)
+    : undefined;
+}
+
+/** Reads a cross-block member path only when its root is not locally bound. */
+function readExposedMemberPath(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): string | undefined {
+  const path = readResolvedMemberPath(node, scope, state);
+  const root = path?.split('.', 1)[0];
+  return root && !scope.getBinding(root) ? path : undefined;
+}
+
+/** Maps a nested destructuring target to its exact cross-block member path. */
+function readPatternExposedMemberPath(
+  pattern: t.Node,
+  targetName: string,
+  basePath: string,
+  scope: Scope,
+  state: ScriptState
+): string | undefined {
+  if (pattern.type === 'Identifier') {
+    return pattern.name === targetName ? basePath : undefined;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return readPatternExposedMemberPath(
+      pattern.left,
+      targetName,
+      basePath,
+      scope,
+      state
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (
+        property.type !== 'ObjectProperty' ||
+        !patternContains(property.value, targetName)
+      ) {
+        continue;
+      }
+      const key = readResolvedPropertyKey(property, scope, state);
+      return key
+        ? readPatternExposedMemberPath(
+            property.value,
+            targetName,
+            appendTemplatePath(basePath, key),
+            scope,
+            state
+          )
+        : undefined;
+    }
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (let index = 0; index < pattern.elements.length; index += 1) {
+      const element = pattern.elements[index];
+      if (!element || !patternContains(element, targetName)) continue;
+      return readPatternExposedMemberPath(
+        element,
+        targetName,
+        appendTemplatePath(basePath, String(index)),
+        scope,
+        state
+      );
+    }
+  }
+  return undefined;
+}
+
+/** Selects one nested literal member without evaluating application code. */
+function selectStaticMemberExpression(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  state: ScriptState,
+  atPosition: number,
+  seen: Set<t.Node>
+): ScopedExpression | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  const nextSeen = new Set(seen).add(expression);
+  if (expression.type === 'ThisExpression') {
+    const substitution = readThisSubstitution(state);
+    return substitution
+      ? selectStaticMemberExpression(
+          substitution.node,
+          key,
+          substitution.scope,
+          state,
+          atPosition,
+          nextSeen
+        )
+      : undefined;
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    const substitution = binding
+      ? readParameterSubstitution(binding, state)
+      : undefined;
+    if (substitution) {
+      return selectStaticMemberExpression(
+        substitution.node,
+        key,
+        substitution.scope,
+        state,
+        atPosition,
+        nextSeen
+      );
+    }
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const parentKey = readResolvedMemberProperty(expression, scope, state);
+    const parent = parentKey
+      ? selectStaticMemberExpression(
+          expression.object,
+          parentKey,
+          scope,
+          state,
+          atPosition,
+          nextSeen
+        )
+      : undefined;
+    return parent
+      ? selectStaticMemberExpression(
+          parent.node,
+          key,
+          parent.scope,
+          state,
+          atPosition,
+          nextSeen
+        )
+      : undefined;
+  }
+  const index = key.match(/^(0|[1-9]\d*)$/) ? Number(key) : undefined;
+  if (index !== undefined) {
+    const entry = readArrayEntry(
+      expression,
+      index,
+      scope,
+      new Set(),
+      atPosition,
+      state
+    );
+    return entry.status === 'known' ? entry.expression : undefined;
+  }
+  const entry = readObjectEntry(
+    expression,
+    key,
+    scope,
+    new Set(),
+    atPosition,
+    state
+  );
+  return entry.status === 'known' ? entry.expression : undefined;
+}
+
+function resolveKnownBinding(
+  binding: Binding,
+  state: ScriptState,
+  seen: Set<Binding>
+): KnownValue | undefined {
+  const cacheable = state.parameterSubstitutions.length === 0;
+  const mutableSource = state.mutableImportSources.get(binding);
+  if (mutableSource && state.unsafeMutableNamespaceSources.has(mutableSource)) {
+    if (cacheable) state.resolvedBindings.add(binding);
+    return undefined;
+  }
+  const existing = state.bindings.get(binding);
+  if (existing) return existing;
+  if (cacheable && state.resolvedBindings.has(binding)) return undefined;
+  if (seen.has(binding)) return undefined;
+  seen.add(binding);
+
+  const source = getBindingSource(binding);
+  const value = source
+    ? resolvePatternKnownValue(
+        source.pattern,
+        source.expression.node,
+        binding.identifier.name,
+        source.expression.scope,
+        state,
+        seen,
+        source.expression.node.end ?? Number.POSITIVE_INFINITY
+      )
+    : undefined;
+  if (value) state.bindings.set(binding, value);
+  if (cacheable) state.resolvedBindings.add(binding);
+  return value;
+}
+
+/** Resolves values that Vue automatically unwraps at the template boundary. */
+function resolveTemplateKnownBinding(
+  binding: Binding,
+  state: ScriptState
+): KnownValue | undefined {
+  const direct = resolveKnownBinding(binding, state, new Set());
+  if (direct) return direct;
+  const source = getBindingSource(binding);
+  if (!source || source.pattern.type !== 'Identifier') return undefined;
+  const value = resolveTemplateKnownExpression(
+    source.expression.node,
+    source.expression.scope,
+    state
+  );
+  if (
+    !value ||
+    !isVueWrapperExpression(
+      source.expression.node,
+      source.expression.scope,
+      state
+    )
+  ) {
+    return value;
+  }
+  // Vue does not render a component stored in a ref/computed wrapper as an
+  // exact template component alias. Keep these aliases opaque so extraction
+  // fails closed instead of publishing a component shape that differs from
+  // runtime behavior.
+  if (value.type === 'component' || value.type === 'vue-builtin') {
+    return undefined;
+  }
+  return isSafelyReadContainerBinding(
+    binding,
+    binding.identifier,
+    Number.POSITIVE_INFINITY,
+    true,
+    state
+  )
+    ? value
+    : undefined;
+}
+
+/** Returns whether an expression creates a Vue ref or computed ref. */
+function isVueWrapperExpression(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): boolean {
+  const expression = unwrapExpression(node);
+  if (
+    !expression ||
+    (expression.type !== 'CallExpression' &&
+      expression.type !== 'OptionalCallExpression')
+  ) {
+    return false;
+  }
+  return (
+    resolveKnownExpression(expression.callee, scope, state, new Set())?.type ===
+    'vue-wrapper'
+  );
+}
+
+/** Models only Vue's top-level ref, shallowRef, and computed unwrapping. */
+function resolveTemplateKnownExpression(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState
+): KnownValue | undefined {
+  const direct = resolveKnownExpression(node, scope, state, new Set());
+  if (direct) return direct;
+  const expression = unwrapExpression(node);
+  if (
+    !expression ||
+    (expression.type !== 'CallExpression' &&
+      expression.type !== 'OptionalCallExpression')
+  ) {
+    return undefined;
+  }
+  const wrapper = resolveKnownExpression(
+    expression.callee,
+    scope,
+    state,
+    new Set()
+  );
+  if (wrapper?.type !== 'vue-wrapper') return undefined;
+  const first = expression.arguments[0];
+  if (
+    !first ||
+    first.type === 'ArgumentPlaceholder' ||
+    first.type === 'SpreadElement'
+  ) {
+    return undefined;
+  }
+  if (wrapper.kind === 'ref') {
+    return resolveKnownExpression(first, scope, state, new Set());
+  }
+  const getter = resolveComputedGetter(first, scope, state);
+  return getter
+    ? resolveFunctionTemplateValue(getter.node, getter.scope, state)
+    : undefined;
+}
+
+/** Resolves the function Vue invokes for one computed ref. */
+function resolveComputedGetter(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): (ScopedExpression & { node: t.Function }) | undefined {
+  const direct = resolveCalledFunction(node, scope, state, new Set());
+  if (direct) return direct;
+  const object = resolveObjectExpression(node, scope, new Set());
+  if (!object) return undefined;
+  const entry = readObjectEntry(
+    object.node,
+    'get',
+    object.scope,
+    new Set(),
+    node.end ?? Number.POSITIVE_INFINITY,
+    state
+  );
+  return entry.status === 'known'
+    ? resolveCalledFunction(
+        entry.expression.node,
+        entry.expression.scope,
+        state,
+        new Set()
+      )
+    : undefined;
+}
+
+/** Resolves the container values Vue exposes after wrapper unwrapping. */
+function resolveVueTemplateContainerSources(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): ScopedExpression[] | undefined {
+  const expression = unwrapExpression(node);
+  if (
+    !expression ||
+    (expression.type !== 'CallExpression' &&
+      expression.type !== 'OptionalCallExpression')
+  ) {
+    return undefined;
+  }
+  const wrapper = resolveKnownExpression(
+    expression.callee,
+    scope,
+    state,
+    new Set()
+  );
+  if (
+    wrapper?.type !== 'vue-wrapper' &&
+    wrapper?.type !== 'container-wrapper' &&
+    wrapper?.type !== 'identity'
+  ) {
+    return undefined;
+  }
+  const first = expression.arguments[0];
+  if (
+    !first ||
+    first.type === 'ArgumentPlaceholder' ||
+    first.type === 'SpreadElement'
+  ) {
+    return [];
+  }
+  if (
+    wrapper.type === 'container-wrapper' ||
+    wrapper.type === 'identity' ||
+    wrapper.kind === 'ref'
+  ) {
+    return [{ node: first, scope }];
+  }
+  const getter = resolveComputedGetter(first, scope, state);
+  return getter
+    ? collectFunctionReturnExpressions(getter.node, getter.scope, state)
+    : [];
+}
+
+/** Resolves whether a Vue container proxy forwards or blocks direct writes. */
+function readContainerWritePolicy(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): ContainerWritePolicy | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const wrapper = resolveKnownExpression(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (wrapper?.type !== 'container-wrapper') return undefined;
+    const first = expression.arguments[0];
+    const innerPolicy =
+      first &&
+      first.type !== 'ArgumentPlaceholder' &&
+      first.type !== 'SpreadElement'
+        ? readContainerWritePolicy(first, scope, state, seen)
+        : undefined;
+    return composeContainerWritePolicy(wrapper.kind, innerPolicy);
+  }
+  if (expression.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(expression.name);
+  if (!binding || seen.has(binding) || !binding.constant) return undefined;
+  return readBindingContainerWritePolicy(binding, state, seen);
+}
+
+/** Applies Vue's proxy-idempotence rules to a nested wrapper call. */
+function composeContainerWritePolicy(
+  wrapper: ContainerWrapperKind,
+  inner: ContainerWritePolicy | undefined
+): ContainerWritePolicy {
+  if (wrapper === 'to-raw') return 'forward';
+  if (wrapper === 'unref') return inner ?? 'forward';
+  if (inner === 'readonly-deep' || inner === 'readonly-shallow') return inner;
+  if (wrapper === 'readonly') return 'readonly-deep';
+  if (wrapper === 'shallow-readonly') return 'readonly-shallow';
+  return 'forward';
+}
+
+/** Reads the write behavior of a direct Vue wrapper binding or exact alias. */
+function readBindingContainerWritePolicy(
+  binding: Binding,
+  state: ScriptState,
+  seen: Set<Binding> = new Set()
+): ContainerWritePolicy | undefined {
+  if (state.containerWritePolicies.has(binding)) {
+    return state.containerWritePolicies.get(binding);
+  }
+  if (seen.has(binding)) return undefined;
+  state.containerWritePolicies.set(binding, undefined);
+  const declaration = binding.path.node;
+  const policy =
+    declaration.type === 'VariableDeclarator' && declaration.init
+      ? readContainerWritePolicy(
+          declaration.init,
+          binding.path.scope,
+          state,
+          new Set(seen).add(binding)
+        )
+      : undefined;
+  state.containerWritePolicies.set(binding, policy);
+  return policy;
+}
+
+/** Collects the expressions returned directly by a local function. */
+function collectFunctionReturnExpressions(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState
+): ScopedExpression[] {
+  const functionScope = state.scopes.get(fn) ?? scope;
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return [{ node: fn.body, scope: functionScope }];
+  }
+  const functionPath = state.paths.get(fn);
+  if (!functionPath || fn.body.type !== 'BlockStatement') return [];
+  const result: ScopedExpression[] = [];
+  functionPath.traverse({
+    Function(path) {
+      path.skip();
+    },
+    ReturnStatement(path) {
+      if (path.node.argument) {
+        result.push({ node: path.node.argument, scope: path.scope });
+      }
+    },
+  });
+  return result;
+}
+
+/** Returns whether a local call can forward a translator or invoke a callback. */
+function callMayCarryTranslationFunction(
+  call: t.CallExpression | t.OptionalCallExpression,
+  scope: Scope,
+  state: ScriptState
+): boolean {
+  if (
+    state.activeTranslationFunctions.size > 0 &&
+    resolveCalledFunction(call.callee, scope, state, new Set())
+  ) {
+    return true;
+  }
+  return call.arguments.some((argument) => {
+    if (argument.type === 'ArgumentPlaceholder') return false;
+    const value =
+      argument.type === 'SpreadElement' ? argument.argument : argument;
+    return (
+      expressionMayProduceStringFunction(value, scope, state, new Set()) ||
+      containerMayContainStringFunction(value, scope, state, new Set()) ||
+      resolveCalledFunction(value, scope, state, new Set()) !== undefined
+    );
+  });
+}
+
+/** Returns whether a call passes a translator, excluding ordinary callbacks. */
+function callArgumentsMayProvideTranslationFunction(
+  call: t.CallExpression | t.OptionalCallExpression,
+  scope: Scope,
+  state: ScriptState
+): boolean {
+  return call.arguments.some((argument) => {
+    if (argument.type === 'ArgumentPlaceholder') return false;
+    const value =
+      argument.type === 'SpreadElement' ? argument.argument : argument;
+    return (
+      expressionMayProduceStringFunction(value, scope, state, new Set()) ||
+      containerMayContainStringFunction(value, scope, state, new Set())
+    );
+  });
+}
+
+/** Runs analysis with simple call arguments bound to the callee parameters. */
+function withCallParameterSubstitutions<T>(
+  call: t.CallExpression | t.OptionalCallExpression,
+  called: ScopedExpression & { node: t.Function },
+  callScope: Scope,
+  state: ScriptState,
+  analyze: () => T
+): T {
+  const argumentsByPosition = call.arguments.map((argument) =>
+    argument.type === 'ArgumentPlaceholder' || argument.type === 'SpreadElement'
+      ? undefined
+      : { node: argument, scope: callScope }
+  );
+  return withFunctionParameterSubstitutions(
+    called,
+    argumentsByPosition,
+    state,
+    analyze
+  );
+}
+
+/** Runs analysis with scoped values bound to one local function's parameters. */
+function withFunctionParameterSubstitutions<T>(
+  called: ScopedExpression & { node: t.Function },
+  values: Array<ScopedExpression | undefined>,
+  state: ScriptState,
+  analyze: () => T
+): T {
+  const functionScope = state.scopes.get(called.node) ?? called.scope;
+  const substitutions = new Map<Binding, ScopedExpression>();
+  called.node.params.forEach((parameter, index) => {
+    const names = collectPatternBindingNames(parameter);
+    const argument =
+      parameter.type === 'RestElement'
+        ? {
+            node: {
+              type: 'ArrayExpression',
+              elements: values.slice(index).map((value) => value?.node ?? null),
+            } as t.ArrayExpression,
+            scope: values.slice(index).find(Boolean)?.scope ?? functionScope,
+          }
+        : values[index];
+    for (const name of names) {
+      const binding = functionScope.getBinding(name);
+      if (!binding) continue;
+      if (argument) {
+        const selected = selectPatternExpression(
+          parameter.type === 'RestElement' ? parameter.argument : parameter,
+          argument.node,
+          name,
+          argument.scope,
+          argument.node.end ?? Number.POSITIVE_INFINITY,
+          state
+        );
+        if (selected) substitutions.set(binding, selected);
+      } else if (
+        parameter.type === 'AssignmentPattern' &&
+        patternContains(parameter.left, name)
+      ) {
+        substitutions.set(binding, {
+          node: parameter.right,
+          scope: functionScope,
+        });
+      }
+    }
+  });
+  if (substitutions.size === 0) return analyze();
+  state.parameterSubstitutions.push(substitutions);
+  try {
+    return analyze();
+  } finally {
+    state.parameterSubstitutions.pop();
+  }
+}
+
+/** Runs callback analysis with the built-in mapper's ordinary-function thisArg. */
+function withFunctionThisSubstitution<T>(
+  called: ScopedExpression & { node: t.Function },
+  value: ScopedExpression | undefined,
+  state: ScriptState,
+  analyze: () => T
+): T {
+  if (!value || called.node.type === 'ArrowFunctionExpression') {
+    return analyze();
+  }
+  state.thisSubstitutions.push(value);
+  try {
+    return analyze();
+  } finally {
+    state.thisSubstitutions.pop();
+  }
+}
+
+/** Collects every identifier bound by one function parameter pattern. */
+function collectPatternBindingNames(pattern: t.Node): string[] {
+  if (pattern.type === 'Identifier') return [pattern.name];
+  if (pattern.type === 'RestElement') {
+    return collectPatternBindingNames(pattern.argument);
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return collectPatternBindingNames(pattern.left);
+  }
+  if (pattern.type === 'ArrayPattern') {
+    return pattern.elements.flatMap((element) =>
+      element ? collectPatternBindingNames(element) : []
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return pattern.properties.flatMap((property) =>
+      collectPatternBindingNames(
+        property.type === 'RestElement' ? property.argument : property.value
+      )
+    );
+  }
+  return [];
+}
+
+/** Reads the innermost active call argument for a parameter binding. */
+function readParameterSubstitution(
+  binding: Binding,
+  state: ScriptState
+): ScopedExpression | undefined {
+  for (
+    let index = state.parameterSubstitutions.length - 1;
+    index >= 0;
+    index -= 1
+  ) {
+    const value = state.parameterSubstitutions[index].get(binding);
+    if (value) return value;
+  }
+  return undefined;
+}
+
+/** Reads the active mapper thisArg for an ordinary callback function. */
+function readThisSubstitution(
+  state: ScriptState
+): ScopedExpression | undefined {
+  return state.thisSubstitutions.at(-1);
+}
+
+/** Materializes a direct parameter/member return before its call scope closes. */
+function materializeParameterExpression(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState
+): ScopedExpression {
+  const expression = unwrapExpression(node);
+  if (!expression) return { node, scope };
+  if (expression.type === 'ThisExpression') {
+    return readThisSubstitution(state) ?? { node: expression, scope };
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    return (
+      (binding && readParameterSubstitution(binding, state)) ?? {
+        node: expression,
+        scope,
+      }
+    );
+  }
+  if (expression.type === 'ArrayExpression') {
+    const elements = expression.elements.map((element) => {
+      if (!element) return null;
+      if (element.type === 'SpreadElement') {
+        const value = materializeParameterExpression(
+          element.argument,
+          scope,
+          state
+        );
+        return { ...element, argument: value.node as t.Expression };
+      }
+      return materializeParameterExpression(element, scope, state)
+        .node as t.Expression;
+    });
+    return { node: { ...expression, elements }, scope };
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const selectedKey = readResolvedMemberProperty(expression, scope, state);
+    if (selectedKey !== undefined) {
+      const selected = selectStaticMemberExpression(
+        expression.object,
+        selectedKey,
+        scope,
+        state,
+        expression.end ?? Number.POSITIVE_INFINITY,
+        new Set()
+      );
+      if (selected) {
+        return materializeParameterExpression(
+          selected.node,
+          selected.scope,
+          state
+        );
+      }
+    }
+    const object = materializeParameterExpression(
+      expression.object,
+      scope,
+      state
+    ).node as typeof expression.object;
+    const property = materializeParameterExpression(
+      expression.property,
+      scope,
+      state
+    ).node as typeof expression.property;
+    return {
+      node: { ...expression, object, property } as typeof expression,
+      scope,
+    };
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = materializeParameterExpression(
+      expression.callee,
+      scope,
+      state
+    ).node as typeof expression.callee;
+    const args = expression.arguments.map((argument) => {
+      if (argument.type === 'ArgumentPlaceholder') return argument;
+      if (argument.type === 'SpreadElement') {
+        return {
+          ...argument,
+          argument: materializeParameterExpression(
+            argument.argument,
+            scope,
+            state
+          ).node as t.Expression,
+        };
+      }
+      return materializeParameterExpression(argument, scope, state)
+        .node as t.Expression;
+    });
+    return {
+      node: { ...expression, callee, arguments: args } as typeof expression,
+      scope,
+    };
+  }
+  return { node: expression, scope };
+}
+
+/** Returns one known value only when every reachable return agrees. */
+function resolveFunctionTemplateValue(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState
+): KnownValue | undefined {
+  const functionScope = state.scopes.get(fn) ?? scope;
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return resolveTemplateKnownExpression(fn.body, functionScope, state);
+  }
+  // Block-bodied getters execute arbitrary application code. Their possible
+  // GT identities are tracked separately and deliberately fail closed.
+  return undefined;
+}
+
+function resolvePatternKnownValue(
+  pattern: t.Node,
+  valueNode: t.Node,
+  targetName: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  atPosition: number
+): KnownValue | undefined {
+  const exposedBase = readExposedMemberPath(valueNode, scope, state);
+  const exposedPath = exposedBase
+    ? readPatternExposedMemberPath(
+        pattern,
+        targetName,
+        exposedBase,
+        scope,
+        state
+      )
+    : undefined;
+  const exposed = exposedPath
+    ? state.analysis.values.get(exposedPath)
+    : undefined;
+  if (exposed) return exposed;
+  if (pattern.type === 'Identifier') {
+    return pattern.name === targetName
+      ? resolveKnownExpression(valueNode, scope, state, seen)
+      : undefined;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    if (isStaticallyUndefined(valueNode, scope)) {
+      return resolvePatternKnownValue(
+        pattern.left,
+        pattern.right,
+        targetName,
+        scope,
+        state,
+        seen,
+        atPosition
+      );
+    }
+    return resolvePatternKnownValue(
+      pattern.left,
+      valueNode,
+      targetName,
+      scope,
+      state,
+      seen,
+      atPosition
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type !== 'ObjectProperty') continue;
+      if (!patternContains(property.value, targetName)) continue;
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) return undefined;
+      const namespace = resolveKnownExpression(valueNode, scope, state, seen);
+      if (namespace?.type === 'namespace') {
+        return knownExport(namespace.source, key);
+      }
+      const entry = readObjectEntry(
+        valueNode,
+        key,
+        scope,
+        new Set(),
+        atPosition,
+        state
+      );
+      return entry.status === 'known'
+        ? resolvePatternKnownValue(
+            property.value,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            state,
+            seen,
+            atPosition
+          )
+        : entry.status === 'absent'
+          ? resolveKnownPatternDefault(
+              property.value,
+              targetName,
+              scope,
+              state,
+              seen,
+              atPosition
+            )
+          : undefined;
+    }
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (let index = 0; index < pattern.elements.length; index += 1) {
+      const target = pattern.elements[index];
+      if (!target || !patternContains(target, targetName)) continue;
+      const entry = readArrayEntry(
+        valueNode,
+        index,
+        scope,
+        new Set(),
+        atPosition,
+        state
+      );
+      if (entry.status === 'absent') {
+        return resolveKnownPatternDefault(
+          target,
+          targetName,
+          scope,
+          state,
+          seen,
+          atPosition
+        );
+      }
+      return entry.status === 'known'
+        ? resolvePatternKnownValue(
+            target,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            state,
+            seen,
+            atPosition
+          )
+        : undefined;
+    }
+  }
+  return undefined;
+}
+
+function resolveKnownPatternDefault(
+  pattern: t.Node,
+  targetName: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  atPosition: number
+): KnownValue | undefined {
+  return pattern.type === 'AssignmentPattern' &&
+    patternContains(pattern.left, targetName)
+    ? resolvePatternKnownValue(
+        pattern.left,
+        pattern.right,
+        targetName,
+        scope,
+        state,
+        seen,
+        atPosition
+      )
+    : undefined;
+}
+
+function getBindingSource(
+  binding: Binding
+): { expression: ScopedExpression; pattern: t.Node } | undefined {
+  const declaration = binding.path.node;
+  if (declaration.type !== 'VariableDeclarator') return undefined;
+
+  if (declaration.init) {
+    if (!binding.constant) return undefined;
+    return {
+      expression: { node: declaration.init, scope: binding.path.scope },
+      pattern: declaration.id,
+    };
+  }
+
+  if (binding.constantViolations.length !== 1) return undefined;
+  const violation = binding.constantViolations[0];
+  if (
+    !violation.isAssignmentExpression() ||
+    violation.node.operator !== '=' ||
+    !isBindingPattern(violation.node.left) ||
+    !isUnconditionalSiblingAssignment(binding, violation)
+  ) {
+    return undefined;
+  }
+  const assignmentEnd = violation.node.end ?? Number.POSITIVE_INFINITY;
+  if (
+    binding.referencePaths.some(
+      (reference) => (reference.node.start ?? assignmentEnd) < assignmentEnd
+    )
+  ) {
+    return undefined;
+  }
+  return {
+    expression: { node: violation.node.right, scope: violation.scope },
+    pattern: violation.node.left,
+  };
+}
+
+/**
+ * Accepts a deferred initializer only when it is an unconditional sibling
+ * statement of the declaration.
+ *
+ * Source order alone is insufficient: assignments inside branches, loops, or
+ * uncalled nested functions may never execute, so treating them as definite
+ * would publish a catalog under a hash the runtime does not use.
+ */
+function isUnconditionalSiblingAssignment(
+  binding: Binding,
+  assignment: NodePath<t.AssignmentExpression>
+): boolean {
+  const declarationStatement = binding.path.getStatementParent();
+  const assignmentStatement = assignment.getStatementParent();
+  const assignmentFunction = assignment.getFunctionParent()?.node;
+  return Boolean(
+    declarationStatement &&
+    assignmentStatement?.isExpressionStatement() &&
+    declarationStatement.parentPath?.node ===
+      assignmentStatement.parentPath?.node &&
+    binding.referencePaths.every(
+      (reference) => reference.getFunctionParent()?.node === assignmentFunction
+    )
+  );
+}
+
+function exposeOptionsApiBindings(
+  ast: t.File,
+  state: ScriptState,
+  templateBindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const stateFunctions = new Map<t.Function, 'data' | 'setup'>();
+
+  traverse(ast, {
+    ExportDefaultDeclaration(path) {
+      const options = resolveOptionsObject(
+        path.node.declaration,
+        path.scope,
+        state,
+        new Set()
+      );
+      if (!options) {
+        if (hasTemplateRelevantBindings(state)) {
+          addVueError(
+            context,
+            babelLocation(path.node.loc),
+            'Could not statically resolve the Vue Options API object used with gt-vue',
+            'Use a direct, immutable options object without escaped container aliases'
+          );
+        }
+        return;
+      }
+      const entries = collectObjectEntries(
+        options.node,
+        options.scope,
+        new Set(),
+        Number.POSITIVE_INFINITY,
+        state
+      );
+      if (
+        hasTemplateRelevantBindings(state) &&
+        (objectEntryIsUnknown(entries, 'components') ||
+          objectEntryIsUnknown(entries, 'setup'))
+      ) {
+        addVueError(
+          context,
+          babelLocation(path.node.loc),
+          'Could not statically resolve the Vue Options API components or setup used with gt-vue',
+          'Use explicit components and setup properties after any dynamic object spreads'
+        );
+      }
+      const components = entries.entries.get('components');
+      if (components) {
+        const staticComponents = readStaticFromScope(
+          components.node,
+          components.scope,
+          new Set(),
+          Number.POSITIVE_INFINITY,
+          state.analysis
+        );
+        if (
+          !isStaticallyUndefined(components.node, components.scope) &&
+          !staticComponents.ok
+        ) {
+          exposeRegisteredComponents(
+            components,
+            state,
+            templateBindings,
+            context
+          );
+        }
+      }
+      const setup = entries.entries.get('setup');
+      if (setup) {
+        const setupFunction = resolveSetupFunction(
+          setup.node,
+          setup.scope,
+          new Set()
+        );
+        if (setupFunction) {
+          stateFunctions.set(setupFunction, 'setup');
+        } else {
+          const staticSetup = readStaticFromScope(
+            setup.node,
+            setup.scope,
+            new Set(),
+            Number.POSITIVE_INFINITY,
+            state.analysis
+          );
+          if (
+            hasTemplateRelevantBindings(state) &&
+            !isStaticallyUndefined(setup.node, setup.scope) &&
+            !staticSetup.ok
+          ) {
+            addVueError(
+              context,
+              babelLocation(setup.node.loc),
+              'Could not statically resolve the Vue Options API setup function used with gt-vue',
+              'Use a direct function, an immutable function alias, or an explicit undefined setup value'
+            );
+          }
+        }
+      }
+      const data = entries.entries.get('data');
+      if (data) {
+        const dataFunction = resolveSetupFunction(
+          data.node,
+          data.scope,
+          new Set()
+        );
+        if (dataFunction) {
+          stateFunctions.set(dataFunction, 'data');
+        } else if (hasTemplateRelevantBindings(state)) {
+          addVueError(
+            context,
+            babelLocation(data.node.loc),
+            'Could not statically resolve the Vue Options API data function used with gt-vue',
+            'Use a direct function or an immutable function alias for data()'
+          );
+        }
+      }
+      const computed = entries.entries.get('computed');
+      if (computed) {
+        exposeOptionsComputed(computed, state, templateBindings, context);
+      }
+      const methods = entries.entries.get('methods');
+      if (methods) {
+        exposeOptionsMethods(methods, state, templateBindings, context);
+      }
+    },
+  });
+
+  if (stateFunctions.size === 0) return;
+  const stateReturns = new Map<t.Function, Array<ScopedExpression | undefined>>(
+    [...stateFunctions.keys()].map((fn) => [fn, []])
+  );
+  traverse(ast, {
+    ArrowFunctionExpression(path) {
+      if (
+        stateFunctions.has(path.node) &&
+        path.node.body.type !== 'BlockStatement'
+      ) {
+        stateReturns
+          .get(path.node)
+          ?.push({ node: path.node.body, scope: path.scope });
+      }
+    },
+    ReturnStatement(path) {
+      const parent = path.getFunctionParent();
+      if (!parent || !stateFunctions.has(parent.node)) {
+        return;
+      }
+      stateReturns
+        .get(parent.node)
+        ?.push(
+          path.node.argument
+            ? { node: path.node.argument, scope: path.scope }
+            : undefined
+        );
+    },
+  });
+  const orderedFunctions = [...stateReturns].sort(
+    ([first], [second]) =>
+      Number(stateFunctions.get(first) === 'setup') -
+      Number(stateFunctions.get(second) === 'setup')
+  );
+  for (const [fn, returns] of orderedFunctions) {
+    exposeConsistentSetupReturns(
+      returns,
+      state,
+      templateBindings,
+      context,
+      !setupAlwaysTerminates(fn),
+      stateFunctions.get(fn) ?? 'setup'
+    );
+  }
+}
+
+/** Returns whether a property can still be supplied by unresolved object data. */
+function objectEntryIsUnknown(
+  entries: CollectedObjectEntries,
+  name: string
+): boolean {
+  return (
+    !entries.entries.has(name) &&
+    (entries.unknownAll || entries.unknownNames.has(name))
+  );
+}
+
+/**
+ * Returns whether every reachable setup path ends before falling through.
+ * Template bindings are exposed only in that case because Vue receives no
+ * setup state on a fallthrough path.
+ */
+function setupAlwaysTerminates(setup: t.Function): boolean {
+  return setup.body.type !== 'BlockStatement'
+    ? true
+    : blockAlwaysTerminates(setup.body);
+}
+
+function blockAlwaysTerminates(block: t.BlockStatement): boolean {
+  return block.body.some(statementAlwaysTerminates);
+}
+
+function statementAlwaysTerminates(statement: t.Statement): boolean {
+  if (
+    statement.type === 'ReturnStatement' ||
+    statement.type === 'ThrowStatement'
+  ) {
+    return true;
+  }
+  if (statement.type === 'BlockStatement') {
+    return blockAlwaysTerminates(statement);
+  }
+  if (statement.type !== 'IfStatement' || !statement.alternate) return false;
+  return (
+    statementAlwaysTerminates(statement.consequent) &&
+    statementAlwaysTerminates(statement.alternate)
+  );
+}
+
+/** Exposes statically resolved Options API component registrations. */
+function exposeRegisteredComponents(
+  object: ScopedExpression,
+  state: ScriptState,
+  templateBindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const entries = collectObjectEntries(
+    object.node,
+    object.scope,
+    new Set(),
+    Number.POSITIVE_INFINITY,
+    state
+  );
+  if (
+    hasTemplateRelevantBindings(state) &&
+    (entries.unknownAll || entries.unknownNames.size > 0)
+  ) {
+    addVueError(
+      context,
+      babelLocation(object.node.loc),
+      'Could not statically resolve the Vue Options API components registry used with gt-vue',
+      'Use an immutable components object without dynamic spreads or escaped aliases'
+    );
+  }
+  for (const [name, entry] of entries.entries) {
+    const value = resolveKnownExpression(
+      entry.node,
+      entry.scope,
+      state,
+      new Set()
+    );
+    if (value?.type === 'component' || value?.type === 'vue-builtin') {
+      if (value.type === 'component') {
+        templateBindings.registeredComponents.set(name, value.name);
+      } else {
+        templateBindings.registeredVueBuiltins.set(name, value.name);
+      }
+    } else if (
+      expressionMayProduceComponent(entry.node, entry.scope, state, new Set())
+    ) {
+      templateBindings.uncertainRegisteredComponents.add(name);
+      if (
+        expressionMayProduceComponent(
+          entry.node,
+          entry.scope,
+          state,
+          new Set(),
+          'translation'
+        )
+      ) {
+        templateBindings.uncertainRegisteredGTComponents.add(name);
+      }
+    }
+  }
+}
+
+/** Exposes Options API computed values after Vue's automatic unwrapping. */
+function exposeOptionsComputed(
+  object: ScopedExpression,
+  state: ScriptState,
+  templateBindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const entries = collectObjectEntries(
+    object.node,
+    object.scope,
+    new Set(),
+    Number.POSITIVE_INFINITY,
+    state
+  );
+  if (
+    hasTemplateRelevantBindings(state) &&
+    (entries.unknownAll || entries.unknownNames.size > 0)
+  ) {
+    addVueError(
+      context,
+      babelLocation(object.node.loc),
+      'Could not statically resolve Vue Options API computed properties used with gt-vue',
+      'Use an immutable computed object with statically named properties'
+    );
+  }
+  for (const [name, entry] of entries.entries) {
+    const getter =
+      resolveCalledFunction(entry.node, entry.scope, state, new Set()) ??
+      resolveComputedGetter(entry.node, entry.scope, state);
+    if (!getter) continue;
+    const known = resolveFunctionTemplateValue(
+      getter.node,
+      getter.scope,
+      state
+    );
+    if (
+      known?.type === 'component' ||
+      known?.type === 'string' ||
+      known?.type === 'vue-builtin'
+    ) {
+      clearTemplateBinding(name, templateBindings);
+      exposeKnownValue(name, known, templateBindings, state.analysis);
+      continue;
+    }
+    const component = functionMayReturnComponent(
+      getter.node,
+      getter.scope,
+      state,
+      new Set()
+    );
+    const gtComponent = functionMayReturnComponent(
+      getter.node,
+      getter.scope,
+      state,
+      new Set(),
+      'translation'
+    );
+    const stringFunction = functionMayReturnStringFunction(
+      getter.node,
+      getter.scope,
+      state,
+      new Set()
+    );
+    if (component) templateBindings.uncertainComponents.add(name);
+    if (gtComponent) templateBindings.uncertainGTComponents.add(name);
+    if (stringFunction) {
+      templateBindings.uncertainStringFunctions.add(name);
+    }
+    const possibleStrings = collectFunctionPossibleStaticStrings(
+      getter.node,
+      getter.scope,
+      state
+    );
+    if (possibleStrings.size > 0) {
+      templateBindings.possibleStaticStrings.set(name, possibleStrings);
+    }
+    for (const returned of collectFunctionReturnExpressions(
+      getter.node,
+      getter.scope,
+      state
+    )) {
+      for (const path of collectPossibleGTContainerPaths(
+        returned.node,
+        returned.scope,
+        name,
+        state,
+        new Set(),
+        new Set()
+      )) {
+        templateBindings.possibleGTContainers.add(path);
+      }
+    }
+  }
+}
+
+/** Exposes Options API methods that may return component identity. */
+function exposeOptionsMethods(
+  object: ScopedExpression,
+  state: ScriptState,
+  templateBindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const entries = collectObjectEntries(
+    object.node,
+    object.scope,
+    new Set(),
+    Number.POSITIVE_INFINITY,
+    state
+  );
+  if (
+    hasTemplateRelevantBindings(state) &&
+    (entries.unknownAll || entries.unknownNames.size > 0)
+  ) {
+    addVueError(
+      context,
+      babelLocation(object.node.loc),
+      'Could not statically resolve Vue Options API methods used with gt-vue',
+      'Use an immutable methods object with statically named methods'
+    );
+  }
+  for (const [name, entry] of entries.entries) {
+    const factory = readComponentFactoryExpression(
+      entry.node,
+      entry.scope,
+      state
+    );
+    if (factory) {
+      templateBindings.componentFactories.add(name);
+      if (factory.gt) templateBindings.gtComponentFactories.add(name);
+    }
+    const called = resolveCalledFunction(
+      entry.node,
+      entry.scope,
+      state,
+      new Set()
+    );
+    if (
+      called &&
+      functionMayReturnGTContainer(called.node, called.scope, state, new Set())
+    ) {
+      templateBindings.gtContainerFactories.add(name);
+    }
+  }
+}
+
+/** Exposes only setup bindings that agree across every explicit return. */
+function exposeConsistentSetupReturns(
+  returns: Array<ScopedExpression | undefined>,
+  state: ScriptState,
+  templateBindings: TemplateBindings,
+  context: VueExtractionContext,
+  hasFallthrough: boolean,
+  source: 'data' | 'setup'
+): void {
+  const returnValues = returns.map((entry) => {
+    if (!entry || (source === 'setup' && isSetupRenderReturn(entry))) {
+      return new Map<string, TemplateExposure | undefined>();
+    }
+    return collectTemplateExposures(entry, state, context);
+  });
+  if (hasFallthrough) returnValues.push(new Map());
+  const first = returnValues[0];
+  if (!first) return;
+
+  const names = new Set(returnValues.flatMap((values) => [...values.keys()]));
+  let reportedUncertainty = false;
+  for (const name of names) {
+    const exposures = returnValues.map((values) => values.get(name));
+    const exposure = exposures[0];
+    const consistent =
+      exposure !== undefined &&
+      returnValues.every(
+        (values) =>
+          values.has(name) && equalTemplateExposure(exposure, values.get(name))
+      );
+    if (!consistent) {
+      if (!reportedUncertainty && exposures.some(isTemplateRelevantExposure)) {
+        addVueError(
+          context,
+          undefined,
+          `Could not statically resolve consistent Options API ${source} returns used with gt-vue`,
+          `Return the same translation bindings from every reachable ${source} path`
+        );
+        reportedUncertainty = true;
+      }
+      continue;
+    }
+    clearTemplateBinding(name, templateBindings);
+    exposeTemplateExposure(name, exposure, templateBindings);
+  }
+}
+
+/** Recognizes the render-function form of an Options API setup return. */
+function isSetupRenderReturn(entry: ScopedExpression): boolean {
+  const expression = unwrapExpression(entry.node);
+  return (
+    expression?.type === 'ArrowFunctionExpression' ||
+    expression?.type === 'FunctionExpression'
+  );
+}
+
+/** Identifies exposures that can affect extraction or rich-content traversal. */
+function isTemplateRelevantExposure(
+  exposure: TemplateExposure | undefined
+): boolean {
+  if (
+    exposure?.type === 'factory' ||
+    exposure?.type === 'possible-static-strings' ||
+    exposure?.type === 'uncertain' ||
+    (exposure?.type === 'container' && exposure.possibleGT)
+  ) {
+    return true;
+  }
+  return (
+    exposure?.type === 'known' &&
+    (exposure.value.type === 'component' ||
+      exposure.value.type === 'hook' ||
+      exposure.value.type === 'string' ||
+      exposure.value.type === 'vue-builtin' ||
+      exposure.value.type === 'namespace')
+  );
+}
+
+function collectTemplateExposures(
+  object: ScopedExpression,
+  state: ScriptState,
+  context: VueExtractionContext
+): Map<string, TemplateExposure | undefined> {
+  const result = new Map<string, TemplateExposure | undefined>();
+  const entries = collectObjectEntries(
+    object.node,
+    object.scope,
+    new Set(),
+    Number.POSITIVE_INFINITY,
+    state
+  );
+  if (
+    hasTemplateRelevantBindings(state) &&
+    (entries.unknownAll || entries.unknownNames.size > 0)
+  ) {
+    addVueError(
+      context,
+      babelLocation(object.node.loc),
+      'Could not statically resolve an Options API setup return used with gt-vue',
+      'Return an immutable object without dynamic spreads or escaped aliases'
+    );
+  }
+  for (const [name, entry] of entries.entries) {
+    const known = resolveTemplateKnownExpression(
+      entry.node,
+      entry.scope,
+      state
+    );
+    if (known) {
+      result.set(name, { type: 'known', value: known });
+      continue;
+    }
+    const called = resolveCalledFunction(
+      entry.node,
+      entry.scope,
+      state,
+      new Set()
+    );
+    if (called) {
+      const gt = functionMayReturnComponent(
+        called.node,
+        called.scope,
+        state,
+        new Set(),
+        'translation'
+      );
+      const vue = functionMayReturnComponent(
+        called.node,
+        called.scope,
+        state,
+        new Set(),
+        'vue'
+      );
+      const gtContainer = functionMayReturnGTContainer(
+        called.node,
+        called.scope,
+        state,
+        new Set()
+      );
+      if (gt || vue || gtContainer) {
+        result.set(name, { type: 'factory', gt, gtContainer });
+        continue;
+      }
+    }
+    const lengths = new Map<string, number>();
+    const kinds = collectContainerKinds(
+      entry.node,
+      entry.scope,
+      name,
+      state,
+      new Set(),
+      new Set(),
+      Number.POSITIVE_INFINITY,
+      lengths
+    );
+    for (const [path, kind] of kinds) {
+      result.set(path, {
+        type: 'container',
+        kind,
+        length: lengths.get(path),
+      });
+    }
+    if (
+      !componentContainerShapeIsKnown(
+        entry.node,
+        entry.scope,
+        state,
+        new Set(),
+        Number.POSITIVE_INFINITY
+      )
+    ) {
+      for (const path of collectPossibleGTContainerPaths(
+        entry.node,
+        entry.scope,
+        name,
+        state,
+        new Set(),
+        new Set()
+      )) {
+        const current = result.get(path);
+        result.set(
+          path,
+          current?.type === 'container'
+            ? { ...current, possibleGT: true }
+            : { type: 'container', possibleGT: true }
+        );
+      }
+    }
+    const staticValue = readStaticFromScope(
+      entry.node,
+      entry.scope,
+      new Set(),
+      Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (staticValue.ok) {
+      result.set(name, { type: 'static', value: staticValue.value });
+    } else if (!result.has(name)) {
+      const component = expressionMayProduceComponent(
+        entry.node,
+        entry.scope,
+        state,
+        new Set()
+      );
+      const gtComponent = expressionMayProduceComponent(
+        entry.node,
+        entry.scope,
+        state,
+        new Set(),
+        'translation'
+      );
+      const stringFunction = expressionMayProduceStringFunction(
+        entry.node,
+        entry.scope,
+        state,
+        new Set()
+      );
+      result.set(
+        name,
+        component || gtComponent || stringFunction
+          ? {
+              type: 'uncertain',
+              component,
+              gtComponent,
+              stringFunction,
+            }
+          : undefined
+      );
+    }
+    for (const [path, value] of collectStaticMemberValues(
+      entry.node,
+      entry.scope,
+      name,
+      state,
+      new Set(),
+      new Set(),
+      Number.POSITIVE_INFINITY
+    )) {
+      result.set(path, { type: 'static', value });
+    }
+    for (const [path, values] of collectPossibleStaticStringMembers(
+      entry.node,
+      entry.scope,
+      name,
+      state,
+      new Set(),
+      new Set(),
+      Number.POSITIVE_INFINITY
+    )) {
+      if (!result.get(path) || result.get(path)?.type !== 'static') {
+        result.set(path, { type: 'possible-static-strings', values });
+      }
+    }
+    for (const candidate of collectComponentMemberCandidates(
+      entry.node,
+      entry.scope,
+      name,
+      state,
+      true,
+      new Set(),
+      new Set()
+    )) {
+      if (candidate.name === name) continue;
+      result.set(
+        candidate.name,
+        candidate.certain
+          ? { type: 'known', value: candidate.value }
+          : {
+              type: 'uncertain',
+              component: candidate.value.type !== 'string',
+              gtComponent: candidate.value.type === 'component',
+              stringFunction: candidate.value.type === 'string',
+            }
+      );
+    }
+  }
+  return result;
+}
+
+function equalTemplateExposure(
+  first: TemplateExposure,
+  second: TemplateExposure | undefined
+): boolean {
+  if (!second || first.type !== second.type) return false;
+  if (first.type === 'static' && second.type === 'static') {
+    return Object.is(first.value, second.value);
+  }
+  if (first.type === 'factory' && second.type === 'factory') {
+    return first.gt === second.gt && first.gtContainer === second.gtContainer;
+  }
+  if (
+    first.type === 'possible-static-strings' &&
+    second.type === 'possible-static-strings'
+  ) {
+    return (
+      first.values.size === second.values.size &&
+      [...first.values].every((value) => second.values.has(value))
+    );
+  }
+  if (first.type === 'container' && second.type === 'container') {
+    return (
+      first.kind === second.kind &&
+      first.length === second.length &&
+      first.possibleGT === second.possibleGT
+    );
+  }
+  if (first.type === 'uncertain' && second.type === 'uncertain') {
+    return (
+      first.component === second.component &&
+      first.gtComponent === second.gtComponent &&
+      first.stringFunction === second.stringFunction
+    );
+  }
+  return (
+    first.type === 'known' &&
+    second.type === 'known' &&
+    knownValueKey(first.value) === knownValueKey(second.value)
+  );
+}
+
+function exposeTemplateExposure(
+  name: string,
+  exposure: TemplateExposure,
+  templateBindings: TemplateBindings
+): void {
+  if (exposure.type === 'known') {
+    exposeKnownValue(name, exposure.value, templateBindings);
+  } else if (exposure.type === 'container') {
+    if (exposure.kind) {
+      templateBindings.containerKinds.set(name, exposure.kind);
+    }
+    if (exposure.length !== undefined) {
+      templateBindings.arrayLengths.set(name, exposure.length);
+    }
+    if (exposure.possibleGT) {
+      templateBindings.possibleGTContainers.add(name);
+    }
+  } else if (exposure.type === 'uncertain') {
+    if (exposure.component) {
+      templateBindings.uncertainComponents.add(name);
+    }
+    if (exposure.gtComponent) {
+      templateBindings.uncertainGTComponents.add(name);
+    }
+    if (exposure.stringFunction) {
+      templateBindings.uncertainStringFunctions.add(name);
+    }
+  } else if (exposure.type === 'factory') {
+    templateBindings.componentFactories.add(name);
+    if (exposure.gt) templateBindings.gtComponentFactories.add(name);
+    if (exposure.gtContainer) templateBindings.gtContainerFactories.add(name);
+  } else if (exposure.type === 'possible-static-strings') {
+    templateBindings.possibleStaticStrings.set(name, exposure.values);
+  } else {
+    templateBindings.staticValues.set(name, exposure.value);
+  }
+}
+
+/** Reads the last value when every write is an unconditional sibling statement. */
+function readDefiniteFinalBindingAssignment(
+  binding: Binding
+): ScopedExpression | undefined {
+  if (binding.constantViolations.length === 0) return undefined;
+  const assignments = binding.constantViolations.filter(
+    (violation): violation is NodePath<t.AssignmentExpression> =>
+      violation.isAssignmentExpression() &&
+      violation.node.operator === '=' &&
+      patternContains(violation.node.left, binding.identifier.name) &&
+      isUnconditionalSiblingAssignment(binding, violation)
+  );
+  if (assignments.length !== binding.constantViolations.length) {
+    return undefined;
+  }
+  const last = [...assignments]
+    .sort((first, second) => (first.node.start ?? 0) - (second.node.start ?? 0))
+    .at(-1);
+  return last ? { node: last.node.right, scope: last.scope } : undefined;
+}
+
+/**
+ * Reads every value a mutable binding can hold at one source position.
+ * Definite sibling assignments replace earlier candidates, while an uncertain
+ * write retains both branches so an alias cannot lose historical GT provenance.
+ */
+function readPossibleBindingValuesAtPosition(
+  binding: Binding,
+  atPosition: number,
+  state: ScriptState
+): ScopedExpression[] {
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    !patternContains(declaration.id, binding.identifier.name)
+  ) {
+    return [];
+  }
+  const initial = declaration.init
+    ? selectPatternExpression(
+        declaration.id,
+        declaration.init,
+        binding.identifier.name,
+        binding.path.scope,
+        declaration.init.end ?? atPosition,
+        state
+      )
+    : undefined;
+  let values = initial ? [initial] : [];
+  const violations = [...binding.constantViolations]
+    .filter(
+      (violation) =>
+        (violation.node.start ?? Number.POSITIVE_INFINITY) < atPosition
+    )
+    .sort(
+      (first, second) =>
+        (first.node.start ?? Number.POSITIVE_INFINITY) -
+        (second.node.start ?? Number.POSITIVE_INFINITY)
+    );
+  for (const violation of violations) {
+    if (
+      !violation.isAssignmentExpression() ||
+      violation.node.operator !== '=' ||
+      !isBindingPattern(violation.node.left) ||
+      !patternContains(violation.node.left, binding.identifier.name)
+    ) {
+      continue;
+    }
+    const selected = selectPatternExpression(
+      violation.node.left,
+      violation.node.right,
+      binding.identifier.name,
+      violation.scope,
+      violation.node.end ?? atPosition,
+      state
+    );
+    if (!selected) continue;
+    if (isUnconditionalSiblingAssignment(binding, violation)) {
+      values = [selected];
+    } else {
+      values.push(selected);
+    }
+  }
+  return values;
+}
+
+/** Conservatively models whether a destructuring default can execute. */
+function expressionMayBeUndefined(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression) return true;
+  const staticValue = readStaticFromScope(
+    expression,
+    scope,
+    new Set(),
+    expression.end ?? Number.POSITIVE_INFINITY,
+    state.analysis
+  );
+  if (staticValue.ok) return staticValue.value === undefined;
+  if (resolveKnownExpression(expression, scope, state, new Set())) return false;
+  if (expression.type === 'Identifier') {
+    if (!scope.getBinding(expression.name)) {
+      return expression.name === 'undefined';
+    }
+    const binding = scope.getBinding(expression.name)!;
+    if (seen.has(binding)) return true;
+    const source = getBindingSource(binding);
+    if (!source) return true;
+    const selected = selectPatternExpression(
+      source.pattern,
+      source.expression.node,
+      expression.name,
+      source.expression.scope,
+      source.expression.node.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    return selected
+      ? expressionMayBeUndefined(
+          selected.node,
+          selected.scope,
+          state,
+          new Set(seen).add(binding)
+        )
+      : true;
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return (
+      expressionMayBeUndefined(expression.consequent, scope, state, seen) ||
+      expressionMayBeUndefined(expression.alternate, scope, state, seen)
+    );
+  }
+  if (expression.type === 'LogicalExpression') return true;
+  if (expression.type === 'SequenceExpression') {
+    return expressionMayBeUndefined(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      seen
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return expressionMayBeUndefined(expression.right, scope, state, seen);
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expressionMayBeUndefined(expression.argument, scope, state, seen);
+  }
+  if (expression.type === 'UnaryExpression') {
+    return expression.operator === 'void';
+  }
+  return (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression' ||
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  );
+}
+
+const {
+  readDefiniteArrayInteger,
+  readDefiniteFinalContainerHasGT,
+  readDefiniteFinalContainerSnapshot,
+} = createSnapshotAnalysis({
+  readonlyArrayTransforms: READONLY_ARRAY_TRANSFORMS,
+  collectObjectEntries,
+  collectTransformArrayEntries,
+  memberChainIsReadOnly,
+  readBindingContainerWritePolicy,
+  readResolvedMemberPath,
+  readResolvedMemberProperty,
+  readStaticFromScope,
+  resolveKnownExpression,
+  resolveVueTemplateContainerSources,
+});
+
+const {
+  evaluateReplayAtPosition,
+  isReplayGetterStringLeaf,
+  readDefiniteReplayGTContainerPaths,
+  readReplayComponentCandidates,
+  readReplayComponentFactoryCandidates,
+  readReplayContainerMetadata,
+  readReplayLeafState,
+  readSafeReplayLeafOverride,
+  replayBindingRetainsUnsafeIdentity,
+} = createReplayAnalysis({
+  ordinaryGlobalValues: ORDINARY_GLOBAL_VALUES,
+  readonlyArrayTransforms: READONLY_ARRAY_TRANSFORMS,
+  bindingReadsUnsafeMutableImport,
+  collectFunctionReturnExpressions,
+  collectPatternBindingNames,
+  composeContainerWritePolicy,
+  knownValueKey,
+  readDefiniteArrayInteger,
+  readResolvedMemberPath,
+  readResolvedMemberProperty,
+  readResolvedPropertyKey,
+  readStaticFromScope,
+  resolveCalledFunction,
+  resolveComputedGetter,
+  resolveKnownExpression,
+});
+
+/**
+ * Describes whether a program binding is a container that can directly yield
+ * `<T>`, or a callable that can return such a container.
+ *
+ * Keeping these cases separate avoids treating a function object as though
+ * indexing the function itself could select one of its returned values.
+ */
+function readBindingGTContainerExposure(
+  binding: Binding,
+  state: ScriptState
+): GTContainerExposure {
+  const result: GTContainerExposure = {
+    containers: new Set(),
+    factories: new Set(),
+  };
+  const sources: ScopedExpression[] = [];
+  const source = getBindingSource(binding);
+  if (source) {
+    const selected = selectPatternExpression(
+      source.pattern,
+      source.expression.node,
+      binding.identifier.name,
+      source.expression.scope,
+      source.expression.node.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (selected) sources.push(selected);
+  } else {
+    const finalAssignment = readDefiniteFinalBindingAssignment(binding);
+    if (finalAssignment) sources.push(finalAssignment);
+  }
+
+  for (const candidate of sources) {
+    const callable = resolveCalledFunction(
+      candidate.node,
+      candidate.scope,
+      state,
+      new Set()
+    );
+    if (callable) {
+      if (
+        functionMayReturnGTContainer(
+          callable.node,
+          callable.scope,
+          state,
+          new Set()
+        )
+      ) {
+        result.factories.add(binding.identifier.name);
+      }
+    } else {
+      const candidatePaths = collectPossibleGTContainerPaths(
+        candidate.node,
+        candidate.scope,
+        binding.identifier.name,
+        state,
+        new Set(),
+        new Set([binding])
+      );
+      for (const path of candidatePaths) {
+        result.containers.add(path);
+      }
+    }
+  }
+
+  for (const violation of binding.constantViolations) {
+    if (
+      !violation.isAssignmentExpression() ||
+      !patternContains(violation.node.left, binding.identifier.name)
+    ) {
+      continue;
+    }
+    for (const path of collectPossibleGTContainerPaths(
+      violation.node.right,
+      violation.scope,
+      binding.identifier.name,
+      state,
+      new Set(),
+      new Set([binding])
+    )) {
+      result.containers.add(path);
+    }
+  }
+
+  const mutationPaths = bindingMutationGTContainerPaths(binding, state);
+  for (const path of mutationPaths) result.containers.add(path);
+  const replayPaths = readDefiniteReplayGTContainerPaths(binding, state);
+  if (replayPaths === null) {
+    result.containers.add(binding.identifier.name);
+  } else if (replayPaths) {
+    result.containers = replayPaths;
+  } else {
+    const finalHasGT = readDefiniteFinalContainerHasGT(binding, state);
+    if (finalHasGT === false) result.containers.clear();
+  }
+  const declaration = binding.path.node;
+  if (
+    replayPaths !== null &&
+    !replayBindingRetainsUnsafeIdentity(binding, state) &&
+    result.containers.size > 0 &&
+    mutationPaths.size === 0 &&
+    sources.length === 1 &&
+    declaration.type === 'VariableDeclarator' &&
+    declaration.id.type === 'Identifier' &&
+    Boolean(declaration.init) &&
+    binding.constant &&
+    isSafelyReadContainerBinding(
+      binding,
+      binding.identifier,
+      Number.POSITIVE_INFINITY,
+      false,
+      state
+    ) &&
+    componentContainerShapeIsKnown(
+      sources[0].node,
+      sources[0].scope,
+      state,
+      new Set(),
+      Number.POSITIVE_INFINITY
+    )
+  ) {
+    // Exact immutable leaves are already exposed by
+    // collectProgramComponentMembers; a broad taint would hide that precision.
+    result.containers.clear();
+  }
+  return result;
+}
+
+/** Returns whether a callable can return a container with an immediate T. */
+function functionMayReturnGTContainer(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState,
+  seenNodes: Set<t.Node>
+): boolean {
+  if (seenNodes.has(fn)) return false;
+  const nextNodes = new Set(seenNodes).add(fn);
+  return collectFunctionReturnExpressions(fn, scope, state).some((value) =>
+    expressionMayProduceGTContainer(
+      value.node,
+      value.scope,
+      state,
+      nextNodes,
+      new Set()
+    )
+  );
+}
+
+/** Returns whether one callback return preserves the selected parameter value. */
+function functionMayReturnParameter(
+  fn: t.Function,
+  scope: Scope,
+  parameterIndex: number,
+  state: ScriptState
+): boolean {
+  const parameter = fn.params[parameterIndex];
+  if (!parameter) return false;
+  const functionScope = state.scopes.get(fn) ?? scope;
+  const parameterBindings = new Set(
+    collectPatternBindingNames(parameter).flatMap((name) => {
+      const binding = functionScope.getBinding(name);
+      return binding ? [binding] : [];
+    })
+  );
+  return collectFunctionReturnExpressions(fn, scope, state).some((value) =>
+    expressionMayResolveToBinding(
+      value.node,
+      value.scope,
+      parameterBindings,
+      new Set()
+    )
+  );
+}
+
+/** Tracks exact value-preserving aliases without treating member reads as identity. */
+function expressionMayResolveToBinding(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  targets: Set<Binding>,
+  seen: Set<Binding>
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression) return false;
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) return false;
+    if (targets.has(binding)) return true;
+    if (seen.has(binding)) return false;
+    const source = getBindingSource(binding);
+    return Boolean(
+      source?.pattern.type === 'Identifier' &&
+      expressionMayResolveToBinding(
+        source.expression.node,
+        source.expression.scope,
+        targets,
+        new Set(seen).add(binding)
+      )
+    );
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return (
+      expressionMayResolveToBinding(
+        expression.consequent,
+        scope,
+        targets,
+        seen
+      ) ||
+      expressionMayResolveToBinding(expression.alternate, scope, targets, seen)
+    );
+  }
+  if (expression.type === 'LogicalExpression') {
+    return (
+      expressionMayResolveToBinding(expression.left, scope, targets, seen) ||
+      expressionMayResolveToBinding(expression.right, scope, targets, seen)
+    );
+  }
+  if (expression.type === 'SequenceExpression') {
+    return expressionMayResolveToBinding(
+      expression.expressions.at(-1),
+      scope,
+      targets,
+      seen
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return expressionMayResolveToBinding(
+      expression.right,
+      scope,
+      targets,
+      seen
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expressionMayResolveToBinding(
+      expression.argument,
+      scope,
+      targets,
+      seen
+    );
+  }
+  return false;
+}
+
+/**
+ * Collects the flattened paths of containers that can directly yield `<T>`.
+ * A path is attached to the container, not the T leaf, which preserves the
+ * distinction between `[T]` and `[[T]]` across successive template indexes.
+ */
+function collectPossibleGTContainerPaths(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  basePath: string,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>
+): Set<string> {
+  const result = new Set<string>();
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return result;
+  const nextNodes = new Set(seenNodes).add(expression);
+  const transformedEntries =
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+      ? collectTransformArrayEntries(
+          expression,
+          scope,
+          state,
+          new Set(),
+          expression.end ?? Number.POSITIVE_INFINITY
+        )
+      : undefined;
+  if (
+    transformedEntries === undefined &&
+    expressionMayProduceGTContainer(
+      expression,
+      scope,
+      state,
+      seenNodes,
+      seenBindings
+    )
+  ) {
+    result.add(basePath);
+  }
+  const collect = (
+    value: t.Node | null | undefined,
+    valueScope: Scope,
+    path: string
+  ): void => {
+    for (const candidate of collectPossibleGTContainerPaths(
+      value,
+      valueScope,
+      path,
+      state,
+      nextNodes,
+      seenBindings
+    )) {
+      result.add(candidate);
+    }
+  };
+
+  if (transformedEntries !== undefined) {
+    if (
+      transformedEntries.some(
+        (entry) =>
+          entry &&
+          expressionMayProduceComponent(
+            entry.node,
+            entry.scope,
+            state,
+            new Set(),
+            'T'
+          )
+      )
+    ) {
+      result.add(basePath);
+    }
+    transformedEntries.forEach((entry, index) => {
+      if (entry) {
+        collect(
+          entry.node,
+          entry.scope,
+          appendTemplatePath(basePath, String(index))
+        );
+      }
+    });
+    return result;
+  }
+
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      const prefix = `${expression.name}.`;
+      for (const values of [
+        state.analysis.values,
+        state.analysis.templateValues,
+      ]) {
+        for (const [path, value] of values) {
+          if (
+            value.type !== 'component' ||
+            value.name !== 'T' ||
+            !path.startsWith(prefix)
+          ) {
+            continue;
+          }
+          const parent = path.slice(0, path.lastIndexOf('.'));
+          result.add(`${basePath}${parent.slice(expression.name.length)}`);
+        }
+      }
+      for (const path of state.analysis.possibleGTContainers) {
+        if (path === expression.name || path.startsWith(prefix)) {
+          result.add(`${basePath}${path.slice(expression.name.length)}`);
+        }
+      }
+      return result;
+    }
+    const substitution = readParameterSubstitution(binding, state);
+    if (substitution) {
+      for (const candidate of collectPossibleGTContainerPaths(
+        substitution.node,
+        substitution.scope,
+        basePath,
+        state,
+        nextNodes,
+        seenBindings
+      )) {
+        result.add(candidate);
+      }
+      return result;
+    }
+    if (seenBindings.has(binding)) return result;
+    const cacheable =
+      binding.constant && state.parameterSubstitutions.length === 0;
+    const remapCached = (paths: Iterable<string>): void => {
+      for (const path of paths) {
+        result.add(
+          path === binding.identifier.name
+            ? basePath
+            : `${basePath}${path.slice(binding.identifier.name.length)}`
+        );
+      }
+    };
+    const cached = cacheable ? state.gtContainerPaths.get(binding) : undefined;
+    if (cached) {
+      remapCached(cached);
+      return result;
+    }
+    if (cacheable && state.gtContainerPathsInProgress.has(binding)) {
+      return result;
+    }
+    if (cacheable) state.gtContainerPathsInProgress.add(binding);
+    const source = getBindingSource(binding);
+    const selectedValues = source
+      ? [
+          selectPatternExpression(
+            source.pattern,
+            source.expression.node,
+            binding.identifier.name,
+            source.expression.scope,
+            source.expression.node.end ?? Number.POSITIVE_INFINITY,
+            state
+          ),
+        ]
+      : readPossibleBindingValuesAtPosition(
+          binding,
+          expression.start ?? Number.POSITIVE_INFINITY,
+          state
+        );
+    try {
+      const canonicalBase = cacheable ? binding.identifier.name : basePath;
+      const canonical = new Set<string>();
+      if (result.has(basePath)) canonical.add(canonicalBase);
+      for (const selected of selectedValues) {
+        if (!selected) continue;
+        for (const candidate of collectPossibleGTContainerPaths(
+          selected.node,
+          selected.scope,
+          canonicalBase,
+          state,
+          nextNodes,
+          new Set(seenBindings).add(binding)
+        )) {
+          canonical.add(candidate);
+        }
+      }
+      for (const path of bindingMutationGTContainerPaths(
+        binding,
+        state,
+        new Set(seenBindings).add(binding)
+      )) {
+        canonical.add(
+          cacheable
+            ? path
+            : path === binding.identifier.name
+              ? basePath
+              : `${basePath}${path.slice(binding.identifier.name.length)}`
+        );
+      }
+      if (cacheable) {
+        state.gtContainerPaths.set(binding, canonical);
+        remapCached(canonical);
+      } else {
+        for (const path of canonical) result.add(path);
+      }
+      return result;
+    } finally {
+      if (cacheable) state.gtContainerPathsInProgress.delete(binding);
+    }
+  }
+
+  if (expression.type === 'ArrayExpression') {
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (entries) {
+      entries.forEach((entry, index) => {
+        if (entry)
+          collect(
+            entry.node,
+            entry.scope,
+            appendTemplatePath(basePath, String(index))
+          );
+      });
+      return result;
+    }
+    let uncertainIndex = false;
+    expression.elements.forEach((element, index) => {
+      if (!element) return;
+      if (element.type === 'SpreadElement') {
+        uncertainIndex = true;
+        collect(element.argument, scope, basePath);
+        return;
+      }
+      collect(
+        element,
+        scope,
+        appendTemplatePath(
+          basePath,
+          uncertainIndex ? unknownTemplatePathSegment : String(index)
+        )
+      );
+    });
+    return result;
+  }
+
+  if (expression.type === 'ObjectExpression') {
+    const entries = collectObjectEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    for (const [key, entry] of entries.entries) {
+      collect(entry.node, entry.scope, appendTemplatePath(basePath, key));
+    }
+    for (const property of expression.properties) {
+      if (property.type === 'SpreadElement') continue;
+      if (readResolvedPropertyKey(property, scope, state) !== undefined) {
+        continue;
+      }
+      const value =
+        property.type === 'ObjectProperty' ? property.value : property;
+      collect(
+        value,
+        scope,
+        appendTemplatePath(basePath, unknownTemplatePathSegment)
+      );
+    }
+    return result;
+  }
+
+  if (expression.type === 'ConditionalExpression') {
+    const condition = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (condition.ok) {
+      collect(
+        condition.value ? expression.consequent : expression.alternate,
+        scope,
+        basePath
+      );
+    } else {
+      collect(expression.consequent, scope, basePath);
+      collect(expression.alternate, scope, basePath);
+    }
+    return result;
+  }
+  if (expression.type === 'LogicalExpression') {
+    collect(expression.left, scope, basePath);
+    collect(expression.right, scope, basePath);
+    return result;
+  }
+  if (expression.type === 'SequenceExpression') {
+    collect(expression.expressions.at(-1), scope, basePath);
+    return result;
+  }
+  if (expression.type === 'AssignmentExpression') {
+    collect(expression.right, scope, basePath);
+    return result;
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    collect(expression.argument, scope, basePath);
+    return result;
+  }
+  if (
+    expression.type !== 'CallExpression' &&
+    expression.type !== 'OptionalCallExpression'
+  ) {
+    return result;
+  }
+
+  const sources = resolveVueTemplateContainerSources(expression, scope, state);
+  if (sources) {
+    for (const source of sources) collect(source.node, source.scope, basePath);
+    return result;
+  }
+  const called = resolveCalledFunction(
+    expression.callee,
+    scope,
+    state,
+    new Set()
+  );
+  if (called) {
+    withCallParameterSubstitutions(expression, called, scope, state, () => {
+      for (const returned of collectFunctionReturnExpressions(
+        called.node,
+        called.scope,
+        state
+      )) {
+        collect(returned.node, returned.scope, basePath);
+      }
+    });
+    return result;
+  }
+  if (callTargetsUnknownImport(expression.callee, scope)) {
+    for (const argument of expression.arguments) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      collect(
+        argument.type === 'SpreadElement' ? argument.argument : argument,
+        scope,
+        basePath
+      );
+    }
+    return result;
+  }
+  const callee = unwrapExpression(expression.callee);
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'OptionalMemberExpression')
+  ) {
+    return result;
+  }
+  const method = readResolvedMemberProperty(callee, scope, state);
+  if (!method) return result;
+  const addPaths = (paths: Iterable<string>): void => {
+    for (const path of paths) result.add(path);
+  };
+  const collectPaths = (
+    value: t.Node,
+    valueScope: Scope,
+    path = basePath
+  ): Set<string> =>
+    collectPossibleGTContainerPaths(
+      value,
+      valueScope,
+      path,
+      state,
+      nextNodes,
+      seenBindings
+    );
+  const removeFirstChild = (path: string): string => {
+    if (path === basePath) return basePath;
+    const suffix = path.slice(basePath.length + 1);
+    const separator = suffix.indexOf('.');
+    return separator === -1
+      ? basePath
+      : `${basePath}.${suffix.slice(separator + 1)}`;
+  };
+  const replaceFirstChildWithUnknown = (path: string): string => {
+    if (path === basePath) return basePath;
+    const suffix = path.slice(basePath.length + 1);
+    const separator = suffix.indexOf('.');
+    const remaining = separator === -1 ? '' : suffix.slice(separator);
+    return `${appendTemplatePath(basePath, unknownTemplatePathSegment)}${remaining}`;
+  };
+  const receiverPath = readResolvedMemberPath(callee.object, scope, state);
+  const collectMappedPaths = (
+    source: t.Node,
+    callback: t.Node | undefined,
+    includeSourceParameter = true
+  ): Set<string> => {
+    const sourcePaths = collectPaths(source, scope);
+    if (!callback) return sourcePaths;
+    const callbackFunction = resolveCalledFunction(
+      callback,
+      scope,
+      state,
+      new Set()
+    );
+    if (!callbackFunction) return sourcePaths;
+    const mapped = new Set<string>();
+    const sourceEntries = collectTransformArrayEntries(
+      source,
+      scope,
+      state,
+      new Set()
+    );
+    if (sourceEntries) {
+      const childPath = appendTemplatePath(
+        basePath,
+        unknownTemplatePathSegment
+      );
+      for (const [index, entry] of sourceEntries.entries()) {
+        if (!entry) continue;
+        const callbackValues: Array<ScopedExpression | undefined> = [
+          entry,
+          {
+            node: { type: 'NumericLiteral', value: index } as t.NumericLiteral,
+            scope,
+          },
+        ];
+        if (includeSourceParameter)
+          callbackValues.push({ node: source, scope });
+        withFunctionParameterSubstitutions(
+          callbackFunction,
+          callbackValues,
+          state,
+          () => {
+            if (
+              functionMayReturnComponent(
+                callbackFunction.node,
+                callbackFunction.scope,
+                state,
+                new Set(),
+                'T'
+              )
+            ) {
+              mapped.add(basePath);
+            }
+            for (const returned of collectFunctionReturnExpressions(
+              callbackFunction.node,
+              callbackFunction.scope,
+              state
+            )) {
+              for (const path of collectPossibleGTContainerPaths(
+                returned.node,
+                returned.scope,
+                childPath,
+                state,
+                nextNodes,
+                seenBindings
+              )) {
+                mapped.add(path);
+              }
+            }
+          }
+        );
+      }
+      return mapped;
+    }
+    if (
+      functionMayReturnParameter(
+        callbackFunction.node,
+        callbackFunction.scope,
+        0,
+        state
+      )
+    ) {
+      for (const path of sourcePaths) mapped.add(path);
+    }
+    if (
+      functionMayReturnComponent(
+        callbackFunction.node,
+        callbackFunction.scope,
+        state,
+        new Set(),
+        'T'
+      )
+    ) {
+      mapped.add(basePath);
+    }
+    const childPath = appendTemplatePath(basePath, unknownTemplatePathSegment);
+    for (const returned of collectFunctionReturnExpressions(
+      callbackFunction.node,
+      callbackFunction.scope,
+      state
+    )) {
+      for (const path of collectPossibleGTContainerPaths(
+        returned.node,
+        returned.scope,
+        childPath,
+        state,
+        nextNodes,
+        seenBindings
+      )) {
+        mapped.add(path);
+      }
+    }
+    return mapped;
+  };
+  if (
+    receiverPath === 'Array' &&
+    method === 'from' &&
+    !scope.getBinding('Array')
+  ) {
+    const source = expression.arguments[0];
+    if (
+      source &&
+      source.type !== 'ArgumentPlaceholder' &&
+      source.type !== 'SpreadElement'
+    ) {
+      const mapper = expression.arguments[1];
+      addPaths(
+        collectMappedPaths(
+          source,
+          mapper &&
+            mapper.type !== 'ArgumentPlaceholder' &&
+            mapper.type !== 'SpreadElement'
+            ? mapper
+            : undefined,
+          false
+        )
+      );
+    }
+    return result;
+  }
+  if (
+    receiverPath === 'Object' &&
+    method === 'assign' &&
+    !scope.getBinding('Object')
+  ) {
+    for (const argument of expression.arguments) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      collect(
+        argument.type === 'SpreadElement' ? argument.argument : argument,
+        scope,
+        basePath
+      );
+    }
+    return result;
+  }
+  if (
+    receiverPath === 'Object' &&
+    (method === 'values' || method === 'entries') &&
+    !scope.getBinding('Object')
+  ) {
+    const source = expression.arguments[0];
+    if (
+      source &&
+      source.type !== 'ArgumentPlaceholder' &&
+      source.type !== 'SpreadElement'
+    ) {
+      for (const path of collectPaths(source, scope)) {
+        const valuePath = replaceFirstChildWithUnknown(path);
+        result.add(
+          method === 'entries'
+            ? path === basePath
+              ? appendTemplatePath(basePath, unknownTemplatePathSegment)
+              : appendTemplatePath(valuePath, '1')
+            : valuePath
+        );
+      }
+    }
+    return result;
+  }
+  if (
+    [
+      'concat',
+      'copyWithin',
+      'fill',
+      'filter',
+      'splice',
+      'reverse',
+      'slice',
+      'sort',
+      'toReversed',
+      'toSorted',
+      'toSpliced',
+      'with',
+    ].includes(method)
+  ) {
+    collect(callee.object, scope, basePath);
+  }
+  if (method === 'concat') {
+    for (const argument of expression.arguments) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      collect(
+        argument.type === 'SpreadElement' ? argument.argument : argument,
+        scope,
+        basePath
+      );
+    }
+  }
+  if (method === 'with' || method === 'toSpliced') {
+    const inserted =
+      method === 'with'
+        ? expression.arguments.slice(1, 2)
+        : expression.arguments.slice(2);
+    const childPath = appendTemplatePath(basePath, unknownTemplatePathSegment);
+    for (const argument of inserted) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      const value =
+        argument.type === 'SpreadElement' ? argument.argument : argument;
+      if (expressionMayProduceComponent(value, scope, state, new Set(), 'T')) {
+        result.add(basePath);
+      }
+      collect(value, scope, childPath);
+    }
+  }
+  if (method === 'fill') {
+    const value = expression.arguments[0];
+    if (
+      value &&
+      value.type !== 'ArgumentPlaceholder' &&
+      value.type !== 'SpreadElement'
+    ) {
+      if (expressionMayProduceComponent(value, scope, state, new Set(), 'T')) {
+        result.add(basePath);
+      }
+      collect(
+        value,
+        scope,
+        appendTemplatePath(basePath, unknownTemplatePathSegment)
+      );
+    }
+  }
+  if (method === 'map') {
+    const callback = expression.arguments[0];
+    addPaths(
+      collectMappedPaths(
+        callee.object,
+        callback &&
+          callback.type !== 'ArgumentPlaceholder' &&
+          callback.type !== 'SpreadElement'
+          ? callback
+          : undefined
+      )
+    );
+  }
+  if (method === 'flat' || method === 'flatMap') {
+    const mapped = new Set<string>();
+    if (method === 'flat') {
+      const sourcePaths = collectPaths(callee.object, scope);
+      const depthArgument = expression.arguments[0];
+      const depthValue =
+        depthArgument &&
+        depthArgument.type !== 'ArgumentPlaceholder' &&
+        depthArgument.type !== 'SpreadElement'
+          ? readStaticFromScope(
+              depthArgument,
+              scope,
+              new Set(),
+              depthArgument.end ?? Number.POSITIVE_INFINITY,
+              state.analysis
+            )
+          : { ok: true as const, value: 1 };
+      if (depthValue.ok && typeof depthValue.value !== 'bigint') {
+        const numericDepth = Number(depthValue.value);
+        const depth = Number.isNaN(numericDepth)
+          ? 0
+          : numericDepth === Number.POSITIVE_INFINITY
+            ? Number.POSITIVE_INFINITY
+            : Math.max(0, Math.trunc(numericDepth));
+        for (const sourcePath of sourcePaths) {
+          let flattened = sourcePath;
+          for (
+            let index = 0;
+            index < depth && flattened !== basePath;
+            index += 1
+          ) {
+            flattened = removeFirstChild(flattened);
+          }
+          mapped.add(flattened);
+        }
+      } else if (!depthValue.ok) {
+        for (const sourcePath of sourcePaths) {
+          let flattened = sourcePath;
+          mapped.add(flattened);
+          while (flattened !== basePath) {
+            flattened = removeFirstChild(flattened);
+            mapped.add(flattened);
+          }
+        }
+      }
+    } else {
+      const callback = expression.arguments[0];
+      for (const path of collectMappedPaths(
+        callee.object,
+        callback &&
+          callback.type !== 'ArgumentPlaceholder' &&
+          callback.type !== 'SpreadElement'
+          ? callback
+          : undefined
+      )) {
+        mapped.add(removeFirstChild(path));
+      }
+    }
+    addPaths(mapped);
+  }
+  if (method === 'reduce' || method === 'reduceRight') {
+    const receiverPaths = collectPaths(callee.object, scope);
+    addPaths(receiverPaths);
+    if (receiverPaths.size > 0) result.add(basePath);
+    const callback = expression.arguments[0];
+    if (
+      callback &&
+      callback.type !== 'ArgumentPlaceholder' &&
+      callback.type !== 'SpreadElement'
+    ) {
+      const callbackFunction = resolveCalledFunction(
+        callback,
+        scope,
+        state,
+        new Set()
+      );
+      if (callbackFunction) {
+        if (
+          functionMayReturnComponent(
+            callbackFunction.node,
+            callbackFunction.scope,
+            state,
+            new Set(),
+            'T'
+          )
+        ) {
+          result.add(basePath);
+        }
+        for (const returned of collectFunctionReturnExpressions(
+          callbackFunction.node,
+          callbackFunction.scope,
+          state
+        )) {
+          collect(returned.node, returned.scope, basePath);
+        }
+      }
+    }
+    for (const argument of expression.arguments) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      const value =
+        argument.type === 'SpreadElement' ? argument.argument : argument;
+      addPaths(collectPaths(value, scope));
+      if (expressionMayProduceComponent(value, scope, state, new Set(), 'T')) {
+        result.add(basePath);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Tracks containers whose immediate indexed/property value can be `<T>`.
+ * Nested containers deliberately do not taint their parent: selecting from
+ * `[[T]]` yields an array, and only a second selection can yield T.
+ */
+function expressionMayProduceGTContainer(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return false;
+  const nextNodes = new Set(seenNodes).add(expression);
+  const exposedPath = readExposedMemberPath(expression, scope, state);
+  if (exposedPath && state.analysis.possibleGTContainers.has(exposedPath)) {
+    return true;
+  }
+
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      return state.analysis.possibleGTContainers.has(expression.name);
+    }
+    const substitution = readParameterSubstitution(binding, state);
+    if (substitution) {
+      return expressionMayProduceGTContainer(
+        substitution.node,
+        substitution.scope,
+        state,
+        nextNodes,
+        seenBindings
+      );
+    }
+    const cacheable = state.parameterSubstitutions.length === 0;
+    const cached = cacheable
+      ? state.gtContainerPossibilities.get(binding)
+      : undefined;
+    if (cached !== undefined) return cached;
+    if (seenBindings.has(binding)) return false;
+    if (state.gtContainerPossibilitiesInProgress.has(binding)) return false;
+    if (cacheable) state.gtContainerPossibilitiesInProgress.add(binding);
+    try {
+      const source = getBindingSource(binding);
+      const finalAssignment = source
+        ? undefined
+        : readDefiniteFinalBindingAssignment(binding);
+      const selected = source
+        ? selectPatternExpression(
+            source.pattern,
+            source.expression.node,
+            binding.identifier.name,
+            source.expression.scope,
+            source.expression.node.end ?? Number.POSITIVE_INFINITY,
+            state
+          )
+        : finalAssignment;
+      const result = Boolean(
+        selected &&
+        expressionMayProduceGTContainer(
+          selected.node,
+          selected.scope,
+          state,
+          nextNodes,
+          new Set(seenBindings).add(binding)
+        )
+      );
+      if (cacheable) state.gtContainerPossibilities.set(binding, result);
+      return result;
+    } finally {
+      if (cacheable) state.gtContainerPossibilitiesInProgress.delete(binding);
+    }
+  }
+
+  if (expression.type === 'ArrayExpression') {
+    const entries = collectArrayEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (entries) {
+      return entries.some(
+        (entry) =>
+          entry &&
+          expressionMayProduceComponent(
+            entry.node,
+            entry.scope,
+            state,
+            new Set(),
+            'T'
+          )
+      );
+    }
+    return expression.elements.some((element) => {
+      if (!element) return false;
+      return element.type === 'SpreadElement'
+        ? expressionMayProduceGTContainer(
+            element.argument,
+            scope,
+            state,
+            nextNodes,
+            seenBindings
+          )
+        : expressionMayProduceComponent(element, scope, state, new Set(), 'T');
+    });
+  }
+
+  if (expression.type === 'ObjectExpression') {
+    const entries = collectObjectEntries(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (
+      [...entries.entries.values()].some((entry) =>
+        entry.node.type === 'ObjectMethod'
+          ? entry.node.kind === 'get' &&
+            functionMayReturnComponent(
+              entry.node,
+              entry.scope,
+              state,
+              new Set(),
+              'T'
+            )
+          : expressionMayProduceComponent(
+              entry.node,
+              entry.scope,
+              state,
+              new Set(),
+              'T'
+            )
+      )
+    ) {
+      return true;
+    }
+    return expression.properties.some((property) => {
+      if (property.type === 'SpreadElement') {
+        return expressionMayProduceGTContainer(
+          property.argument,
+          scope,
+          state,
+          nextNodes,
+          seenBindings
+        );
+      }
+      return (
+        property.computed &&
+        readResolvedPropertyKey(property, scope, state) === undefined &&
+        (property.type === 'ObjectMethod'
+          ? property.kind === 'get' &&
+            functionMayReturnComponent(property, scope, state, new Set(), 'T')
+          : expressionMayProduceComponent(
+              property.value,
+              scope,
+              state,
+              new Set(),
+              'T'
+            ))
+      );
+    });
+  }
+
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const sources = resolveVueTemplateContainerSources(
+      expression,
+      scope,
+      state
+    );
+    if (sources) {
+      return sources.some((source) =>
+        expressionMayProduceGTContainer(
+          source.node,
+          source.scope,
+          state,
+          nextNodes,
+          seenBindings
+        )
+      );
+    }
+    const calleePath = readResolvedMemberPath(expression.callee, scope, state);
+    if (calleePath && state.analysis.gtContainerFactories.has(calleePath)) {
+      return true;
+    }
+    const called = resolveCalledFunction(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (called) {
+      const mayReturnContainer = withCallParameterSubstitutions(
+        expression,
+        called,
+        scope,
+        state,
+        () =>
+          functionMayReturnGTContainer(
+            called.node,
+            called.scope,
+            state,
+            nextNodes
+          )
+      );
+      if (mayReturnContainer) return true;
+    }
+    return callMayProduceGTContainer(
+      expression,
+      scope,
+      state,
+      nextNodes,
+      seenBindings
+    );
+  }
+
+  if (expression.type === 'ConditionalExpression') {
+    const condition = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    const alternatives = condition.ok
+      ? [condition.value ? expression.consequent : expression.alternate]
+      : [expression.consequent, expression.alternate];
+    return alternatives.some((alternative) =>
+      expressionMayProduceGTContainer(
+        alternative,
+        scope,
+        state,
+        nextNodes,
+        seenBindings
+      )
+    );
+  }
+  if (expression.type === 'LogicalExpression') {
+    const staticLeft = readStaticFromScope(
+      expression.left,
+      scope,
+      new Set(),
+      expression.left.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (staticLeft.ok) {
+      const selectsRight =
+        expression.operator === '??'
+          ? staticLeft.value == null
+          : expression.operator === '||'
+            ? !staticLeft.value
+            : Boolean(staticLeft.value);
+      return selectsRight
+        ? expressionMayProduceGTContainer(
+            expression.right,
+            scope,
+            state,
+            nextNodes,
+            seenBindings
+          )
+        : expressionMayProduceGTContainer(
+            expression.left,
+            scope,
+            state,
+            nextNodes,
+            seenBindings
+          );
+    }
+    return (
+      expressionMayProduceGTContainer(
+        expression.left,
+        scope,
+        state,
+        nextNodes,
+        seenBindings
+      ) ||
+      expressionMayProduceGTContainer(
+        expression.right,
+        scope,
+        state,
+        nextNodes,
+        seenBindings
+      )
+    );
+  }
+  if (expression.type === 'SequenceExpression') {
+    return expressionMayProduceGTContainer(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      nextNodes,
+      seenBindings
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return expressionMayProduceGTContainer(
+      expression.right,
+      scope,
+      state,
+      nextNodes,
+      seenBindings
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expressionMayProduceGTContainer(
+      expression.argument,
+      scope,
+      state,
+      nextNodes,
+      seenBindings
+    );
+  }
+  return false;
+}
+
+/** Models standard calls that preserve or create array registry values. */
+function callMayProduceGTContainer(
+  call: t.CallExpression | t.OptionalCallExpression,
+  scope: Scope,
+  state: ScriptState,
+  seenNodes: Set<t.Node>,
+  seenBindings: Set<Binding>
+): boolean {
+  const callee = unwrapExpression(call.callee);
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'OptionalMemberExpression')
+  ) {
+    return false;
+  }
+  const method = readResolvedMemberProperty(callee, scope, state);
+  if (!method) return false;
+  const first = call.arguments[0];
+  const firstExpression =
+    first &&
+    first.type !== 'ArgumentPlaceholder' &&
+    first.type !== 'SpreadElement'
+      ? first
+      : undefined;
+  const receiverPath = readResolvedMemberPath(callee.object, scope, state);
+  if (
+    receiverPath === 'Array' &&
+    method === 'from' &&
+    !scope.getBinding('Array')
+  ) {
+    const sourceHasT = expressionMayProduceGTContainer(
+      firstExpression,
+      scope,
+      state,
+      seenNodes,
+      seenBindings
+    );
+    const mapper = call.arguments[1];
+    if (
+      !mapper ||
+      mapper.type === 'ArgumentPlaceholder' ||
+      mapper.type === 'SpreadElement'
+    ) {
+      return sourceHasT;
+    }
+    const mapperFunction = resolveCalledFunction(
+      mapper,
+      scope,
+      state,
+      new Set()
+    );
+    if (!mapperFunction) return sourceHasT;
+    return (
+      (sourceHasT &&
+        functionMayReturnParameter(
+          mapperFunction.node,
+          mapperFunction.scope,
+          0,
+          state
+        )) ||
+      functionMayReturnComponent(
+        mapperFunction.node,
+        mapperFunction.scope,
+        state,
+        new Set(),
+        'T'
+      )
+    );
+  }
+  if (
+    receiverPath === 'Object' &&
+    method === 'assign' &&
+    !scope.getBinding('Object')
+  ) {
+    return call.arguments.some(
+      (argument) =>
+        argument.type !== 'ArgumentPlaceholder' &&
+        expressionMayProduceGTContainer(
+          argument.type === 'SpreadElement' ? argument.argument : argument,
+          scope,
+          state,
+          seenNodes,
+          seenBindings
+        )
+    );
+  }
+  if (
+    receiverPath === 'Object' &&
+    ['freeze', 'seal', 'preventExtensions'].includes(method) &&
+    !scope.getBinding('Object')
+  ) {
+    return expressionMayProduceGTContainer(
+      firstExpression,
+      scope,
+      state,
+      seenNodes,
+      seenBindings
+    );
+  }
+  const receiverHasT = expressionMayProduceGTContainer(
+    callee.object,
+    scope,
+    state,
+    seenNodes,
+    seenBindings
+  );
+  if (
+    ['filter', 'reverse', 'slice', 'sort', 'toReversed', 'toSorted'].includes(
+      method
+    )
+  ) {
+    return receiverHasT;
+  }
+  if (method === 'map') {
+    const mapper = call.arguments[0];
+    if (
+      !mapper ||
+      mapper.type === 'ArgumentPlaceholder' ||
+      mapper.type === 'SpreadElement'
+    ) {
+      return receiverHasT;
+    }
+    const mapperFunction = resolveCalledFunction(
+      mapper,
+      scope,
+      state,
+      new Set()
+    );
+    if (!mapperFunction) return receiverHasT;
+    return (
+      (receiverHasT &&
+        functionMayReturnParameter(
+          mapperFunction.node,
+          mapperFunction.scope,
+          0,
+          state
+        )) ||
+      functionMayReturnComponent(
+        mapperFunction.node,
+        mapperFunction.scope,
+        state,
+        new Set(),
+        'T'
+      )
+    );
+  }
+  if (method === 'concat') {
+    return (
+      receiverHasT ||
+      call.arguments.some(
+        (argument) =>
+          argument.type !== 'ArgumentPlaceholder' &&
+          (expressionMayProduceComponent(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            state,
+            new Set(),
+            'T'
+          ) ||
+            expressionMayProduceGTContainer(
+              argument.type === 'SpreadElement' ? argument.argument : argument,
+              scope,
+              state,
+              seenNodes,
+              seenBindings
+            ))
+      )
+    );
+  }
+  if (method === 'fill') {
+    return Boolean(
+      firstExpression &&
+      expressionMayProduceComponent(
+        firstExpression,
+        scope,
+        state,
+        new Set(),
+        'T'
+      )
+    );
+  }
+  if (['with', 'toSpliced'].includes(method)) {
+    const inserted =
+      method === 'toSpliced'
+        ? call.arguments.slice(2)
+        : method === 'with'
+          ? call.arguments.slice(1, 2)
+          : [first];
+    return (
+      receiverHasT ||
+      inserted.some(
+        (argument) =>
+          argument &&
+          argument.type !== 'ArgumentPlaceholder' &&
+          expressionMayProduceComponent(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            state,
+            new Set(),
+            'T'
+          )
+      )
+    );
+  }
+  return receiverHasT && method === 'copyWithin';
+}
+
+/** Collects container paths affected by in-place writes that can add T. */
+function bindingMutationGTContainerPaths(
+  binding: Binding,
+  state: ScriptState,
+  seenAliases: Set<Binding> = new Set([binding])
+): Set<string> {
+  const cached = state.mutationGTContainerPaths.get(binding);
+  if (cached) return new Set(cached);
+  if (state.mutationGTContainerPathsInProgress.has(binding)) return new Set();
+  state.mutationGTContainerPathsInProgress.add(binding);
+  const result = new Set<string>();
+  const writePolicy = readBindingContainerWritePolicy(binding, state);
+  const blocksWriteAtDepth = (depth: number): boolean =>
+    writePolicy === 'readonly-deep' ||
+    (writePolicy === 'readonly-shallow' && depth <= 1);
+  const appendProperties = (properties: string[]): string =>
+    properties.reduce(appendTemplatePath, binding.identifier.name);
+  const collectAssignedContainer = (
+    value: t.Node,
+    scope: Scope,
+    properties: string[]
+  ): void => {
+    for (const path of collectPossibleGTContainerPaths(
+      value,
+      scope,
+      appendProperties(properties),
+      state,
+      new Set(),
+      new Set([binding])
+    )) {
+      result.add(path);
+    }
+  };
+
+  for (const reference of binding.referencePaths) {
+    let current: NodePath<t.Node> = reference;
+    const properties: string[] = [];
+    while (
+      current.parentPath &&
+      (current.parentPath.isMemberExpression() ||
+        current.parentPath.isOptionalMemberExpression()) &&
+      current.parentPath.node.object === current.node
+    ) {
+      const property = readResolvedMemberProperty(
+        current.parentPath.node,
+        current.parentPath.scope,
+        state
+      );
+      if (property === undefined) properties.push(unknownTemplatePathSegment);
+      else properties.push(property);
+      current = current.parentPath;
+    }
+    const parent = current.parentPath;
+    if (parent?.isAssignmentExpression() && parent.node.left === current.node) {
+      const target =
+        properties[0] === 'value' ? properties.slice(1) : properties;
+      if (blocksWriteAtDepth(target.length)) continue;
+      if (
+        target.length > 0 &&
+        expressionMayProduceComponent(
+          parent.node.right,
+          parent.scope,
+          state,
+          new Set([binding]),
+          'T'
+        )
+      ) {
+        result.add(appendProperties(target.slice(0, -1)));
+      }
+      collectAssignedContainer(parent.node.right, parent.scope, target);
+      continue;
+    }
+    if (!parent?.isCallExpression()) continue;
+    if (parent.node.callee !== current.node) {
+      const callee = readResolvedMemberPath(
+        parent.node.callee,
+        parent.scope,
+        state
+      );
+      const argumentIndex = parent.node.arguments.findIndex(
+        (argument) => argument === reference.node
+      );
+      if (callee === 'Object.assign' && argumentIndex === 0) {
+        if (blocksWriteAtDepth(1)) continue;
+        for (const source of parent.node.arguments.slice(1)) {
+          if (source.type === 'ArgumentPlaceholder') continue;
+          collectAssignedContainer(
+            source.type === 'SpreadElement' ? source.argument : source,
+            parent.scope,
+            []
+          );
+        }
+      } else if (callee === 'Reflect.set' && argumentIndex === 0) {
+        if (blocksWriteAtDepth(1)) continue;
+        const key = parent.node.arguments[1];
+        const value = parent.node.arguments[2];
+        if (
+          value &&
+          value.type !== 'ArgumentPlaceholder' &&
+          value.type !== 'SpreadElement'
+        ) {
+          const staticKey =
+            key &&
+            key.type !== 'ArgumentPlaceholder' &&
+            key.type !== 'SpreadElement'
+              ? readStaticFromScope(
+                  key,
+                  parent.scope,
+                  new Set(),
+                  key.end ?? Number.POSITIVE_INFINITY,
+                  state.analysis
+                )
+              : undefined;
+          const property =
+            staticKey?.ok &&
+            (typeof staticKey.value === 'string' ||
+              typeof staticKey.value === 'number')
+              ? String(staticKey.value)
+              : unknownTemplatePathSegment;
+          if (
+            expressionMayProduceComponent(
+              value,
+              parent.scope,
+              state,
+              new Set([binding]),
+              'T'
+            )
+          ) {
+            result.add(binding.identifier.name);
+          }
+          collectAssignedContainer(value, parent.scope, [property]);
+        }
+      }
+      continue;
+    }
+    const method = properties.at(-1);
+    const target = properties
+      .slice(0, -1)
+      .filter((property, index) => !(index === 0 && property === 'value'));
+    if (blocksWriteAtDepth(target.length + 1)) continue;
+    const argumentsToCheck =
+      method === 'splice'
+        ? parent.node.arguments.slice(2)
+        : method === 'fill'
+          ? parent.node.arguments.slice(0, 1)
+          : method === 'push' || method === 'unshift'
+            ? parent.node.arguments
+            : [];
+    for (const argument of argumentsToCheck) {
+      if (argument.type === 'ArgumentPlaceholder') continue;
+      const value =
+        argument.type === 'SpreadElement' ? argument.argument : argument;
+      if (
+        expressionMayProduceComponent(
+          value,
+          parent.scope,
+          state,
+          new Set([binding]),
+          'T'
+        )
+      ) {
+        result.add(appendProperties(target));
+      }
+      collectAssignedContainer(value, parent.scope, [
+        ...target,
+        unknownTemplatePathSegment,
+      ]);
+    }
+  }
+  for (const reference of binding.referencePaths) {
+    const declarator = reference.parentPath;
+    if (
+      !declarator?.isVariableDeclarator() ||
+      declarator.node.init !== reference.node ||
+      declarator.node.id.type !== 'Identifier'
+    ) {
+      continue;
+    }
+    const alias = declarator.scope.getBinding(declarator.node.id.name);
+    if (!alias || seenAliases.has(alias)) continue;
+    const aliasPaths = bindingMutationGTContainerPaths(
+      alias,
+      state,
+      new Set(seenAliases).add(alias)
+    );
+    for (const path of aliasPaths) {
+      result.add(
+        path === alias.identifier.name
+          ? binding.identifier.name
+          : `${binding.identifier.name}${path.slice(alias.identifier.name.length)}`
+      );
+    }
+  }
+  state.mutationGTContainerPaths.set(binding, new Set(result));
+  state.mutationGTContainerPathsInProgress.delete(binding);
+  return result;
+}
+
+/** Detects a component alias whose value escaped the safe static subset. */
+function bindingMayReferenceComponent(
+  binding: Binding,
+  state: ScriptState,
+  kind?: ComponentKind
+): boolean {
+  const cacheKey = kind ?? 'any';
+  const cached =
+    state.parameterSubstitutions.length === 0
+      ? state.componentPossibilities.get(binding)?.get(cacheKey)
+      : undefined;
+  if (cached !== undefined) return cached;
+  const declaration = binding.path.node;
+  const result =
+    declaration.type === 'VariableDeclarator' &&
+    declaration.init &&
+    patternMayProduceComponent(
+      declaration.id,
+      declaration.init,
+      binding.identifier.name,
+      binding.path.scope,
+      state,
+      new Set([binding]),
+      kind
+    )
+      ? true
+      : binding.constantViolations.some((violation) =>
+          constantViolationMayAssignComponent(
+            violation,
+            binding.identifier.name,
+            state,
+            new Set([binding]),
+            kind
+          )
+        );
+  if (state.parameterSubstitutions.length === 0) {
+    const possibilities =
+      state.componentPossibilities.get(binding) ??
+      new Map<ComponentKind | 'any', boolean>();
+    possibilities.set(cacheKey, result);
+    state.componentPossibilities.set(binding, possibilities);
+  }
+  return result;
+}
+
+/**
+ * Proves a const direct-alias chain cannot itself be a string translator.
+ *
+ * Container contents may still mutate, but an array or object never becomes
+ * callable. Caching only this positive proof avoids memoizing an unresolved
+ * false result that could depend on cross-block or callback analysis.
+ */
+function bindingIsDefinitelyNotStringFunction(
+  binding: Binding,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  if (state.definiteNonStringFunctionBindings.has(binding)) return true;
+  if (
+    !binding.constant ||
+    seen.has(binding) ||
+    state.parameterSubstitutions.length > 0 ||
+    state.definiteNonStringFunctionBindingsInProgress.has(binding)
+  ) {
+    return false;
+  }
+  const source = getBindingSource(binding);
+  if (source?.pattern.type !== 'Identifier') return false;
+  const expression = unwrapExpression(source.expression.node);
+  if (!expression) return false;
+
+  state.definiteNonStringFunctionBindingsInProgress.add(binding);
+  try {
+    const known = resolveKnownExpression(
+      expression,
+      source.expression.scope,
+      state,
+      new Set([binding])
+    );
+    let result = Boolean(known && known.type !== 'string');
+    if (!known && expression.type === 'Identifier') {
+      const target = source.expression.scope.getBinding(expression.name);
+      result = Boolean(
+        target &&
+        bindingIsDefinitelyNotStringFunction(
+          target,
+          state,
+          new Set(seen).add(binding)
+        )
+      );
+    } else if (
+      !known &&
+      (expression.type === 'ArrayExpression' ||
+        expression.type === 'ObjectExpression')
+    ) {
+      result = true;
+    }
+    if (result) state.definiteNonStringFunctionBindings.add(binding);
+    return result;
+  } finally {
+    state.definiteNonStringFunctionBindingsInProgress.delete(binding);
+  }
+}
+
+/** Detects a string translator alias whose value escaped exact analysis. */
+function bindingMayReferenceStringFunction(
+  binding: Binding,
+  state: ScriptState
+): boolean {
+  if (bindingIsDefinitelyNotStringFunction(binding, state, new Set())) {
+    return false;
+  }
+  const finalAssignment = readDefiniteFinalBindingAssignment(binding);
+  if (finalAssignment) {
+    return expressionMayProduceStringFunction(
+      finalAssignment.node,
+      finalAssignment.scope,
+      state,
+      new Set([binding])
+    );
+  }
+  const declaration = binding.path.node;
+  if (
+    declaration.type === 'VariableDeclarator' &&
+    declaration.init &&
+    patternMayProduceStringFunction(
+      declaration.id,
+      declaration.init,
+      binding.identifier.name,
+      binding.path.scope,
+      state,
+      new Set([binding])
+    )
+  ) {
+    return true;
+  }
+  return binding.constantViolations.some(
+    (violation) =>
+      violation.isAssignmentExpression() &&
+      patternContains(violation.node.left, binding.identifier.name) &&
+      expressionMayProduceStringFunction(
+        violation.node.right,
+        violation.scope,
+        state,
+        new Set([binding])
+      )
+  );
+}
+
+/** Tracks expressions whose resulting value can be a gt-vue string function. */
+function expressionMayProduceStringFunction(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  if (state.analysis.stats) state.analysis.stats.stringFunctionVisits += 1;
+  const expression = unwrapExpression(node);
+  if (!expression) return false;
+  const resolved = resolveKnownExpression(expression, scope, state, new Set());
+  if (resolved?.type === 'string') return true;
+  const exposedPath = readExposedMemberPath(expression, scope, state);
+  if (exposedPath && state.analysis.uncertainStringFunctions.has(exposedPath)) {
+    return true;
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      return state.analysis.uncertainStringFunctions.has(expression.name);
+    }
+    const substitution = readParameterSubstitution(binding, state);
+    if (substitution) {
+      return expressionMayProduceStringFunction(
+        substitution.node,
+        substitution.scope,
+        state,
+        seen
+      );
+    }
+    if (bindingIsDefinitelyNotStringFunction(binding, state, seen)) {
+      return false;
+    }
+    if (seen.has(binding)) return false;
+    const nextSeen = new Set(seen).add(binding);
+    const declaration = binding.path.node;
+    if (
+      declaration.type === 'VariableDeclarator' &&
+      declaration.init &&
+      patternMayProduceStringFunction(
+        declaration.id,
+        declaration.init,
+        binding.identifier.name,
+        binding.path.scope,
+        state,
+        nextSeen
+      )
+    ) {
+      return true;
+    }
+    return binding.constantViolations.some(
+      (violation) =>
+        violation.isAssignmentExpression() &&
+        patternContains(violation.node.left, binding.identifier.name) &&
+        expressionMayProduceStringFunction(
+          violation.node.right,
+          violation.scope,
+          state,
+          nextSeen
+        )
+    );
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const property = readResolvedMemberProperty(expression, scope, state);
+    if (!property) return false;
+    const entry = readObjectEntry(
+      expression.object,
+      property,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (
+      entry.status === 'known' &&
+      expressionMayProduceStringFunction(
+        entry.expression.node,
+        entry.expression.scope,
+        state,
+        seen
+      )
+    ) {
+      return true;
+    }
+    return objectGetterMayProduceStringFunction(
+      expression.object,
+      property,
+      scope,
+      state,
+      seen
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = resolveKnownExpression(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    const firstArgument = expression.arguments[0];
+    const first =
+      firstArgument &&
+      firstArgument.type !== 'ArgumentPlaceholder' &&
+      firstArgument.type !== 'SpreadElement'
+        ? firstArgument
+        : undefined;
+    if (callee?.type === 'vue-wrapper') {
+      return callee.kind === 'computed'
+        ? computedSourceMayProduceStringFunction(first, scope, state, seen)
+        : expressionMayProduceStringFunction(first, scope, state, seen);
+    }
+    const called = resolveCalledFunction(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (called) {
+      const mayReturnStringFunction = withCallParameterSubstitutions(
+        expression,
+        called,
+        scope,
+        state,
+        () =>
+          functionMayReturnStringFunction(
+            called.node,
+            called.scope,
+            state,
+            seen
+          )
+      );
+      if (mayReturnStringFunction) return true;
+    }
+    return expression.arguments.some(
+      (argument) =>
+        argument.type !== 'ArgumentPlaceholder' &&
+        (expressionMayProduceStringFunction(
+          argument.type === 'SpreadElement' ? argument.argument : argument,
+          scope,
+          state,
+          seen
+        ) ||
+          containerMayContainStringFunction(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            scope,
+            state,
+            new Set()
+          ))
+    );
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return (
+      expressionMayProduceStringFunction(
+        expression.consequent,
+        scope,
+        state,
+        seen
+      ) ||
+      expressionMayProduceStringFunction(
+        expression.alternate,
+        scope,
+        state,
+        seen
+      )
+    );
+  }
+  if (expression.type === 'LogicalExpression') {
+    return (
+      expressionMayProduceStringFunction(expression.left, scope, state, seen) ||
+      expressionMayProduceStringFunction(expression.right, scope, state, seen)
+    );
+  }
+  if (expression.type === 'SequenceExpression') {
+    return expressionMayProduceStringFunction(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      seen
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return expressionMayProduceStringFunction(
+      expression.right,
+      scope,
+      state,
+      seen
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expressionMayProduceStringFunction(
+      expression.argument,
+      scope,
+      state,
+      seen
+    );
+  }
+  return false;
+}
+
+/** Tracks a destructured string-function value, including rest bindings. */
+function patternMayProduceStringFunction(
+  pattern: t.Node,
+  valueNode: t.Node,
+  targetName: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  const exposedBase = readExposedMemberPath(valueNode, scope, state);
+  const exposedPath = exposedBase
+    ? readPatternExposedMemberPath(
+        pattern,
+        targetName,
+        exposedBase,
+        scope,
+        state
+      )
+    : undefined;
+  if (
+    exposedPath &&
+    (state.analysis.values.get(exposedPath)?.type === 'string' ||
+      state.analysis.uncertainStringFunctions.has(exposedPath))
+  ) {
+    return true;
+  }
+  if (pattern.type === 'Identifier') {
+    return (
+      pattern.name === targetName &&
+      expressionMayProduceStringFunction(valueNode, scope, state, seen)
+    );
+  }
+  if (pattern.type === 'RestElement') {
+    return false;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return (
+      patternContains(pattern.left, targetName) &&
+      (expressionMayProduceStringFunction(valueNode, scope, state, seen) ||
+        (expressionMayBeUndefined(valueNode, scope, state, new Set()) &&
+          expressionMayProduceStringFunction(
+            pattern.right,
+            scope,
+            state,
+            seen
+          )))
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      const containsTarget =
+        property.type === 'RestElement'
+          ? patternContains(property.argument, targetName)
+          : patternContains(property.value, targetName);
+      if (!containsTarget) continue;
+      if (property.type === 'RestElement') {
+        return false;
+      }
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) return true;
+      const entry = readObjectEntry(
+        valueNode,
+        key,
+        scope,
+        new Set(),
+        valueNode.end ?? Number.POSITIVE_INFINITY,
+        state
+      );
+      return entry.status === 'known'
+        ? patternMayProduceStringFunction(
+            property.value,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            state,
+            seen
+          )
+        : objectGetterMayProduceStringFunction(
+            valueNode,
+            key,
+            scope,
+            state,
+            seen
+          ) ||
+            expressionMayProduceStringFunction(
+              property.value.type === 'AssignmentPattern'
+                ? property.value.right
+                : undefined,
+              scope,
+              state,
+              seen
+            );
+    }
+    return false;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (let index = 0; index < pattern.elements.length; index += 1) {
+      const target = pattern.elements[index];
+      if (!target || !patternContains(target, targetName)) continue;
+      if (target.type === 'RestElement') {
+        return false;
+      }
+      const entry = readArrayEntry(
+        valueNode,
+        index,
+        scope,
+        new Set(),
+        valueNode.end ?? Number.POSITIVE_INFINITY,
+        state
+      );
+      return entry.status === 'known'
+        ? patternMayProduceStringFunction(
+            target,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            state,
+            seen
+          )
+        : target.type === 'AssignmentPattern' &&
+            expressionMayProduceStringFunction(
+              target.right,
+              scope,
+              state,
+              seen
+            );
+    }
+  }
+  return false;
+}
+
+/** Finds string-function values nested in data containers. */
+function containerMayContainStringFunction(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return false;
+  const nextSeen = new Set(seen).add(expression);
+  if (expression.type === 'ObjectExpression') {
+    return expression.properties.some((property) => {
+      if (property.type === 'SpreadElement') {
+        return containerMayContainStringFunction(
+          property.argument,
+          scope,
+          state,
+          nextSeen
+        );
+      }
+      if (property.type === 'ObjectMethod') {
+        return (
+          property.kind === 'get' &&
+          functionMayReturnStringFunction(property, scope, state, new Set())
+        );
+      }
+      return (
+        expressionMayProduceStringFunction(
+          property.value,
+          scope,
+          state,
+          new Set()
+        ) ||
+        containerMayContainStringFunction(
+          property.value,
+          scope,
+          state,
+          nextSeen
+        )
+      );
+    });
+  }
+  if (expression.type === 'ArrayExpression') {
+    return expression.elements.some((element) => {
+      if (!element) return false;
+      const value =
+        element.type === 'SpreadElement' ? element.argument : element;
+      return (
+        expressionMayProduceStringFunction(value, scope, state, new Set()) ||
+        containerMayContainStringFunction(value, scope, state, nextSeen)
+      );
+    });
+  }
+  return false;
+}
+
+/** Tracks assignment and for-of writes into one top-level component alias. */
+function constantViolationMayAssignComponent(
+  violation: NodePath<t.Node>,
+  targetName: string,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  if (
+    violation.isAssignmentExpression() &&
+    patternContains(violation.node.left, targetName)
+  ) {
+    return expressionMayProduceComponent(
+      violation.node.right,
+      violation.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  if (
+    violation.isForOfStatement() &&
+    patternContains(violation.node.left, targetName)
+  ) {
+    return (
+      expressionMayProduceComponent(
+        violation.node.right,
+        violation.scope,
+        state,
+        seen,
+        kind
+      ) ||
+      containerMayContainComponent(
+        violation.node.right,
+        violation.scope,
+        state,
+        new Set(),
+        kind
+      )
+    );
+  }
+  return false;
+}
+
+/** Tracks expressions whose resulting identity can be a GT/Vue component. */
+function expressionMayProduceComponent(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression) return false;
+  const resolved = resolveKnownExpression(expression, scope, state, new Set());
+  if (resolved?.type === 'component') {
+    return kind !== 'vue' && (kind !== 'T' || resolved.name === 'T');
+  }
+  if (resolved?.type === 'vue-builtin') {
+    return kind !== 'translation' && kind !== 'T';
+  }
+  const exposedPath = readExposedMemberPath(expression, scope, state);
+  if (
+    exposedPath &&
+    (kind === 'translation' || kind === 'T'
+      ? state.analysis.uncertainGTComponents.has(exposedPath)
+      : state.analysis.uncertainComponents.has(exposedPath))
+  ) {
+    return true;
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) {
+      return kind === 'translation' || kind === 'T'
+        ? state.analysis.uncertainGTComponents.has(expression.name)
+        : state.analysis.uncertainComponents.has(expression.name);
+    }
+    const substitution = readParameterSubstitution(binding, state);
+    if (substitution) {
+      return expressionMayProduceComponent(
+        substitution.node,
+        substitution.scope,
+        state,
+        seen,
+        kind
+      );
+    }
+    const cacheKey = kind ?? 'any';
+    if (state.parameterSubstitutions.length === 0) {
+      const cached = state.componentPossibilities.get(binding)?.get(cacheKey);
+      if (cached !== undefined) return cached;
+    }
+    if (seen.has(binding)) return false;
+    const nextSeen = new Set(seen).add(binding);
+    const declaration = binding.path.node;
+    const result =
+      declaration.type === 'VariableDeclarator' &&
+      !!declaration.init &&
+      patternMayProduceComponent(
+        declaration.id,
+        declaration.init,
+        binding.identifier.name,
+        binding.path.scope,
+        state,
+        nextSeen,
+        kind
+      )
+        ? true
+        : bindingIterationMayProduceComponent(binding, state, nextSeen, kind)
+          ? true
+          : binding.constantViolations.some((violation) =>
+              constantViolationMayAssignComponent(
+                violation,
+                binding.identifier.name,
+                state,
+                nextSeen,
+                kind
+              )
+            );
+    if (state.parameterSubstitutions.length === 0) {
+      const possibilities =
+        state.componentPossibilities.get(binding) ??
+        new Map<ComponentKind | 'any', boolean>();
+      possibilities.set(cacheKey, result);
+      state.componentPossibilities.set(binding, possibilities);
+    }
+    return result;
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const property = readResolvedMemberProperty(expression, scope, state);
+    const namespace = resolveNamespaceOrigin(
+      expression.object,
+      scope,
+      state,
+      new Set()
+    );
+    const member =
+      namespace && property
+        ? knownExport(namespace.source, property)
+        : undefined;
+    if (member?.type === 'component') {
+      return kind !== 'vue' && (kind !== 'T' || member.name === 'T');
+    }
+    if (member?.type === 'vue-builtin') {
+      return kind !== 'translation' && kind !== 'T';
+    }
+    const arrayIndex = property?.match(/^(0|[1-9]\d*)$/)
+      ? Number(property)
+      : undefined;
+    if (
+      arrayIndex !== undefined &&
+      arrayElementMayProduceComponent(
+        expression.object,
+        arrayIndex,
+        scope,
+        state,
+        seen,
+        kind
+      )
+    ) {
+      return true;
+    }
+    return Boolean(
+      property &&
+      objectPropertyMayProduceComponent(
+        expression.object,
+        property,
+        scope,
+        state,
+        seen,
+        kind
+      )
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = resolveKnownExpression(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    const firstArgument = expression.arguments[0];
+    const first =
+      firstArgument &&
+      firstArgument.type !== 'ArgumentPlaceholder' &&
+      firstArgument.type !== 'SpreadElement'
+        ? firstArgument
+        : undefined;
+    if (callee?.type === 'identity' || callee?.type === 'defineComponent') {
+      return expressionMayProduceComponent(first, scope, state, seen, kind);
+    }
+    if (callee?.type === 'vue-wrapper') {
+      return callee.kind === 'computed'
+        ? computedSourceMayProduceComponent(first, scope, state, seen, kind)
+        : expressionMayProduceComponent(first, scope, state, seen, kind);
+    }
+    const calledFunction = resolveCalledFunction(
+      expression.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (calledFunction) {
+      const mayReturnComponent = withCallParameterSubstitutions(
+        expression,
+        calledFunction,
+        scope,
+        state,
+        () =>
+          functionMayReturnComponent(
+            calledFunction.node,
+            calledFunction.scope,
+            state,
+            seen,
+            kind
+          )
+      );
+      if (mayReturnComponent) return true;
+    }
+    const memberCallee = unwrapExpression(expression.callee);
+    if (
+      memberCallee &&
+      (memberCallee.type === 'MemberExpression' ||
+        memberCallee.type === 'OptionalMemberExpression') &&
+      ['reduce', 'reduceRight'].includes(
+        readResolvedMemberProperty(memberCallee, scope, state) ?? ''
+      )
+    ) {
+      const reduced = reduceCallMayProduceComponent(
+        expression,
+        memberCallee,
+        scope,
+        state,
+        seen,
+        kind
+      );
+      if (reduced !== undefined) return reduced;
+    }
+    return expression.arguments.some(
+      (argument) =>
+        argument.type !== 'ArgumentPlaceholder' &&
+        expressionMayProduceComponent(
+          argument.type === 'SpreadElement' ? argument.argument : argument,
+          scope,
+          state,
+          seen,
+          kind
+        )
+    );
+  }
+  if (expression.type === 'ConditionalExpression') {
+    const condition = readStaticFromScope(
+      expression.test,
+      scope,
+      new Set(),
+      expression.test.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (condition.ok) {
+      return expressionMayProduceComponent(
+        condition.value ? expression.consequent : expression.alternate,
+        scope,
+        state,
+        seen,
+        kind
+      );
+    }
+    return (
+      expressionMayProduceComponent(
+        expression.consequent,
+        scope,
+        state,
+        seen,
+        kind
+      ) ||
+      expressionMayProduceComponent(
+        expression.alternate,
+        scope,
+        state,
+        seen,
+        kind
+      )
+    );
+  }
+  if (expression.type === 'LogicalExpression') {
+    const left = resolveKnownExpression(
+      expression.left,
+      scope,
+      state,
+      new Set()
+    );
+    if (left) {
+      return expression.operator === '&&'
+        ? expressionMayProduceComponent(
+            expression.right,
+            scope,
+            state,
+            seen,
+            kind
+          )
+        : left.type === 'component'
+          ? kind !== 'vue' && (kind !== 'T' || left.name === 'T')
+          : left.type === 'vue-builtin' &&
+            kind !== 'translation' &&
+            kind !== 'T';
+    }
+    const staticLeft = readStaticFromScope(
+      expression.left,
+      scope,
+      new Set(),
+      expression.left.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (staticLeft.ok) {
+      const selectsRight =
+        expression.operator === '??'
+          ? staticLeft.value == null
+          : expression.operator === '||'
+            ? !staticLeft.value
+            : Boolean(staticLeft.value);
+      return selectsRight
+        ? expressionMayProduceComponent(
+            expression.right,
+            scope,
+            state,
+            seen,
+            kind
+          )
+        : false;
+    }
+    return (
+      expressionMayProduceComponent(
+        expression.left,
+        scope,
+        state,
+        seen,
+        kind
+      ) ||
+      expressionMayProduceComponent(expression.right, scope, state, seen, kind)
+    );
+  }
+  if (expression.type === 'SequenceExpression') {
+    return expressionMayProduceComponent(
+      expression.expressions.at(-1),
+      scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return expressionMayProduceComponent(
+      expression.right,
+      scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expressionMayProduceComponent(
+      expression.argument,
+      scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  return false;
+}
+
+/** Models finite reduce calls whose callback invocation order is knowable. */
+function reduceCallMayProduceComponent(
+  call: t.CallExpression | t.OptionalCallExpression,
+  callee: t.MemberExpression | t.OptionalMemberExpression,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean | undefined {
+  const method = readResolvedMemberProperty(callee, scope, state);
+  if (method !== 'reduce' && method !== 'reduceRight') return undefined;
+  const callbackNode = call.arguments[0];
+  if (
+    !callbackNode ||
+    callbackNode.type === 'ArgumentPlaceholder' ||
+    callbackNode.type === 'SpreadElement'
+  ) {
+    return undefined;
+  }
+  const callback = resolveCalledFunction(callbackNode, scope, state, new Set());
+  const entries = collectTransformArrayEntries(
+    callee.object,
+    scope,
+    state,
+    new Set()
+  );
+  if (!callback || !entries || entries.some((entry) => !entry)) {
+    return undefined;
+  }
+  const ordered = entries.map((entry, index) => ({ entry: entry!, index }));
+  if (method === 'reduceRight') ordered.reverse();
+  const initialArgument = call.arguments[1];
+  const initial =
+    initialArgument &&
+    initialArgument.type !== 'ArgumentPlaceholder' &&
+    initialArgument.type !== 'SpreadElement'
+      ? { node: initialArgument, scope }
+      : ordered.shift()?.entry;
+  if (!initial) return false;
+  if (ordered.length === 0) {
+    return expressionMayProduceComponent(
+      initial.node,
+      initial.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  const finalValue = ordered.at(-1)!;
+  const source = { node: callee.object, scope };
+  const invoke = (accumulator: ScopedExpression): boolean =>
+    withFunctionParameterSubstitutions(
+      callback,
+      [
+        accumulator,
+        finalValue.entry,
+        {
+          node: {
+            type: 'NumericLiteral',
+            value: finalValue.index,
+          } as t.NumericLiteral,
+          scope,
+        },
+        source,
+      ],
+      state,
+      () =>
+        functionMayReturnComponent(
+          callback.node,
+          callback.scope,
+          state,
+          seen,
+          kind
+        )
+    );
+  if (ordered.length === 1) return invoke(initial);
+  if (functionMayReturnParameter(callback.node, callback.scope, 1, state)) {
+    return expressionMayProduceComponent(
+      finalValue.entry.node,
+      finalValue.entry.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  if (functionMayReturnParameter(callback.node, callback.scope, 0, state)) {
+    return expressionMayProduceComponent(
+      initial.node,
+      initial.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  return invoke(initial);
+}
+
+/** Tracks a lexical variable populated from a for-of iterable. */
+function bindingIterationMayProduceComponent(
+  binding: Binding,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    declaration.init ||
+    !patternContains(declaration.id, binding.identifier.name)
+  ) {
+    return false;
+  }
+  const declarationPath = state.paths.get(declaration);
+  const loop = declarationPath?.parentPath?.parentPath;
+  if (!loop?.isForOfStatement()) return false;
+  return (
+    expressionMayProduceComponent(
+      loop.node.right,
+      loop.scope,
+      state,
+      seen,
+      kind
+    ) ||
+    containerMayContainComponent(
+      loop.node.right,
+      loop.scope,
+      state,
+      new Set(),
+      kind
+    )
+  );
+}
+
+/** Finds component identities nested in a data container, not function bodies. */
+function containerMayContainComponent(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>,
+  kind?: ComponentKind
+): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return false;
+  const nextSeen = new Set(seen).add(expression);
+  if (expression.type === 'ObjectExpression') {
+    return expression.properties.some((property) => {
+      if (property.type === 'SpreadElement') {
+        return containerMayContainComponent(
+          property.argument,
+          scope,
+          state,
+          nextSeen,
+          kind
+        );
+      }
+      if (property.type === 'ObjectMethod') {
+        return (
+          property.kind === 'get' &&
+          functionMayReturnComponent(property, scope, state, new Set(), kind)
+        );
+      }
+      return (
+        expressionMayProduceComponent(
+          property.value,
+          scope,
+          state,
+          new Set(),
+          kind
+        ) ||
+        containerMayContainComponent(
+          property.value,
+          scope,
+          state,
+          nextSeen,
+          kind
+        )
+      );
+    });
+  }
+  if (expression.type === 'ArrayExpression') {
+    return expression.elements.some((element) => {
+      if (!element) return false;
+      const value =
+        element.type === 'SpreadElement' ? element.argument : element;
+      return (
+        expressionMayProduceComponent(value, scope, state, new Set(), kind) ||
+        containerMayContainComponent(value, scope, state, nextSeen, kind)
+      );
+    });
+  }
+  return false;
+}
+
+/** Tracks one array element without treating sibling values as identity. */
+function arrayElementMayProduceComponent(
+  node: t.Node,
+  index: number,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const expression = unwrapExpression(node);
+  const entry = readArrayEntry(
+    node,
+    index,
+    scope,
+    new Set(),
+    expression?.end ?? Number.POSITIVE_INFINITY,
+    state
+  );
+  if (entry.status === 'known') {
+    return expressionMayProduceComponent(
+      entry.expression.node,
+      entry.expression.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  return findArrayElementOrigins(node, index, scope, new Set(), new Set()).some(
+    (origin) =>
+      expressionMayProduceComponent(
+        origin.node,
+        origin.scope,
+        state,
+        seen,
+        kind
+      )
+  );
+}
+
+/** Finds an array initializer even when its retained container later escapes. */
+function findArrayElementOrigins(
+  node: t.Node,
+  index: number,
+  scope: Scope,
+  seenBindings: Set<Binding>,
+  seenNodes: Set<t.Node>
+): ScopedExpression[] {
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return [];
+  const nextNodes = new Set(seenNodes).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding || seenBindings.has(binding)) return [];
+    const declaration = binding.path.node;
+    return declaration.type === 'VariableDeclarator' && declaration.init
+      ? findArrayElementOrigins(
+          declaration.init,
+          index,
+          binding.path.scope,
+          new Set(seenBindings).add(binding),
+          nextNodes
+        )
+      : [];
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const member = readMemberProperty(expression);
+    const memberIndex = member?.match(/^(0|[1-9]\d*)$/)
+      ? Number(member)
+      : undefined;
+    if (memberIndex === undefined) return [];
+    return findArrayElementOrigins(
+      expression.object,
+      memberIndex,
+      scope,
+      seenBindings,
+      nextNodes
+    ).flatMap((origin) =>
+      findArrayElementOrigins(
+        origin.node,
+        index,
+        origin.scope,
+        seenBindings,
+        nextNodes
+      )
+    );
+  }
+  if (expression.type !== 'ArrayExpression') return [];
+  const element = expression.elements[index];
+  return element && element.type !== 'SpreadElement'
+    ? [{ node: element, scope }]
+    : [];
+}
+
+/** Tracks a destructured value without treating sibling object data as identity. */
+function patternMayProduceComponent(
+  pattern: t.Node,
+  valueNode: t.Node,
+  targetName: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const exposedBase = readExposedMemberPath(valueNode, scope, state);
+  const exposedPath = exposedBase
+    ? readPatternExposedMemberPath(
+        pattern,
+        targetName,
+        exposedBase,
+        scope,
+        state
+      )
+    : undefined;
+  const exposed = exposedPath
+    ? state.analysis.values.get(exposedPath)
+    : undefined;
+  if (exposed?.type === 'component') {
+    return kind !== 'vue' && (kind !== 'T' || exposed.name === 'T');
+  }
+  if (exposed?.type === 'vue-builtin') {
+    return kind !== 'translation' && kind !== 'T';
+  }
+  if (
+    exposedPath &&
+    (kind === 'translation' || kind === 'T'
+      ? state.analysis.uncertainGTComponents.has(exposedPath)
+      : state.analysis.uncertainComponents.has(exposedPath))
+  ) {
+    return true;
+  }
+  if (pattern.type === 'Identifier') {
+    return (
+      pattern.name === targetName &&
+      expressionMayProduceComponent(valueNode, scope, state, seen, kind)
+    );
+  }
+  if (pattern.type === 'RestElement') {
+    return false;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    return patternContains(pattern.left, targetName)
+      ? expressionMayProduceComponent(valueNode, scope, state, seen, kind) ||
+          (expressionMayBeUndefined(valueNode, scope, state, new Set()) &&
+            expressionMayProduceComponent(
+              pattern.right,
+              scope,
+              state,
+              seen,
+              kind
+            ))
+      : false;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (
+        property.type === 'RestElement' &&
+        patternContains(property.argument, targetName)
+      ) {
+        return false;
+      }
+      if (
+        property.type !== 'ObjectProperty' ||
+        !patternContains(property.value, targetName)
+      ) {
+        continue;
+      }
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) {
+        return patternDefaultMayProduceComponent(
+          property.value,
+          targetName,
+          scope,
+          state,
+          seen,
+          kind
+        );
+      }
+      const namespace = resolveNamespaceOrigin(
+        valueNode,
+        scope,
+        state,
+        new Set()
+      );
+      const exported = namespace
+        ? knownExport(namespace.source, key)
+        : undefined;
+      if (
+        exported?.type === 'component' &&
+        kind !== 'vue' &&
+        (kind !== 'T' || exported.name === 'T')
+      ) {
+        return true;
+      }
+      if (
+        exported?.type === 'vue-builtin' &&
+        kind !== 'translation' &&
+        kind !== 'T'
+      )
+        return true;
+      const entry = readObjectEntry(
+        valueNode,
+        key,
+        scope,
+        new Set(),
+        valueNode.end ?? Number.POSITIVE_INFINITY,
+        state
+      );
+      if (entry.status === 'known') {
+        return patternMayProduceComponent(
+          property.value,
+          entry.expression.node,
+          targetName,
+          entry.expression.scope,
+          state,
+          seen,
+          kind
+        );
+      }
+      if (
+        findObjectPropertyOrigins(
+          valueNode,
+          key,
+          scope,
+          new Set(),
+          new Set(),
+          state
+        ).some((origin) =>
+          patternMayProduceComponent(
+            property.value,
+            origin.node,
+            targetName,
+            origin.scope,
+            state,
+            seen,
+            kind
+          )
+        )
+      ) {
+        return true;
+      }
+      return (
+        objectGetterMayProduceComponent(
+          valueNode,
+          key,
+          scope,
+          state,
+          seen,
+          kind
+        ) ||
+        patternDefaultMayProduceComponent(
+          property.value,
+          targetName,
+          scope,
+          state,
+          seen,
+          kind
+        )
+      );
+    }
+    return false;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (let index = 0; index < pattern.elements.length; index += 1) {
+      const target = pattern.elements[index];
+      if (!target || !patternContains(target, targetName)) continue;
+      if (target.type === 'RestElement') {
+        return false;
+      }
+      const entry = readArrayEntry(
+        valueNode,
+        index,
+        scope,
+        new Set(),
+        valueNode.end ?? Number.POSITIVE_INFINITY,
+        state
+      );
+      if (entry.status === 'known') {
+        return patternMayProduceComponent(
+          target,
+          entry.expression.node,
+          targetName,
+          entry.expression.scope,
+          state,
+          seen,
+          kind
+        );
+      }
+      return (
+        findArrayElementOrigins(
+          valueNode,
+          index,
+          scope,
+          new Set(),
+          new Set()
+        ).some((origin) =>
+          patternMayProduceComponent(
+            target,
+            origin.node,
+            targetName,
+            origin.scope,
+            state,
+            seen,
+            kind
+          )
+        ) ||
+        patternDefaultMayProduceComponent(
+          target,
+          targetName,
+          scope,
+          state,
+          seen,
+          kind
+        )
+      );
+    }
+  }
+  return false;
+}
+
+/** Tracks a destructuring default when the selected source value is unknown. */
+function patternDefaultMayProduceComponent(
+  pattern: t.Node,
+  targetName: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  if (pattern.type === 'AssignmentPattern') {
+    return (
+      patternContains(pattern.left, targetName) &&
+      expressionMayProduceComponent(pattern.right, scope, state, seen, kind)
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return pattern.properties.some(
+      (property) =>
+        property.type === 'ObjectProperty' &&
+        patternContains(property.value, targetName) &&
+        patternDefaultMayProduceComponent(
+          property.value,
+          targetName,
+          scope,
+          state,
+          seen,
+          kind
+        )
+    );
+  }
+  if (pattern.type === 'ArrayPattern') {
+    return pattern.elements.some(
+      (element) =>
+        !!element &&
+        patternContains(element, targetName) &&
+        patternDefaultMayProduceComponent(
+          element,
+          targetName,
+          scope,
+          state,
+          seen,
+          kind
+        )
+    );
+  }
+  return false;
+}
+
+/** Finds a namespace's source even when mutation makes its value untrusted. */
+function resolveNamespaceOrigin(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): Extract<KnownValue, { type: 'namespace' }> | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  const required = readRequireNamespace(expression, scope);
+  if (required) return required;
+  if (expression.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(expression.name);
+  if (!binding) {
+    const value = state.analysis.values.get(expression.name);
+    return value?.type === 'namespace' ? value : undefined;
+  }
+  if (seen.has(binding)) return undefined;
+  const existing = state.bindings.get(binding);
+  if (existing?.type === 'namespace') return existing;
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    declaration.id.type !== 'Identifier' ||
+    !declaration.init
+  ) {
+    return undefined;
+  }
+  return resolveNamespaceOrigin(
+    declaration.init,
+    binding.path.scope,
+    state,
+    new Set(seen).add(binding)
+  );
+}
+
+/** Resolves one object property's resulting identity, not arbitrary siblings. */
+function objectPropertyMayProduceComponent(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const entry = readObjectEntry(
+    node,
+    key,
+    scope,
+    new Set(),
+    node.end ?? Number.POSITIVE_INFINITY,
+    state
+  );
+  return entry.status === 'known'
+    ? expressionMayProduceComponent(
+        entry.expression.node,
+        entry.expression.scope,
+        state,
+        seen,
+        kind
+      )
+    : objectGetterMayProduceComponent(node, key, scope, state, seen, kind) ||
+        objectPropertyOriginMayProduceComponent(
+          node,
+          key,
+          scope,
+          state,
+          seen,
+          new Set(),
+          kind
+        );
+}
+
+/** Retains selected-key provenance when mutation makes a container unsafe. */
+function objectPropertyOriginMayProduceComponent(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  state: ScriptState,
+  seenBindings: Set<Binding>,
+  seenNodes: Set<t.Node>,
+  kind?: ComponentKind
+): boolean {
+  return findObjectPropertyOrigins(
+    node,
+    key,
+    scope,
+    seenBindings,
+    seenNodes,
+    state
+  ).some((origin) =>
+    expressionMayProduceComponent(
+      origin.node,
+      origin.scope,
+      state,
+      seenBindings,
+      kind
+    )
+  );
+}
+
+/** Finds selected property initializers even when their container later escapes. */
+function findObjectPropertyOrigins(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  seenBindings: Set<Binding>,
+  seenNodes: Set<t.Node>,
+  state: ScriptState
+): ScopedExpression[] {
+  const expression = unwrapExpression(node);
+  if (!expression || seenNodes.has(expression)) return [];
+  const nextNodes = new Set(seenNodes).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding || seenBindings.has(binding)) return [];
+    const declaration = binding.path.node;
+    return declaration.type === 'VariableDeclarator' && declaration.init
+      ? findObjectPropertyOrigins(
+          declaration.init,
+          key,
+          binding.path.scope,
+          new Set(seenBindings).add(binding),
+          nextNodes,
+          state
+        )
+      : [];
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const member = readMemberProperty(expression);
+    if (!member) return [];
+    return findObjectPropertyOrigins(
+      expression.object,
+      member,
+      scope,
+      seenBindings,
+      nextNodes,
+      state
+    ).flatMap((origin) =>
+      findObjectPropertyOrigins(
+        origin.node,
+        key,
+        origin.scope,
+        seenBindings,
+        nextNodes,
+        state
+      )
+    );
+  }
+  if (expression.type !== 'ObjectExpression') return [];
+  return expression.properties.flatMap((property) => {
+    if (property.type === 'SpreadElement') {
+      return findObjectPropertyOrigins(
+        property.argument,
+        key,
+        scope,
+        seenBindings,
+        nextNodes,
+        state
+      );
+    }
+    return readResolvedPropertyKey(property, scope, state) === key &&
+      property.type === 'ObjectProperty'
+      ? [{ node: property.value, scope }]
+      : [];
+  });
+}
+
+/** Evaluates a literal getter only when that getter supplies the selected key. */
+function objectGetterMayProduceComponent(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const object = resolveObjectExpression(node, scope, new Set());
+  if (!object) return false;
+  for (let index = object.node.properties.length - 1; index >= 0; index -= 1) {
+    const property = object.node.properties[index];
+    if (property.type === 'SpreadElement') continue;
+    if (readResolvedPropertyKey(property, object.scope, state) !== key) {
+      continue;
+    }
+    return (
+      property.type === 'ObjectMethod' &&
+      property.kind === 'get' &&
+      functionMayReturnComponent(property, object.scope, state, seen, kind)
+    );
+  }
+  return false;
+}
+
+/** Evaluates a literal getter only for possible string-function results. */
+function objectGetterMayProduceStringFunction(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  const object = resolveObjectExpression(node, scope, new Set());
+  if (!object) return false;
+  for (let index = object.node.properties.length - 1; index >= 0; index -= 1) {
+    const property = object.node.properties[index];
+    if (property.type === 'SpreadElement') continue;
+    if (readResolvedPropertyKey(property, object.scope, state) !== key) {
+      continue;
+    }
+    return (
+      property.type === 'ObjectMethod' &&
+      property.kind === 'get' &&
+      functionMayReturnStringFunction(property, object.scope, state, seen)
+    );
+  }
+  return false;
+}
+
+/** Evaluates the value source accepted by Vue's computed wrapper. */
+function computedSourceMayProduceComponent(
+  node: t.Node | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const called = resolveCalledFunction(node, scope, state, new Set());
+  if (called) {
+    return functionMayReturnComponent(
+      called.node,
+      called.scope,
+      state,
+      seen,
+      kind
+    );
+  }
+  const object = node
+    ? resolveObjectExpression(node, scope, new Set())
+    : undefined;
+  if (!object) return false;
+  for (const property of object.node.properties) {
+    if (property.type === 'SpreadElement') continue;
+    if (readResolvedPropertyKey(property, object.scope, state) !== 'get') {
+      continue;
+    }
+    if (property.type === 'ObjectMethod') {
+      return functionMayReturnComponent(
+        property,
+        object.scope,
+        state,
+        seen,
+        kind
+      );
+    }
+    if (property.type === 'ObjectProperty') {
+      const getter = resolveCalledFunction(
+        property.value,
+        object.scope,
+        state,
+        new Set()
+      );
+      return Boolean(
+        getter &&
+        functionMayReturnComponent(getter.node, getter.scope, state, seen, kind)
+      );
+    }
+  }
+  return false;
+}
+
+/** Evaluates the computed getter for possible string-function results. */
+function computedSourceMayProduceStringFunction(
+  node: t.Node | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  if (!node) return false;
+  const getter = resolveComputedGetter(node, scope, state);
+  return Boolean(
+    getter &&
+    functionMayReturnStringFunction(getter.node, getter.scope, state, seen)
+  );
+}
+
+/** Resolves a statically invoked local function without invoking user code. */
+function resolveCalledFunction(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>
+): (ScopedExpression & { node: t.Function }) | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  seen.add(expression);
+  if (
+    expression.type === 'FunctionDeclaration' ||
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'ObjectMethod'
+  ) {
+    return { node: expression, scope };
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = unwrapExpression(expression.callee);
+    return callee &&
+      (callee.type === 'MemberExpression' ||
+        callee.type === 'OptionalMemberExpression') &&
+      readResolvedMemberProperty(callee, scope, state) === 'bind'
+      ? resolveCalledFunction(callee.object, scope, state, seen)
+      : undefined;
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const property = readResolvedMemberProperty(expression, scope, state);
+    if (!property) return undefined;
+    const namespace = resolveKnownExpression(
+      expression.object,
+      scope,
+      state,
+      new Set()
+    );
+    if (namespace?.type === 'local-namespace') {
+      const resolution = state.analysis.localModules?.resolveExport(
+        namespace.modulePath,
+        property
+      );
+      if (resolution?.status === 'resolved') {
+        const callable = materializeLocalExport(
+          resolution.target,
+          state
+        ).callable;
+        if (callable) return callable;
+      }
+    }
+    const object = resolveObjectExpression(expression.object, scope, new Set());
+    if (object) {
+      for (const candidate of object.node.properties) {
+        if (
+          candidate.type === 'ObjectMethod' &&
+          candidate.kind === 'method' &&
+          readResolvedPropertyKey(candidate, object.scope, state) === property
+        ) {
+          return { node: candidate, scope: object.scope };
+        }
+      }
+    }
+    for (const origin of findObjectPropertyOrigins(
+      expression.object,
+      property,
+      scope,
+      new Set(),
+      new Set(),
+      state
+    )) {
+      const called = resolveCalledFunction(
+        origin.node,
+        origin.scope,
+        state,
+        seen
+      );
+      if (called) return called;
+    }
+    return undefined;
+  }
+  if (expression.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(expression.name);
+  const substitution = binding
+    ? readParameterSubstitution(binding, state)
+    : undefined;
+  if (substitution) {
+    return resolveCalledFunction(
+      substitution.node,
+      substitution.scope,
+      state,
+      seen
+    );
+  }
+  const imported = binding
+    ? state.localCallableBindings.get(binding)
+    : undefined;
+  if (imported) return imported;
+  if (binding?.path.isFunctionDeclaration() && binding.constant) {
+    return { node: binding.path.node, scope: binding.path.scope };
+  }
+  if (!binding || !binding.constant) return undefined;
+  const declaration = binding?.path.node;
+  if (declaration?.type !== 'VariableDeclarator' || !declaration.init) {
+    return undefined;
+  }
+  if (declaration.id.type === 'Identifier') {
+    return resolveCalledFunction(
+      declaration.init,
+      binding.path.scope,
+      state,
+      seen
+    );
+  }
+  const selected = selectPatternExpression(
+    declaration.id,
+    declaration.init,
+    expression.name,
+    binding.path.scope,
+    declaration.init.end ?? Number.POSITIVE_INFINITY,
+    state
+  );
+  return selected
+    ? resolveCalledFunction(selected.node, selected.scope, state, seen)
+    : undefined;
+}
+
+/** Detects a call whose implementation is outside this source file. */
+function callTargetsUnknownImport(node: t.Node, scope: Scope): boolean {
+  const expression = unwrapExpression(node);
+  if (!expression || expression.type !== 'Identifier') return false;
+  const binding = scope.getBinding(expression.name);
+  const parent = binding?.path.parentPath;
+  return Boolean(
+    binding?.path.isImportSpecifier() ||
+      binding?.path.isImportDefaultSpecifier() ||
+      binding?.path.isImportNamespaceSpecifier()
+      ? parent?.isImportDeclaration() &&
+          parent.node.source.value !== 'gt-vue' &&
+          parent.node.source.value !== 'vue'
+      : false
+  );
+}
+
+/** Checks only values returned by an invoked function, excluding nested bodies. */
+function functionMayReturnComponent(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  if (state.activeComponentFunctions.has(fn)) return false;
+  state.activeComponentFunctions.add(fn);
+  try {
+    return functionBodyMayReturnComponent(fn, scope, state, seen, kind);
+  } finally {
+    state.activeComponentFunctions.delete(fn);
+  }
+}
+
+/** Checks only values returned by a function for string-function identity. */
+function functionMayReturnStringFunction(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  if (state.activeStringFunctions.has(fn)) return false;
+  state.activeStringFunctions.add(fn);
+  try {
+    const functionScope = state.scopes.get(fn) ?? scope;
+    if (
+      fn.type === 'ArrowFunctionExpression' &&
+      fn.body.type !== 'BlockStatement'
+    ) {
+      return expressionMayProduceStringFunction(
+        fn.body,
+        functionScope,
+        state,
+        seen
+      );
+    }
+    const functionPath = state.paths.get(fn);
+    if (!functionPath || fn.body.type !== 'BlockStatement') return false;
+    let result = false;
+    functionPath.traverse({
+      Function(path) {
+        path.skip();
+      },
+      ReturnStatement(path) {
+        if (
+          expressionMayProduceStringFunction(
+            path.node.argument,
+            path.scope,
+            state,
+            seen
+          )
+        ) {
+          result = true;
+          path.stop();
+        }
+      },
+    });
+    return result;
+  } finally {
+    state.activeStringFunctions.delete(fn);
+  }
+}
+
+function functionBodyMayReturnComponent(
+  fn: t.Function,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<Binding>,
+  kind?: ComponentKind
+): boolean {
+  const functionScope = state.scopes.get(fn) ?? scope;
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return expressionMayProduceComponent(
+      fn.body,
+      functionScope,
+      state,
+      seen,
+      kind
+    );
+  }
+  const functionPath = state.paths.get(fn);
+  if (!functionPath || fn.body.type !== 'BlockStatement') return false;
+  let result = false;
+  functionPath.traverse({
+    Function(path) {
+      path.skip();
+    },
+    ReturnStatement(path) {
+      if (
+        expressionMayProduceComponent(
+          path.node.argument,
+          path.scope,
+          state,
+          seen,
+          kind
+        )
+      ) {
+        result = true;
+        path.stop();
+      }
+    },
+  });
+  return result;
+}
+
+/** Returns whether unresolved Options API data can hide template GT bindings. */
+function hasTemplateRelevantBindings(state: ScriptState): boolean {
+  return [...state.bindings.values(), ...state.analysis.values.values()].some(
+    (value) =>
+      value.type === 'component' ||
+      value.type === 'hook' ||
+      value.type === 'vue-builtin' ||
+      value.type === 'namespace' ||
+      value.type === 'local-namespace' ||
+      value.type === 'string'
+  );
+}
+
+function resolveOptionsObject(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>
+): ScopedExpression | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  seen.add(expression);
+  if (expression.type === 'ObjectExpression')
+    return { node: expression, scope };
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (
+      !binding ||
+      !isSafelyReadContainerBinding(
+        binding,
+        expression,
+        Number.POSITIVE_INFINITY,
+        false,
+        state
+      )
+    ) {
+      return undefined;
+    }
+    const source = getBindingSource(binding);
+    return source
+      ? resolveOptionsObject(
+          source.expression.node,
+          source.expression.scope,
+          state,
+          seen
+        )
+      : undefined;
+  }
+  if (
+    expression.type !== 'CallExpression' &&
+    expression.type !== 'OptionalCallExpression'
+  ) {
+    return undefined;
+  }
+  const callee = resolveKnownExpression(
+    expression.callee,
+    scope,
+    state,
+    new Set()
+  );
+  if (callee?.type !== 'defineComponent') return undefined;
+  const argument = expression.arguments[0];
+  return argument &&
+    argument.type !== 'SpreadElement' &&
+    argument.type !== 'ArgumentPlaceholder'
+    ? resolveOptionsObject(argument, scope, state, seen)
+    : undefined;
+}
+
+function resolveSetupFunction(
+  node: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>
+): t.Function | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  seen.add(expression);
+  if (
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'ObjectMethod'
+  ) {
+    return expression;
+  }
+  if (expression.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(expression.name);
+  if (binding?.path.isFunctionDeclaration()) return binding.path.node;
+  const source = binding ? getBindingSource(binding) : undefined;
+  return source
+    ? resolveSetupFunction(
+        source.expression.node,
+        source.expression.scope,
+        seen
+      )
+    : undefined;
+}
+
+function collectObjectEntries(
+  node: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>,
+  atPosition = node.start ?? Number.POSITIVE_INFINITY,
+  state?: ScriptState
+): CollectedObjectEntries {
+  const result: CollectedObjectEntries = {
+    entries: new Map(),
+    unknownAll: false,
+    unknownNames: new Set(),
+  };
+  const object = resolveObjectExpression(node, scope, seen, atPosition);
+  if (!object) {
+    result.unknownAll = true;
+    return result;
+  }
+  for (const property of object.node.properties) {
+    if (property.type === 'SpreadElement') {
+      const spreadObject = resolveObjectExpression(
+        property.argument,
+        object.scope,
+        new Set(seen),
+        property.argument.start ?? atPosition
+      );
+      if (!spreadObject) {
+        result.entries.clear();
+        result.unknownNames.clear();
+        result.unknownAll = true;
+        continue;
+      }
+      const spreadEntries = collectObjectEntries(
+        spreadObject.node,
+        spreadObject.scope,
+        new Set(seen),
+        property.argument.start ?? atPosition,
+        state
+      );
+      if (spreadEntries.unknownAll) {
+        result.entries.clear();
+        result.unknownNames.clear();
+        result.unknownAll = true;
+      }
+      for (const name of spreadEntries.unknownNames) {
+        result.entries.delete(name);
+        result.unknownNames.add(name);
+      }
+      for (const [name, entry] of spreadEntries.entries) {
+        result.entries.set(name, entry);
+        result.unknownNames.delete(name);
+      }
+      continue;
+    }
+    const key = state
+      ? readResolvedPropertyKey(property, object.scope, state)
+      : readPropertyKey(property);
+    if (key === undefined) {
+      result.entries.clear();
+      result.unknownNames.clear();
+      result.unknownAll = true;
+      continue;
+    }
+    if (property.type === 'ObjectProperty') {
+      result.entries.set(key, { node: property.value, scope: object.scope });
+      result.unknownNames.delete(key);
+    } else if (property.type === 'ObjectMethod' && property.kind === 'method') {
+      result.entries.set(key, { node: property, scope: object.scope });
+      result.unknownNames.delete(key);
+    } else {
+      result.entries.delete(key);
+      result.unknownNames.add(key);
+    }
+  }
+  return result;
+}
+
+function resolveObjectExpression(
+  node: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>,
+  atPosition = node.start ?? Number.POSITIVE_INFINITY
+): { node: t.ObjectExpression; scope: Scope } | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  seen.add(expression);
+  if (expression.type === 'ObjectExpression')
+    return { node: expression, scope };
+  if (expression.type !== 'Identifier') return undefined;
+  const binding = scope.getBinding(expression.name);
+  if (
+    !binding ||
+    !isSafelyReadContainerBinding(binding, expression, atPosition)
+  ) {
+    return undefined;
+  }
+  const source = getBindingSource(binding);
+  return source
+    ? resolveObjectExpression(
+        source.expression.node,
+        source.expression.scope,
+        seen,
+        atPosition
+      )
+    : undefined;
+}
+
+/** Reads one flattened array entry while honoring spread copy timing. */
+function readArrayEntry(
+  node: t.Node,
+  index: number,
+  scope: Scope,
+  seen: Set<t.Node>,
+  atPosition = node.end ?? Number.POSITIVE_INFINITY,
+  state?: ScriptState
+): ObjectEntryResult {
+  const entries = state
+    ? collectTransformArrayEntries(node, scope, state, seen, atPosition)
+    : collectArrayEntries(node, scope, seen, atPosition, state);
+  if (!entries) return { status: 'unknown' };
+  const entry = entries[index];
+  return entry ? { status: 'known', expression: entry } : { status: 'absent' };
+}
+
+/** Flattens only statically knowable array literals and array spreads. */
+function collectArrayEntries(
+  node: t.Node,
+  scope: Scope,
+  seen: Set<t.Node>,
+  atPosition: number,
+  state?: ScriptState
+): Array<ScopedExpression | undefined> | undefined {
+  if (state?.analysis.stats) state.analysis.stats.arrayEntryVisits += 1;
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  if (
+    state &&
+    resolveKnownExpression(expression, scope, state, new Set()) !== undefined
+  ) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen).add(expression);
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) return undefined;
+    const cacheable = Boolean(
+      state && binding.constant && state.parameterSubstitutions.length === 0
+    );
+    if (cacheable && state?.arrayEntries.has(binding)) {
+      const cached = state.arrayEntries.get(binding);
+      return cached ? [...cached] : undefined;
+    }
+    if (cacheable && state?.arrayEntriesInProgress.has(binding)) {
+      return undefined;
+    }
+    if (cacheable) state?.arrayEntriesInProgress.add(binding);
+    try {
+      if (
+        !isSafelyReadContainerBinding(
+          binding,
+          expression,
+          atPosition,
+          false,
+          state
+        )
+      ) {
+        if (cacheable) state?.arrayEntries.set(binding, null);
+        return undefined;
+      }
+      const source = getBindingSource(binding);
+      const entries =
+        source?.pattern.type === 'Identifier'
+          ? collectArrayEntries(
+              source.expression.node,
+              source.expression.scope,
+              nextSeen,
+              atPosition,
+              state
+            )
+          : undefined;
+      if (cacheable) {
+        state?.arrayEntries.set(binding, entries ? [...entries] : null);
+      }
+      return entries;
+    } finally {
+      if (cacheable) state?.arrayEntriesInProgress.delete(binding);
+    }
+  }
+  if (expression.type !== 'ArrayExpression') return undefined;
+  const entries: Array<ScopedExpression | undefined> = [];
+  for (const element of expression.elements) {
+    if (!element) {
+      entries.push(undefined);
+      continue;
+    }
+    if (element.type !== 'SpreadElement') {
+      entries.push({ node: element, scope });
+      continue;
+    }
+    const spread = collectArrayEntries(
+      element.argument,
+      scope,
+      nextSeen,
+      element.argument.end ?? atPosition,
+      state
+    );
+    if (!spread) return undefined;
+    entries.push(...spread);
+  }
+  return entries;
+}
+
+/** Resolves finite array-producing transforms for callbacks and destructuring. */
+function collectTransformArrayEntries(
+  node: t.Node,
+  scope: Scope,
+  state: ScriptState,
+  seen: Set<t.Node>,
+  atPosition = node.end ?? Number.POSITIVE_INFINITY
+): Array<ScopedExpression | undefined> | undefined {
+  if (state.analysis.stats) {
+    state.analysis.stats.transformArrayEntryVisits += 1;
+  }
+  const direct = collectArrayEntries(node, scope, seen, atPosition, state);
+  if (direct) return direct;
+  const expression = unwrapExpression(node);
+  if (
+    expression &&
+    resolveKnownExpression(expression, scope, state, new Set()) !== undefined
+  ) {
+    return undefined;
+  }
+  if (expression?.type === 'Identifier' && !seen.has(expression)) {
+    const binding = scope.getBinding(expression.name);
+    const source = binding ? getBindingSource(binding) : undefined;
+    const readonlyUses = binding
+      ? bindingHasOnlyReadonlyContainerUses(binding, state, new Set())
+      : false;
+    if (
+      binding &&
+      source?.pattern.type === 'Identifier' &&
+      (isSafelyReadContainerBinding(
+        binding,
+        expression,
+        atPosition,
+        true,
+        state
+      ) ||
+        readonlyUses)
+    ) {
+      const cacheable =
+        readonlyUses && state.parameterSubstitutions.length === 0;
+      const cached = cacheable
+        ? state.transformArrayEntries.get(binding)
+        : undefined;
+      if (cached !== undefined) {
+        return cached ? [...cached] : undefined;
+      }
+      if (cacheable && state.transformArrayEntriesInProgress.has(binding)) {
+        return undefined;
+      }
+      if (cacheable) state.transformArrayEntriesInProgress.add(binding);
+      try {
+        const entries = collectTransformArrayEntries(
+          source.expression.node,
+          source.expression.scope,
+          state,
+          new Set(seen).add(expression),
+          atPosition
+        );
+        if (cacheable) {
+          state.transformArrayEntries.set(
+            binding,
+            entries ? [...entries] : null
+          );
+        }
+        return entries;
+      } finally {
+        if (cacheable) state.transformArrayEntriesInProgress.delete(binding);
+      }
+    }
+  }
+  if (
+    !expression ||
+    seen.has(expression) ||
+    (expression.type !== 'CallExpression' &&
+      expression.type !== 'OptionalCallExpression')
+  ) {
+    return undefined;
+  }
+  const callee = unwrapExpression(expression.callee);
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'OptionalMemberExpression')
+  ) {
+    return undefined;
+  }
+  const nextSeen = new Set(seen).add(expression);
+  const method = readResolvedMemberProperty(callee, scope, state);
+  const receiverPath = readResolvedMemberPath(callee.object, scope, state);
+  const argument = (index: number): t.Node | undefined => {
+    const value = expression.arguments[index];
+    return value && value.type !== 'ArgumentPlaceholder'
+      ? value.type === 'SpreadElement'
+        ? value.argument
+        : value
+      : undefined;
+  };
+  const integerArgument = (
+    index: number,
+    fallback: number
+  ): { ok: true; value: number } | { ok: false } => {
+    const node = argument(index);
+    if (!node) return { ok: true, value: fallback };
+    const value = readStaticFromScope(
+      node,
+      scope,
+      new Set(),
+      node.end ?? atPosition,
+      state.analysis,
+      true
+    );
+    if (!value.ok || typeof value.value === 'bigint') return { ok: false };
+    try {
+      const numeric = Number(value.value);
+      return {
+        ok: true,
+        value: Number.isNaN(numeric) ? 0 : Math.trunc(numeric),
+      };
+    } catch {
+      return { ok: false };
+    }
+  };
+  if (
+    receiverPath === 'Array' &&
+    method === 'from' &&
+    !scope.getBinding('Array')
+  ) {
+    const source = argument(0);
+    const entries = source
+      ? collectTransformArrayEntries(source, scope, state, nextSeen, atPosition)
+      : undefined;
+    const mapperNode = argument(1);
+    const mapper = mapperNode
+      ? resolveCalledFunction(mapperNode, scope, state, new Set())
+      : undefined;
+    if (!entries || !mapperNode) return entries;
+    if (!mapper) return undefined;
+    const mapped: Array<ScopedExpression | undefined> = [];
+    for (const [index, entry] of entries.entries()) {
+      if (!entry) {
+        mapped.push(undefined);
+        continue;
+      }
+      withFunctionParameterSubstitutions(
+        mapper,
+        [
+          entry,
+          {
+            node: {
+              type: 'NumericLiteral',
+              value: index,
+            } as t.NumericLiteral,
+            scope,
+          },
+        ],
+        state,
+        () =>
+          withFunctionThisSubstitution(
+            mapper,
+            argument(2) ? { node: argument(2)!, scope } : undefined,
+            state,
+            () => {
+              for (const returned of collectFunctionReturnExpressions(
+                mapper.node,
+                mapper.scope,
+                state
+              )) {
+                mapped.push(
+                  materializeParameterExpression(
+                    returned.node,
+                    returned.scope,
+                    state
+                  )
+                );
+              }
+            }
+          )
+      );
+    }
+    return mapped;
+  }
+  if (
+    receiverPath === 'Object' &&
+    (method === 'values' || method === 'entries') &&
+    !scope.getBinding('Object')
+  ) {
+    const source = argument(0);
+    if (!source) return undefined;
+    const object = collectObjectEntries(
+      source,
+      scope,
+      new Set(),
+      atPosition,
+      state
+    );
+    if (object.unknownAll || object.unknownNames.size > 0) return undefined;
+    return [...object.entries].map(([key, value]) =>
+      method === 'values'
+        ? value
+        : {
+            node: {
+              type: 'ArrayExpression',
+              elements: [
+                { type: 'StringLiteral', value: key } as t.StringLiteral,
+                value.node,
+              ],
+            } as t.ArrayExpression,
+            scope: value.scope,
+          }
+    );
+  }
+  if (!method) return undefined;
+  if (method === 'concat') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    if (!entries) return undefined;
+    const concatenated = [...entries];
+    for (const value of expression.arguments) {
+      if (
+        value.type === 'ArgumentPlaceholder' ||
+        value.type === 'SpreadElement'
+      ) {
+        return undefined;
+      }
+      const nested = collectTransformArrayEntries(
+        value,
+        scope,
+        state,
+        nextSeen,
+        atPosition
+      );
+      if (nested) concatenated.push(...nested);
+      else concatenated.push({ node: value, scope });
+    }
+    return concatenated;
+  }
+  if (method === 'reduce' || method === 'reduceRight') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const callbackNode = argument(0);
+    const callback = callbackNode
+      ? resolveCalledFunction(callbackNode, scope, state, new Set())
+      : undefined;
+    if (!entries || !callback) return undefined;
+    const ordered = entries
+      .map((entry, index) => (entry ? { entry, index } : undefined))
+      .filter(
+        (entry): entry is { entry: ScopedExpression; index: number } =>
+          entry !== undefined
+      );
+    if (method === 'reduceRight') ordered.reverse();
+    const initial = argument(1);
+    let accumulator: ScopedExpression | undefined = initial
+      ? materializeParameterExpression(initial, scope, state)
+      : ordered.shift()?.entry;
+    if (!accumulator) return undefined;
+    for (const current of ordered) {
+      const currentAccumulator: ScopedExpression = accumulator;
+      const nextAccumulator: ScopedExpression | undefined =
+        withFunctionParameterSubstitutions(
+          callback,
+          [
+            currentAccumulator,
+            current.entry,
+            {
+              node: {
+                type: 'NumericLiteral',
+                value: current.index,
+              } as t.NumericLiteral,
+              scope,
+            },
+            { node: callee.object, scope },
+          ],
+          state,
+          () => {
+            const returned = collectFunctionReturnExpressions(
+              callback.node,
+              callback.scope,
+              state
+            );
+            return returned.length === 1
+              ? materializeParameterExpression(
+                  returned[0]!.node,
+                  returned[0]!.scope,
+                  state
+                )
+              : undefined;
+          }
+        );
+      if (!nextAccumulator) return undefined;
+      accumulator = nextAccumulator;
+    }
+    return collectTransformArrayEntries(
+      accumulator.node,
+      accumulator.scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+  }
+  if (method === 'filter') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const callbackNode = argument(0);
+    const callback = callbackNode
+      ? resolveCalledFunction(callbackNode, scope, state, new Set())
+      : undefined;
+    if (!entries || !callback) return undefined;
+    const filtered: Array<ScopedExpression | undefined> = [];
+    for (const [index, entry] of entries.entries()) {
+      if (!entry) continue;
+      const keep = withFunctionParameterSubstitutions(
+        callback,
+        [
+          entry,
+          {
+            node: { type: 'NumericLiteral', value: index } as t.NumericLiteral,
+            scope,
+          },
+          { node: callee.object, scope },
+        ],
+        state,
+        () =>
+          withFunctionThisSubstitution(
+            callback,
+            argument(1) ? { node: argument(1)!, scope } : undefined,
+            state,
+            () => {
+              const returned = collectFunctionReturnExpressions(
+                callback.node,
+                callback.scope,
+                state
+              );
+              if (returned.length === 0) return false;
+              const decisions = returned.map((value) => {
+                const materialized = materializeParameterExpression(
+                  value.node,
+                  value.scope,
+                  state
+                );
+                const result = readStaticFromScope(
+                  materialized.node,
+                  materialized.scope,
+                  new Set(),
+                  materialized.node.end ?? atPosition,
+                  state.analysis
+                );
+                return result.ok ? Boolean(result.value) : undefined;
+              });
+              return decisions.every((decision) => decision === false)
+                ? false
+                : decisions.every((decision) => decision === true)
+                  ? true
+                  : undefined;
+            }
+          )
+      );
+      if (keep === undefined) return undefined;
+      if (keep) filtered.push(entry);
+    }
+    return filtered;
+  }
+  if (method === 'slice') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const start = integerArgument(0, 0);
+    const end = integerArgument(1, entries?.length ?? 0);
+    return entries && start.ok && end.ok
+      ? entries.slice(start.value, end.value)
+      : undefined;
+  }
+  if (method === 'splice') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const start = integerArgument(0, 0);
+    const deleteCount = integerArgument(
+      1,
+      expression.arguments.length < 2 ? Number.POSITIVE_INFINITY : 0
+    );
+    if (!entries || !start.ok || !deleteCount.ok) return undefined;
+    const copy = [...entries];
+    return copy.splice(start.value, Math.max(0, deleteCount.value));
+  }
+  if (method === 'toSpliced') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const start = integerArgument(0, 0);
+    const deleteCount = integerArgument(
+      1,
+      expression.arguments.length < 2 ? Number.POSITIVE_INFINITY : 0
+    );
+    if (
+      !entries ||
+      !start.ok ||
+      !deleteCount.ok ||
+      expression.arguments
+        .slice(2)
+        .some((value) => value.type === 'SpreadElement')
+    ) {
+      return undefined;
+    }
+    const copy = [...entries];
+    copy.splice(
+      start.value,
+      Math.max(0, deleteCount.value),
+      ...expression.arguments.slice(2).map((node) => ({ node, scope }))
+    );
+    return copy;
+  }
+  if (method === 'with') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const index = integerArgument(0, 0);
+    const value = expression.arguments[1];
+    if (
+      !entries ||
+      !index.ok ||
+      !value ||
+      value.type === 'ArgumentPlaceholder' ||
+      value.type === 'SpreadElement'
+    ) {
+      return undefined;
+    }
+    const normalized =
+      index.value < 0 ? entries.length + index.value : index.value;
+    if (normalized < 0 || normalized >= entries.length) return [];
+    const copy = [...entries];
+    copy[normalized] = { node: value, scope };
+    return copy;
+  }
+  if (method === 'fill') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const start = integerArgument(1, 0);
+    const end = integerArgument(2, entries?.length ?? 0);
+    const value = expression.arguments[0];
+    if (!entries || !start.ok || !end.ok || value?.type === 'SpreadElement') {
+      return undefined;
+    }
+    return [...entries].fill(
+      value && value.type !== 'ArgumentPlaceholder'
+        ? { node: value, scope }
+        : undefined,
+      start.value,
+      end.value
+    );
+  }
+  if (method === 'copyWithin') {
+    const entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    const target = integerArgument(0, 0);
+    const start = integerArgument(1, 0);
+    const end = integerArgument(2, entries?.length ?? 0);
+    return entries && target.ok && start.ok && end.ok
+      ? [...entries].copyWithin(target.value, start.value, end.value)
+      : undefined;
+  }
+  if (['reverse', 'sort', 'toReversed', 'toSorted'].includes(method)) {
+    return collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+  }
+  if (method === 'flat') {
+    let entries = collectTransformArrayEntries(
+      callee.object,
+      scope,
+      state,
+      nextSeen,
+      atPosition
+    );
+    if (!entries) return undefined;
+    const depthNode = argument(0);
+    const staticDepth = depthNode
+      ? readStaticFromScope(
+          depthNode,
+          scope,
+          new Set(),
+          depthNode.end ?? atPosition,
+          state.analysis,
+          true
+        )
+      : { ok: true as const, value: 1 };
+    if (!staticDepth.ok || typeof staticDepth.value === 'bigint') {
+      return undefined;
+    }
+    const numericDepth = Number(staticDepth.value);
+    const depth = Number.isNaN(numericDepth)
+      ? 0
+      : numericDepth === Number.POSITIVE_INFINITY
+        ? 32
+        : Math.max(0, Math.trunc(numericDepth));
+    for (let level = 0; level < depth; level += 1) {
+      const flattened: Array<ScopedExpression | undefined> = [];
+      let changed = false;
+      for (const entry of entries) {
+        if (!entry) {
+          flattened.push(undefined);
+          continue;
+        }
+        const nested = collectTransformArrayEntries(
+          entry.node,
+          entry.scope,
+          state,
+          nextSeen,
+          atPosition
+        );
+        if (nested) {
+          flattened.push(...nested);
+          changed = true;
+        } else {
+          flattened.push(entry);
+        }
+      }
+      entries = flattened;
+      if (!changed) break;
+    }
+    return entries;
+  }
+  if (method !== 'map' && method !== 'flatMap') return undefined;
+  const entries = collectTransformArrayEntries(
+    callee.object,
+    scope,
+    state,
+    nextSeen,
+    atPosition
+  );
+  const callbackNode = argument(0);
+  const callback = callbackNode
+    ? resolveCalledFunction(callbackNode, scope, state, new Set())
+    : undefined;
+  if (!entries || !callback) return undefined;
+  const mapped: Array<ScopedExpression | undefined> = [];
+  for (const [index, entry] of entries.entries()) {
+    if (!entry) {
+      mapped.push(undefined);
+      continue;
+    }
+    withFunctionParameterSubstitutions(
+      callback,
+      [
+        entry,
+        {
+          node: { type: 'NumericLiteral', value: index } as t.NumericLiteral,
+          scope,
+        },
+        { node: callee.object, scope },
+      ],
+      state,
+      () =>
+        withFunctionThisSubstitution(
+          callback,
+          argument(1) ? { node: argument(1)!, scope } : undefined,
+          state,
+          () => {
+            for (const returned of collectFunctionReturnExpressions(
+              callback.node,
+              callback.scope,
+              state
+            )) {
+              const materialized = materializeParameterExpression(
+                returned.node,
+                returned.scope,
+                state
+              );
+              if (method === 'flatMap') {
+                const nested = collectTransformArrayEntries(
+                  materialized.node,
+                  materialized.scope,
+                  state,
+                  nextSeen,
+                  atPosition
+                );
+                if (nested) {
+                  mapped.push(
+                    ...nested.map((entry) =>
+                      entry
+                        ? materializeParameterExpression(
+                            entry.node,
+                            entry.scope,
+                            state
+                          )
+                        : undefined
+                    )
+                  );
+                  continue;
+                }
+              }
+              mapped.push(materialized);
+            }
+          }
+        )
+    );
+  }
+  return mapped;
+}
+
+function readObjectEntry(
+  node: t.Node,
+  key: string,
+  scope: Scope,
+  seen: Set<t.Node>,
+  atPosition = node.end ?? Number.POSITIVE_INFINITY,
+  state?: ScriptState
+): ObjectEntryResult {
+  const object = resolveObjectExpression(node, scope, seen, atPosition);
+  if (!object) return { status: 'unknown' };
+  let result: ObjectEntryResult = { status: 'absent' };
+  for (const property of object.node.properties) {
+    if (property.type === 'SpreadElement') {
+      const spread = readObjectEntry(
+        property.argument,
+        key,
+        object.scope,
+        seen,
+        property.argument.end ?? atPosition,
+        state
+      );
+      if (spread.status !== 'absent') result = spread;
+      continue;
+    }
+    const propertyKey = state
+      ? readResolvedPropertyKey(property, object.scope, state)
+      : readPropertyKey(property);
+    if (!propertyKey) {
+      result = { status: 'unknown' };
+    } else if (propertyKey === key) {
+      result =
+        property.type === 'ObjectProperty' ||
+        (property.type === 'ObjectMethod' && property.kind === 'method')
+          ? {
+              status: 'known',
+              expression: {
+                node:
+                  property.type === 'ObjectProperty'
+                    ? property.value
+                    : property,
+                scope: object.scope,
+              },
+            }
+          : { status: 'unknown' };
+    }
+  }
+  return result;
+}
+
+/** Proves that a literal container and all of its const aliases are read-only. */
+function bindingHasOnlyReadonlyContainerUses(
+  binding: Binding,
+  state: ScriptState,
+  seen: Set<Binding>
+): boolean {
+  const cached = state.readonlyContainerUses.get(binding);
+  if (cached !== undefined) return cached;
+  if (!binding.constant || seen.has(binding)) return seen.has(binding);
+  if (state.readonlyContainerUsesInProgress.has(binding)) {
+    return seen.has(binding);
+  }
+  state.readonlyContainerUsesInProgress.add(binding);
+  const nextSeen = new Set(seen).add(binding);
+  try {
+    const result = binding.referencePaths.every((reference) => {
+      const parent = reference.parentPath;
+      if (!parent) return false;
+      if (
+        parent.isVariableDeclarator() &&
+        parent.node.init === reference.node
+      ) {
+        if (parent.node.id.type !== 'Identifier') return false;
+        const alias = parent.scope.getBinding(parent.node.id.name);
+        return Boolean(
+          alias && bindingHasOnlyReadonlyContainerUses(alias, state, nextSeen)
+        );
+      }
+      if (
+        (parent.isMemberExpression() || parent.isOptionalMemberExpression()) &&
+        parent.node.object === reference.node
+      ) {
+        let member: NodePath<t.MemberExpression | t.OptionalMemberExpression> =
+          parent;
+        while (
+          member.parentPath &&
+          (member.parentPath.isMemberExpression() ||
+            member.parentPath.isOptionalMemberExpression()) &&
+          member.parentPath.node.object === member.node
+        ) {
+          member = member.parentPath;
+        }
+        const call = member.parentPath;
+        if (
+          call &&
+          (call.isCallExpression() || call.isOptionalCallExpression()) &&
+          call.node.callee === member.node
+        ) {
+          const method = readResolvedMemberProperty(
+            member.node,
+            member.scope,
+            state
+          );
+          return Boolean(method && READONLY_ARRAY_TRANSFORMS.has(method));
+        }
+        return memberChainIsReadOnly(parent);
+      }
+      if (
+        (parent.isCallExpression() || parent.isOptionalCallExpression()) &&
+        parent.node.arguments.some((argument) => argument === reference.node)
+      ) {
+        const callee = readResolvedMemberPath(
+          parent.node.callee,
+          parent.scope,
+          state
+        );
+        return (
+          callee === 'Array.from' ||
+          callee === 'Object.entries' ||
+          callee === 'Object.values'
+        );
+      }
+      return false;
+    });
+    state.readonlyContainerUses.set(binding, result);
+    return result;
+  } finally {
+    state.readonlyContainerUsesInProgress.delete(binding);
+  }
+}
+
+/**
+ * Rejects container aliases that can be mutated or escape static analysis.
+ *
+ * Babel's `binding.constant` does not account for writes through object
+ * members. Following an initializer in that case can publish a catalog for a
+ * value that does not exist at runtime. Only local property reads, static
+ * destructuring, and object/array copies are safe to inspect.
+ */
+function isSafelyReadContainerBinding(
+  binding: Binding,
+  currentReference: t.Identifier,
+  atPosition: number,
+  allowMemberCalls = false,
+  state?: ScriptState
+): boolean {
+  const currentFunction = binding.referencePaths
+    .find((reference) => reference.node === currentReference)
+    ?.getFunctionParent()?.node;
+  return binding.referencePaths.every((reference) => {
+    if (reference.node === currentReference) return true;
+    if (
+      reference.getFunctionParent()?.node === currentFunction &&
+      (reference.node.start ?? Number.POSITIVE_INFINITY) >= atPosition
+    ) {
+      return true;
+    }
+    const parent = reference.parentPath;
+    if (!parent) return false;
+
+    if (
+      (parent.isMemberExpression() || parent.isOptionalMemberExpression()) &&
+      parent.node.object === reference.node
+    ) {
+      if (literalObjectMemberIsGetter(binding, parent.node)) return false;
+      return (
+        memberChainCallsKnownStringLeaf(binding, parent, state) ||
+        !memberChainCanMutate(parent, allowMemberCalls) ||
+        (memberChainIsReadOnly(parent) &&
+          literalObjectMemberIsPrimitive(binding, parent.node))
+      );
+    }
+    if (parent.isSpreadElement()) {
+      return false;
+    }
+    if (parent.isVariableDeclarator() && parent.node.init === reference.node) {
+      return false;
+    }
+    if (
+      parent.isAssignmentExpression() &&
+      parent.node.right === reference.node
+    ) {
+      return false;
+    }
+    return false;
+  });
+}
+
+/**
+ * Allows a proven translator leaf to be called without treating its parent
+ * object as escaped. Arbitrary object methods remain unsafe because they can
+ * mutate sibling properties through a closure or `this`.
+ */
+function memberChainCallsKnownStringLeaf(
+  binding: Binding,
+  firstMember: NodePath<t.MemberExpression | t.OptionalMemberExpression>,
+  state: ScriptState | undefined
+): boolean {
+  if (!state) return false;
+  const properties: string[] = [];
+  let current: NodePath<t.Node> = firstMember;
+  while (current.isMemberExpression() || current.isOptionalMemberExpression()) {
+    const property = readResolvedMemberProperty(
+      current.node,
+      current.scope,
+      state
+    );
+    if (property === undefined) return false;
+    properties.push(property);
+    const parent = current.parentPath;
+    if (
+      !parent ||
+      (!parent.isMemberExpression() && !parent.isOptionalMemberExpression()) ||
+      parent.node.object !== current.node
+    ) {
+      break;
+    }
+    current = parent;
+  }
+  const call = current.parentPath;
+  if (
+    !call ||
+    (!call.isCallExpression() && !call.isOptionalCallExpression()) ||
+    call.node.callee !== current.node
+  ) {
+    return false;
+  }
+  const declaration = binding.path.node;
+  if (
+    declaration.type !== 'VariableDeclarator' ||
+    declaration.id.type !== 'Identifier' ||
+    !declaration.init
+  ) {
+    return false;
+  }
+  let selected: ScopedExpression = {
+    node: declaration.init,
+    scope: binding.path.scope,
+  };
+  for (const property of properties) {
+    const entry = readObjectEntry(
+      selected.node,
+      property,
+      selected.scope,
+      new Set(),
+      call.node.start ?? Number.POSITIVE_INFINITY,
+      state
+    );
+    if (entry.status !== 'known') return false;
+    selected = entry.expression;
+  }
+  return (
+    resolveKnownExpression(
+      selected.node,
+      selected.scope,
+      state,
+      new Set([binding])
+    )?.type === 'string'
+  );
+}
+
+/** Returns the direct literal property selected from a container declaration. */
+function readLiteralContainerProperty(
+  binding: Binding,
+  member: t.MemberExpression | t.OptionalMemberExpression
+): t.ObjectExpression['properties'][number] | undefined {
+  const key = readMemberProperty(member);
+  const declaration = binding.path.node;
+  const initializer =
+    declaration.type === 'VariableDeclarator'
+      ? unwrapExpression(declaration.init)
+      : undefined;
+  if (!key || initializer?.type !== 'ObjectExpression') return undefined;
+  let result: t.ObjectExpression['properties'][number] | undefined;
+  for (const property of initializer.properties) {
+    if (property.type === 'SpreadElement' || !readPropertyKey(property)) {
+      result = undefined;
+      continue;
+    }
+    if (readPropertyKey(property) === key) result = property;
+  }
+  return result;
+}
+
+/** Getter reads can mutate sibling properties before a later static read. */
+function literalObjectMemberIsGetter(
+  binding: Binding,
+  member: t.MemberExpression | t.OptionalMemberExpression
+): boolean {
+  const property = readLiteralContainerProperty(binding, member);
+  return property?.type === 'ObjectMethod' && property.kind === 'get';
+}
+
+/** Escaping a primitive sibling value cannot mutate the source container. */
+function literalObjectMemberIsPrimitive(
+  binding: Binding,
+  member: t.MemberExpression | t.OptionalMemberExpression
+): boolean {
+  const property = readLiteralContainerProperty(binding, member);
+  return (
+    property?.type === 'ObjectProperty' &&
+    readStaticPrimitive(property.value, () => ({ ok: false })).ok
+  );
+}
+
+/** Distinguishes a harmless value read from a write or method invocation. */
+function memberChainIsReadOnly(
+  memberPath: NodePath<t.MemberExpression | t.OptionalMemberExpression>
+): boolean {
+  let current: NodePath<t.Node> = memberPath;
+  while (
+    current.parentPath &&
+    (current.parentPath.isMemberExpression() ||
+      current.parentPath.isOptionalMemberExpression()) &&
+    current.parentPath.node.object === current.node
+  ) {
+    current = current.parentPath;
+  }
+  const parent = current.parentPath;
+  if (!parent) return false;
+  if (
+    (parent.isAssignmentExpression() && parent.node.left === current.node) ||
+    (parent.isUpdateExpression() && parent.node.argument === current.node) ||
+    (parent.isUnaryExpression({ operator: 'delete' }) &&
+      parent.node.argument === current.node) ||
+    ((parent.isForInStatement() || parent.isForOfStatement()) &&
+      parent.node.left === current.node) ||
+    ((parent.isCallExpression() || parent.isOptionalCallExpression()) &&
+      parent.node.callee === current.node) ||
+    (parent.isNewExpression() && parent.node.callee === current.node) ||
+    (parent.isTaggedTemplateExpression() && parent.node.tag === current.node)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** Returns whether a member read is used to mutate or escape its container. */
+function memberChainCanMutate(
+  memberPath: NodePath<t.MemberExpression | t.OptionalMemberExpression>,
+  allowCalls: boolean
+): boolean {
+  let current: NodePath<t.Node> = memberPath;
+  while (
+    current.parentPath &&
+    (current.parentPath.isMemberExpression() ||
+      current.parentPath.isOptionalMemberExpression()) &&
+    current.parentPath.node.object === current.node
+  ) {
+    current = current.parentPath;
+  }
+  while (current.parentPath) {
+    const parent = current.parentPath;
+    if (
+      (parent.isAssignmentExpression() && parent.node.left === current.node) ||
+      (parent.isUpdateExpression() && parent.node.argument === current.node) ||
+      (parent.isUnaryExpression({ operator: 'delete' }) &&
+        parent.node.argument === current.node) ||
+      ((parent.isForInStatement() || parent.isForOfStatement()) &&
+        parent.node.left === current.node)
+    ) {
+      return true;
+    }
+    if (
+      (parent.isCallExpression() || parent.isOptionalCallExpression()) &&
+      (parent.node.callee !== current.node || !allowCalls)
+    ) {
+      return true;
+    }
+    if (
+      parent.isNewExpression() &&
+      (parent.node.callee !== current.node || !allowCalls)
+    ) {
+      return true;
+    }
+    if (
+      parent.isTaggedTemplateExpression() &&
+      (parent.node.tag !== current.node || !allowCalls)
+    ) {
+      return true;
+    }
+    if (
+      (parent.isVariableDeclarator() && parent.node.init === current.node) ||
+      (parent.isAssignmentExpression() && parent.node.right === current.node) ||
+      (parent.isReturnStatement() && parent.node.argument === current.node) ||
+      parent.isSpreadElement() ||
+      (parent.isObjectProperty() && parent.node.value === current.node) ||
+      (parent.isArrayExpression() &&
+        parent.node.elements.some((element) => element === current.node))
+    ) {
+      return true;
+    }
+    if (!isAssignmentTargetWrapper(parent, current)) return false;
+    current = parent;
+  }
+  return true;
+}
+
+function readStaticFromScope(
+  node: t.Node | null | undefined,
+  scope: Scope,
+  seen: Set<Binding>,
+  atPosition: number,
+  analysis?: VueScriptAnalysis,
+  allowNumericGlobals = false
+): StaticPrimitiveResult {
+  return readStaticPrimitive(node, (identifier) => {
+    const binding = scope.getBinding(identifier.name);
+    if (!binding) {
+      const value = analysis?.staticValues.get(identifier.name);
+      if (analysis?.staticValues.has(identifier.name)) {
+        return { ok: true, value: value! };
+      }
+      if (allowNumericGlobals && identifier.name === 'Infinity') {
+        return { ok: true, value: Number.POSITIVE_INFINITY };
+      }
+      if (allowNumericGlobals && identifier.name === 'NaN') {
+        return { ok: true, value: Number.NaN };
+      }
+      return { ok: false };
+    }
+    const cacheable =
+      analysis !== undefined && atPosition === Number.POSITIVE_INFINITY;
+    const cached = cacheable
+      ? staticBindingResults
+          .get(analysis)
+          ?.get(binding)
+          ?.get(allowNumericGlobals)
+      : undefined;
+    if (cached) return cached;
+    if (seen.has(binding)) return { ok: false };
+    if (cacheable) {
+      const active = staticBindingsInProgress.get(analysis) ?? new Map();
+      const modes = active.get(binding) ?? new Set<boolean>();
+      if (modes.has(allowNumericGlobals)) return { ok: false };
+      modes.add(allowNumericGlobals);
+      active.set(binding, modes);
+      staticBindingsInProgress.set(analysis, active);
+    }
+    const nextSeen = new Set(seen);
+    nextSeen.add(binding);
+    try {
+      const source = getBindingSource(binding);
+      const expression =
+        source && (source.expression.node.end ?? 0) <= atPosition
+          ? selectPatternExpression(
+              source.pattern,
+              source.expression.node,
+              binding.identifier.name,
+              source.expression.scope,
+              source.expression.node.end ?? Number.POSITIVE_INFINITY
+            )
+          : undefined;
+      const result: StaticPrimitiveResult = expression
+        ? readStaticFromScope(
+            expression.node,
+            expression.scope,
+            nextSeen,
+            atPosition,
+            analysis,
+            allowNumericGlobals
+          )
+        : { ok: false };
+      if (cacheable) {
+        const results = staticBindingResults.get(analysis) ?? new Map();
+        const modes = results.get(binding) ?? new Map();
+        modes.set(allowNumericGlobals, result);
+        results.set(binding, modes);
+        staticBindingResults.set(analysis, results);
+      }
+      return result;
+    } finally {
+      if (cacheable) {
+        const active = staticBindingsInProgress.get(analysis);
+        const modes = active?.get(binding);
+        modes?.delete(allowNumericGlobals);
+        if (modes?.size === 0) active?.delete(binding);
+      }
+    }
+  });
+}
+
+function selectPatternExpression(
+  pattern: t.Node,
+  value: t.Node,
+  targetName: string,
+  scope: Scope,
+  atPosition = value.end ?? Number.POSITIVE_INFINITY,
+  state?: ScriptState
+): ScopedExpression | undefined {
+  if (pattern.type === 'Identifier') {
+    return pattern.name === targetName ? { node: value, scope } : undefined;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    if (isStaticallyUndefined(value, scope)) {
+      return selectPatternExpression(
+        pattern.left,
+        pattern.right,
+        targetName,
+        scope,
+        atPosition,
+        state
+      );
+    }
+    return selectPatternExpression(
+      pattern.left,
+      value,
+      targetName,
+      scope,
+      atPosition,
+      state
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type !== 'ObjectProperty') continue;
+      if (!patternContains(property.value, targetName)) continue;
+      const key = state
+        ? readResolvedPropertyKey(property, scope, state)
+        : readPropertyKey(property);
+      if (key === undefined) return undefined;
+      const entry = readObjectEntry(
+        value,
+        key,
+        scope,
+        new Set(),
+        atPosition,
+        state
+      );
+      return entry.status === 'known'
+        ? selectPatternExpression(
+            property.value,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            atPosition,
+            state
+          )
+        : entry.status === 'absent'
+          ? selectPatternDefault(property.value, targetName, scope)
+          : undefined;
+    }
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (let index = 0; index < pattern.elements.length; index += 1) {
+      const target = pattern.elements[index];
+      if (!target || !patternContains(target, targetName)) continue;
+      const entry = readArrayEntry(
+        value,
+        index,
+        scope,
+        new Set(),
+        atPosition,
+        state
+      );
+      if (entry.status === 'absent') {
+        return selectPatternDefault(target, targetName, scope);
+      }
+      return entry.status === 'known'
+        ? selectPatternExpression(
+            target,
+            entry.expression.node,
+            targetName,
+            entry.expression.scope,
+            atPosition,
+            state
+          )
+        : undefined;
+    }
+  }
+  return undefined;
+}
+
+function selectPatternDefault(
+  pattern: t.Node,
+  targetName: string,
+  scope: Scope
+): ScopedExpression | undefined {
+  return pattern.type === 'AssignmentPattern' &&
+    patternContains(pattern.left, targetName)
+    ? { node: pattern.right, scope }
+    : undefined;
+}
+
+function readRequireNamespace(
+  node: t.Node | null | undefined,
+  scope: Scope
+): Extract<KnownValue, { type: 'namespace' }> | undefined {
+  const expression = unwrapExpression(node);
+  if (
+    !expression ||
+    (expression.type !== 'CallExpression' &&
+      expression.type !== 'OptionalCallExpression') ||
+    expression.callee.type !== 'Identifier' ||
+    expression.callee.name !== 'require' ||
+    scope.getBinding('require') ||
+    expression.arguments.length !== 1
+  ) {
+    return undefined;
+  }
+  const argument = expression.arguments[0];
+  if (argument?.type !== 'StringLiteral') return undefined;
+  return argument.value === 'gt-vue' || argument.value === 'vue'
+    ? { type: 'namespace', source: argument.value, mutable: true }
+    : undefined;
+}
+
+/** Resolves a member key when its computed expression is statically primitive. */
+function readResolvedMemberProperty(
+  node: t.MemberExpression | t.OptionalMemberExpression,
+  scope: Scope,
+  state: ScriptState
+): string | undefined {
+  const direct = readMemberProperty(node);
+  if (direct !== undefined || !node.computed) return direct;
+  const computed = unwrapExpression(node.property);
+  const binding =
+    computed?.type === 'Identifier'
+      ? scope.getBinding(computed.name)
+      : undefined;
+  const substitution = binding
+    ? readParameterSubstitution(binding, state)
+    : undefined;
+  const materialized =
+    !substitution && computed
+      ? materializeParameterExpression(computed, scope, state)
+      : undefined;
+  const property = readStaticFromScope(
+    substitution?.node ?? materialized?.node ?? node.property,
+    substitution?.scope ?? materialized?.scope ?? scope,
+    new Set(),
+    node.property.end ?? Number.POSITIVE_INFINITY,
+    state.analysis
+  );
+  return property.ok &&
+    (typeof property.value === 'string' || typeof property.value === 'number')
+    ? String(property.value)
+    : undefined;
+}
+
+/** Resolves an object key whose computed expression is statically primitive. */
+function readResolvedPropertyKey(
+  property: { computed: boolean; key: t.Node },
+  scope: Scope,
+  state: ScriptState
+): string | undefined {
+  const direct = readPropertyKey(property);
+  if (direct !== undefined || !property.computed) return direct;
+  const key = readStaticFromScope(
+    property.key,
+    scope,
+    new Set(),
+    property.key.end ?? Number.POSITIVE_INFINITY,
+    state.analysis
+  );
+  return key.ok &&
+    (typeof key.value === 'string' || typeof key.value === 'number')
+    ? String(key.value)
+    : undefined;
+}

--- a/packages/vue-extractor/src/internal/script/jsx.ts
+++ b/packages/vue-extractor/src/internal/script/jsx.ts
@@ -1,0 +1,1646 @@
+import type { NodePath, Scope } from '@babel/traverse';
+import * as babel from '@babel/types';
+import {
+  HTML_CONTENT_PROPS,
+  type GTProp,
+  type JsxChild,
+  type JsxChildren,
+} from '@generaltranslation/format/types';
+import { isHTMLTag, isSVGTag } from '@vue/shared';
+import { isAcceptedPluralForm } from 'generaltranslation/internal';
+import type { GTComponentName, VueExtractionContext } from '../types.js';
+import {
+  addVueError,
+  babelLocation,
+  createInlineMetadata,
+  type StaticPrimitiveResult,
+  unwrapExpression,
+} from '../utils.js';
+import type { KnownValue } from './model.js';
+
+type Counter = { value: number };
+
+type JSXSlotFunction = {
+  node:
+    | babel.ArrowFunctionExpression
+    | babel.FunctionExpression
+    | babel.ObjectMethod;
+  scope: Scope;
+};
+
+type JSXSlotLayout = {
+  defaultChildren: babel.JSXElement['children'];
+  defaultSlot?: JSXSlotFunction;
+  namedSlots: Map<string, JSXSlotFunction>;
+};
+
+type OrdinaryElementShape = {
+  /** Component slots stay outside T's source tree. */
+  opaque: boolean;
+  /** Proven runtime string tag, retained only for catalog readability. */
+  tag?: string;
+};
+
+/** Narrow script-analysis capabilities required by rich JSX extraction. */
+export type VueJSXAnalysis = {
+  /** Per-file pragma that replaces Vue's VNode factory, when present. */
+  customPragma?: babel.Comment;
+  /** Resolves an expression to a proven gt-vue or Vue runtime identity. */
+  resolveKnownValue: (
+    expression: babel.Expression,
+    scope: Scope
+  ) => KnownValue | undefined;
+  /** Evaluates the side-effect-free primitive subset at this source position. */
+  readStaticPrimitive: (
+    expression: babel.Node,
+    scope: Scope
+  ) => StaticPrimitiveResult;
+  /** Resolves a safely retained object literal without executing user code. */
+  resolveStaticObject: (
+    expression: babel.Node,
+    scope: Scope
+  ) => { node: babel.ObjectExpression; scope: Scope } | undefined;
+  /** Returns Babel's lexical scope for a nested function or expression. */
+  scopeForNode: (node: babel.Node, fallback: Scope) => Scope;
+};
+
+const RESERVED_T_PROPS = new Set(['key', 'ref']);
+const FORMAT_COMPONENTS = new Set<GTComponentName>([
+  'Currency',
+  'DateTime',
+  'Num',
+]);
+const NON_BRANCH_PROP_NAMES = new Set([
+  'branch',
+  'class',
+  'key',
+  'locales',
+  'n',
+  'ref',
+  'ref-for',
+  'ref-key',
+  'ref_for',
+  'ref_key',
+  'style',
+  'v-slots',
+  'vSlots',
+]);
+
+/**
+ * Extracts one statically identified gt-vue `T` JSX element.
+ *
+ * This serializer follows the VNodes emitted by `@vue/babel-plugin-jsx`:
+ * fragments are transparent, JSX text uses the plugin's normalization, and
+ * arbitrary component slots remain opaque because gt-vue does not execute
+ * user slots while calculating a source hash.
+ */
+export function extractVueJSXTranslation(
+  path: NodePath<babel.JSXElement>,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): void {
+  if (analysis.customPragma) {
+    addVueError(
+      context,
+      babelLocation(analysis.customPragma.loc),
+      'Found a custom @jsx pragma in a gt-vue JSX translation file',
+      'Use the default Vue JSX VNode factory for files containing gt-vue <T>'
+    );
+    return;
+  }
+  const errorCount = context.errors.length;
+  const translationContext = readTranslationContext(
+    path.node.openingElement,
+    path.scope,
+    context,
+    analysis
+  );
+  const source = collapseChildren(
+    serializeChildren(
+      path.node.children,
+      { value: 0 },
+      path.scope,
+      context,
+      analysis
+    )
+  );
+  if (context.errors.length !== errorCount) return;
+
+  context.results.push({
+    dataFormat: 'JSX',
+    source,
+    metadata: createInlineMetadata(
+      context,
+      babelLocation(path.node.loc),
+      translationContext
+    ),
+  });
+}
+
+/** Returns whether the visitor is already covered by an outer serialized T. */
+export function isNestedInVueJSXTranslation(
+  path: NodePath<babel.JSXElement>,
+  analysis: VueJSXAnalysis
+): boolean {
+  let current: NodePath | null = path.parentPath;
+  while (current) {
+    if (current.isJSXElement()) {
+      const element = current.node;
+      const identity = resolveElementIdentity(
+        element.openingElement.name,
+        current.scope,
+        analysis
+      );
+      const containingAttribute = findContainingJSXAttribute(path, current);
+      if (
+        containingAttribute &&
+        !(
+          identity?.type === 'component' &&
+          (identity.name === 'Branch' || identity.name === 'Plural') &&
+          isSlotsAttribute(containingAttribute.node)
+        )
+      ) {
+        // JSX inside an event or ordinary prop is not a child VNode of the
+        // surrounding translation. Extract it independently if it is T.
+        return false;
+      }
+      if (identity?.type === 'component') {
+        if (identity.name === 'T') return true;
+        if (identity.name === 'Var' || FORMAT_COMPONENTS.has(identity.name)) {
+          return false;
+        }
+        // Branch and Plural own stable slots, so an outer T reaches them.
+      } else if (
+        identity?.type === 'vue-builtin' &&
+        (identity.name !== 'Fragment' ||
+          isTransparentFragment(element.openingElement.name, identity))
+      ) {
+        if (
+          identity.name === 'Suspense' &&
+          containingAttribute &&
+          isSlotsAttribute(containingAttribute.node)
+        ) {
+          // Explicit Suspense slots have separate lifetimes. The outer
+          // serializer follows the default slot and excludes fallback, while
+          // a T declared in fallback remains an independent translation.
+          return false;
+        }
+        // Vue Fragment aliases and normalized Suspense default content are
+        // transparent to the runtime source tree.
+      } else if (
+        !isLiteralFragment(element.openingElement.name) &&
+        !isNativeElement(element.openingElement.name)
+      ) {
+        // Arbitrary component slots are opaque to the outer translation.
+        return false;
+      }
+    }
+    current = current.parentPath;
+  }
+  return false;
+}
+
+/** Finds an attribute boundary between a nested JSX node and one ancestor. */
+function findContainingJSXAttribute(
+  path: NodePath,
+  ancestor: NodePath<babel.JSXElement>
+): NodePath<babel.JSXAttribute> | undefined {
+  let current: NodePath | null = path.parentPath;
+  while (current && current !== ancestor) {
+    if (
+      current.isJSXAttribute() &&
+      current.parentPath?.isJSXOpeningElement() &&
+      current.parentPath.parentPath === ancestor
+    ) {
+      return current;
+    }
+    current = current.parentPath;
+  }
+  return undefined;
+}
+
+function isSlotsAttribute(attribute: babel.JSXAttribute): boolean {
+  const name = readAttributeName(attribute.name);
+  return name === 'v-slots' || name === 'vSlots';
+}
+
+/** Resolves a JSX tag to the identity tracked by the script analyzer. */
+export function resolveVueJSXElementIdentity(
+  name: babel.JSXElement['openingElement']['name'],
+  scope: Scope,
+  analysis: VueJSXAnalysis
+): KnownValue | undefined {
+  return resolveElementIdentity(name, scope, analysis);
+}
+
+/** Enforces the one supported public shape for a gt-vue variable component. */
+export function validateVueJSXVariableComponent(
+  element: babel.JSXElement,
+  component: 'Currency' | 'DateTime' | 'Num' | 'Var',
+  context: VueExtractionContext
+): void {
+  validateVariableElement(element, component, context);
+}
+
+function readTranslationContext(
+  element: babel.JSXOpeningElement,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): string | undefined {
+  let translationContext: string | undefined;
+  let hasContext = false;
+
+  for (const attribute of element.attributes) {
+    if (attribute.type === 'JSXSpreadAttribute') {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        'Found a spread prop on a gt-vue <T> component in JSX',
+        'Pass context as one explicit static context or $context prop'
+      );
+      continue;
+    }
+    const name = readAttributeName(attribute.name);
+    if (RESERVED_T_PROPS.has(name)) continue;
+    if (name !== 'context' && name !== '$context') {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found unsupported prop "${name}" on a gt-vue <T> component`,
+        'gt-vue <T> currently supports only context'
+      );
+      continue;
+    }
+    if (hasContext) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        'Found duplicate context props on a gt-vue <T> component',
+        'Pass only one context prop'
+      );
+      continue;
+    }
+    hasContext = true;
+    const contextExpression =
+      attribute.value?.type === 'JSXExpressionContainer' &&
+      attribute.value.expression.type !== 'JSXEmptyExpression'
+        ? unwrapExpression(attribute.value.expression)
+        : undefined;
+    if (
+      contextExpression?.type === 'ConditionalExpression' ||
+      contextExpression?.type === 'LogicalExpression'
+    ) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        'Found conditional context on a gt-vue <T> component',
+        'Use one invariant static context string for this translation'
+      );
+      continue;
+    }
+    const value = readJSXAttributePrimitive(attribute, scope, analysis);
+    if (!value.ok || typeof value.value !== 'string') {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        'Found a dynamic context on a gt-vue <T> component',
+        'Use a string literal or an immutable static string'
+      );
+      continue;
+    }
+    translationContext = value.value;
+  }
+  return translationContext;
+}
+
+function serializeChildren(
+  children: Array<
+    | babel.JSXText
+    | babel.JSXExpressionContainer
+    | babel.JSXSpreadChild
+    | babel.JSXElement
+    | babel.JSXFragment
+  >,
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild[] {
+  const result: JsxChild[] = [];
+  for (const child of children) {
+    for (const serialized of serializeChild(
+      child,
+      counter,
+      scope,
+      context,
+      analysis
+    )) {
+      appendSerializedChild(result, serialized);
+    }
+  }
+  return result;
+}
+
+function serializeChild(
+  child:
+    | babel.JSXText
+    | babel.JSXExpressionContainer
+    | babel.JSXSpreadChild
+    | babel.JSXElement
+    | babel.JSXFragment,
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild[] {
+  if (child.type === 'JSXText') {
+    const text = normalizeJSXText(child.value);
+    return text ? [text] : [];
+  }
+  if (child.type === 'JSXElement') {
+    return serializeElement(child, counter, scope, context, analysis);
+  }
+  if (child.type === 'JSXFragment') {
+    return serializeChildren(child.children, counter, scope, context, analysis);
+  }
+  if (child.type === 'JSXSpreadChild') {
+    addVueError(
+      context,
+      babelLocation(child.loc),
+      'Found a spread child inside a gt-vue <T> component in JSX',
+      'Use static JSX children and wrap one runtime value in a gt-vue variable component'
+    );
+    return [];
+  }
+  if (child.expression.type === 'JSXEmptyExpression') return [];
+  return serializeExpression(
+    child.expression,
+    counter,
+    scope,
+    context,
+    analysis
+  );
+}
+
+function serializeExpression(
+  input: babel.Expression,
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild[] {
+  const expression = unwrapExpression(input);
+  if (!expression) return [];
+  if (expression.type === 'JSXElement') {
+    return serializeElement(expression, counter, scope, context, analysis);
+  }
+  if (expression.type === 'JSXFragment') {
+    return serializeChildren(
+      expression.children,
+      counter,
+      scope,
+      context,
+      analysis
+    );
+  }
+  if (expression.type === 'ArrayExpression') {
+    const result: JsxChild[] = [];
+    for (const item of expression.elements) {
+      if (!item) continue;
+      if (item.type === 'SpreadElement') {
+        addVueError(
+          context,
+          babelLocation(item.loc),
+          'Found a spread array child inside a gt-vue <T> component in JSX',
+          'List each static child explicitly'
+        );
+        continue;
+      }
+      for (const serialized of serializeExpression(
+        item,
+        counter,
+        scope,
+        context,
+        analysis
+      )) {
+        appendSerializedChild(result, serialized);
+      }
+    }
+    return result;
+  }
+  if (
+    expression.type === 'ConditionalExpression' ||
+    expression.type === 'LogicalExpression'
+  ) {
+    addVueError(
+      context,
+      babelLocation(expression.loc),
+      'Found conditional JSX content inside a gt-vue <T> component',
+      'Move conditional content outside <T>, or use a static Branch or Plural component'
+    );
+    return [];
+  }
+
+  const value = analysis.readStaticPrimitive(expression, scope);
+  if (!value.ok) {
+    addVueError(
+      context,
+      babelLocation(expression.loc),
+      'Found dynamic JSX content inside a gt-vue <T> component',
+      'Wrap runtime values in <Var>, <Num>, <DateTime>, or <Currency>'
+    );
+    return [];
+  }
+  // Vue drops null and boolean JSX children. All other primitive VNode
+  // children are stringified by gt-vue before the source is hashed.
+  return value.value == null || typeof value.value === 'boolean'
+    ? []
+    : [String(value.value)];
+}
+
+function serializeElement(
+  element: babel.JSXElement,
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild[] {
+  const name = element.openingElement.name;
+  const identity = resolveElementIdentity(name, scope, analysis);
+  if (isTransparentFragment(name, identity)) {
+    return serializeChildren(
+      element.children,
+      counter,
+      scope,
+      context,
+      analysis
+    );
+  }
+
+  counter.value += 1;
+  const id = counter.value;
+  const component = identity?.type === 'component' ? identity.name : undefined;
+
+  validateElementAttributes(element.openingElement, scope, context, analysis);
+  if (component === 'T') {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      'Found a nested gt-vue <T> component inside another <T>',
+      'Split nested translations into sibling <T> components'
+    );
+    return [];
+  }
+  if (
+    component === 'Var' ||
+    component === 'Num' ||
+    component === 'DateTime' ||
+    component === 'Currency'
+  ) {
+    validateVariableElement(element, component, context);
+    const variable =
+      component === 'Num'
+        ? { name: 'n', type: 'n' as const }
+        : component === 'DateTime'
+          ? { name: 'date', type: 'd' as const }
+          : component === 'Currency'
+            ? { name: 'cost', type: 'c' as const }
+            : { name: 'value', type: 'v' as const };
+    return [{ i: id, k: `_gt_${variable.name}_${id}`, v: variable.type }];
+  }
+  if (component === 'Branch' || component === 'Plural') {
+    return [
+      serializeBranchElement(
+        element,
+        id,
+        component,
+        counter,
+        scope,
+        context,
+        analysis
+      ),
+    ];
+  }
+  if (identity?.type === 'vue-builtin' && identity.name === 'Suspense') {
+    return [
+      serializeSuspenseElement(element, id, counter, scope, context, analysis),
+    ];
+  }
+  if (identity?.type === 'vue-builtin' && identity.name === 'Fragment') {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      'Found a renamed Vue Fragment binding inside a gt-vue JSX translation',
+      'Use <>, literal <Fragment>, or a Vue namespace member such as <Vue.Fragment>; the Vue JSX transform compiles renamed Fragment bindings as component slots'
+    );
+    return [];
+  }
+  if (identity?.type === 'vue-builtin') {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      `Found unsupported Vue <${identity.name}> content inside a gt-vue JSX translation`,
+      'Move this Vue builtin outside <T>'
+    );
+    return [];
+  }
+  if (!identity && isUnboundNonNativeElement(name, scope)) {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      `Could not determine whether JSX tag <${readElementDisplayName(name) ?? 'unknown'}> is a component or custom element`,
+      'Import or locally bind the component, or move the configured custom element outside <T>'
+    );
+    return [];
+  }
+
+  const ordinaryShape = identity
+    ? undefined
+    : resolveOrdinaryElementShape(name, scope, analysis, new Set());
+  if (!identity && !ordinaryShape) {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      `Could not statically resolve whether JSX tag <${readElementDisplayName(name) ?? 'unknown'}> renders an element or component`,
+      'Use a native tag, imported component, defineComponent result, or an immutable tag expression that cannot switch between element and component shapes'
+    );
+    return [];
+  }
+
+  const data = readContentProps(
+    element.openingElement,
+    scope,
+    context,
+    analysis
+  );
+  const tag = ordinaryShape?.tag ?? readElementDisplayName(name);
+  if (!tag) {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      'Found unsupported namespaced JSX syntax inside a gt-vue <T> component',
+      'Use a native element or a statically imported component'
+    );
+    return [];
+  }
+  if (ordinaryShape?.opaque) {
+    return [
+      {
+        t: tag,
+        i: id,
+        ...(Object.keys(data).length > 0 && { d: data }),
+      },
+    ];
+  }
+
+  const children = serializeChildren(
+    element.children,
+    counter,
+    scope,
+    context,
+    analysis
+  );
+  return [
+    {
+      t: tag,
+      i: id,
+      ...(Object.keys(data).length > 0 && { d: data }),
+      ...(children.length > 0 && { c: collapseChildren(children) }),
+    },
+  ];
+}
+
+/**
+ * Serializes Vue Suspense's normalized default content without evaluating its
+ * fallback. Vue requires that default slot to resolve to one VNode root; an
+ * ambiguous or multi-root shape is rejected before it can hash differently.
+ */
+function serializeSuspenseElement(
+  element: babel.JSXElement,
+  id: number,
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild {
+  const slots = readJSXSlotLayout(
+    element,
+    scope,
+    context,
+    analysis,
+    'suspense'
+  );
+  const directSlot = readDirectSuspenseSlot(element, scope, context, analysis);
+  if (directSlot.present) {
+    slots.defaultChildren = [];
+    slots.defaultSlot = directSlot.slot;
+  }
+
+  for (const name of slots.namedSlots.keys()) {
+    if (name === 'fallback' || name.startsWith('_')) continue;
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      `Found unsupported named slot "${name}" on Vue <Suspense> inside a gt-vue <T> component`,
+      'Use only the default and fallback Suspense slots'
+    );
+  }
+
+  if (slots.defaultSlot) {
+    validateSuspenseSlotRoot(slots.defaultSlot, element, context);
+  } else {
+    validateSuspenseImplicitRoot(slots.defaultChildren, element, context);
+  }
+
+  const children = slots.defaultSlot
+    ? serializeSlotFunction(slots.defaultSlot, counter, context, analysis)
+    : serializeChildren(
+        slots.defaultChildren,
+        counter,
+        scope,
+        context,
+        analysis
+      );
+  const data = readContentProps(
+    element.openingElement,
+    scope,
+    context,
+    analysis
+  );
+  return {
+    t: 'Suspense',
+    i: id,
+    ...(Object.keys(data).length > 0 && { d: data }),
+    ...(children.length > 0 && { c: collapseChildren(children) }),
+  };
+}
+
+/** Reads the unambiguous one-function JSX spelling for a default slot. */
+function readDirectSuspenseSlot(
+  element: babel.JSXElement,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): { present: boolean; slot?: JSXSlotFunction } {
+  if (
+    hasExplicitAttribute(element.openingElement, 'v-slots') ||
+    hasExplicitAttribute(element.openingElement, 'vSlots')
+  ) {
+    return { present: false };
+  }
+  const children = element.children.filter(isMeaningfulJSXChild);
+  if (
+    children.length !== 1 ||
+    children[0]?.type !== 'JSXExpressionContainer' ||
+    children[0].expression.type === 'JSXEmptyExpression'
+  ) {
+    return { present: false };
+  }
+  const value = unwrapExpression(children[0].expression);
+  if (
+    !value ||
+    (value.type !== 'ArrowFunctionExpression' &&
+      value.type !== 'FunctionExpression')
+  ) {
+    return { present: false };
+  }
+  if (value.params.length > 0 || value.async || value.generator) {
+    addVueError(
+      context,
+      babelLocation(value.loc),
+      'Found a dynamic or scoped default slot on Vue <Suspense> inside a gt-vue <T> component',
+      'Use a synchronous zero-argument function with static returned content'
+    );
+    return { present: true };
+  }
+  return {
+    present: true,
+    slot: {
+      node: value,
+      scope: analysis.scopeForNode(value, scope),
+    },
+  };
+}
+
+/** Enforces the single-root contract for children wrapped by the JSX plugin. */
+function validateSuspenseImplicitRoot(
+  children: babel.JSXElement['children'],
+  element: babel.JSXElement,
+  context: VueExtractionContext
+): void {
+  const roots = children.filter(isMeaningfulJSXChild);
+  if (roots.length > 1) {
+    addSuspenseRootError(element, context);
+    return;
+  }
+  const root = roots[0];
+  if (
+    root?.type === 'JSXExpressionContainer' &&
+    root.expression.type !== 'JSXEmptyExpression'
+  ) {
+    const expression = unwrapExpression(root.expression);
+    if (
+      expression?.type !== 'JSXElement' &&
+      expression?.type !== 'JSXFragment'
+    ) {
+      addVueError(
+        context,
+        babelLocation(root.loc),
+        'Could not statically prove the default root of Vue <Suspense> inside a gt-vue <T> component',
+        'Use one JSX element, Fragment, or a static zero-argument default slot'
+      );
+    }
+  }
+}
+
+/** Enforces the single-root contract for an explicit static slot function. */
+function validateSuspenseSlotRoot(
+  slot: JSXSlotFunction,
+  element: babel.JSXElement,
+  context: VueExtractionContext
+): void {
+  const returned = readStaticSlotReturn(slot);
+  const expression = returned && unwrapExpression(returned);
+  if (expression?.type !== 'ArrayExpression') return;
+  const roots = expression.elements.filter(Boolean);
+  if (
+    roots.length > 1 ||
+    roots.some(
+      (root) =>
+        root?.type === 'SpreadElement' ||
+        (root?.type !== 'JSXElement' && root?.type !== 'JSXFragment')
+    )
+  ) {
+    addSuspenseRootError(element, context);
+  }
+}
+
+/** Reports the stable diagnostic shared by all invalid Suspense root shapes. */
+function addSuspenseRootError(
+  element: babel.JSXElement,
+  context: VueExtractionContext
+): void {
+  addVueError(
+    context,
+    babelLocation(element.loc),
+    'Found more than one or an invalid default root inside Vue <Suspense> within a gt-vue <T> component',
+    'Wrap the Suspense default content in one element or Fragment, or move <T> inside <Suspense>'
+  );
+}
+
+/** Serializes GT-owned Branch and Plural slots with independent ID scopes. */
+function serializeBranchElement(
+  element: babel.JSXElement,
+  id: number,
+  component: 'Branch' | 'Plural',
+  counter: Counter,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild {
+  const slots = readJSXSlotLayout(element, scope, context, analysis);
+  if (
+    component === 'Plural' &&
+    !hasExplicitAttribute(element.openingElement, 'n')
+  ) {
+    addVueError(
+      context,
+      babelLocation(element.openingElement.loc),
+      'Found a gt-vue <Plural> component without an n prop',
+      'Pass the numeric selector through <Plural n={count} />'
+    );
+  }
+
+  const children = slots.defaultSlot
+    ? serializeSlotFunction(slots.defaultSlot, counter, context, analysis)
+    : serializeChildren(
+        slots.defaultChildren,
+        counter,
+        scope,
+        context,
+        analysis
+      );
+  const branches: Record<string, JsxChildren> = {};
+  for (const [name, slot] of slots.namedSlots) {
+    if (name.startsWith('_')) continue;
+    if (component === 'Plural' && !isAcceptedPluralForm(name)) continue;
+    branches[name] = collapseChildren(
+      serializeSlotFunction(slot, { value: id }, context, analysis)
+    );
+  }
+  readBranchAttributeSources(
+    element.openingElement,
+    component,
+    branches,
+    scope,
+    context,
+    analysis
+  );
+
+  const data = readContentProps(
+    element.openingElement,
+    scope,
+    context,
+    analysis
+  );
+  if (Object.keys(branches).length > 0) {
+    data.b = branches;
+    data.t = component === 'Plural' ? 'p' : 'b';
+  }
+  return {
+    t: component,
+    i: id,
+    ...(Object.keys(data).length > 0 && { d: data }),
+    ...(children.length > 0 && { c: collapseChildren(children) }),
+  };
+}
+
+/** Reconstructs the slots object emitted by the Vue JSX transform. */
+function readJSXSlotLayout(
+  element: babel.JSXElement,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis,
+  owner: 'branch' | 'suspense' = 'branch'
+): JSXSlotLayout {
+  const ownerLabel =
+    owner === 'suspense' ? 'Vue <Suspense>' : 'a gt-vue JSX branch component';
+  const vSlots = element.openingElement.attributes.filter(
+    (attribute): attribute is babel.JSXAttribute =>
+      attribute.type === 'JSXAttribute' && isSlotsAttribute(attribute)
+  );
+  if (vSlots.length > 1) {
+    addVueError(
+      context,
+      babelLocation(vSlots[1]!.loc),
+      `Found more than one v-slots prop on ${ownerLabel}`,
+      'Pass one static slots object'
+    );
+  }
+
+  const meaningfulChildren = element.children.filter(isMeaningfulJSXChild);
+  const objectSlotChild =
+    vSlots.length === 0 &&
+    meaningfulChildren.length === 1 &&
+    meaningfulChildren[0]?.type === 'JSXExpressionContainer' &&
+    meaningfulChildren[0].expression.type !== 'JSXEmptyExpression'
+      ? analysis.resolveStaticObject(meaningfulChildren[0].expression, scope)
+      : undefined;
+  if (objectSlotChild) {
+    addVueError(
+      context,
+      babelLocation(meaningfulChildren[0]?.loc),
+      'Found Vue object-slot child syntax in a gt-vue JSX translation',
+      'Pass the static slots object through v-slots so extraction is independent of the JSX enableObjectSlots compiler option'
+    );
+  }
+  const vSlotsObject = vSlots[0]
+    ? readSlotsAttributeObject(vSlots[0], scope, context, analysis, ownerLabel)
+    : undefined;
+  const slotsObject = vSlotsObject;
+  const namedSlots = new Map<string, JSXSlotFunction>();
+  let defaultSlot: JSXSlotFunction | undefined;
+  if (slotsObject) {
+    for (const [name, slot] of readStaticSlotObject(
+      slotsObject,
+      context,
+      analysis
+    )) {
+      if (name === 'default') defaultSlot = slot;
+      else namedSlots.set(name, slot);
+    }
+  }
+
+  return {
+    defaultChildren: objectSlotChild ? [] : element.children,
+    ...(defaultSlot && { defaultSlot }),
+    namedSlots,
+  };
+}
+
+function readSlotsAttributeObject(
+  attribute: babel.JSXAttribute,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis,
+  ownerLabel: string
+): { node: babel.ObjectExpression; scope: Scope } | undefined {
+  const expression =
+    attribute.value?.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type !== 'JSXEmptyExpression'
+      ? attribute.value.expression
+      : undefined;
+  const object = expression
+    ? analysis.resolveStaticObject(expression, scope)
+    : undefined;
+  if (!object) {
+    addVueError(
+      context,
+      babelLocation(attribute.loc),
+      `Found dynamic v-slots on ${ownerLabel}`,
+      'Use a retained object literal with statically named zero-argument slot functions'
+    );
+  }
+  return object;
+}
+
+/** Reads statically named zero-argument functions from one JSX slots object. */
+function readStaticSlotObject(
+  object: { node: babel.ObjectExpression; scope: Scope },
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): Map<string, JSXSlotFunction> {
+  const slots = new Map<string, JSXSlotFunction>();
+  for (const property of object.node.properties) {
+    if (property.type === 'SpreadElement') {
+      addVueError(
+        context,
+        babelLocation(property.loc),
+        'Found a spread in a gt-vue JSX slots object',
+        'List every static slot explicitly'
+      );
+      continue;
+    }
+    const name = readStaticObjectKey(property, object.scope, analysis);
+    if (name === undefined) {
+      addVueError(
+        context,
+        babelLocation(property.loc),
+        'Found a dynamic slot name in a gt-vue JSX slots object',
+        'Use a static string slot name'
+      );
+      continue;
+    }
+    if (slots.has(name)) {
+      addVueError(
+        context,
+        babelLocation(property.loc),
+        `Found duplicate JSX slot "${name}" in a gt-vue translation`,
+        'Define every slot once'
+      );
+      continue;
+    }
+    const value =
+      property.type === 'ObjectMethod'
+        ? property
+        : unwrapExpression(property.value);
+    if (
+      !value ||
+      (value.type !== 'ArrowFunctionExpression' &&
+        value.type !== 'FunctionExpression' &&
+        value.type !== 'ObjectMethod') ||
+      value.params.length > 0 ||
+      value.async ||
+      value.generator
+    ) {
+      addVueError(
+        context,
+        babelLocation(property.loc),
+        `Found a dynamic or scoped JSX slot "${name}" in a gt-vue translation`,
+        'Use a synchronous zero-argument function with static returned content'
+      );
+      continue;
+    }
+    slots.set(name, {
+      node: value,
+      scope: analysis.scopeForNode(value, object.scope),
+    });
+  }
+  return slots;
+}
+
+function serializeSlotFunction(
+  slot: JSXSlotFunction,
+  counter: Counter,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): JsxChild[] {
+  const returned = readStaticSlotReturn(slot);
+  if (!returned) {
+    addVueError(
+      context,
+      babelLocation(slot.node.loc),
+      'Found a JSX slot with a dynamic function body in a gt-vue translation',
+      'Return static slot content directly from the zero-argument function'
+    );
+    return [];
+  }
+  return serializeExpression(returned, counter, slot.scope, context, analysis);
+}
+
+/** Returns the expression from a slot body that contains only one return. */
+function readStaticSlotReturn(
+  slot: JSXSlotFunction
+): babel.Expression | undefined {
+  const body = slot.node.body;
+  if (body.type !== 'BlockStatement') return body;
+  const statements = body.body.filter(
+    (statement) => statement.type !== 'EmptyStatement'
+  );
+  const returned =
+    statements.length === 1 && statements[0]?.type === 'ReturnStatement'
+      ? statements[0].argument
+      : undefined;
+  return returned ?? undefined;
+}
+
+function readStaticObjectKey(
+  property: babel.ObjectMethod | babel.ObjectProperty,
+  scope: Scope,
+  analysis: VueJSXAnalysis
+): string | undefined {
+  if (!property.computed) {
+    if (property.key.type === 'Identifier') return property.key.name;
+    if (
+      property.key.type === 'StringLiteral' ||
+      property.key.type === 'NumericLiteral'
+    ) {
+      return String(property.key.value);
+    }
+    return undefined;
+  }
+  const key = analysis.readStaticPrimitive(property.key, scope);
+  return key.ok &&
+    (typeof key.value === 'string' || typeof key.value === 'number')
+    ? String(key.value)
+    : undefined;
+}
+
+function readBranchAttributeSources(
+  element: babel.JSXOpeningElement,
+  component: 'Branch' | 'Plural',
+  branches: Record<string, JsxChildren>,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): void {
+  const seenBranchProps = new Set<string>();
+  for (const attribute of element.attributes) {
+    if (attribute.type !== 'JSXAttribute') continue;
+    const name = readAttributeName(attribute.name);
+    if (
+      !isBranchPropName(name) ||
+      (component === 'Plural' && !isAcceptedPluralForm(name))
+    ) {
+      continue;
+    }
+    if (seenBranchProps.has(name)) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found duplicate branch prop "${name}" on a gt-vue <${component}> component`,
+        'Pass each branch prop once so Vue JSX compiler options cannot change which value is hashed'
+      );
+      continue;
+    }
+    seenBranchProps.add(name);
+    if (Object.prototype.hasOwnProperty.call(branches, name)) continue;
+    const value = readJSXAttributePrimitive(attribute, scope, analysis);
+    if (!value.ok) {
+      if (isStaticallyNonBranchAttribute(attribute, scope)) continue;
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found dynamic branch prop "${name}" on a gt-vue <${component}> component`,
+        'Use a static primitive branch prop or a static named slot'
+      );
+      continue;
+    }
+    branches[name] =
+      value.value == null || typeof value.value === 'boolean'
+        ? []
+        : String(value.value);
+  }
+}
+
+function isBranchPropName(name: string): boolean {
+  return !(
+    NON_BRANCH_PROP_NAMES.has(name) ||
+    name.startsWith('aria-') ||
+    name.startsWith('data-') ||
+    /^on[^a-z]/.test(name)
+  );
+}
+
+function isStaticallyNonBranchAttribute(
+  attribute: babel.JSXAttribute,
+  scope: Scope
+): boolean {
+  const expression =
+    attribute.value?.type === 'JSXExpressionContainer' &&
+    attribute.value.expression.type !== 'JSXEmptyExpression'
+      ? unwrapExpression(attribute.value.expression)
+      : undefined;
+  if (!expression) return false;
+  if (expression.type === 'Identifier' && expression.name === 'undefined') {
+    return !scope.hasBinding('undefined');
+  }
+  return (
+    expression.type === 'ArrayExpression' ||
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'ClassExpression' ||
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'JSXElement' ||
+    expression.type === 'JSXFragment' ||
+    expression.type === 'NewExpression' ||
+    expression.type === 'ObjectExpression' ||
+    expression.type === 'RegExpLiteral' ||
+    (expression.type === 'UnaryExpression' && expression.operator === 'void')
+  );
+}
+
+function hasExplicitAttribute(
+  element: babel.JSXOpeningElement,
+  name: string
+): boolean {
+  return element.attributes.some(
+    (attribute) =>
+      attribute.type === 'JSXAttribute' &&
+      readAttributeName(attribute.name) === name
+  );
+}
+
+function isMeaningfulJSXChild(
+  child: babel.JSXElement['children'][number]
+): boolean {
+  if (child.type === 'JSXText') return normalizeJSXText(child.value) !== '';
+  return !(
+    child.type === 'JSXExpressionContainer' &&
+    child.expression.type === 'JSXEmptyExpression'
+  );
+}
+
+function validateVariableElement(
+  element: babel.JSXElement,
+  component: 'Currency' | 'DateTime' | 'Num' | 'Var',
+  context: VueExtractionContext
+): void {
+  if (context.validatedVariableComponents.has(element)) return;
+  context.validatedVariableComponents.add(element);
+
+  const explicitProps = new Set<string>();
+  let hasSpread = false;
+  for (const attribute of element.openingElement.attributes) {
+    if (attribute.type === 'JSXSpreadAttribute') {
+      hasSpread = true;
+    } else {
+      explicitProps.add(readAttributeName(attribute.name));
+    }
+  }
+  if (hasSpread) {
+    addVueError(
+      context,
+      babelLocation(element.openingElement.loc),
+      `Found a spread prop on a gt-vue <${component}> component`,
+      'Pass variable component props explicitly'
+    );
+  }
+  if (component === 'Var') {
+    for (const prop of ['name', 'value']) {
+      if (!explicitProps.has(prop)) continue;
+      addVueError(
+        context,
+        babelLocation(element.openingElement.loc),
+        `Found unsupported ${prop} prop on a gt-vue <Var> component`,
+        'Pass the variable as the default child of <Var>'
+      );
+    }
+    return;
+  }
+  if (!explicitProps.has('value')) {
+    addVueError(
+      context,
+      babelLocation(element.openingElement.loc),
+      `Found a gt-vue <${component}> component without a value prop`,
+      `Pass the runtime value through <${component} value={value} />`
+    );
+  }
+  if (hasMeaningfulChildren(element.children)) {
+    addVueError(
+      context,
+      babelLocation(element.loc),
+      `Found children on a gt-vue <${component}> component`,
+      `Use only the required value prop: <${component} value={value} />`
+    );
+  }
+}
+
+function hasMeaningfulChildren(
+  children: babel.JSXElement['children']
+): boolean {
+  return children.some((child) => {
+    if (child.type === 'JSXText') return normalizeJSXText(child.value) !== '';
+    return !(
+      child.type === 'JSXExpressionContainer' &&
+      child.expression.type === 'JSXEmptyExpression'
+    );
+  });
+}
+
+function validateElementAttributes(
+  element: babel.JSXOpeningElement,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): void {
+  const seenContentProps = new Set<string>();
+  for (const attribute of element.attributes) {
+    if (attribute.type === 'JSXSpreadAttribute') {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        'Found a spread prop inside a gt-vue <T> component in JSX',
+        'Pass props by static name so their effect on the translation source is known'
+      );
+      continue;
+    }
+    const name = readAttributeName(attribute.name);
+    if (isVueJSXDirectiveName(name) && !isSlotsAttribute(attribute)) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found Vue JSX directive "${name}" inside a gt-vue <T> component`,
+        'Move the directive outside <T> so the translated VNode source stays static'
+      );
+      continue;
+    }
+    if (name === 'innerHTML' || name === 'textContent') {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found source-shaping prop "${name}" inside a gt-vue <T> component`,
+        'Use static JSX children instead'
+      );
+      continue;
+    }
+    const contentProp = (
+      Object.values(HTML_CONTENT_PROPS) as readonly string[]
+    ).includes(name);
+    if (!contentProp) continue;
+    if (seenContentProps.has(name)) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found duplicate translatable prop "${name}" inside a gt-vue <T> component`,
+        'Pass each translatable element prop once so Vue JSX compiler options cannot change which value is hashed'
+      );
+      continue;
+    }
+    seenContentProps.add(name);
+    const value = readJSXAttributePrimitive(attribute, scope, analysis);
+    if (!value.ok) {
+      addVueError(
+        context,
+        babelLocation(attribute.loc),
+        `Found dynamic translatable prop "${name}" inside a gt-vue <T> component`,
+        'Use a static string for translatable element props'
+      );
+    }
+  }
+}
+
+function isVueJSXDirectiveName(name: string): boolean {
+  return /^v(?:-|[A-Z])/.test(name);
+}
+
+function readContentProps(
+  element: babel.JSXOpeningElement,
+  scope: Scope,
+  context: VueExtractionContext,
+  analysis: VueJSXAnalysis
+): GTProp {
+  const data: GTProp = {};
+  const entries = Object.entries(HTML_CONTENT_PROPS);
+  for (const attribute of element.attributes) {
+    if (attribute.type !== 'JSXAttribute') continue;
+    const name = readAttributeName(attribute.name);
+    const entry = entries.find(([, propName]) => propName === name);
+    if (!entry) continue;
+    const value = readJSXAttributePrimitive(attribute, scope, analysis);
+    if (value.ok && typeof value.value === 'string') {
+      (data as Record<string, unknown>)[entry[0]] = value.value;
+    } else if (!value.ok) {
+      // validateElementAttributes owns the single user-facing diagnostic.
+      void context;
+    }
+  }
+  return data;
+}
+
+function readJSXAttributePrimitive(
+  attribute: babel.JSXAttribute,
+  scope: Scope,
+  analysis: VueJSXAnalysis
+): StaticPrimitiveResult {
+  if (!attribute.value) return { ok: true, value: true };
+  if (attribute.value.type === 'StringLiteral') {
+    return { ok: true, value: normalizeJSXText(attribute.value.value) };
+  }
+  if (
+    attribute.value.type !== 'JSXExpressionContainer' ||
+    attribute.value.expression.type === 'JSXEmptyExpression'
+  ) {
+    return { ok: false };
+  }
+  return analysis.readStaticPrimitive(attribute.value.expression, scope);
+}
+
+function resolveElementIdentity(
+  name: babel.JSXElement['openingElement']['name'],
+  scope: Scope,
+  analysis: VueJSXAnalysis
+): KnownValue | undefined {
+  const expression = jsxNameToExpression(name);
+  return expression ? analysis.resolveKnownValue(expression, scope) : undefined;
+}
+
+function jsxNameToExpression(
+  name: babel.JSXElement['openingElement']['name']
+): babel.Expression | undefined {
+  if (name.type === 'JSXIdentifier') return babel.identifier(name.name);
+  if (name.type === 'JSXNamespacedName') return undefined;
+  const object = jsxMemberObjectToExpression(name.object);
+  return object
+    ? babel.memberExpression(object, babel.identifier(name.property.name))
+    : undefined;
+}
+
+function jsxMemberObjectToExpression(
+  object: babel.JSXMemberExpression['object']
+): babel.Expression | undefined {
+  if (object.type === 'JSXIdentifier') return babel.identifier(object.name);
+  const parent = jsxMemberObjectToExpression(object.object);
+  return parent
+    ? babel.memberExpression(parent, babel.identifier(object.property.name))
+    : undefined;
+}
+
+function isLiteralFragment(
+  name: babel.JSXElement['openingElement']['name']
+): boolean {
+  // Vue's JSX transforms (verified in 1.4 and 3.0) select the Fragment helper
+  // before checking lexical bindings. Consequently literal `<Fragment>` is
+  // transparent even when source code declares a same-named local binding.
+  return name.type === 'JSXIdentifier' && name.name === 'Fragment';
+}
+
+/** Matches only Fragment spellings the Vue JSX transform keeps transparent. */
+function isTransparentFragment(
+  name: babel.JSXElement['openingElement']['name'],
+  identity: KnownValue | undefined
+): boolean {
+  return (
+    isLiteralFragment(name) ||
+    (identity?.type === 'vue-builtin' &&
+      identity.name === 'Fragment' &&
+      name.type === 'JSXMemberExpression' &&
+      name.property.name === 'Fragment')
+  );
+}
+
+/** Detects tags whose VNode type can change with plugin `isCustomElement`. */
+function isUnboundNonNativeElement(
+  name: babel.JSXElement['openingElement']['name'],
+  scope: Scope
+): boolean {
+  if (name.type === 'JSXIdentifier') {
+    return (
+      name.name !== 'Fragment' &&
+      !isNativeElement(name) &&
+      !scope.hasBinding(name.name)
+    );
+  }
+  if (name.type === 'JSXNamespacedName') return true;
+  let object = name.object;
+  while (object.type === 'JSXMemberExpression') object = object.object;
+  return !scope.hasBinding(object.name);
+}
+
+function isNativeElement(
+  name: babel.JSXElement['openingElement']['name']
+): boolean {
+  return (
+    name.type === 'JSXIdentifier' &&
+    (isHTMLTag(name.name) || isSVGTag(name.name))
+  );
+}
+
+/** Proves whether a non-GT JSX tag is traversable or slot-opaque. */
+function resolveOrdinaryElementShape(
+  name: babel.JSXElement['openingElement']['name'],
+  scope: Scope,
+  analysis: VueJSXAnalysis,
+  seen: Set<babel.Node>
+): OrdinaryElementShape | undefined {
+  if (isNativeElement(name)) {
+    return { opaque: false, tag: (name as babel.JSXIdentifier).name };
+  }
+  if (name.type === 'JSXNamespacedName') return undefined;
+  if (name.type === 'JSXMemberExpression') {
+    let root = name.object;
+    while (root.type === 'JSXMemberExpression') root = root.object;
+    const binding = scope.getBinding(root.name);
+    return binding?.path.isImportSpecifier() ||
+      binding?.path.isImportDefaultSpecifier() ||
+      binding?.path.isImportNamespaceSpecifier()
+      ? { opaque: true }
+      : undefined;
+  }
+  const binding = scope.getBinding(name.name);
+  if (!binding) return undefined;
+  if (
+    binding.path.isImportSpecifier() ||
+    binding.path.isImportDefaultSpecifier() ||
+    binding.path.isImportNamespaceSpecifier() ||
+    binding.path.isFunctionDeclaration() ||
+    binding.path.isClassDeclaration()
+  ) {
+    return { opaque: true };
+  }
+  const declaration = binding.path.node;
+  return declaration.type === 'VariableDeclarator' && declaration.init
+    ? resolveOrdinaryElementExpression(
+        declaration.init,
+        binding.path.scope,
+        analysis,
+        seen
+      )
+    : undefined;
+}
+
+/** Classifies a retained tag expression without executing application code. */
+function resolveOrdinaryElementExpression(
+  input: babel.Expression,
+  scope: Scope,
+  analysis: VueJSXAnalysis,
+  seen: Set<babel.Node>
+): OrdinaryElementShape | undefined {
+  const expression = unwrapExpression(input);
+  if (!expression || seen.has(expression)) return undefined;
+  const nextSeen = new Set(seen);
+  nextSeen.add(expression);
+
+  const primitive = analysis.readStaticPrimitive(expression, scope);
+  if (primitive.ok) {
+    return typeof primitive.value === 'string'
+      ? { opaque: false, tag: primitive.value }
+      : undefined;
+  }
+  if (
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'ClassExpression' ||
+    expression.type === 'ObjectExpression'
+  ) {
+    return { opaque: true };
+  }
+  if (expression.type === 'Identifier') {
+    const binding = scope.getBinding(expression.name);
+    if (!binding) return undefined;
+    if (
+      binding.path.isImportSpecifier() ||
+      binding.path.isImportDefaultSpecifier() ||
+      binding.path.isImportNamespaceSpecifier() ||
+      binding.path.isFunctionDeclaration() ||
+      binding.path.isClassDeclaration()
+    ) {
+      return { opaque: true };
+    }
+    const declaration = binding.path.node;
+    return declaration.type === 'VariableDeclarator' && declaration.init
+      ? resolveOrdinaryElementExpression(
+          declaration.init,
+          binding.path.scope,
+          analysis,
+          nextSeen
+        )
+      : undefined;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    if (expression.callee.type === 'V8IntrinsicIdentifier') return undefined;
+    const callee = analysis.resolveKnownValue(expression.callee, scope);
+    if (callee?.type === 'defineComponent') return { opaque: true };
+    const argument = expression.arguments[0];
+    return callee?.type === 'identity' &&
+      expression.arguments.length === 1 &&
+      argument &&
+      argument.type !== 'SpreadElement' &&
+      argument.type !== 'ArgumentPlaceholder'
+      ? resolveOrdinaryElementExpression(argument, scope, analysis, nextSeen)
+      : undefined;
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return mergeOrdinaryElementShapes(
+      resolveOrdinaryElementExpression(
+        expression.consequent,
+        scope,
+        analysis,
+        nextSeen
+      ),
+      resolveOrdinaryElementExpression(
+        expression.alternate,
+        scope,
+        analysis,
+        nextSeen
+      )
+    );
+  }
+  if (expression.type === 'LogicalExpression') {
+    return mergeOrdinaryElementShapes(
+      resolveOrdinaryElementExpression(
+        expression.left,
+        scope,
+        analysis,
+        nextSeen
+      ),
+      resolveOrdinaryElementExpression(
+        expression.right,
+        scope,
+        analysis,
+        nextSeen
+      )
+    );
+  }
+  if (expression.type === 'SequenceExpression') {
+    const last = expression.expressions.at(-1);
+    return last
+      ? resolveOrdinaryElementExpression(last, scope, analysis, nextSeen)
+      : undefined;
+  }
+  return undefined;
+}
+
+/** Combines alternate tags only when they preserve traversal semantics. */
+function mergeOrdinaryElementShapes(
+  left: OrdinaryElementShape | undefined,
+  right: OrdinaryElementShape | undefined
+): OrdinaryElementShape | undefined {
+  if (!left || !right || left.opaque !== right.opaque) return undefined;
+  return {
+    opaque: left.opaque,
+    ...(left.tag === right.tag && left.tag !== undefined && { tag: left.tag }),
+  };
+}
+
+function readElementDisplayName(
+  name: babel.JSXElement['openingElement']['name']
+): string | undefined {
+  if (name.type === 'JSXIdentifier') return name.name;
+  if (name.type === 'JSXNamespacedName') return undefined;
+  const object = readMemberDisplayName(name.object);
+  return object ? `${object}.${name.property.name}` : undefined;
+}
+
+function readMemberDisplayName(
+  object: babel.JSXMemberExpression['object']
+): string | undefined {
+  if (object.type === 'JSXIdentifier') return object.name;
+  const parent = readMemberDisplayName(object.object);
+  return parent ? `${parent}.${object.property.name}` : undefined;
+}
+
+function readAttributeName(name: babel.JSXAttribute['name']): string {
+  return name.type === 'JSXIdentifier'
+    ? name.name
+    : `${name.namespace.name}:${name.name.name}`;
+}
+
+/** Mirrors `@vue/babel-plugin-jsx`'s JSX text and string-prop transform. */
+function normalizeJSXText(text: string): string {
+  const lines = text.split(/\r\n|\n|\r/);
+  let lastNonEmptyLine = 0;
+  for (let index = 0; index < lines.length; index += 1) {
+    if (/[^ \t]/.test(lines[index]!)) lastNonEmptyLine = index;
+  }
+
+  let result = '';
+  for (let index = 0; index < lines.length; index += 1) {
+    const isFirstLine = index === 0;
+    const isLastLine = index === lines.length - 1;
+    const isLastNonEmptyLine = index === lastNonEmptyLine;
+    let line = lines[index]!.replace(/\t/g, ' ');
+    if (!isFirstLine) line = line.replace(/^ +/, '');
+    if (!isLastLine) line = line.replace(/ +$/, '');
+    if (!line) continue;
+    if (!isLastNonEmptyLine) line += ' ';
+    result += line;
+  }
+  return result;
+}
+
+function appendSerializedChild(result: JsxChild[], child: JsxChild): void {
+  const previous = result.at(-1);
+  if (typeof previous === 'string' && typeof child === 'string') {
+    result[result.length - 1] = previous + child;
+  } else {
+    result.push(child);
+  }
+}
+
+function collapseChildren(children: JsxChild[]): JsxChildren {
+  return children.length === 1 ? children[0]! : children;
+}

--- a/packages/vue-extractor/src/internal/script/knownValues.ts
+++ b/packages/vue-extractor/src/internal/script/knownValues.ts
@@ -1,0 +1,162 @@
+import type { GTComponentName, VueBuiltinName } from '../types.js';
+import type { KnownValue } from './model.js';
+
+/** Public gt-vue component exports recognized by script analysis. */
+export const COMPONENT_IMPORTS = new Set<GTComponentName>([
+  'T',
+  'Var',
+  'Num',
+  'DateTime',
+  'Currency',
+  'Plural',
+  'Branch',
+]);
+
+/** Vue exports whose exact runtime identity changes rich traversal. */
+export const VUE_BUILTIN_IMPORTS = new Set<VueBuiltinName>([
+  'Fragment',
+  'Suspense',
+]);
+
+/** Array methods that do not mutate the receiver's retained identity. */
+export const READONLY_ARRAY_TRANSFORMS = new Set([
+  'at',
+  'concat',
+  'entries',
+  'every',
+  'filter',
+  'find',
+  'findIndex',
+  'findLast',
+  'findLastIndex',
+  'flat',
+  'flatMap',
+  'forEach',
+  'includes',
+  'indexOf',
+  'join',
+  'keys',
+  'lastIndexOf',
+  'map',
+  'reduce',
+  'reduceRight',
+  'slice',
+  'some',
+  'toReversed',
+  'toSorted',
+  'toSpliced',
+  'values',
+  'with',
+]);
+
+/** Unbound globals whose values cannot be gt-vue translation identities. */
+export const ORDINARY_GLOBAL_VALUES = new Set([
+  'Array',
+  'BigInt',
+  'Boolean',
+  'Date',
+  'Error',
+  'Map',
+  'Number',
+  'Object',
+  'RegExp',
+  'Set',
+  'String',
+  'Symbol',
+  'WeakMap',
+  'WeakSet',
+  'undefined',
+]);
+
+/** Returns the recognized identity of one gt-vue or Vue export. */
+export function knownExport(
+  source: 'gt-vue' | 'vue',
+  name: string
+): KnownValue | undefined {
+  if (source === 'vue') {
+    if (
+      name === 'createVNode' ||
+      name === 'defineAsyncComponent' ||
+      name === 'h'
+    ) {
+      return { type: 'vue-call', name };
+    }
+    if (name === 'defineComponent') return { type: 'defineComponent' };
+    if (name === 'markRaw') return { type: 'identity' };
+    if (name === 'unref') {
+      return {
+        type: 'container-wrapper',
+        kind: 'unref',
+        writePolicy: 'forward',
+      };
+    }
+    if (name === 'toRaw') {
+      return {
+        type: 'container-wrapper',
+        kind: 'to-raw',
+        writePolicy: 'forward',
+      };
+    }
+    if (name === 'computed') return { type: 'vue-wrapper', kind: 'computed' };
+    if (name === 'ref' || name === 'shallowRef') {
+      return { type: 'vue-wrapper', kind: 'ref' };
+    }
+    if (name === 'readonly') {
+      return {
+        type: 'container-wrapper',
+        kind: 'readonly',
+        writePolicy: 'readonly-deep',
+      };
+    }
+    if (name === 'shallowReadonly') {
+      return {
+        type: 'container-wrapper',
+        kind: 'shallow-readonly',
+        writePolicy: 'readonly-shallow',
+      };
+    }
+    if (name === 'reactive') {
+      return {
+        type: 'container-wrapper',
+        kind: 'reactive',
+        writePolicy: 'forward',
+      };
+    }
+    if (name === 'shallowReactive') {
+      return {
+        type: 'container-wrapper',
+        kind: 'shallow-reactive',
+        writePolicy: 'forward',
+      };
+    }
+    return VUE_BUILTIN_IMPORTS.has(name as VueBuiltinName)
+      ? { type: 'vue-builtin', name: name as VueBuiltinName }
+      : undefined;
+  }
+  if (COMPONENT_IMPORTS.has(name as GTComponentName)) {
+    return { type: 'component', name: name as GTComponentName };
+  }
+  if (name === 'msg') return { type: 'string', kind: 'msg' };
+  if (name === 'useGT') return { type: 'hook', kind: 'gt' };
+  if (name === 'useMessages') return { type: 'hook', kind: 'messages' };
+  return undefined;
+}
+
+/** Produces a stable equality key for recognized runtime identities. */
+export function knownValueKey(value: KnownValue): string {
+  if (value.type === 'component') return `component:${value.name}`;
+  if (value.type === 'hook') return `hook:${value.kind}`;
+  if (value.type === 'string') return `string:${value.kind}`;
+  if (value.type === 'namespace') return `namespace:${value.source}`;
+  if (value.type === 'local-namespace') {
+    return `local-namespace:${value.modulePath}`;
+  }
+  if (value.type === 'vue-builtin') return `vue-builtin:${value.name}`;
+  if (value.type === 'vue-call') return `vue-call:${value.name}`;
+  if (value.type === 'vue-wrapper') return `vue-wrapper:${value.kind}`;
+  if (value.type === 'container-wrapper') {
+    return `container-wrapper:${value.kind}`;
+  }
+  if (value.type === 'identity') return 'identity';
+  return 'defineComponent';
+}

--- a/packages/vue-extractor/src/internal/script/localModules.ts
+++ b/packages/vue-extractor/src/internal/script/localModules.ts
@@ -37,6 +37,14 @@ const GT_EXPORT_NAMES = [
   'useMessages',
 ] as const;
 
+/** Complete public value surface currently exported by the gt-vue runtime. */
+const GT_RUNTIME_EXPORT_NAMES = [
+  ...GT_EXPORT_NAMES,
+  'createGT',
+  'useLocale',
+  'useSetLocale',
+] as const;
+
 const VUE_EXPORT_NAMES = [
   'Suspense',
   'computed',
@@ -152,6 +160,12 @@ export type LocalModuleResolver = {
   resolveModule(importer: string, specifier: string): string | undefined;
 };
 
+/** Package-provenance behavior that is broader than source extraction. */
+export type LocalModuleResolverOptions = {
+  /** Includes gt-vue setup and locale APIs that extraction never calls. */
+  recognizeAllGTRuntimeExports?: boolean;
+};
+
 /**
  * Creates a cycle-safe ESM resolver for local source files and index barrels.
  *
@@ -159,7 +173,8 @@ export type LocalModuleResolver = {
  * Bare aliases are accepted only through the caller's explicit resolver hook.
  */
 export function createLocalModuleResolver(
-  resolveModuleOption: VueExtractionOptions['resolveModule']
+  resolveModuleOption: VueExtractionOptions['resolveModule'],
+  options: LocalModuleResolverOptions = {}
 ): LocalModuleResolver {
   const records = new Map<string, LocalModuleRecord | null>();
   const recoveredRecords = new Map<string, RecoveredModuleRecord | null>();
@@ -459,7 +474,10 @@ export function createLocalModuleResolver(
       return target.source === 'gt-vue' ? '*' : undefined;
     }
     if (target.type !== 'namespace') return undefined;
-    return GT_EXPORT_NAMES.some((name) =>
+    const candidateNames = options.recognizeAllGTRuntimeExports
+      ? [...GT_RUNTIME_EXPORT_NAMES]
+      : [...GT_EXPORT_NAMES];
+    return candidateNames.some((name) =>
       Boolean(
         readGTExportName(
           resolveExportInternal(target.modulePath, name, seen),
@@ -494,7 +512,11 @@ export function createLocalModuleResolver(
       };
     }
     if (isExternalModule(source)) {
-      return knownExternalExport(source, exportName)
+      return knownExternalExport(
+        source,
+        exportName,
+        options.recognizeAllGTRuntimeExports === true
+      )
         ? {
             status: 'resolved',
             target: {
@@ -1103,9 +1125,14 @@ function isExternalModule(source: string): source is ExternalModuleName {
 
 function knownExternalExport(
   source: ExternalModuleName,
-  exportName: string
+  exportName: string,
+  recognizeAllGTRuntimeExports: boolean
 ): boolean {
-  return source === 'gt-vue'
-    ? (GT_EXPORT_NAMES as readonly string[]).includes(exportName)
-    : (VUE_EXPORT_NAMES as readonly string[]).includes(exportName);
+  if (source === 'vue') {
+    return (VUE_EXPORT_NAMES as readonly string[]).includes(exportName);
+  }
+  const recognizedNames = recognizeAllGTRuntimeExports
+    ? GT_RUNTIME_EXPORT_NAMES
+    : GT_EXPORT_NAMES;
+  return (recognizedNames as readonly string[]).includes(exportName);
 }

--- a/packages/vue-extractor/src/internal/script/localModules.ts
+++ b/packages/vue-extractor/src/internal/script/localModules.ts
@@ -1,0 +1,1111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import traverseModule, { type Scope } from '@babel/traverse';
+import type * as t from '@babel/types';
+import {
+  initSync as initModuleLexer,
+  parse as parseModuleImports,
+} from 'es-module-lexer';
+import type { VueExtractionOptions } from '../../types.js';
+import { parseScriptAst } from './parser.js';
+import { isKnownNonVueGTRuntime } from './runtimeModules.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+const SOURCE_EXTENSIONS = [
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mts',
+  '.mjs',
+  '.cts',
+  '.cjs',
+  '.vue',
+] as const;
+
+const GT_EXPORT_NAMES = [
+  'T',
+  'Var',
+  'Num',
+  'DateTime',
+  'Currency',
+  'Plural',
+  'Branch',
+  'msg',
+  'useGT',
+  'useMessages',
+] as const;
+
+const VUE_EXPORT_NAMES = [
+  'Suspense',
+  'computed',
+  'createVNode',
+  'defineComponent',
+  'defineAsyncComponent',
+  'Fragment',
+  'h',
+  'markRaw',
+  'reactive',
+  'readonly',
+  'ref',
+  'shallowReactive',
+  'shallowReadonly',
+  'shallowRef',
+  'toRaw',
+  'unref',
+] as const;
+
+type ExternalModuleName = 'gt-vue' | 'vue';
+
+type DeclaredExport =
+  | { type: 'expression'; node: t.Node }
+  | { type: 'local'; name: string }
+  | { type: 'namespace'; source: string }
+  | { type: 'reexport'; importedName: string; source: string };
+
+type RecoveredDeclaredExport = Extract<
+  DeclaredExport,
+  { type: 'namespace' | 'reexport' }
+>;
+
+type RecoveredModuleRecord = {
+  explicitExports: Map<string, RecoveredDeclaredExport | 'ambiguous'>;
+  filePath: string;
+  starExports: string[];
+};
+
+type ImportedBinding = {
+  importedName: string | '*';
+  source: string;
+};
+
+/** One parsed local source module used exclusively for static analysis. */
+export type LocalModuleRecord = {
+  ast: t.File;
+  explicitExports: Map<string, DeclaredExport | 'ambiguous'>;
+  filePath: string;
+  imports: Map<string, ImportedBinding>;
+  programScope: Scope;
+  starExports: string[];
+};
+
+/** A statically resolved ESM export without executing project code. */
+export type LocalExportTarget =
+  | {
+      exportName: string;
+      originKey: string;
+      record: LocalModuleRecord;
+      type: 'local';
+    }
+  | {
+      node: t.Node;
+      originKey: string;
+      record: LocalModuleRecord;
+      type: 'expression';
+    }
+  | {
+      exportName: string;
+      originKey: string;
+      source: ExternalModuleName;
+      type: 'external';
+    }
+  | {
+      originKey: string;
+      source: ExternalModuleName;
+      type: 'external-namespace';
+    }
+  | {
+      /** A statically proven export from an official non-Vue GT runtime. */
+      originKey: string;
+      type: 'ordinary-external';
+    }
+  | {
+      modulePath: string;
+      originKey: string;
+      type: 'namespace';
+    };
+
+/** Result of resolving one named export through a local ESM graph. */
+export type LocalExportResolution =
+  | { status: 'absent' | 'ambiguous' }
+  | {
+      gtExportName?: string | '*';
+      hasGTSourceReference?: boolean;
+      /** Fully resolved targets recovered from an otherwise invalid module. */
+      recoveredTargets?: LocalExportTarget[];
+      status: 'invalid';
+    }
+  | { status: 'resolved'; target: LocalExportTarget };
+
+/** Read-only local source resolver used by the Vue script analyzer. */
+export type LocalModuleResolver = {
+  getRecord(filePath: string): LocalModuleRecord | undefined;
+  /** Whether the caller supplied project-specific bare-specifier semantics. */
+  hasCustomResolver: boolean;
+  /** Whether a resolved module belongs to project source rather than an install. */
+  isProjectModule(filePath: string): boolean;
+  listExportNames(filePath: string): string[];
+  /** Whether a named export is statically connected to the gt-vue runtime. */
+  hasGTExportReference(filePath: string, exportName: string): boolean;
+  resolveExport(filePath: string, exportName: string): LocalExportResolution;
+  resolveModule(importer: string, specifier: string): string | undefined;
+};
+
+/**
+ * Creates a cycle-safe ESM resolver for local source files and index barrels.
+ *
+ * The resolver reads and parses source text but never imports or executes it.
+ * Bare aliases are accepted only through the caller's explicit resolver hook.
+ */
+export function createLocalModuleResolver(
+  resolveModuleOption: VueExtractionOptions['resolveModule']
+): LocalModuleResolver {
+  const records = new Map<string, LocalModuleRecord | null>();
+  const recoveredRecords = new Map<string, RecoveredModuleRecord | null>();
+  const resolutions = new Map<string, LocalExportResolution>();
+
+  const isProjectModule = (filePath: string): boolean => {
+    const realPath = readRealPath(path.resolve(filePath));
+    // The caller's resolver contract accepts local workspace source even when
+    // it sits above the metadata project root. Resolve symlinks before checking
+    // the package boundary so linked workspaces remain local while installed
+    // package implementations stay opaque.
+    return !realPath.split(path.sep).includes('node_modules');
+  };
+
+  const resolveModule = (
+    importer: string,
+    specifier: string
+  ): string | undefined => {
+    if (specifier === 'gt-vue' || specifier === 'vue') return undefined;
+    let requested: string | undefined;
+    if (resolveModuleOption) {
+      try {
+        const resolved = resolveModuleOption(specifier, importer);
+        requested = resolved
+          ? path.isAbsolute(resolved)
+            ? resolved
+            : path.resolve(path.dirname(importer), resolved)
+          : undefined;
+      } catch {
+        // A project resolver is advisory. Relative paths retain the safe,
+        // filesystem-only fallback below when the hook cannot resolve them.
+      }
+    }
+    if (
+      !requested &&
+      (specifier.startsWith('.') || path.isAbsolute(specifier))
+    ) {
+      requested = path.isAbsolute(specifier)
+        ? specifier
+        : path.resolve(path.dirname(importer), specifier);
+    }
+    return requested ? resolveSourceFile(requested) : undefined;
+  };
+
+  const getRecord = (filePath: string): LocalModuleRecord | undefined => {
+    const normalized = path.resolve(filePath);
+    if (!isProjectModule(normalized)) return undefined;
+    const cached = records.get(normalized);
+    if (cached !== undefined) return cached ?? undefined;
+    // The sentinel also makes self-imports and parse-time cycles fail closed.
+    records.set(normalized, null);
+    const parsed = parseLocalModule(normalized);
+    records.set(normalized, parsed ?? null);
+    return parsed;
+  };
+
+  const getRecoveredRecord = (
+    filePath: string
+  ): RecoveredModuleRecord | undefined => {
+    const normalized = path.resolve(filePath);
+    if (!isProjectModule(normalized)) return undefined;
+    const cached = recoveredRecords.get(normalized);
+    if (cached !== undefined) return cached ?? undefined;
+    const recovered = recoverMalformedModuleExports(normalized);
+    recoveredRecords.set(normalized, recovered ?? null);
+    return recovered;
+  };
+
+  const resolveExportInternal = (
+    filePath: string,
+    exportName: string,
+    seen: Set<string>
+  ): LocalExportResolution => {
+    const normalized = path.resolve(filePath);
+    if (!isProjectModule(normalized)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${normalized}#${exportName}`,
+          type: 'ordinary-external',
+        },
+      };
+    }
+    const cycleKey = `${normalized}\0${exportName}`;
+    if (seen.has(cycleKey)) return { status: 'absent' };
+    const nextSeen = new Set(seen).add(cycleKey);
+    const record = getRecord(normalized);
+    if (!record) {
+      const recovered = getRecoveredRecord(normalized);
+      return recovered
+        ? resolveRecoveredExport(recovered, exportName, nextSeen)
+        : { status: 'invalid' };
+    }
+    const explicit = record.explicitExports.get(exportName);
+    if (explicit === 'ambiguous') return { status: 'ambiguous' };
+    if (explicit) {
+      return resolveDeclaredExport(record, exportName, explicit, nextSeen);
+    }
+    if (exportName === 'default') return { status: 'absent' };
+
+    const candidates: LocalExportTarget[] = [];
+    let ambiguous = false;
+    let invalid = false;
+    let invalidGTExportName: string | '*' | undefined;
+    let invalidGTSourceReference = false;
+    let recoveredTargets: LocalExportTarget[] | undefined = [];
+    for (const source of record.starExports) {
+      const candidate = resolveFromSource(record, source, exportName, nextSeen);
+      if (candidate.status === 'absent') continue;
+      const candidateGTExportName = readGTExportName(candidate, nextSeen);
+      invalidGTSourceReference ||= candidateGTExportName !== undefined;
+      invalidGTExportName ??= candidateGTExportName;
+      if (candidate.status === 'resolved') {
+        candidates.push(candidate.target);
+        recoveredTargets?.push(candidate.target);
+      }
+      if (candidate.status === 'ambiguous') {
+        ambiguous = true;
+        recoveredTargets = undefined;
+      }
+      if (candidate.status === 'invalid') {
+        invalid = true;
+        invalidGTSourceReference ||= candidate.hasGTSourceReference === true;
+        invalidGTExportName ??= candidate.gtExportName;
+        if (recoveredTargets && candidate.recoveredTargets) {
+          recoveredTargets.push(...candidate.recoveredTargets);
+        } else {
+          recoveredTargets = undefined;
+        }
+      }
+    }
+    const origins = new Set(candidates.map(({ originKey }) => originKey));
+    if (origins.size > 1) {
+      ambiguous = true;
+      recoveredTargets = undefined;
+    }
+    if (
+      recoveredTargets &&
+      new Set(recoveredTargets.map(({ originKey }) => originKey)).size > 1
+    ) {
+      ambiguous = true;
+      recoveredTargets = undefined;
+    }
+    if (invalid) {
+      return {
+        ...(invalidGTSourceReference && {
+          hasGTSourceReference: true,
+        }),
+        ...(invalidGTExportName && {
+          gtExportName: invalidGTExportName,
+        }),
+        ...(recoveredTargets?.length && {
+          recoveredTargets: uniqueRecoveredTargets(recoveredTargets),
+        }),
+        status: 'invalid',
+      };
+    }
+    if (ambiguous) return { status: 'ambiguous' };
+    return candidates.length === 0
+      ? { status: 'absent' }
+      : { status: 'resolved', target: candidates[0]! };
+  };
+
+  const resolveRecoveredExport = (
+    record: RecoveredModuleRecord,
+    exportName: string,
+    seen: Set<string>
+  ): LocalExportResolution => {
+    const explicit = record.explicitExports.get(exportName);
+    if (explicit === 'ambiguous') return { status: 'ambiguous' };
+    if (explicit) {
+      const resolution =
+        explicit.type === 'reexport'
+          ? resolveFromSource(
+              record,
+              explicit.source,
+              explicit.importedName,
+              seen
+            )
+          : resolveRecoveredNamespace(record, explicit.source);
+      return invalidateRecoveredResolution(resolution, seen);
+    }
+    if (exportName === 'default') return { status: 'invalid' };
+
+    let gtExportName: string | '*' | undefined;
+    let recoveredTargets: LocalExportTarget[] | undefined = [];
+    for (const source of record.starExports) {
+      const candidate = resolveFromSource(record, source, exportName, seen);
+      if (candidate.status === 'absent') continue;
+      gtExportName ??= readGTExportName(candidate, seen);
+      if (recoveredTargets && candidate.status === 'resolved') {
+        recoveredTargets.push(candidate.target);
+      } else if (
+        recoveredTargets &&
+        candidate.status === 'invalid' &&
+        candidate.recoveredTargets
+      ) {
+        recoveredTargets.push(...candidate.recoveredTargets);
+      } else {
+        recoveredTargets = undefined;
+      }
+    }
+    if (
+      recoveredTargets &&
+      new Set(recoveredTargets.map(({ originKey }) => originKey)).size > 1
+    ) {
+      recoveredTargets = undefined;
+    }
+    return {
+      ...(gtExportName && {
+        gtExportName,
+        hasGTSourceReference: true,
+      }),
+      ...(recoveredTargets?.length && {
+        recoveredTargets: uniqueRecoveredTargets(recoveredTargets),
+      }),
+      status: 'invalid',
+    };
+  };
+
+  const resolveRecoveredNamespace = (
+    record: RecoveredModuleRecord,
+    source: string
+  ): LocalExportResolution => {
+    if (isKnownNonVueGTRuntime(source)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${source}#namespace`,
+          type: 'ordinary-external',
+        },
+      };
+    }
+    if (isExternalModule(source)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${source}#namespace`,
+          source,
+          type: 'external-namespace',
+        },
+      };
+    }
+    const modulePath = resolveModule(record.filePath, source);
+    if (!modulePath) return { status: 'invalid' };
+    if (!isProjectModule(modulePath)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${modulePath}#namespace`,
+          type: 'ordinary-external',
+        },
+      };
+    }
+    return {
+      status: 'resolved',
+      target: {
+        modulePath,
+        originKey: `${modulePath}#namespace`,
+        type: 'namespace',
+      },
+    };
+  };
+
+  const invalidateRecoveredResolution = (
+    resolution: LocalExportResolution,
+    seen: Set<string>
+  ): LocalExportResolution => {
+    const gtExportName = readGTExportName(resolution, seen);
+    return {
+      ...(gtExportName && {
+        gtExportName,
+        hasGTSourceReference: true,
+      }),
+      ...(resolution.status === 'resolved'
+        ? { recoveredTargets: [resolution.target] }
+        : resolution.status === 'invalid' && resolution.recoveredTargets
+          ? { recoveredTargets: resolution.recoveredTargets }
+          : {}),
+      status: 'invalid',
+    };
+  };
+
+  const readGTExportName = (
+    resolution: LocalExportResolution,
+    seen: Set<string>
+  ): string | '*' | undefined => {
+    if (resolution.status === 'invalid') {
+      return resolution.gtExportName;
+    }
+    if (resolution.status !== 'resolved') return undefined;
+    const { target } = resolution;
+    if (target.type === 'external') {
+      return target.source === 'gt-vue' ? target.exportName : undefined;
+    }
+    if (target.type === 'external-namespace') {
+      return target.source === 'gt-vue' ? '*' : undefined;
+    }
+    if (target.type !== 'namespace') return undefined;
+    return GT_EXPORT_NAMES.some((name) =>
+      Boolean(
+        readGTExportName(
+          resolveExportInternal(target.modulePath, name, seen),
+          seen
+        )
+      )
+    )
+      ? '*'
+      : undefined;
+  };
+
+  const resolutionReferencesGT = (
+    resolution: LocalExportResolution,
+    seen: Set<string>
+  ): boolean => {
+    return readGTExportName(resolution, seen) !== undefined;
+  };
+
+  const resolveFromSource = (
+    record: Pick<LocalModuleRecord, 'filePath'>,
+    source: string,
+    exportName: string,
+    seen: Set<string>
+  ): LocalExportResolution => {
+    if (isKnownNonVueGTRuntime(source)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${source}#${exportName}`,
+          type: 'ordinary-external',
+        },
+      };
+    }
+    if (isExternalModule(source)) {
+      return knownExternalExport(source, exportName)
+        ? {
+            status: 'resolved',
+            target: {
+              exportName,
+              originKey: `${source}#${exportName}`,
+              source,
+              type: 'external',
+            },
+          }
+        : { status: 'absent' };
+    }
+    const modulePath = resolveModule(record.filePath, source);
+    if (!modulePath) return { status: 'invalid' };
+    if (!isProjectModule(modulePath)) {
+      return {
+        status: 'resolved',
+        target: {
+          originKey: `${modulePath}#${exportName}`,
+          type: 'ordinary-external',
+        },
+      };
+    }
+    return resolveExportInternal(modulePath, exportName, seen);
+  };
+
+  const resolveDeclaredExport = (
+    record: LocalModuleRecord,
+    exportName: string,
+    declared: DeclaredExport,
+    seen: Set<string>
+  ): LocalExportResolution => {
+    if (declared.type === 'reexport') {
+      return resolveFromSource(
+        record,
+        declared.source,
+        declared.importedName,
+        seen
+      );
+    }
+    if (declared.type === 'namespace') {
+      if (isKnownNonVueGTRuntime(declared.source)) {
+        return {
+          status: 'resolved',
+          target: {
+            originKey: `${declared.source}#namespace`,
+            type: 'ordinary-external',
+          },
+        };
+      }
+      if (isExternalModule(declared.source)) {
+        return {
+          status: 'resolved',
+          target: {
+            originKey: `${declared.source}#namespace`,
+            source: declared.source,
+            type: 'external-namespace',
+          },
+        };
+      }
+      const modulePath = resolveModule(record.filePath, declared.source);
+      if (modulePath && !isProjectModule(modulePath)) {
+        return {
+          status: 'resolved',
+          target: {
+            originKey: `${modulePath}#namespace`,
+            type: 'ordinary-external',
+          },
+        };
+      }
+      return modulePath
+        ? {
+            status: 'resolved',
+            target: {
+              modulePath,
+              originKey: `${modulePath}#namespace`,
+              type: 'namespace',
+            },
+          }
+        : { status: 'invalid' };
+    }
+    if (declared.type === 'local') {
+      const imported = record.imports.get(declared.name);
+      if (imported) {
+        if (imported.importedName === '*') {
+          if (isKnownNonVueGTRuntime(imported.source)) {
+            return {
+              status: 'resolved',
+              target: {
+                originKey: `${imported.source}#namespace`,
+                type: 'ordinary-external',
+              },
+            };
+          }
+          if (isExternalModule(imported.source)) {
+            return {
+              status: 'resolved',
+              target: {
+                originKey: `${imported.source}#namespace`,
+                source: imported.source,
+                type: 'external-namespace',
+              },
+            };
+          }
+          const modulePath = resolveModule(record.filePath, imported.source);
+          if (modulePath && !isProjectModule(modulePath)) {
+            return {
+              status: 'resolved',
+              target: {
+                originKey: `${modulePath}#namespace`,
+                type: 'ordinary-external',
+              },
+            };
+          }
+          return modulePath
+            ? {
+                status: 'resolved',
+                target: {
+                  modulePath,
+                  originKey: `${modulePath}#namespace`,
+                  type: 'namespace',
+                },
+              }
+            : { status: 'invalid' };
+        }
+        return resolveFromSource(
+          record,
+          imported.source,
+          imported.importedName,
+          seen
+        );
+      }
+      return {
+        status: 'resolved',
+        target: {
+          exportName: declared.name,
+          originKey: `${record.filePath}#local:${declared.name}`,
+          record,
+          type: 'local',
+        },
+      };
+    }
+    return {
+      status: 'resolved',
+      target: {
+        node: declared.node,
+        originKey: `${record.filePath}#expression:${exportName}`,
+        record,
+        type: 'expression',
+      },
+    };
+  };
+
+  const resolveExport = (
+    filePath: string,
+    exportName: string
+  ): LocalExportResolution => {
+    const cacheKey = `${path.resolve(filePath)}\0${exportName}`;
+    const cached = resolutions.get(cacheKey);
+    if (cached) return cached;
+    const result = resolveExportInternal(filePath, exportName, new Set());
+    resolutions.set(cacheKey, result);
+    return result;
+  };
+
+  const listExportNames = (filePath: string): string[] => {
+    return [...collectExportNames(filePath, new Set())].sort();
+  };
+
+  const collectExportNames = (
+    filePath: string,
+    seen: Set<string>
+  ): Set<string> => {
+    const normalized = path.resolve(filePath);
+    if (seen.has(normalized)) return new Set();
+    const record = getRecord(normalized);
+    const recovered = record ? undefined : getRecoveredRecord(normalized);
+    if (!record && !recovered) return new Set();
+    const moduleRecord = record ?? recovered!;
+    const nextSeen = new Set(seen).add(normalized);
+    const names = new Set(moduleRecord.explicitExports.keys());
+    for (const source of moduleRecord.starExports) {
+      if (source === 'gt-vue') {
+        for (const name of GT_EXPORT_NAMES) names.add(name);
+      } else if (source === 'vue') {
+        for (const name of VUE_EXPORT_NAMES) names.add(name);
+      } else if (isKnownNonVueGTRuntime(source)) {
+        continue;
+      } else {
+        const modulePath = resolveModule(moduleRecord.filePath, source);
+        if (!modulePath || !isProjectModule(modulePath)) continue;
+        for (const name of collectExportNames(modulePath, nextSeen)) {
+          if (name !== 'default') names.add(name);
+        }
+      }
+    }
+    return names;
+  };
+
+  const hasGTExportReference = (
+    filePath: string,
+    exportName: string
+  ): boolean => {
+    return resolutionReferencesGT(
+      resolveExportInternal(filePath, exportName, new Set()),
+      new Set()
+    );
+  };
+
+  return {
+    getRecord,
+    hasCustomResolver: resolveModuleOption !== undefined,
+    hasGTExportReference,
+    isProjectModule,
+    listExportNames,
+    resolveExport,
+    resolveModule,
+  };
+}
+
+/** Deduplicates recovered graph targets without discarding their identities. */
+function uniqueRecoveredTargets(
+  targets: LocalExportTarget[]
+): LocalExportTarget[] {
+  return [
+    ...new Map(targets.map((target) => [target.originKey, target])).values(),
+  ];
+}
+
+function resolveSourceFile(requested: string): string | undefined {
+  const candidates: string[] = [requested];
+  const extension = path.extname(requested).toLowerCase();
+  if (!extension) {
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(`${requested}${sourceExtension}`);
+    }
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(path.join(requested, `index${sourceExtension}`));
+    }
+  } else if (['.js', '.jsx', '.mjs'].includes(extension)) {
+    const base = requested.slice(0, -extension.length);
+    for (const sourceExtension of SOURCE_EXTENSIONS) {
+      candidates.push(`${base}${sourceExtension}`);
+    }
+  }
+  return candidates.find(isReadableFile);
+}
+
+function isReadableFile(filePath: string): boolean {
+  try {
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/** Resolves symlinks when possible while retaining missing-path diagnostics. */
+function readRealPath(filePath: string): string {
+  try {
+    return fs.realpathSync.native(filePath);
+  } catch {
+    return filePath;
+  }
+}
+
+function parseLocalModule(filePath: string): LocalModuleRecord | undefined {
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  const extension = path.extname(filePath).toLowerCase();
+  // Node treats these extensions as CommonJS regardless of package metadata.
+  // Parsing ESM-looking syntax here would prove an identity the application
+  // cannot actually import with ESM semantics, so both formats fail closed.
+  if (extension === '.cjs' || extension === '.cts') return undefined;
+  let language = extension.slice(1);
+  if (extension === '.mjs') language = 'js';
+  if (extension === '.mts') language = 'ts';
+  // A local .vue module must be parsed with the consuming application's exact
+  // compiler. The extractor deliberately fails closed here instead of
+  // reintroducing a bundled-compiler mismatch through barrel resolution.
+  if (extension === '.vue') return undefined;
+  if (!['js', 'jsx', 'ts', 'tsx'].includes(language)) return undefined;
+
+  let ast: t.File;
+  try {
+    ast = parseScriptAst(source, language);
+  } catch {
+    return undefined;
+  }
+  let programScope: Scope | undefined;
+  traverse(ast, {
+    Program(programPath) {
+      programScope = programPath.scope;
+      programPath.stop();
+    },
+  });
+  if (!programScope) return undefined;
+
+  const record: LocalModuleRecord = {
+    ast,
+    explicitExports: new Map(),
+    filePath,
+    imports: collectImportedBindings(ast),
+    programScope,
+    starExports: [],
+  };
+  collectExports(record);
+  return record;
+}
+
+let moduleLexerInitialized = false;
+
+/**
+ * Recovers only source-bound runtime exports from an otherwise invalid module.
+ *
+ * The recovered declarations establish provenance, but never become executable
+ * analyzer input. Their resolutions remain invalid so consumers fail closed
+ * while type-only and unrelated module references stay invisible.
+ */
+function recoverMalformedModuleExports(
+  filePath: string
+): RecoveredModuleRecord | undefined {
+  const extension = path.extname(filePath).toLowerCase();
+  if (extension === '.cjs' || extension === '.cts' || extension === '.vue') {
+    return undefined;
+  }
+  let source: string;
+  try {
+    source = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return undefined;
+  }
+  if (!moduleLexerInitialized) {
+    initModuleLexer();
+    moduleLexerInitialized = true;
+  }
+  let moduleImports: ReturnType<typeof parseModuleImports>[0];
+  try {
+    [moduleImports] = parseModuleImports(source);
+  } catch {
+    return undefined;
+  }
+
+  const record: RecoveredModuleRecord = {
+    explicitExports: new Map(),
+    filePath,
+    starExports: [],
+  };
+  const statements = new Set<string>();
+  for (const moduleImport of moduleImports) {
+    if (
+      moduleImport.d !== -1 ||
+      moduleImport.ss < 0 ||
+      moduleImport.se <= moduleImport.ss
+    ) {
+      continue;
+    }
+    statements.add(source.slice(moduleImport.ss, moduleImport.se));
+  }
+
+  for (const statementSource of statements) {
+    const statement = parseRecoveredModuleStatement(statementSource, extension);
+    if (!statement) continue;
+    collectRecoveredExport(record, statement);
+  }
+  return record.explicitExports.size > 0 || record.starExports.length > 0
+    ? record
+    : undefined;
+}
+
+/** Parses one lexed declaration under the source file's supported grammars. */
+function parseRecoveredModuleStatement(
+  source: string,
+  extension: string
+): t.Statement | undefined {
+  const declaredLanguage =
+    extension === '.mjs'
+      ? 'js'
+      : extension === '.mts'
+        ? 'ts'
+        : extension.slice(1);
+  const languages = new Set<string>([declaredLanguage]);
+  if (declaredLanguage === 'js' || declaredLanguage === 'jsx') {
+    languages.add('flow');
+  }
+  languages.add('tsx');
+  for (const language of languages) {
+    try {
+      const ast = parseScriptAst(source, language);
+      if (ast.program.body.length === 1) return ast.program.body[0];
+    } catch {
+      // Try the next project-compatible grammar for this isolated statement.
+    }
+  }
+  return undefined;
+}
+
+/** Adds runtime re-exports without trusting declarations around the syntax error. */
+function collectRecoveredExport(
+  record: RecoveredModuleRecord,
+  statement: t.Statement
+): void {
+  if (statement.type === 'ExportAllDeclaration') {
+    if (statement.exportKind !== 'type') {
+      record.starExports.push(statement.source.value);
+    }
+    return;
+  }
+  if (
+    statement.type !== 'ExportNamedDeclaration' ||
+    statement.exportKind === 'type' ||
+    !statement.source
+  ) {
+    return;
+  }
+  for (const specifier of statement.specifiers) {
+    if (
+      specifier.type === 'ExportSpecifier' &&
+      specifier.exportKind === 'type'
+    ) {
+      continue;
+    }
+    const exportedName =
+      specifier.exported.type === 'Identifier'
+        ? specifier.exported.name
+        : specifier.exported.value;
+    if (specifier.type === 'ExportNamespaceSpecifier') {
+      addRecoveredExplicitExport(record, exportedName, {
+        source: statement.source.value,
+        type: 'namespace',
+      });
+      continue;
+    }
+    if (specifier.type !== 'ExportSpecifier') continue;
+    addRecoveredExplicitExport(record, exportedName, {
+      importedName: specifier.local.name,
+      source: statement.source.value,
+      type: 'reexport',
+    });
+  }
+}
+
+/** Preserves ambiguity instead of selecting an arbitrary recovered identity. */
+function addRecoveredExplicitExport(
+  record: RecoveredModuleRecord,
+  name: string,
+  value: RecoveredDeclaredExport
+): void {
+  record.explicitExports.set(
+    name,
+    record.explicitExports.has(name) ? 'ambiguous' : value
+  );
+}
+
+function collectImportedBindings(ast: t.File): Map<string, ImportedBinding> {
+  const imports = new Map<string, ImportedBinding>();
+  for (const statement of ast.program.body) {
+    if (
+      statement.type !== 'ImportDeclaration' ||
+      isTypeOnlyImportKind(statement.importKind)
+    ) {
+      continue;
+    }
+    for (const specifier of statement.specifiers) {
+      if (
+        specifier.type === 'ImportSpecifier' &&
+        !isTypeOnlyImportKind(specifier.importKind)
+      ) {
+        imports.set(specifier.local.name, {
+          importedName:
+            specifier.imported.type === 'Identifier'
+              ? specifier.imported.name
+              : specifier.imported.value,
+          source: statement.source.value,
+        });
+      } else if (specifier.type === 'ImportDefaultSpecifier') {
+        imports.set(specifier.local.name, {
+          importedName: 'default',
+          source: statement.source.value,
+        });
+      } else if (specifier.type === 'ImportNamespaceSpecifier') {
+        imports.set(specifier.local.name, {
+          importedName: '*',
+          source: statement.source.value,
+        });
+      }
+    }
+  }
+  return imports;
+}
+
+/** Returns whether Babel classified an ESM binding as type-only. */
+function isTypeOnlyImportKind(kind: string | null | undefined): boolean {
+  return kind === 'type' || kind === 'typeof';
+}
+
+function collectExports(record: LocalModuleRecord): void {
+  for (const statement of record.ast.program.body) {
+    if (statement.type === 'ExportAllDeclaration') {
+      if (statement.exportKind !== 'type') {
+        record.starExports.push(statement.source.value);
+      }
+      continue;
+    }
+    if (statement.type === 'ExportDefaultDeclaration') {
+      addExplicitExport(record, 'default', {
+        node: statement.declaration,
+        type: 'expression',
+      });
+      continue;
+    }
+    if (
+      statement.type !== 'ExportNamedDeclaration' ||
+      statement.exportKind === 'type'
+    ) {
+      continue;
+    }
+    if (statement.declaration) {
+      for (const name of declaredNames(statement.declaration)) {
+        addExplicitExport(record, name, { name, type: 'local' });
+      }
+    }
+    for (const specifier of statement.specifiers) {
+      if (
+        specifier.type === 'ExportSpecifier' &&
+        specifier.exportKind === 'type'
+      ) {
+        continue;
+      }
+      const exportedName =
+        specifier.exported.type === 'Identifier'
+          ? specifier.exported.name
+          : specifier.exported.value;
+      if (specifier.type === 'ExportNamespaceSpecifier') {
+        if (statement.source) {
+          addExplicitExport(record, exportedName, {
+            source: statement.source.value,
+            type: 'namespace',
+          });
+        }
+        continue;
+      }
+      if (specifier.type !== 'ExportSpecifier') continue;
+      const localName = specifier.local.name;
+      addExplicitExport(
+        record,
+        exportedName,
+        statement.source
+          ? {
+              importedName: localName,
+              source: statement.source.value,
+              type: 'reexport',
+            }
+          : { name: localName, type: 'local' }
+      );
+    }
+  }
+}
+
+function addExplicitExport(
+  record: LocalModuleRecord,
+  name: string,
+  value: DeclaredExport
+): void {
+  record.explicitExports.set(
+    name,
+    record.explicitExports.has(name) ? 'ambiguous' : value
+  );
+}
+
+function declaredNames(declaration: t.Declaration): string[] {
+  if (
+    declaration.type === 'FunctionDeclaration' ||
+    declaration.type === 'ClassDeclaration'
+  ) {
+    return declaration.id ? [declaration.id.name] : [];
+  }
+  if (declaration.type !== 'VariableDeclaration') return [];
+  return declaration.declarations.flatMap(({ id }) => patternNames(id));
+}
+
+function patternNames(pattern: t.Node): string[] {
+  if (pattern.type === 'Identifier') return [pattern.name];
+  if (pattern.type === 'RestElement') return patternNames(pattern.argument);
+  if (pattern.type === 'AssignmentPattern') return patternNames(pattern.left);
+  if (pattern.type === 'ArrayPattern') {
+    return pattern.elements.flatMap((element) =>
+      element ? patternNames(element) : []
+    );
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return pattern.properties.flatMap((property) =>
+      property.type === 'RestElement'
+        ? patternNames(property.argument)
+        : patternNames(property.value)
+    );
+  }
+  return [];
+}
+
+function isExternalModule(source: string): source is ExternalModuleName {
+  return source === 'gt-vue' || source === 'vue';
+}
+
+function knownExternalExport(
+  source: ExternalModuleName,
+  exportName: string
+): boolean {
+  return source === 'gt-vue'
+    ? (GT_EXPORT_NAMES as readonly string[]).includes(exportName)
+    : (VUE_EXPORT_NAMES as readonly string[]).includes(exportName);
+}

--- a/packages/vue-extractor/src/internal/script/localModules.ts
+++ b/packages/vue-extractor/src/internal/script/localModules.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import traverseModule, { type Scope } from '@babel/traverse';
+import traverseModule, {
+  type Binding,
+  type NodePath,
+  type Scope,
+} from '@babel/traverse';
 import type * as t from '@babel/types';
 import {
   initSync as initModuleLexer,
@@ -149,6 +153,11 @@ export type LocalExportResolution =
 /** Read-only local source resolver used by the Vue script analyzer. */
 export type LocalModuleResolver = {
   getRecord(filePath: string): LocalModuleRecord | undefined;
+  /** Returns the exact GT leaf behind an export, excluding namespace containers. */
+  getGTExportName(
+    filePath: string,
+    exportName: string
+  ): string | '*' | undefined;
   /** Whether the caller supplied project-specific bare-specifier semantics. */
   hasCustomResolver: boolean;
   /** Whether a resolved module belongs to project source rather than an install. */
@@ -179,6 +188,10 @@ export function createLocalModuleResolver(
   const records = new Map<string, LocalModuleRecord | null>();
   const recoveredRecords = new Map<string, RecoveredModuleRecord | null>();
   const resolutions = new Map<string, LocalExportResolution>();
+  const recordPaths = new WeakMap<
+    LocalModuleRecord,
+    WeakMap<t.Node, NodePath<t.Node>>
+  >();
 
   const isProjectModule = (filePath: string): boolean => {
     const realPath = readRealPath(path.resolve(filePath));
@@ -460,10 +473,13 @@ export function createLocalModuleResolver(
 
   const readGTExportName = (
     resolution: LocalExportResolution,
-    seen: Set<string>
+    seen: Set<string>,
+    allowNamespaceContainers = true
   ): string | '*' | undefined => {
     if (resolution.status === 'invalid') {
-      return resolution.gtExportName;
+      return allowNamespaceContainers || resolution.gtExportName !== '*'
+        ? resolution.gtExportName
+        : undefined;
     }
     if (resolution.status !== 'resolved') return undefined;
     const { target } = resolution;
@@ -471,21 +487,487 @@ export function createLocalModuleResolver(
       return target.source === 'gt-vue' ? target.exportName : undefined;
     }
     if (target.type === 'external-namespace') {
-      return target.source === 'gt-vue' ? '*' : undefined;
+      return allowNamespaceContainers && target.source === 'gt-vue'
+        ? '*'
+        : undefined;
     }
-    if (target.type !== 'namespace') return undefined;
-    const candidateNames = options.recognizeAllGTRuntimeExports
-      ? [...GT_RUNTIME_EXPORT_NAMES]
-      : [...GT_EXPORT_NAMES];
-    return candidateNames.some((name) =>
-      Boolean(
-        readGTExportName(
-          resolveExportInternal(target.modulePath, name, seen),
-          seen
+    if (target.type === 'namespace') {
+      if (!allowNamespaceContainers) return undefined;
+      const candidateNames = options.recognizeAllGTRuntimeExports
+        ? [...GT_RUNTIME_EXPORT_NAMES]
+        : [...GT_EXPORT_NAMES];
+      return candidateNames.some((name) =>
+        Boolean(
+          readGTExportName(
+            resolveExportInternal(target.modulePath, name, seen),
+            seen,
+            allowNamespaceContainers
+          )
         )
       )
-    )
-      ? '*'
+        ? '*'
+        : undefined;
+    }
+    if (target.type === 'ordinary-external') return undefined;
+    const state: DerivedGTState = {
+      bindings: new Set(),
+      nodes: new Set(),
+      record: target.record,
+      resolutions: seen,
+      allowNamespaceContainers,
+    };
+    if (target.type === 'expression') {
+      return readDerivedGT(target.node, state);
+    }
+    const binding = target.record.programScope.getBinding(target.exportName);
+    return binding ? readDerivedGTBinding(binding, state) : undefined;
+  };
+
+  type DerivedGTState = {
+    allowNamespaceContainers: boolean;
+    bindings: Set<Binding>;
+    nodes: Set<t.Node>;
+    record: LocalModuleRecord;
+    resolutions: Set<string>;
+  };
+
+  /** Lazily indexes lexical paths only when package provenance needs them. */
+  const readNodePath = (
+    record: LocalModuleRecord,
+    node: t.Node
+  ): NodePath<t.Node> | undefined => {
+    let paths = recordPaths.get(record);
+    if (!paths) {
+      paths = new WeakMap();
+      traverse(record.ast, {
+        enter(nodePath) {
+          paths!.set(nodePath.node, nodePath as NodePath<t.Node>);
+        },
+      });
+      recordPaths.set(record, paths);
+    }
+    return paths.get(node);
+  };
+
+  /** Rejects a namespace member whose value is overwritten in this module. */
+  const namespaceMemberIsWritten = (
+    binding: Binding,
+    exportName: string
+  ): boolean => {
+    return binding.referencePaths.some((reference) => {
+      const member = reference.parentPath;
+      if (
+        (!member?.isMemberExpression() &&
+          !member?.isOptionalMemberExpression()) ||
+        member.node.object !== reference.node ||
+        readStaticMemberName(member.node) !== exportName
+      ) {
+        return false;
+      }
+      const parent = member.parentPath?.node;
+      return Boolean(
+        (parent?.type === 'AssignmentExpression' &&
+          parent.left === member.node) ||
+        (parent?.type === 'UpdateExpression' &&
+          parent.argument === member.node) ||
+        (parent?.type === 'UnaryExpression' &&
+          parent.operator === 'delete' &&
+          parent.argument === member.node) ||
+        ((parent?.type === 'ForInStatement' ||
+          parent?.type === 'ForOfStatement') &&
+          parent.left === member.node)
+      );
+    });
+  };
+
+  /** Follows immutable aliases while rejecting mutation and lexical shadows. */
+  const readDerivedGTBinding = (
+    binding: Binding,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    if (!binding.constant || state.bindings.has(binding)) return undefined;
+    const next = {
+      ...state,
+      bindings: new Set(state.bindings).add(binding),
+    };
+    if (binding.kind === 'module') {
+      const imported = state.record.imports.get(binding.identifier.name);
+      if (!imported) return undefined;
+      if (imported.importedName === '*') {
+        return state.allowNamespaceContainers && imported.source === 'gt-vue'
+          ? '*'
+          : undefined;
+      }
+      return readGTExportName(
+        resolveFromSource(
+          state.record,
+          imported.source,
+          imported.importedName,
+          state.resolutions
+        ),
+        state.resolutions,
+        state.allowNamespaceContainers
+      );
+    }
+    const declaration = binding.path.node;
+    if (declaration.type === 'VariableDeclarator') {
+      if (declaration.id.type === 'Identifier') {
+        return readDerivedGT(declaration.init, next);
+      }
+      return readDestructuredGTBinding(binding, declaration, next);
+    }
+    return declaration.type === 'FunctionDeclaration'
+      ? readDerivedGT(declaration, next)
+      : undefined;
+  };
+
+  /** Resolves one exact leaf destructured from a direct gt-vue namespace. */
+  const readDestructuredGTBinding = (
+    binding: Binding,
+    declaration: t.VariableDeclarator,
+    state: DerivedGTState
+  ): string | undefined => {
+    if (
+      declaration.id.type !== 'ObjectPattern' ||
+      declaration.id.properties.some(
+        (property) => property.type === 'RestElement'
+      )
+    ) {
+      return undefined;
+    }
+    const property = declaration.id.properties.find(
+      (candidate): candidate is t.ObjectProperty =>
+        candidate.type === 'ObjectProperty' &&
+        !candidate.computed &&
+        candidate.value.type === 'Identifier' &&
+        candidate.value === binding.identifier
+    );
+    const exportName = property ? readStaticObjectKey(property) : undefined;
+    if (
+      !exportName ||
+      !knownExternalExport(
+        'gt-vue',
+        exportName,
+        options.recognizeAllGTRuntimeExports === true
+      )
+    ) {
+      return undefined;
+    }
+
+    const namespace = unwrapLocalExpression(declaration.init);
+    if (!namespace || namespace.type !== 'Identifier') return undefined;
+    const namespaceBinding = readNodePath(
+      state.record,
+      namespace
+    )?.scope.getBinding(namespace.name);
+    const imported = namespaceBinding
+      ? state.record.imports.get(namespaceBinding.identifier.name)
+      : undefined;
+    return namespaceBinding?.kind === 'module' &&
+      namespaceBinding.constant &&
+      imported?.source === 'gt-vue' &&
+      imported.importedName === '*' &&
+      !namespaceMemberIsWritten(namespaceBinding, exportName)
+      ? exportName
+      : undefined;
+  };
+
+  /** Resolves a direct gt-vue value, including immutable local aliases. */
+  const readDirectGT = (
+    node: t.Node | null | undefined,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    const expression = unwrapLocalExpression(node);
+    if (!expression || state.nodes.has(expression)) return undefined;
+    const next = { ...state, nodes: new Set(state.nodes).add(expression) };
+    if (expression.type === 'Identifier') {
+      const binding = readNodePath(state.record, expression)?.scope.getBinding(
+        expression.name
+      );
+      return binding ? readDerivedGTBinding(binding, next) : undefined;
+    }
+    if (
+      expression.type !== 'MemberExpression' &&
+      expression.type !== 'OptionalMemberExpression'
+    ) {
+      return undefined;
+    }
+    const property = readStaticMemberName(expression);
+    const object = unwrapLocalExpression(expression.object);
+    if (!property || object?.type !== 'Identifier') return undefined;
+    const binding = readNodePath(state.record, object)?.scope.getBinding(
+      object.name
+    );
+    if (!binding || binding.kind !== 'module' || !binding.constant) {
+      return undefined;
+    }
+    const imported = state.record.imports.get(binding.identifier.name);
+    if (!imported || imported.importedName !== '*') return undefined;
+    if (namespaceMemberIsWritten(binding, property)) return undefined;
+    if (imported.source === 'gt-vue') {
+      return knownExternalExport(
+        imported.source,
+        property,
+        options.recognizeAllGTRuntimeExports === true
+      )
+        ? property
+        : undefined;
+    }
+    const modulePath = resolveModule(state.record.filePath, imported.source);
+    return modulePath && isProjectModule(modulePath)
+      ? readGTExportName(
+          resolveExportInternal(modulePath, property, state.resolutions),
+          state.resolutions,
+          state.allowNamespaceContainers
+        )
+      : undefined;
+  };
+
+  /** Recognizes only explicit aliases and Vue component wrapper forms. */
+  const readDerivedGT = (
+    node: t.Node | null | undefined,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    const direct = readDirectGT(node, state);
+    if (direct) return direct;
+    const expression = unwrapLocalExpression(node);
+    if (!expression || state.nodes.has(expression)) return undefined;
+    const next = { ...state, nodes: new Set(state.nodes).add(expression) };
+    if (
+      expression.type === 'ArrowFunctionExpression' ||
+      expression.type === 'FunctionExpression' ||
+      expression.type === 'FunctionDeclaration' ||
+      expression.type === 'ObjectMethod'
+    ) {
+      return readFunctionRenderedGT(expression, next);
+    }
+    if (expression.type === 'ObjectExpression') {
+      return readComponentObjectGT(expression, next);
+    }
+    if (
+      (expression.type === 'CallExpression' ||
+        expression.type === 'OptionalCallExpression') &&
+      isVueHelper(expression.callee, state, 'defineComponent')
+    ) {
+      const component = expression.arguments[0];
+      return component &&
+        component.type !== 'SpreadElement' &&
+        component.type !== 'ArgumentPlaceholder'
+        ? readDerivedGT(component, next)
+        : undefined;
+    }
+    return readRenderedGT(expression, state);
+  };
+
+  /** Checks only return values owned by the wrapper function itself. */
+  const readFunctionRenderedGT = (
+    fn: t.Function,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    if (
+      fn.type === 'ArrowFunctionExpression' &&
+      fn.body.type !== 'BlockStatement'
+    ) {
+      return readRenderedGT(fn.body, state);
+    }
+    const functionPath = readNodePath(state.record, fn);
+    if (!functionPath) return undefined;
+    let result: string | '*' | undefined;
+    functionPath.traverse({
+      ReturnStatement(returnPath) {
+        if (result || returnPath.getFunctionParent()?.node !== fn) return;
+        result = readRenderedGT(returnPath.node.argument, state);
+      },
+    });
+    return result;
+  };
+
+  /** Checks the two component options that can directly produce rendered output. */
+  const readComponentObjectGT = (
+    object: t.ObjectExpression,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    for (const property of object.properties) {
+      if (property.type === 'SpreadElement') continue;
+      const name = readStaticObjectKey(property);
+      if (name !== 'render' && name !== 'setup') continue;
+      const value =
+        property.type === 'ObjectProperty' ? property.value : property;
+      const result = readDerivedGT(value, state);
+      if (result) return result;
+    }
+    return undefined;
+  };
+
+  /** Recognizes GT only in returned JSX or the h/createVNode component slot. */
+  const readRenderedGT = (
+    node: t.Node | null | undefined,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    const expression = unwrapLocalExpression(node);
+    if (!expression || state.nodes.has(expression)) return undefined;
+    const next = { ...state, nodes: new Set(state.nodes).add(expression) };
+    if (
+      expression.type === 'ArrowFunctionExpression' ||
+      expression.type === 'FunctionExpression'
+    ) {
+      return readFunctionRenderedGT(expression, next);
+    }
+    if (expression.type === 'JSXElement') {
+      const component = readJSXComponentGT(
+        expression.openingElement.name,
+        next
+      );
+      if (component) return component;
+      for (const child of expression.children) {
+        const value =
+          child.type === 'JSXExpressionContainer'
+            ? child.expression.type === 'JSXEmptyExpression'
+              ? undefined
+              : child.expression
+            : child;
+        const result = readRenderedGT(value, next);
+        if (result) return result;
+      }
+      return undefined;
+    }
+    if (expression.type === 'JSXFragment') {
+      for (const child of expression.children) {
+        const value =
+          child.type === 'JSXExpressionContainer'
+            ? child.expression.type === 'JSXEmptyExpression'
+              ? undefined
+              : child.expression
+            : child;
+        const result = readRenderedGT(value, next);
+        if (result) return result;
+      }
+      return undefined;
+    }
+    if (expression.type === 'ConditionalExpression') {
+      return (
+        readRenderedGT(expression.consequent, next) ??
+        readRenderedGT(expression.alternate, next)
+      );
+    }
+    if (expression.type === 'LogicalExpression') {
+      return (
+        readRenderedGT(expression.left, next) ??
+        readRenderedGT(expression.right, next)
+      );
+    }
+    if (
+      (expression.type !== 'CallExpression' &&
+        expression.type !== 'OptionalCallExpression') ||
+      (!isVueHelper(expression.callee, state, 'h') &&
+        !isVueHelper(expression.callee, state, 'createVNode'))
+    ) {
+      return undefined;
+    }
+    const component = expression.arguments[0];
+    return component &&
+      component.type !== 'SpreadElement' &&
+      component.type !== 'ArgumentPlaceholder'
+      ? readDirectGT(component, next)
+      : undefined;
+  };
+
+  /** Resolves an imported GT component used as a JSX element name. */
+  const readJSXComponentGT = (
+    name: t.JSXIdentifier | t.JSXMemberExpression | t.JSXNamespacedName,
+    state: DerivedGTState
+  ): string | '*' | undefined => {
+    if (name.type === 'JSXMemberExpression') {
+      if (name.object.type !== 'JSXIdentifier') return undefined;
+      const binding = readNodePath(state.record, name.object)?.scope.getBinding(
+        name.object.name
+      );
+      if (!binding || binding.kind !== 'module' || !binding.constant) {
+        return undefined;
+      }
+      const imported = state.record.imports.get(binding.identifier.name);
+      if (!imported || imported.importedName !== '*') return undefined;
+      const property = name.property.name;
+      if (namespaceMemberIsWritten(binding, property)) return undefined;
+      if (imported.source === 'gt-vue') {
+        return knownExternalExport(
+          imported.source,
+          property,
+          options.recognizeAllGTRuntimeExports === true
+        )
+          ? property
+          : undefined;
+      }
+      const modulePath = resolveModule(state.record.filePath, imported.source);
+      return modulePath && isProjectModule(modulePath)
+        ? readGTExportName(
+            resolveExportInternal(modulePath, property, state.resolutions),
+            state.resolutions,
+            state.allowNamespaceContainers
+          )
+        : undefined;
+    }
+    if (name.type !== 'JSXIdentifier' || /^[a-z]/.test(name.name)) return;
+    const binding = readNodePath(state.record, name)?.scope.getBinding(
+      name.name
+    );
+    return binding ? readDerivedGTBinding(binding, state) : undefined;
+  };
+
+  /** Matches a direct or namespace ESM import from Vue without evaluating calls. */
+  const isVueHelper = (
+    node: t.Node,
+    state: DerivedGTState,
+    exportName: 'createVNode' | 'defineComponent' | 'h'
+  ): boolean => {
+    const expression = unwrapLocalExpression(node);
+    if (!expression) return false;
+    const identifier =
+      expression.type === 'Identifier'
+        ? expression
+        : (expression.type === 'MemberExpression' ||
+              expression.type === 'OptionalMemberExpression') &&
+            readStaticMemberName(expression) === exportName
+          ? unwrapLocalExpression(expression.object)
+          : undefined;
+    if (!identifier || identifier.type !== 'Identifier') return false;
+    const binding = readNodePath(state.record, identifier)?.scope.getBinding(
+      identifier.name
+    );
+    const imported =
+      binding?.kind === 'module'
+        ? state.record.imports.get(binding.identifier.name)
+        : undefined;
+    const expectedImport = expression.type === 'Identifier' ? exportName : '*';
+    return (
+      binding?.constant === true &&
+      imported?.source === 'vue' &&
+      imported.importedName === expectedImport &&
+      (expectedImport !== '*' || !namespaceMemberIsWritten(binding, exportName))
+    );
+  };
+
+  const readStaticMemberName = (
+    member: t.MemberExpression | t.OptionalMemberExpression
+  ): string | undefined => {
+    if (!member.computed && member.property.type === 'Identifier') {
+      return member.property.name;
+    }
+    return member.computed && member.property.type === 'StringLiteral'
+      ? member.property.value
+      : undefined;
+  };
+
+  const readStaticObjectKey = (property: {
+    computed?: boolean;
+    key?: t.Node;
+  }): string | undefined => {
+    if (!property.key) return undefined;
+    if (!property.computed && property.key.type === 'Identifier') {
+      return property.key.name;
+    }
+    return property.key.type === 'StringLiteral'
+      ? property.key.value
       : undefined;
   };
 
@@ -725,8 +1207,19 @@ export function createLocalModuleResolver(
     );
   };
 
+  const getGTExportName = (
+    filePath: string,
+    exportName: string
+  ): string | '*' | undefined => {
+    const resolution = resolveExportInternal(filePath, exportName, new Set());
+    return resolution.status === 'resolved'
+      ? readGTExportName(resolution, new Set(), false)
+      : undefined;
+  };
+
   return {
     getRecord,
+    getGTExportName,
     hasCustomResolver: resolveModuleOption !== undefined,
     hasGTExportReference,
     isProjectModule,
@@ -734,6 +1227,26 @@ export function createLocalModuleResolver(
     resolveExport,
     resolveModule,
   };
+}
+
+/** Removes syntax-only wrappers without importing the compiler-facing utilities. */
+function unwrapLocalExpression(
+  input: t.Node | null | undefined
+): t.Node | undefined {
+  let current = input ?? undefined;
+  while (
+    current &&
+    (current.type === 'TSAsExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSInstantiationExpression' ||
+      current.type === 'TypeCastExpression' ||
+      current.type === 'ParenthesizedExpression')
+  ) {
+    current = current.expression;
+  }
+  return current;
 }
 
 /** Deduplicates recovered graph targets without discarding their identities. */

--- a/packages/vue-extractor/src/internal/script/model.ts
+++ b/packages/vue-extractor/src/internal/script/model.ts
@@ -1,0 +1,356 @@
+import type { Binding, NodePath, Scope } from '@babel/traverse';
+import type * as t from '@babel/types';
+import type {
+  GTComponentName,
+  StringFunctionKind,
+  TemplateContainerKind,
+  VueBuiltinName,
+} from '../types.js';
+import type { LocalModuleResolver } from './localModules.js';
+
+/** A statically recognized value that affects Vue translation extraction. */
+export type KnownValue =
+  | { type: 'component'; name: GTComponentName }
+  | { type: 'hook'; kind: Exclude<StringFunctionKind, 'msg'> }
+  | { type: 'string'; kind: StringFunctionKind }
+  | {
+      type: 'namespace';
+      source: 'gt-vue' | 'vue';
+      /** CommonJS namespace objects can be mutated through member writes. */
+      mutable: boolean;
+    }
+  | {
+      /** Immutable ESM namespace imported from a statically resolved barrel. */
+      type: 'local-namespace';
+      modulePath: string;
+    }
+  | { type: 'vue-builtin'; name: VueBuiltinName }
+  | {
+      type: 'vue-call';
+      name: 'createVNode' | 'defineAsyncComponent' | 'h';
+    }
+  | {
+      type: 'container-wrapper';
+      kind: ContainerWrapperKind;
+      writePolicy: ContainerWritePolicy;
+    }
+  | { type: 'vue-wrapper'; kind: 'computed' | 'ref' }
+  | { type: 'identity' }
+  | { type: 'defineComponent' };
+
+export type ContainerWritePolicy =
+  | 'forward'
+  | 'readonly-deep'
+  | 'readonly-shallow';
+
+export type ContainerWrapperKind =
+  | 'reactive'
+  | 'readonly'
+  | 'shallow-reactive'
+  | 'shallow-readonly'
+  | 'to-raw'
+  | 'unref';
+
+/** Import information shared by the two script blocks of one Vue SFC. */
+export type VueScriptAnalysis = {
+  /** Optional visit counters used by deterministic complexity regressions. */
+  stats?: VueScriptAnalysisStats;
+  /** Absolute path of the source file currently being extracted. */
+  entryFile?: string;
+  /** Whether static analysis reached the gt-vue package through source code. */
+  hasGTSourceReference: boolean;
+  /** Read-only local ESM graph used to resolve application barrels. */
+  localModules?: LocalModuleResolver;
+  /** Lengths of statically known, non-mutated normal-script arrays. */
+  arrayLengths: Map<string, number>;
+  /** Normal-script callables that may return a GT or Vue component. */
+  componentFactories: Set<string>;
+  /** Statically known normal-script container paths. */
+  containerKinds: Map<string, TemplateContainerKind>;
+  /** Normal-script names that take precedence over component registrations. */
+  directBindings: Set<string>;
+  /** Normal-script callables that may specifically return a GT component. */
+  gtComponentFactories: Set<string>;
+  /** Statically visible string alternatives for non-singleton expressions. */
+  possibleStaticStrings: Map<string, Set<string>>;
+  /** Container or factory paths whose selected value can be `<T>`. */
+  possibleGTContainers: Set<string>;
+  /** Normal-script callables returning containers that may directly contain T. */
+  gtContainerFactories: Set<string>;
+  staticValues: Map<string, string | number | bigint | boolean | null>;
+  /** Values exposed to templates after Vue's top-level ref unwrapping. */
+  templateValues: Map<string, KnownValue>;
+  /** Cross-block component bindings whose runtime identity is not provable. */
+  uncertainComponents: Set<string>;
+  /** Cross-block aliases that can specifically resolve to a GT component. */
+  uncertainGTComponents: Set<string>;
+  /** Cross-block aliases that may resolve to a gt-vue string function. */
+  uncertainStringFunctions: Set<string>;
+  /** Mutable local helpers that are unsafe only when passed a translator. */
+  uncertainTranslationHelpers: Set<string>;
+  values: Map<string, KnownValue>;
+};
+
+/** Internal analyzer visits whose growth should remain bounded by source size. */
+export type VueScriptAnalysisStats = {
+  arrayEntryVisits: number;
+  containerKindVisits: number;
+  finalContainerSnapshotReads: number;
+  knownExpressionVisits: number;
+  stringFunctionVisits: number;
+  transformArrayEntryVisits: number;
+};
+
+/** Babel expression paired with the lexical scope in which it is evaluated. */
+export type ScopedExpression = { node: t.Node; scope: Scope };
+
+export type ComponentKind = 'translation' | 'vue' | 'T';
+
+export type TemplateKnownValue = Extract<
+  KnownValue,
+  { type: 'component' | 'string' | 'vue-builtin' }
+>;
+
+export type ComponentMemberCandidate = {
+  certain: boolean;
+  name: string;
+  value: TemplateKnownValue;
+};
+
+export type ComponentFactoryCandidate = { gt: boolean; name: string };
+
+export type ObjectEntryResult =
+  | { status: 'absent' }
+  | { status: 'known'; expression: ScopedExpression }
+  | { status: 'unknown' };
+
+export type CollectedObjectEntries = {
+  entries: Map<string, ScopedExpression>;
+  unknownAll: boolean;
+  unknownNames: Set<string>;
+};
+
+export type TemplateExposure =
+  | { type: 'known'; value: KnownValue }
+  | {
+      type: 'container';
+      kind?: TemplateContainerKind;
+      length?: number;
+      possibleGT?: true;
+    }
+  | {
+      type: 'uncertain';
+      component: boolean;
+      gtComponent: boolean;
+      stringFunction: boolean;
+    }
+  | { type: 'factory'; gt: boolean; gtContainer?: boolean }
+  | { type: 'possible-static-strings'; values: Set<string> }
+  | {
+      type: 'static';
+      value: string | number | bigint | boolean | null;
+    };
+
+export type GTContainerExposure = {
+  containers: Set<string>;
+  factories: Set<string>;
+};
+
+export type FinalContainerSnapshot =
+  | {
+      kind: 'array';
+      entries: Array<ScopedExpression | undefined>;
+    }
+  | {
+      kind: 'object';
+      entries: Map<string, ScopedExpression>;
+    };
+
+export type FinalContainerOperation = {
+  position: number;
+  apply: (
+    snapshot: FinalContainerSnapshot
+  ) => FinalContainerSnapshot | undefined;
+};
+
+export type ContainerIdentityReplay = {
+  unsafeBindings: Set<Binding>;
+  values: Map<Binding, ReplayValue | undefined>;
+};
+
+export type ReplayValue =
+  | ReplayCollectionReference
+  | ReplayComputedReference
+  | ReplayContainerReference
+  | ReplayFunctionReference
+  | ReplayGetterReference
+  | ReplayLeaf
+  | ReplayMethodReference
+  | ReplayRefReference
+  | ReplayUnsafe;
+
+export type ReplayContainerReference = {
+  type: 'container';
+  identity: ReplayContainerIdentity;
+  writePolicy: ContainerWritePolicy;
+};
+
+export type ReplayContainerIdentity = {
+  escaped: boolean;
+  snapshot: ReplayContainerSnapshot;
+};
+
+export type ReplayRefReference = {
+  type: 'ref';
+  identity: ReplayRefIdentity;
+  writePolicy: ContainerWritePolicy;
+};
+
+export type ReplayRefIdentity = {
+  escaped: boolean;
+  value: ReplayValue | undefined;
+};
+
+export type ReplayComputedReference = {
+  type: 'computed';
+  getter: ScopedExpression & { node: t.Function };
+  writePolicy: ContainerWritePolicy;
+};
+
+export type ReplayGetterReference = {
+  type: 'getter';
+  getter: ScopedExpression & { node: t.Function };
+  substitutions: Map<Binding, ReplayValue>;
+};
+
+export type ReplayFunctionReference = {
+  type: 'function';
+  boundArguments: ReplayValue[];
+  callable: ScopedExpression & { node: t.Function };
+  substitutions: Map<Binding, ReplayValue>;
+  thisValue?: ReplayValue;
+};
+
+export type ReplayMethodReference = {
+  type: 'method';
+  callable: ScopedExpression & { node: t.Function };
+  receiver?: ReplayContainerReference;
+  substitutions: Map<Binding, ReplayValue>;
+};
+
+export type ReplayCollectionReference = {
+  type: 'collection';
+  identity: ReplayCollectionIdentity;
+  iteration: 'entries' | 'values';
+  writePolicy: ContainerWritePolicy;
+};
+
+export type ReplayCollectionIdentity = {
+  entries: Map<string, ReplayValue>;
+  escaped: boolean;
+  kind: 'map' | 'set';
+  templateKeys: Map<string, string>;
+};
+
+export type ReplayContainerSnapshot =
+  | {
+      kind: 'array';
+      entries: Array<ReplayValue | undefined>;
+    }
+  | {
+      kind: 'object';
+      entries: Map<string, ReplayValue>;
+      prototype?: ReplayContainerReference;
+      setters?: Map<string, ReplayMethodReference>;
+    };
+
+export type ReplayLeaf = {
+  type: 'leaf';
+  exactSelection?: boolean;
+  expression: ScopedExpression;
+  hasGT: boolean | undefined;
+  knownValue?: TemplateKnownValue;
+  selectionKind?: 'collection' | 'getter' | 'member' | 'ref';
+};
+
+export type ReplayUnsafe = { type: 'unsafe' };
+
+export type ReplayEvaluationContext = {
+  /** Enables getter side effects only while replaying actual program execution. */
+  allowGetterEffects?: boolean;
+  substitutions: Map<Binding, ReplayValue>;
+  thisValue?: ReplayValue;
+  unsafeBindings: Set<Binding>;
+  values: Map<Binding, ReplayValue | undefined>;
+};
+
+export type ReplayLeafState =
+  | { status: 'leaf'; value: ReplayLeaf }
+  | { status: 'unsafe' };
+
+/** Mutable analysis caches shared by one parsed script block. */
+export type ScriptState = {
+  activeComponentFunctions: Set<t.Function>;
+  activeReplayFunctions: Set<t.Function>;
+  activeStringFunctions: Set<t.Function>;
+  activeTranslationFunctions: Set<t.Function>;
+  analysis: VueScriptAnalysis;
+  attachedLocalModules: Set<string>;
+  arrayEntries: Map<Binding, Array<ScopedExpression | undefined> | null>;
+  arrayEntriesInProgress: Set<Binding>;
+  componentPossibilities: Map<Binding, Map<ComponentKind | 'any', boolean>>;
+  componentFactoryCandidates: Map<Binding, ComponentFactoryCandidate[]>;
+  componentFactoryCandidatesInProgress: Set<Binding>;
+  bindings: Map<Binding, KnownValue>;
+  containerKindSnapshots: Map<
+    Binding,
+    {
+      arrayLengths: Map<string, number>;
+      kinds: Map<string, TemplateContainerKind>;
+    }
+  >;
+  containerKindSnapshotsInProgress: Set<Binding>;
+  containerIdentityReplays: WeakMap<t.Node, ContainerIdentityReplay>;
+  containerWritePolicies: Map<Binding, ContainerWritePolicy | undefined>;
+  /** Immutable aliases proven to hold a non-callable or known non-string value. */
+  definiteNonStringFunctionBindings: Set<Binding>;
+  definiteNonStringFunctionBindingsInProgress: Set<Binding>;
+  entryProgram: t.Program;
+  finalContainerSnapshots: Map<Binding, FinalContainerSnapshot>;
+  finalContainerSnapshotsInProgress: Set<Binding>;
+  gtContainerPossibilities: Map<Binding, boolean>;
+  gtContainerPossibilitiesInProgress: Set<Binding>;
+  gtContainerPaths: Map<Binding, Set<string>>;
+  gtContainerPathsInProgress: Set<Binding>;
+  localCallableBindings: Map<Binding, ScopedExpression & { node: t.Function }>;
+  mutationGTContainerPaths: Map<Binding, Set<string>>;
+  mutationGTContainerPathsInProgress: Set<Binding>;
+  mutationPossibleStaticStrings: Map<Binding, Map<string, Set<string>>>;
+  mutationPossibleStaticStringsInProgress: Set<Binding>;
+  mutableImportSources: Map<Binding, 'gt-vue' | 'vue'>;
+  nextReplayIdentityKey: number;
+  parameterSubstitutions: Array<Map<Binding, ScopedExpression>>;
+  paths: WeakMap<t.Node, NodePath<t.Node>>;
+  possibleStaticStrings: Map<Binding, Set<string>>;
+  possibleStaticStringsInProgress: Set<Binding>;
+  possibleStaticStringMembers: Map<Binding, Map<string, Set<string>>>;
+  possibleStaticStringMembersInProgress: Set<Binding>;
+  readonlyContainerUses: Map<Binding, boolean>;
+  readonlyContainerUsesInProgress: Set<Binding>;
+  replayIdentityKeys: WeakMap<object, string>;
+  resolvedBindings: Set<Binding>;
+  scopes: WeakMap<t.Node, Scope>;
+  thisSubstitutions: ScopedExpression[];
+  transformArrayEntries: Map<
+    Binding,
+    Array<ScopedExpression | undefined> | null
+  >;
+  transformArrayEntriesInProgress: Set<Binding>;
+  /** Import and alias bindings that may call a forwarded translator. */
+  uncertainTranslationHelperBindings: Set<Binding>;
+  /** Whether this block uses GT through an unsupported dynamic import. */
+  unsupportedDynamicGTReference: boolean;
+  /** Whether a used GT reference came through a malformed local module. */
+  unsupportedMalformedGTReference: boolean;
+  unsafeMutableNamespaceSources: Set<'gt-vue' | 'vue'>;
+};

--- a/packages/vue-extractor/src/internal/script/parser.ts
+++ b/packages/vue-extractor/src/internal/script/parser.ts
@@ -1,0 +1,38 @@
+import { parse, type ParserPlugin } from '@babel/parser';
+import type * as t from '@babel/types';
+
+/** Returns the Babel syntax plugins accepted by a Vue script language. */
+function getParserPlugins(language: string | undefined): ParserPlugin[] {
+  const normalizedLanguage = language?.toLowerCase();
+  const plugins: ParserPlugin[] = ['decorators-legacy'];
+  if (normalizedLanguage === 'ts' || normalizedLanguage === 'tsx') {
+    plugins.push('typescript');
+  }
+  if (normalizedLanguage === 'flow') {
+    plugins.push('flow');
+  }
+  // JavaScript files commonly contain JSX without using a .jsx extension.
+  // TypeScript retains its explicit .tsx contract to avoid interpreting type
+  // syntax as JSX.
+  if (
+    normalizedLanguage === undefined ||
+    normalizedLanguage === 'js' ||
+    normalizedLanguage === 'jsx' ||
+    normalizedLanguage === 'flow' ||
+    normalizedLanguage === 'tsx'
+  ) {
+    plugins.push('jsx');
+  }
+  return plugins;
+}
+
+/** Parses one JavaScript or TypeScript block using Vue-compatible syntax. */
+export function parseScriptAst(
+  source: string,
+  language: string | undefined
+): t.File {
+  return parse(source, {
+    plugins: getParserPlugins(language),
+    sourceType: 'module',
+  });
+}

--- a/packages/vue-extractor/src/internal/script/replay.ts
+++ b/packages/vue-extractor/src/internal/script/replay.ts
@@ -1,0 +1,2979 @@
+import type { Binding, NodePath, Scope } from '@babel/traverse';
+import type * as t from '@babel/types';
+import {
+  appendTemplatePath,
+  recursiveTemplatePathSegment,
+  unknownTemplatePathSegment,
+} from '../templatePath.js';
+import type { TemplateContainerKind } from '../types.js';
+import { unwrapExpression, type StaticPrimitiveResult } from '../utils.js';
+import type {
+  ComponentFactoryCandidate,
+  ComponentMemberCandidate,
+  ContainerIdentityReplay,
+  ContainerWrapperKind,
+  ContainerWritePolicy,
+  KnownValue,
+  ReplayCollectionReference,
+  ReplayComputedReference,
+  ReplayContainerIdentity,
+  ReplayContainerReference,
+  ReplayContainerSnapshot,
+  ReplayEvaluationContext,
+  ReplayGetterReference,
+  ReplayLeaf,
+  ReplayLeafState,
+  ReplayMethodReference,
+  ReplayRefReference,
+  ReplayUnsafe,
+  ReplayValue,
+  ScopedExpression,
+  ScriptState,
+  VueScriptAnalysis,
+} from './model.js';
+
+/** Static-analysis operations consumed by the source-ordered replay SCC. */
+export type ReplayAnalysisDependencies = {
+  ordinaryGlobalValues: ReadonlySet<string>;
+  readonlyArrayTransforms: ReadonlySet<string>;
+  bindingReadsUnsafeMutableImport: (
+    binding: Binding,
+    state: ScriptState
+  ) => boolean;
+  collectFunctionReturnExpressions: (
+    fn: t.Function,
+    scope: Scope,
+    state: ScriptState
+  ) => ScopedExpression[];
+  collectPatternBindingNames: (pattern: t.Node) => string[];
+  composeContainerWritePolicy: (
+    wrapper: ContainerWrapperKind,
+    inner: ContainerWritePolicy | undefined
+  ) => ContainerWritePolicy;
+  knownValueKey: (value: KnownValue) => string;
+  readDefiniteArrayInteger: (
+    node: t.Node | undefined,
+    fallback: number,
+    scope: Scope,
+    state: ScriptState
+  ) => number | undefined;
+  readResolvedMemberPath: (
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ) => string | undefined;
+  readResolvedMemberProperty: (
+    node: t.MemberExpression | t.OptionalMemberExpression,
+    scope: Scope,
+    state: ScriptState
+  ) => string | undefined;
+  readResolvedPropertyKey: (
+    property: { computed: boolean; key: t.Node },
+    scope: Scope,
+    state: ScriptState
+  ) => string | undefined;
+  readStaticFromScope: (
+    node: t.Node | null | undefined,
+    scope: Scope,
+    seen: Set<Binding>,
+    atPosition: number,
+    analysis?: VueScriptAnalysis,
+    allowNumericGlobals?: boolean
+  ) => StaticPrimitiveResult;
+  resolveCalledFunction: (
+    node: t.Node | null | undefined,
+    scope: Scope,
+    state: ScriptState,
+    seen: Set<t.Node>
+  ) => (ScopedExpression & { node: t.Function }) | undefined;
+  resolveComputedGetter: (
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ) => (ScopedExpression & { node: t.Function }) | undefined;
+  resolveKnownExpression: (
+    node: t.Node | null | undefined,
+    scope: Scope,
+    state: ScriptState,
+    seen: Set<Binding>
+  ) => KnownValue | undefined;
+};
+
+/** Narrow replay queries used by the surrounding script analyzer. */
+export type ReplayAnalysis = {
+  evaluateReplayAtPosition: (
+    node: t.Node,
+    scope: Scope,
+    atPosition: number,
+    state: ScriptState
+  ) => ReplayValue | undefined;
+  readDefiniteReplayGTContainerPaths: (
+    binding: Binding,
+    state: ScriptState
+  ) => Set<string> | null | undefined;
+  readReplayComponentCandidates: (
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ) => ComponentMemberCandidate[] | undefined;
+  readReplayComponentFactoryCandidates: (
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ) => ComponentFactoryCandidate[] | undefined;
+  readReplayContainerMetadata: (
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ) =>
+    | {
+        arrayLengths: Map<string, number>;
+        kinds: Map<string, TemplateContainerKind>;
+      }
+    | undefined;
+  readReplayLeafState: (
+    binding: Binding,
+    state: ScriptState
+  ) => ReplayLeafState | undefined;
+  readSafeReplayLeafOverride: (
+    binding: Binding,
+    replayLeaf: ReplayLeafState | undefined,
+    state: ScriptState
+  ) => Extract<ReplayLeafState, { status: 'leaf' }> | undefined;
+  isReplayGetterStringLeaf: (value: ReplayLeaf) => boolean;
+  replayBindingRetainsUnsafeIdentity: (
+    binding: Binding,
+    state: ScriptState
+  ) => boolean;
+};
+
+/**
+ * Creates the finite source-ordered identity analyzer used by script analysis.
+ * Dependencies are injected so the replay evaluator remains one cohesive SCC
+ * without creating a runtime import cycle back to the script orchestrator.
+ */
+export function createReplayAnalysis({
+  ordinaryGlobalValues: ORDINARY_GLOBAL_VALUES,
+  readonlyArrayTransforms: READONLY_ARRAY_TRANSFORMS,
+  bindingReadsUnsafeMutableImport,
+  collectFunctionReturnExpressions,
+  collectPatternBindingNames,
+  composeContainerWritePolicy,
+  knownValueKey,
+  readDefiniteArrayInteger,
+  readResolvedMemberPath,
+  readResolvedMemberProperty,
+  readResolvedPropertyKey,
+  readStaticFromScope,
+  resolveCalledFunction,
+  resolveComputedGetter,
+  resolveKnownExpression,
+}: ReplayAnalysisDependencies): ReplayAnalysis {
+  const replayUnsafe: ReplayUnsafe = { type: 'unsafe' };
+
+  /** Creates one fresh runtime container identity for source-ordered replay. */
+  function createReplayContainer(
+    snapshot: ReplayContainerSnapshot
+  ): ReplayContainerReference {
+    return {
+      type: 'container',
+      identity: { escaped: false, snapshot },
+      writePolicy: 'forward',
+    };
+  }
+
+  /** Returns a reference with the write behavior Vue applies to one wrapper. */
+  function wrapReplayContainer(
+    value: ReplayContainerReference,
+    wrapper: ContainerWrapperKind
+  ): ReplayContainerReference {
+    return {
+      type: 'container',
+      identity: value.identity,
+      writePolicy: composeContainerWritePolicy(wrapper, value.writePolicy),
+    };
+  }
+
+  /** Applies a Vue proxy wrapper to a container, ref, or computed reference. */
+  function wrapReplayReference(
+    value:
+      | ReplayCollectionReference
+      | ReplayComputedReference
+      | ReplayContainerReference
+      | ReplayRefReference,
+    wrapper: ContainerWrapperKind
+  ):
+    | ReplayCollectionReference
+    | ReplayComputedReference
+    | ReplayContainerReference
+    | ReplayRefReference {
+    if (value.type === 'container') return wrapReplayContainer(value, wrapper);
+    return {
+      ...value,
+      writePolicy: composeContainerWritePolicy(wrapper, value.writePolicy),
+    };
+  }
+
+  /** Marks an escaped identity and every nested identity reachable through it. */
+  function markReplayContainerEscaped(
+    value: ReplayContainerReference,
+    seen: Set<object> = new Set()
+  ): void {
+    if (seen.has(value.identity)) return;
+    seen.add(value.identity);
+    value.identity.escaped = true;
+    const entries =
+      value.identity.snapshot.kind === 'array'
+        ? value.identity.snapshot.entries
+        : value.identity.snapshot.entries.values();
+    for (const entry of entries) {
+      if (entry?.type === 'container') markReplayContainerEscaped(entry, seen);
+      if (entry?.type === 'ref') markReplayRefEscaped(entry, seen);
+      if (entry?.type === 'collection') {
+        markReplayCollectionEscaped(entry, seen);
+      }
+    }
+    if (value.identity.snapshot.kind === 'object') {
+      const prototype = value.identity.snapshot.prototype;
+      if (prototype) markReplayContainerEscaped(prototype, seen);
+    }
+  }
+
+  /** Marks a ref and every container reachable through its current value unsafe. */
+  function markReplayRefEscaped(
+    value: ReplayRefReference,
+    seen: Set<object> = new Set()
+  ): void {
+    if (seen.has(value.identity)) return;
+    seen.add(value.identity);
+    value.identity.escaped = true;
+    const current = value.identity.value;
+    if (current?.type === 'container')
+      markReplayContainerEscaped(current, seen);
+    if (current?.type === 'ref') markReplayRefEscaped(current, seen);
+    if (current?.type === 'collection') {
+      markReplayCollectionEscaped(current, seen);
+    }
+  }
+
+  /** Marks a Map or Set abstraction unsafe after an unmodelled escape. */
+  function markReplayCollectionEscaped(
+    value: ReplayCollectionReference,
+    seen: Set<object> = new Set()
+  ): void {
+    if (seen.has(value.identity)) return;
+    seen.add(value.identity);
+    value.identity.escaped = true;
+    for (const entry of value.identity.entries.values()) {
+      if (entry.type === 'container') markReplayContainerEscaped(entry, seen);
+      if (entry.type === 'ref') markReplayRefEscaped(entry, seen);
+      if (entry.type === 'collection') markReplayCollectionEscaped(entry, seen);
+    }
+  }
+
+  /** Marks any mutable replay value unsafe after an unsupported operation. */
+  function markReplayValueEscaped(value: ReplayValue | undefined): void {
+    if (value?.type === 'container') markReplayContainerEscaped(value);
+    if (value?.type === 'ref') markReplayRefEscaped(value);
+    if (value?.type === 'collection') markReplayCollectionEscaped(value);
+    if (value?.type === 'function') {
+      for (const captured of value.substitutions.values()) {
+        markReplayValueEscaped(captured);
+      }
+      for (const captured of value.boundArguments) {
+        markReplayValueEscaped(captured);
+      }
+    }
+  }
+
+  /** Reads a ref value through the proxy policy currently wrapping the ref. */
+  function readReplayRefValue(
+    value: ReplayRefReference
+  ): ReplayValue | undefined {
+    if (value.identity.escaped) return replayUnsafe;
+    const current = value.identity.value;
+    if (
+      current?.type === 'collection' ||
+      current?.type === 'container' ||
+      current?.type === 'ref' ||
+      current?.type === 'computed'
+    ) {
+      if (value.writePolicy === 'readonly-deep') {
+        return wrapReplayReference(current, 'readonly');
+      }
+    }
+    return current?.type === 'leaf'
+      ? { ...current, exactSelection: true, selectionKind: 'ref' }
+      : current;
+  }
+
+  /** Applies Vue's deep readonly conversion to a value read through a proxy. */
+  function wrapReplayReadValue(
+    value: ReplayValue | undefined,
+    policy: ContainerWritePolicy
+  ): ReplayValue | undefined {
+    if (
+      value &&
+      policy === 'readonly-deep' &&
+      (value.type === 'collection' ||
+        value.type === 'computed' ||
+        value.type === 'container' ||
+        value.type === 'ref')
+    ) {
+      return wrapReplayReference(value, 'readonly');
+    }
+    return value;
+  }
+
+  /** Evaluates a supported property getter against the current replay state. */
+  function evaluateReplayGetter(
+    value: ReplayGetterReference,
+    receiver: ReplayContainerReference,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    if (!context.allowGetterEffects) {
+      const body = value.getter.node.body;
+      if (
+        body.type === 'BlockStatement' &&
+        (body.body.length !== 1 || body.body[0]?.type !== 'ReturnStatement')
+      ) {
+        return undefined;
+      }
+      const returns = collectFunctionReturnExpressions(
+        value.getter.node,
+        value.getter.scope,
+        state
+      );
+      return returns.length === 1
+        ? evaluateReplayExpression(returns[0]!.node, returns[0]!.scope, state, {
+            ...context,
+            substitutions: new Map(value.substitutions),
+            thisValue: receiver,
+          })
+        : undefined;
+    }
+    const result = executeReplayFunction(
+      value.getter,
+      [],
+      state,
+      {
+        ...context,
+        substitutions: new Map(value.substitutions),
+        thisValue: receiver,
+      },
+      receiver
+    );
+    return result.executed ? result.value : undefined;
+  }
+
+  /** Reads a child using prototype lookup and Vue proxy conversion rules. */
+  function readReplayContainerEntry(
+    value: ReplayContainerReference,
+    property: string,
+    state: ScriptState,
+    context: ReplayEvaluationContext,
+    seen: Set<ReplayContainerIdentity> = new Set(),
+    receiver: ReplayContainerReference = value
+  ): ReplayValue | undefined {
+    if (value.identity.escaped || seen.has(value.identity)) return replayUnsafe;
+    const snapshot = value.identity.snapshot;
+    let entry: ReplayValue | undefined;
+    if (snapshot.kind === 'array') {
+      entry = /^(0|[1-9]\d*)$/.test(property)
+        ? snapshot.entries[Number(property)]
+        : undefined;
+    } else if (snapshot.entries.has(property)) {
+      entry = snapshot.entries.get(property);
+    } else if (snapshot.prototype) {
+      entry = readReplayContainerEntry(
+        snapshot.prototype,
+        property,
+        state,
+        context,
+        new Set(seen).add(value.identity),
+        receiver
+      );
+    }
+    let fromGetter = false;
+    if (entry?.type === 'getter') {
+      fromGetter = true;
+      entry = evaluateReplayGetter(entry, receiver, state, context);
+    }
+    if (entry?.type === 'method') {
+      entry = { ...entry, receiver };
+    }
+    if (entry?.type === 'leaf') {
+      entry = {
+        ...entry,
+        exactSelection: true,
+        selectionKind: fromGetter ? 'getter' : 'member',
+      };
+    }
+    return wrapReplayReadValue(entry, value.writePolicy);
+  }
+
+  /** Lists the property names visible through a finite object prototype chain. */
+  function readReplayVisibleObjectKeys(
+    value: ReplayContainerReference,
+    seen: Set<ReplayContainerIdentity> = new Set()
+  ): Set<string> | undefined {
+    if (
+      value.identity.escaped ||
+      value.identity.snapshot.kind !== 'object' ||
+      seen.has(value.identity)
+    ) {
+      return undefined;
+    }
+    const keys = value.identity.snapshot.prototype
+      ? readReplayVisibleObjectKeys(
+          value.identity.snapshot.prototype,
+          new Set(seen).add(value.identity)
+        )
+      : new Set<string>();
+    if (!keys) return undefined;
+    for (const key of value.identity.snapshot.entries.keys()) keys.add(key);
+    return keys;
+  }
+
+  /** Lists every value a template can select from one finite container. */
+  function readReplayVisibleContainerEntries(
+    value: ReplayContainerReference,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): Array<readonly [string, ReplayValue | undefined]> | undefined {
+    if (value.identity.escaped) return undefined;
+    const snapshot = value.identity.snapshot;
+    if (snapshot.kind === 'array') {
+      return snapshot.entries.map((entry, index) => [String(index), entry]);
+    }
+    const keys = readReplayVisibleObjectKeys(value);
+    if (!keys) return undefined;
+    const entries: Array<readonly [string, ReplayValue]> = [];
+    for (const key of keys) {
+      const entry = readReplayContainerEntry(value, key, state, context);
+      if (!entry) return undefined;
+      entries.push([key, entry]);
+    }
+    return entries;
+  }
+
+  /** Resolves whether a non-container value is definitely `<T>` at this point. */
+  function createReplayLeaf(
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ): ReplayLeaf {
+    const expression = unwrapExpression(node) ?? node;
+    const known = resolveKnownExpression(expression, scope, state, new Set());
+    const knownValue =
+      known?.type === 'component' ||
+      known?.type === 'string' ||
+      known?.type === 'vue-builtin'
+        ? known
+        : undefined;
+    if (known) {
+      return {
+        type: 'leaf',
+        expression: { node: expression, scope },
+        hasGT: known.type === 'component' && known.name === 'T',
+        knownValue,
+      };
+    }
+    const primitive = readStaticFromScope(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    const ordinaryGlobal =
+      expression.type === 'Identifier' &&
+      !scope.getBinding(expression.name) &&
+      ORDINARY_GLOBAL_VALUES.has(expression.name);
+    return {
+      type: 'leaf',
+      expression: { node: expression, scope },
+      hasGT: primitive.ok || ordinaryGlobal ? false : undefined,
+      knownValue,
+    };
+  }
+
+  /** Reads a statically named member chain from a replayed container. */
+  function evaluateReplayMember(
+    node: t.MemberExpression | t.OptionalMemberExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const object = evaluateReplayExpression(node.object, scope, state, context);
+    const property = readResolvedMemberProperty(node, scope, state);
+    if (property === undefined) return undefined;
+    if (object?.type === 'unsafe') return object;
+    if (object?.type === 'container') {
+      return readReplayContainerEntry(object, property, state, context);
+    }
+    if (property !== 'value') return undefined;
+    if (object?.type === 'ref') return readReplayRefValue(object);
+    if (object?.type === 'computed') {
+      return evaluateReplayComputed(object, state, context);
+    }
+    return undefined;
+  }
+
+  /** Shallow-copies the enumerable own entries of one container reference. */
+  function copyReplayContainerEntries(
+    value: ReplayContainerReference,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayContainerSnapshot | undefined {
+    if (value.identity.escaped) return undefined;
+    const snapshot = value.identity.snapshot;
+    if (snapshot.kind === 'array') {
+      return {
+        kind: 'array',
+        entries: snapshot.entries.map((_entry, index) =>
+          readReplayContainerEntry(value, String(index), state, context)
+        ),
+      };
+    }
+    return {
+      kind: 'object',
+      entries: new Map(
+        [...snapshot.entries.keys()].flatMap((key) => {
+          const entry = readReplayContainerEntry(value, key, state, context);
+          return entry ? [[key, entry] as const] : [];
+        })
+      ),
+    };
+  }
+
+  /** Evaluates one finite array literal without losing nested object identity. */
+  function evaluateReplayArray(
+    node: t.ArrayExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayContainerReference | ReplayUnsafe | undefined {
+    const entries: Array<ReplayValue | undefined> = [];
+    for (const element of node.elements) {
+      if (!element) {
+        entries.push(undefined);
+        continue;
+      }
+      if (element.type === 'SpreadElement') {
+        const spread = evaluateReplayExpression(
+          element.argument,
+          scope,
+          state,
+          context
+        );
+        if (spread?.type === 'unsafe') return spread;
+        if (spread?.type === 'container' && spread.identity.escaped) {
+          return replayUnsafe;
+        }
+        if (
+          spread?.type !== 'container' ||
+          spread.identity.snapshot.kind !== 'array'
+        ) {
+          return undefined;
+        }
+        const copied = copyReplayContainerEntries(spread, state, context);
+        if (!copied || copied.kind !== 'array') return undefined;
+        entries.push(...copied.entries);
+        continue;
+      }
+      entries.push(evaluateReplayExpression(element, scope, state, context));
+    }
+    return createReplayContainer({ kind: 'array', entries });
+  }
+
+  /** Evaluates one finite object literal with JavaScript shallow-spread semantics. */
+  function evaluateReplayObject(
+    node: t.ObjectExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayContainerReference | ReplayUnsafe | undefined {
+    const entries = new Map<string, ReplayValue>();
+    const setters = new Map<string, ReplayMethodReference>();
+    for (const property of node.properties) {
+      if (property.type === 'SpreadElement') {
+        const spread = evaluateReplayExpression(
+          property.argument,
+          scope,
+          state,
+          context
+        );
+        if (spread?.type === 'unsafe') return spread;
+        if (spread?.type === 'container' && spread.identity.escaped) {
+          return replayUnsafe;
+        }
+        if (
+          spread?.type !== 'container' ||
+          spread.identity.snapshot.kind !== 'object'
+        ) {
+          return undefined;
+        }
+        const copied = copyReplayContainerEntries(spread, state, context);
+        if (!copied || copied.kind !== 'object') return undefined;
+        for (const [key, value] of copied.entries) entries.set(key, value);
+        continue;
+      }
+      if (property.type === 'ObjectMethod' && property.kind === 'get') {
+        const key = readResolvedPropertyKey(property, scope, state);
+        if (key === undefined) return undefined;
+        entries.set(key, {
+          type: 'getter',
+          getter: {
+            node: property,
+            scope: state.scopes.get(property) ?? scope,
+          },
+          substitutions: new Map(context.substitutions),
+        });
+        continue;
+      }
+      if (property.type === 'ObjectMethod' && property.kind === 'method') {
+        const key = readResolvedPropertyKey(property, scope, state);
+        if (key === undefined) return undefined;
+        entries.set(key, {
+          type: 'method',
+          callable: {
+            node: property,
+            scope: state.scopes.get(property) ?? scope,
+          },
+          substitutions: new Map(context.substitutions),
+        });
+        continue;
+      }
+      if (property.type === 'ObjectMethod' && property.kind === 'set') {
+        const key = readResolvedPropertyKey(property, scope, state);
+        if (key === undefined) return undefined;
+        setters.set(key, {
+          type: 'method',
+          callable: {
+            node: property,
+            scope: state.scopes.get(property) ?? scope,
+          },
+          substitutions: new Map(context.substitutions),
+        });
+        continue;
+      }
+      if (property.type !== 'ObjectProperty') return undefined;
+      const key = readResolvedPropertyKey(property, scope, state);
+      if (key === undefined) return undefined;
+      const value = evaluateReplayExpression(
+        property.value,
+        scope,
+        state,
+        context
+      );
+      if (!value) return undefined;
+      entries.set(key, value);
+    }
+    return createReplayContainer({ kind: 'object', entries, setters });
+  }
+
+  /** Evaluates a computed getter against the current, not captured, bindings. */
+  function evaluateReplayComputed(
+    value: ReplayComputedReference,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const returns = collectFunctionReturnExpressions(
+      value.getter.node,
+      value.getter.scope,
+      state
+    );
+    if (returns.length !== 1) return undefined;
+    const result = evaluateReplayExpression(
+      returns[0]!.node,
+      returns[0]!.scope,
+      state,
+      context
+    );
+    return result &&
+      (result.type === 'collection' ||
+        result.type === 'container' ||
+        result.type === 'ref' ||
+        result.type === 'computed')
+      ? wrapReplayReference(
+          result,
+          value.writePolicy === 'readonly-deep'
+            ? 'readonly'
+            : value.writePolicy === 'readonly-shallow'
+              ? 'shallow-readonly'
+              : 'unref'
+        )
+      : result;
+  }
+
+  /** Evaluates an expression while applying its supported direct side effects. */
+  function executeReplayExpression(
+    node: t.Expression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const expression = unwrapExpression(node);
+    if (
+      expression?.type === 'UnaryExpression' &&
+      expression.operator === 'delete' &&
+      (expression.argument.type === 'MemberExpression' ||
+        expression.argument.type === 'OptionalMemberExpression')
+    ) {
+      return applyReplayMemberDelete(expression.argument, scope, state, context)
+        ? createReplayLeaf(expression, scope, state)
+        : undefined;
+    }
+    if (expression?.type !== 'AssignmentExpression') {
+      return evaluateReplayExpression(node, scope, state, context);
+    }
+    if (expression.operator !== '=') return undefined;
+    const replacement = evaluateReplayExpression(
+      expression.right,
+      scope,
+      state,
+      context
+    );
+    if (expression.left.type === 'Identifier') {
+      const binding = scope.getBinding(expression.left.name);
+      if (binding) {
+        if (replacement?.type === 'unsafe') context.unsafeBindings.add(binding);
+        else context.unsafeBindings.delete(binding);
+        context.values.set(binding, replacement);
+      }
+      return replacement;
+    }
+    if (
+      expression.left.type === 'MemberExpression' ||
+      expression.left.type === 'OptionalMemberExpression'
+    ) {
+      return applyReplayMemberAssignment(
+        expression.left,
+        expression.right,
+        scope,
+        state,
+        context
+      )
+        ? replacement
+        : undefined;
+    }
+    return undefined;
+  }
+
+  /** Executes one finite local function body with captured identities intact. */
+  function executeReplayFunction(
+    callable: ScopedExpression & { node: t.Function },
+    arguments_: ReplayValue[],
+    state: ScriptState,
+    context: ReplayEvaluationContext,
+    thisValue: ReplayValue | undefined = context.thisValue
+  ): { executed: boolean; value: ReplayValue | undefined } {
+    if (state.activeReplayFunctions.has(callable.node)) {
+      return { executed: false, value: undefined };
+    }
+    const functionScope = state.scopes.get(callable.node) ?? callable.scope;
+    const substitutions = new Map(context.substitutions);
+    for (const [index, parameter] of callable.node.params.entries()) {
+      const name =
+        parameter.type === 'Identifier'
+          ? parameter.name
+          : parameter.type === 'RestElement' &&
+              parameter.argument.type === 'Identifier'
+            ? parameter.argument.name
+            : undefined;
+      if (!name) return { executed: false, value: undefined };
+      const binding = functionScope.getBinding(name);
+      if (!binding) return { executed: false, value: undefined };
+      if (parameter.type === 'RestElement') {
+        substitutions.set(
+          binding,
+          createReplayContainer({
+            kind: 'array',
+            entries: arguments_.slice(index),
+          })
+        );
+        break;
+      }
+      const argument = arguments_[index];
+      if (!argument) return { executed: false, value: undefined };
+      substitutions.set(binding, argument);
+    }
+    const localContext = {
+      ...context,
+      substitutions,
+      thisValue,
+    };
+    state.activeReplayFunctions.add(callable.node);
+    try {
+      if (callable.node.body.type !== 'BlockStatement') {
+        return {
+          executed: true,
+          value: executeReplayExpression(
+            callable.node.body,
+            functionScope,
+            state,
+            localContext
+          ),
+        };
+      }
+      const bodyPath = state.paths.get(callable.node.body);
+      const statements = bodyPath?.isBlockStatement()
+        ? bodyPath.get('body')
+        : undefined;
+      if (!statements || !Array.isArray(statements)) {
+        return { executed: false, value: undefined };
+      }
+      for (const statement of statements) {
+        if (statement.isReturnStatement()) {
+          return {
+            executed: true,
+            value: statement.node.argument
+              ? executeReplayExpression(
+                  statement.node.argument,
+                  statement.scope,
+                  state,
+                  localContext
+                )
+              : undefined,
+          };
+        }
+        if (
+          !statement.isVariableDeclaration() &&
+          !statement.isExpressionStatement()
+        ) {
+          return { executed: false, value: undefined };
+        }
+        replayContainerStatement(
+          statement as NodePath<t.Node>,
+          state,
+          localContext
+        );
+      }
+      return { executed: true, value: undefined };
+    } finally {
+      state.activeReplayFunctions.delete(callable.node);
+    }
+  }
+
+  /** Reads one exact callback return for array transform replay. */
+  function evaluateReplayCallback(
+    callback: ScopedExpression & { node: t.Function },
+    argument: ReplayValue,
+    source: ReplayContainerReference,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const result = executeReplayFunction(callback, [argument], state, context);
+    if (!result.executed) {
+      invalidateReplayFunctionCaptures(callback.node, state, context);
+      markReplayContainerEscaped(source);
+      return undefined;
+    }
+    return result.value;
+  }
+
+  /** Detects writes hidden inside an expression-bodied callback. */
+  function replayExpressionHasWrites(
+    node: t.Node,
+    state: ScriptState
+  ): boolean {
+    const path = state.paths.get(node);
+    if (!path) return true;
+    let writes = false;
+    const mark = (candidate: NodePath<t.Node>): void => {
+      writes = true;
+      candidate.stop();
+    };
+    path.traverse({
+      AssignmentExpression: mark,
+      UpdateExpression: mark,
+      UnaryExpression(candidate) {
+        if (candidate.node.operator === 'delete') mark(candidate);
+      },
+    });
+    return writes;
+  }
+
+  /** Applies a finite array copy transform at the exact call position. */
+  function evaluateReplayArrayTransform(
+    value: ReplayContainerReference,
+    method: string,
+    call: t.CallExpression | t.OptionalCallExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayContainerReference | ReplayUnsafe | undefined {
+    if (value.identity.escaped) return replayUnsafe;
+    if (value.identity.snapshot.kind !== 'array') return undefined;
+    if (
+      call.arguments.some(
+        (argument) =>
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+      )
+    ) {
+      return undefined;
+    }
+    const copied = copyReplayContainerEntries(value, state, context);
+    if (!copied || copied.kind !== 'array') return undefined;
+    const entries = copied.entries;
+    const argumentNode = (index: number): t.Expression | undefined => {
+      const argument = call.arguments[index];
+      return argument && argument.type !== 'ArgumentPlaceholder'
+        ? (argument as t.Expression)
+        : undefined;
+    };
+    if (method === 'slice') {
+      const start = readDefiniteArrayInteger(argumentNode(0), 0, scope, state);
+      const end = readDefiniteArrayInteger(
+        argumentNode(1),
+        entries.length,
+        scope,
+        state
+      );
+      return start === undefined || end === undefined
+        ? undefined
+        : createReplayContainer({
+            kind: 'array',
+            entries: entries.slice(start, end),
+          });
+    }
+    if (method === 'concat') {
+      for (const argument of call.arguments) {
+        const item = evaluateReplayExpression(
+          argument as t.Expression,
+          scope,
+          state,
+          context
+        );
+        if (!item) return undefined;
+        if (
+          item.type === 'container' &&
+          item.identity.snapshot.kind === 'array'
+        ) {
+          const flattened = copyReplayContainerEntries(item, state, context);
+          if (!flattened || flattened.kind !== 'array') return undefined;
+          entries.push(...flattened.entries);
+        } else {
+          entries.push(item);
+        }
+      }
+      return createReplayContainer({ kind: 'array', entries });
+    }
+    if (method === 'map') {
+      const callbackNode = argumentNode(0);
+      const callback = callbackNode
+        ? resolveCalledFunction(callbackNode, scope, state, new Set())
+        : undefined;
+      if (!callback) return undefined;
+      const mapped: Array<ReplayValue | undefined> = [];
+      for (const entry of entries) {
+        if (!entry) {
+          mapped.push(undefined);
+          continue;
+        }
+        const result = evaluateReplayCallback(
+          callback,
+          entry,
+          value,
+          state,
+          context
+        );
+        if (!result) return undefined;
+        mapped.push(result);
+      }
+      return createReplayContainer({ kind: 'array', entries: mapped });
+    }
+    if (method === 'toSpliced') {
+      const start = readDefiniteArrayInteger(argumentNode(0), 0, scope, state);
+      const deleteCount = readDefiniteArrayInteger(
+        argumentNode(1),
+        call.arguments.length === 0
+          ? 0
+          : call.arguments.length === 1
+            ? entries.length
+            : 0,
+        scope,
+        state
+      );
+      if (start === undefined || deleteCount === undefined) return undefined;
+      const inserted: ReplayValue[] = [];
+      for (const argument of call.arguments.slice(2)) {
+        const item = evaluateReplayExpression(
+          argument as t.Expression,
+          scope,
+          state,
+          context
+        );
+        if (!item) return undefined;
+        inserted.push(item);
+      }
+      entries.splice(start, Math.max(0, deleteCount), ...inserted);
+      return createReplayContainer({ kind: 'array', entries });
+    }
+    if (method === 'toReversed') {
+      return createReplayContainer({
+        kind: 'array',
+        entries: entries.reverse(),
+      });
+    }
+    if (method === 'toSorted') {
+      return entries.length <= 1
+        ? createReplayContainer({ kind: 'array', entries })
+        : undefined;
+    }
+    if (method === 'with') {
+      const index = readDefiniteArrayInteger(argumentNode(0), 0, scope, state);
+      const replacement = argumentNode(1);
+      if (index === undefined || !replacement) return undefined;
+      const normalized = index < 0 ? entries.length + index : index;
+      if (normalized < 0 || normalized >= entries.length) return undefined;
+      const item = evaluateReplayExpression(replacement, scope, state, context);
+      if (!item) return undefined;
+      entries[normalized] = item;
+      return createReplayContainer({ kind: 'array', entries });
+    }
+    return undefined;
+  }
+
+  /** Mutates one replayed array when the built-in operation is deterministic. */
+  function applyReplayArrayMutation(
+    value: ReplayContainerReference,
+    method: string,
+    call: t.CallExpression | t.OptionalCallExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): boolean {
+    if (value.identity.snapshot.kind !== 'array') return false;
+    if (value.writePolicy !== 'forward') return true;
+    if (
+      call.arguments.some(
+        (argument) =>
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+      )
+    ) {
+      markReplayContainerEscaped(value);
+      return false;
+    }
+    const entries = value.identity.snapshot.entries;
+    const evaluated = call.arguments.map((argument) =>
+      evaluateReplayExpression(argument as t.Expression, scope, state, context)
+    );
+    if (evaluated.some((entry) => !entry)) {
+      markReplayContainerEscaped(value);
+      return false;
+    }
+    const items = evaluated as ReplayValue[];
+    if (method === 'pop') entries.pop();
+    else if (method === 'shift') entries.shift();
+    else if (method === 'push') entries.push(...items);
+    else if (method === 'unshift') entries.unshift(...items);
+    else if (method === 'splice') {
+      const first = call.arguments[0] as t.Expression | undefined;
+      const second = call.arguments[1] as t.Expression | undefined;
+      const start = readDefiniteArrayInteger(first, 0, scope, state);
+      const deleteCount = readDefiniteArrayInteger(
+        second,
+        call.arguments.length === 0
+          ? 0
+          : call.arguments.length === 1
+            ? entries.length
+            : 0,
+        scope,
+        state
+      );
+      if (start === undefined || deleteCount === undefined) {
+        markReplayContainerEscaped(value);
+        return false;
+      }
+      entries.splice(start, Math.max(0, deleteCount), ...items.slice(2));
+    } else {
+      return false;
+    }
+    return true;
+  }
+
+  /** Evaluates known wrappers, transforms, and mutators in source order. */
+  function evaluateReplayCall(
+    node: t.CallExpression | t.OptionalCallExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const wrapper = resolveKnownExpression(
+      node.callee,
+      scope,
+      state,
+      new Set()
+    );
+    const first = node.arguments[0];
+    if (
+      wrapper?.type === 'container-wrapper' &&
+      first &&
+      first.type !== 'ArgumentPlaceholder' &&
+      first.type !== 'SpreadElement'
+    ) {
+      const value = evaluateReplayExpression(first, scope, state, context);
+      if (value?.type === 'unsafe') return value;
+      if (wrapper.kind === 'unref') {
+        if (value?.type === 'ref') return readReplayRefValue(value);
+        if (value?.type === 'computed') {
+          return evaluateReplayComputed(value, state, context);
+        }
+        return value;
+      }
+      return value &&
+        (value.type === 'container' ||
+          value.type === 'collection' ||
+          value.type === 'ref' ||
+          value.type === 'computed')
+        ? wrapReplayReference(value, wrapper.kind)
+        : undefined;
+    }
+    if (
+      wrapper?.type === 'identity' &&
+      first &&
+      first.type !== 'ArgumentPlaceholder' &&
+      first.type !== 'SpreadElement'
+    ) {
+      return evaluateReplayExpression(first, scope, state, context);
+    }
+    if (wrapper?.type === 'vue-wrapper' && wrapper.kind === 'ref') {
+      const initial =
+        first &&
+        first.type !== 'ArgumentPlaceholder' &&
+        first.type !== 'SpreadElement'
+          ? evaluateReplayExpression(first, scope, state, context)
+          : createReplayLeaf(node, scope, state);
+      return {
+        type: 'ref',
+        identity: { escaped: false, value: initial },
+        writePolicy: 'forward',
+      };
+    }
+    if (wrapper?.type === 'vue-wrapper' && wrapper.kind === 'computed') {
+      const getter =
+        first &&
+        first.type !== 'ArgumentPlaceholder' &&
+        first.type !== 'SpreadElement'
+          ? resolveComputedGetter(first, scope, state)
+          : undefined;
+      return getter
+        ? { type: 'computed', getter, writePolicy: 'forward' }
+        : undefined;
+    }
+    if (wrapper?.type === 'hook') {
+      return createReplayLeaf(node, scope, state);
+    }
+
+    const calleePath = readResolvedMemberPath(node.callee, scope, state);
+    if (calleePath === 'Array.from' && !scope.getBinding('Array')) {
+      if (
+        node.arguments.length > 1 ||
+        !first ||
+        first.type === 'ArgumentPlaceholder' ||
+        first.type === 'SpreadElement'
+      ) {
+        return undefined;
+      }
+      const source = evaluateReplayExpression(first, scope, state, context);
+      if (source?.type === 'unsafe') return source;
+      if (source?.type === 'collection') {
+        if (source.identity.escaped) return replayUnsafe;
+        if (source.identity.kind === 'map' && source.iteration === 'entries') {
+          return undefined;
+        }
+        return createReplayContainer({
+          kind: 'array',
+          entries: [...source.identity.entries.values()],
+        });
+      }
+      if (
+        source?.type !== 'container' ||
+        source.identity.snapshot.kind !== 'array'
+      ) {
+        return undefined;
+      }
+      if (source.identity.escaped) return replayUnsafe;
+      const copied = copyReplayContainerEntries(source, state, context);
+      return copied?.kind === 'array'
+        ? createReplayContainer(copied)
+        : undefined;
+    }
+    if (calleePath === 'Object.assign' && !scope.getBinding('Object')) {
+      if (
+        !first ||
+        first.type === 'ArgumentPlaceholder' ||
+        first.type === 'SpreadElement'
+      ) {
+        return undefined;
+      }
+      const target = evaluateReplayExpression(first, scope, state, context);
+      if (
+        target?.type !== 'container' ||
+        target.identity.snapshot.kind !== 'object'
+      ) {
+        return undefined;
+      }
+      if (target.writePolicy !== 'forward') return target;
+      for (const argument of node.arguments.slice(1)) {
+        if (
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+        ) {
+          markReplayContainerEscaped(target);
+          return undefined;
+        }
+        const source = evaluateReplayExpression(
+          argument,
+          scope,
+          state,
+          context
+        );
+        if (source?.type === 'unsafe') {
+          markReplayContainerEscaped(target);
+          return target;
+        }
+        if (
+          source?.type !== 'container' ||
+          source.identity.snapshot.kind !== 'object'
+        ) {
+          markReplayContainerEscaped(target);
+          return undefined;
+        }
+        if (source.identity.escaped) {
+          markReplayContainerEscaped(target);
+          return target;
+        }
+        const copied = copyReplayContainerEntries(source, state, context);
+        if (!copied || copied.kind !== 'object') return undefined;
+        for (const [key, value] of copied.entries) {
+          target.identity.snapshot.entries.set(key, value);
+        }
+      }
+      return target;
+    }
+    if (calleePath === 'Object.create' && !scope.getBinding('Object')) {
+      if (
+        !first ||
+        first.type === 'ArgumentPlaceholder' ||
+        first.type === 'SpreadElement'
+      ) {
+        return undefined;
+      }
+      const prototype = evaluateReplayExpression(first, scope, state, context);
+      if (
+        prototype?.type !== 'container' ||
+        prototype.identity.snapshot.kind !== 'object'
+      ) {
+        return undefined;
+      }
+      return createReplayContainer({
+        kind: 'object',
+        entries: new Map(),
+        prototype,
+      });
+    }
+    if (calleePath === 'Object.setPrototypeOf' && !scope.getBinding('Object')) {
+      const prototypeNode = node.arguments[1];
+      if (
+        !first ||
+        first.type === 'ArgumentPlaceholder' ||
+        first.type === 'SpreadElement' ||
+        !prototypeNode ||
+        prototypeNode.type === 'ArgumentPlaceholder' ||
+        prototypeNode.type === 'SpreadElement'
+      ) {
+        return undefined;
+      }
+      const target = evaluateReplayExpression(first, scope, state, context);
+      const prototype = evaluateReplayExpression(
+        prototypeNode,
+        scope,
+        state,
+        context
+      );
+      if (
+        target?.type !== 'container' ||
+        target.identity.snapshot.kind !== 'object' ||
+        target.writePolicy !== 'forward' ||
+        prototype?.type !== 'container' ||
+        prototype.identity.snapshot.kind !== 'object'
+      ) {
+        return undefined;
+      }
+      target.identity.snapshot.prototype = prototype;
+      return target;
+    }
+
+    const replayCallee = evaluateReplayExpression(
+      node.callee,
+      scope,
+      state,
+      context
+    );
+    if (
+      replayCallee?.type === 'leaf' &&
+      (replayCallee.knownValue?.type === 'string' ||
+        (replayCallee.expression.node.type === 'Identifier' &&
+          !replayCallee.expression.scope.getBinding(
+            replayCallee.expression.node.name
+          ) &&
+          ORDINARY_GLOBAL_VALUES.has(replayCallee.expression.node.name)))
+    ) {
+      return {
+        type: 'leaf',
+        expression: { node, scope },
+        hasGT: false,
+      };
+    }
+    if (replayCallee?.type === 'function') {
+      const arguments_: ReplayValue[] = [];
+      for (const argument of node.arguments) {
+        if (
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+        ) {
+          markReplayValueEscaped(replayCallee);
+          return undefined;
+        }
+        const value = evaluateReplayExpression(argument, scope, state, context);
+        if (!value) {
+          markReplayValueEscaped(replayCallee);
+          return undefined;
+        }
+        arguments_.push(value);
+      }
+      const result = executeReplayFunction(
+        replayCallee.callable,
+        [...replayCallee.boundArguments, ...arguments_],
+        state,
+        {
+          ...context,
+          substitutions: new Map(replayCallee.substitutions),
+        },
+        replayCallee.thisValue
+      );
+      if (!result.executed) {
+        markReplayValueEscaped(replayCallee);
+        for (const argument of arguments_) markReplayValueEscaped(argument);
+        return undefined;
+      }
+      return result.value ?? createReplayLeaf(node, scope, state);
+    }
+    if (replayCallee?.type === 'method' && replayCallee.receiver) {
+      const arguments_: ReplayValue[] = [];
+      for (const argument of node.arguments) {
+        if (
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+        ) {
+          markReplayContainerEscaped(replayCallee.receiver);
+          return undefined;
+        }
+        const value = evaluateReplayExpression(argument, scope, state, context);
+        if (!value) {
+          markReplayContainerEscaped(replayCallee.receiver);
+          return undefined;
+        }
+        arguments_.push(value);
+      }
+      const result = executeReplayFunction(
+        replayCallee.callable,
+        arguments_,
+        state,
+        {
+          ...context,
+          substitutions: new Map(replayCallee.substitutions),
+        },
+        replayCallee.receiver
+      );
+      if (!result.executed) {
+        markReplayContainerEscaped(replayCallee.receiver);
+        return undefined;
+      }
+      return result.value ?? createReplayLeaf(node, scope, state);
+    }
+
+    const localFunction = resolveCalledFunction(
+      node.callee,
+      scope,
+      state,
+      new Set()
+    );
+    if (localFunction) {
+      const arguments_: ReplayValue[] = [];
+      for (const argument of node.arguments) {
+        if (
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+        ) {
+          invalidateReplayFunctionCaptures(localFunction.node, state, context);
+          return undefined;
+        }
+        const value = evaluateReplayExpression(argument, scope, state, context);
+        if (!value) {
+          invalidateReplayFunctionCaptures(localFunction.node, state, context);
+          return undefined;
+        }
+        arguments_.push(value);
+      }
+      const result = executeReplayFunction(
+        localFunction,
+        arguments_,
+        state,
+        context
+      );
+      if (result.executed) {
+        return result.value ?? createReplayLeaf(node, scope, state);
+      }
+      for (const argument of arguments_) markReplayValueEscaped(argument);
+      invalidateReplayFunctionCaptures(localFunction.node, state, context);
+      return undefined;
+    }
+
+    const callee = unwrapExpression(node.callee);
+    if (
+      callee?.type === 'MemberExpression' ||
+      callee?.type === 'OptionalMemberExpression'
+    ) {
+      const value = evaluateReplayExpression(
+        callee.object,
+        scope,
+        state,
+        context
+      );
+      const method = readResolvedMemberProperty(callee, scope, state);
+      if (value?.type === 'collection' && method) {
+        if (value.identity.escaped) return replayUnsafe;
+        if (method === 'values') return { ...value, iteration: 'values' };
+        const firstArgument = node.arguments[0];
+        const keyValue =
+          firstArgument &&
+          firstArgument.type !== 'ArgumentPlaceholder' &&
+          firstArgument.type !== 'SpreadElement'
+            ? evaluateReplayExpression(firstArgument, scope, state, context)
+            : undefined;
+        const key = keyValue ? replayCollectionKey(keyValue, state) : undefined;
+        if (method === 'get' && value.identity.kind === 'map') {
+          const entry =
+            key === undefined ? undefined : value.identity.entries.get(key);
+          return entry?.type === 'leaf'
+            ? {
+                ...entry,
+                exactSelection: true,
+                selectionKind: 'collection',
+              }
+            : entry;
+        }
+        if (method === 'set' && value.identity.kind === 'map') {
+          if (value.writePolicy !== 'forward') return value;
+          const next = node.arguments[1];
+          const entry =
+            next &&
+            next.type !== 'ArgumentPlaceholder' &&
+            next.type !== 'SpreadElement'
+              ? evaluateReplayExpression(next, scope, state, context)
+              : undefined;
+          if (key === undefined || !entry) {
+            markReplayCollectionEscaped(value);
+            return undefined;
+          }
+          value.identity.entries.set(key, entry);
+          const templateKey = keyValue
+            ? replayCollectionTemplateKey(keyValue, context, state)
+            : undefined;
+          if (templateKey !== undefined) {
+            value.identity.templateKeys.set(key, templateKey);
+          }
+          return value;
+        }
+        if (method === 'add' && value.identity.kind === 'set' && keyValue) {
+          if (value.writePolicy !== 'forward') return value;
+          value.identity.entries.set(
+            key ?? `entry:${value.identity.entries.size}`,
+            keyValue
+          );
+          return value;
+        }
+        if (method === 'delete' && key !== undefined) {
+          if (value.writePolicy !== 'forward') {
+            return createReplayLeaf(node, scope, state);
+          }
+          value.identity.entries.delete(key);
+          value.identity.templateKeys.delete(key);
+          return createReplayLeaf(node, scope, state);
+        }
+        markReplayCollectionEscaped(value);
+        return undefined;
+      }
+      if (value?.type === 'container' && method) {
+        const transformed = evaluateReplayArrayTransform(
+          value,
+          method,
+          node,
+          scope,
+          state,
+          context
+        );
+        if (transformed) return transformed;
+        const callbackNode = node.arguments[0];
+        const callback =
+          callbackNode &&
+          callbackNode.type !== 'ArgumentPlaceholder' &&
+          callbackNode.type !== 'SpreadElement'
+            ? resolveCalledFunction(callbackNode, scope, state, new Set())
+            : undefined;
+        if (
+          callback &&
+          method === 'forEach' &&
+          value.identity.snapshot.kind === 'array'
+        ) {
+          for (const entry of value.identity.snapshot.entries) {
+            if (!entry) continue;
+            const result = executeReplayFunction(
+              callback,
+              [entry],
+              state,
+              context
+            );
+            if (!result.executed) {
+              invalidateReplayFunctionCaptures(callback.node, state, context);
+              markReplayContainerEscaped(value);
+              return undefined;
+            }
+          }
+          return createReplayLeaf(node, scope, state);
+        }
+        if (
+          callback &&
+          [
+            'every',
+            'filter',
+            'find',
+            'findIndex',
+            'findLast',
+            'findLastIndex',
+            'flatMap',
+            'forEach',
+            'reduce',
+            'reduceRight',
+            'some',
+          ].includes(method)
+        ) {
+          invalidateReplayFunctionCaptures(callback.node, state, context);
+          const body = callback.node.body;
+          if (
+            (body.type !== 'BlockStatement' &&
+              replayExpressionHasWrites(body, state)) ||
+            (body.type === 'BlockStatement' &&
+              body.body.some(
+                (statement) => statement.type !== 'ReturnStatement'
+              ))
+          ) {
+            markReplayContainerEscaped(value);
+          }
+        }
+        if (
+          ['pop', 'push', 'shift', 'splice', 'unshift'].includes(method) &&
+          applyReplayArrayMutation(value, method, node, scope, state, context)
+        ) {
+          return createReplayLeaf(node, scope, state);
+        }
+        if (!READONLY_ARRAY_TRANSFORMS.has(method)) {
+          markReplayContainerEscaped(value);
+        }
+        return undefined;
+      }
+    }
+
+    for (const argument of node.arguments) {
+      if (
+        argument.type === 'ArgumentPlaceholder' ||
+        argument.type === 'SpreadElement'
+      ) {
+        continue;
+      }
+      const value = evaluateReplayExpression(argument, scope, state, context);
+      if (value?.type === 'container') markReplayContainerEscaped(value);
+      if (value?.type === 'ref') markReplayRefEscaped(value);
+      if (value?.type === 'collection') markReplayCollectionEscaped(value);
+    }
+    return undefined;
+  }
+
+  /** Produces a stable key for the finite Map/Set values the replay supports. */
+  function replayCollectionKey(
+    value: ReplayValue,
+    state: ScriptState
+  ): string | undefined {
+    if (value.type === 'leaf') {
+      if (value.knownValue) return knownValueKey(value.knownValue);
+      const primitive = readStaticFromScope(
+        value.expression.node,
+        value.expression.scope,
+        new Set(),
+        value.expression.node.end ?? Number.POSITIVE_INFINITY,
+        state.analysis
+      );
+      return primitive.ok
+        ? `${typeof primitive.value}:${String(primitive.value)}`
+        : undefined;
+    }
+    if (
+      value.type !== 'container' &&
+      value.type !== 'ref' &&
+      value.type !== 'collection'
+    ) {
+      return undefined;
+    }
+    const identity = value.identity;
+    const existing = state.replayIdentityKeys.get(identity);
+    if (existing) return existing;
+    const key = `identity:${state.nextReplayIdentityKey++}`;
+    state.replayIdentityKeys.set(identity, key);
+    return key;
+  }
+
+  /** Names a collection key when the template can reference the same binding. */
+  function replayCollectionTemplateKey(
+    value: ReplayValue,
+    context: ReplayEvaluationContext,
+    state: ScriptState
+  ): string | undefined {
+    if (value.type === 'leaf') {
+      const primitive = readStaticFromScope(
+        value.expression.node,
+        value.expression.scope,
+        new Set(),
+        value.expression.node.end ?? Number.POSITIVE_INFINITY,
+        state.analysis
+      );
+      if (
+        primitive.ok &&
+        (typeof primitive.value === 'string' ||
+          typeof primitive.value === 'number')
+      ) {
+        return String(primitive.value);
+      }
+      return readResolvedMemberPath(
+        value.expression.node,
+        value.expression.scope,
+        state
+      );
+    }
+    if (!('identity' in value)) return undefined;
+    for (const [binding, candidate] of context.values) {
+      if (
+        candidate &&
+        candidate.type === value.type &&
+        'identity' in candidate &&
+        candidate.identity === value.identity
+      ) {
+        return binding.identifier.name;
+      }
+    }
+    return undefined;
+  }
+
+  /** Evaluates finite Map, Set, and transparent Proxy constructors. */
+  function evaluateReplayNewExpression(
+    node: t.NewExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const callee = unwrapExpression(node.callee);
+    if (callee?.type !== 'Identifier') {
+      return undefined;
+    }
+    const localBinding = scope.getBinding(callee.name);
+    if (localBinding) {
+      const declaration = localBinding.path.node;
+      const classNode =
+        declaration.type === 'ClassDeclaration' ||
+        declaration.type === 'ClassExpression'
+          ? declaration
+          : declaration.type === 'VariableDeclarator' &&
+              declaration.init?.type === 'ClassExpression'
+            ? declaration.init
+            : undefined;
+      if (!classNode || classNode.superClass || classNode.decorators?.length) {
+        return undefined;
+      }
+      const prototypeEntries = new Map<string, ReplayValue>();
+      const prototypeSetters = new Map<string, ReplayMethodReference>();
+      const instanceEntries = new Map<string, ReplayValue>();
+      const instance = createReplayContainer({
+        kind: 'object',
+        entries: instanceEntries,
+        prototype: createReplayContainer({
+          kind: 'object',
+          entries: prototypeEntries,
+          setters: prototypeSetters,
+        }),
+      });
+      const instanceContext: ReplayEvaluationContext = {
+        ...context,
+        thisValue: instance,
+      };
+      let constructor: (ScopedExpression & { node: t.ClassMethod }) | undefined;
+      for (const member of classNode.body.body) {
+        if ('decorators' in member && member.decorators?.length)
+          return undefined;
+        if (member.type === 'ClassProperty' && !member.static) {
+          if (!member.value) continue;
+          const key = readResolvedPropertyKey(member, scope, state);
+          if (key === undefined) return undefined;
+          const value = evaluateReplayExpression(
+            member.value,
+            state.scopes.get(member.value) ?? scope,
+            state,
+            instanceContext
+          );
+          if (!value) return undefined;
+          instanceEntries.set(key, value);
+          continue;
+        }
+        if (member.type !== 'ClassMethod' || member.static) continue;
+        if (member.kind === 'constructor') {
+          constructor = {
+            node: member,
+            scope: state.scopes.get(member) ?? scope,
+          };
+          continue;
+        }
+        const key = readResolvedPropertyKey(member, scope, state);
+        if (key === undefined) return undefined;
+        if (member.kind === 'get') {
+          prototypeEntries.set(key, {
+            type: 'getter',
+            getter: {
+              node: member,
+              scope: state.scopes.get(member) ?? scope,
+            },
+            substitutions: new Map(context.substitutions),
+          });
+        } else if (member.kind === 'method') {
+          prototypeEntries.set(key, {
+            type: 'method',
+            callable: {
+              node: member,
+              scope: state.scopes.get(member) ?? scope,
+            },
+            substitutions: new Map(context.substitutions),
+          });
+        } else if (member.kind === 'set') {
+          prototypeSetters.set(key, {
+            type: 'method',
+            callable: {
+              node: member,
+              scope: state.scopes.get(member) ?? scope,
+            },
+            substitutions: new Map(context.substitutions),
+          });
+        }
+      }
+      if (!constructor) return instance;
+      const arguments_: ReplayValue[] = [];
+      for (const argument of node.arguments) {
+        if (
+          argument.type === 'ArgumentPlaceholder' ||
+          argument.type === 'SpreadElement'
+        ) {
+          return undefined;
+        }
+        const value = evaluateReplayExpression(argument, scope, state, context);
+        if (!value) return undefined;
+        arguments_.push(value);
+      }
+      const result = executeReplayFunction(
+        constructor,
+        arguments_,
+        state,
+        instanceContext,
+        instance
+      );
+      if (!result.executed) {
+        markReplayContainerEscaped(instance);
+        return undefined;
+      }
+      return result.value?.type === 'container' ? result.value : instance;
+    }
+    const first = node.arguments[0];
+    if (callee.name === 'Map' || callee.name === 'Set') {
+      const entries = new Map<string, ReplayValue>();
+      const templateKeys = new Map<string, string>();
+      if (
+        first &&
+        first.type !== 'ArgumentPlaceholder' &&
+        first.type !== 'SpreadElement'
+      ) {
+        const source = evaluateReplayExpression(first, scope, state, context);
+        if (
+          source?.type !== 'container' ||
+          source.identity.snapshot.kind !== 'array'
+        ) {
+          return undefined;
+        }
+        const copied = copyReplayContainerEntries(source, state, context);
+        if (!copied || copied.kind !== 'array') return undefined;
+        for (const [index, item] of copied.entries.entries()) {
+          if (!item) continue;
+          if (callee.name === 'Set') {
+            const key = replayCollectionKey(item, state) ?? `index:${index}`;
+            entries.set(key, item);
+            const templateKey = replayCollectionTemplateKey(
+              item,
+              context,
+              state
+            );
+            if (templateKey !== undefined) templateKeys.set(key, templateKey);
+            continue;
+          }
+          if (
+            item.type !== 'container' ||
+            item.identity.snapshot.kind !== 'array'
+          ) {
+            return undefined;
+          }
+          const keyValue = readReplayContainerEntry(item, '0', state, context);
+          const mapValue = readReplayContainerEntry(item, '1', state, context);
+          if (!keyValue || !mapValue) return undefined;
+          const key = replayCollectionKey(keyValue, state);
+          if (key === undefined) return undefined;
+          entries.set(key, mapValue);
+          const templateKey = replayCollectionTemplateKey(
+            keyValue,
+            context,
+            state
+          );
+          if (templateKey !== undefined) templateKeys.set(key, templateKey);
+        }
+      }
+      return {
+        type: 'collection',
+        identity: {
+          entries,
+          escaped: false,
+          kind: callee.name === 'Map' ? 'map' : 'set',
+          templateKeys,
+        },
+        iteration: callee.name === 'Map' ? 'entries' : 'values',
+        writePolicy: 'forward',
+      };
+    }
+    if (
+      callee.name !== 'Proxy' ||
+      !first ||
+      first.type === 'ArgumentPlaceholder' ||
+      first.type === 'SpreadElement'
+    ) {
+      return undefined;
+    }
+    const target = evaluateReplayExpression(first, scope, state, context);
+    const handlerNode = node.arguments[1];
+    if (
+      !handlerNode ||
+      handlerNode.type === 'ArgumentPlaceholder' ||
+      handlerNode.type === 'SpreadElement'
+    ) {
+      return undefined;
+    }
+    const handler = unwrapExpression(handlerNode);
+    if (handler?.type !== 'ObjectExpression') return undefined;
+    if (handler.properties.length === 0) return target;
+    const getProperty = handler.properties.find(
+      (property) =>
+        property.type === 'ObjectMethod' &&
+        readResolvedPropertyKey(property, scope, state) === 'get'
+    );
+    if (getProperty?.type !== 'ObjectMethod') return undefined;
+    const returns = collectFunctionReturnExpressions(getProperty, scope, state);
+    if (returns.length !== 1) return undefined;
+    const returned = evaluateReplayExpression(
+      returns[0]!.node,
+      returns[0]!.scope,
+      state,
+      context
+    );
+    return returned
+      ? createReplayContainer({
+          kind: 'object',
+          entries: new Map([[unknownTemplatePathSegment, returned]]),
+        })
+      : undefined;
+  }
+
+  /** Evaluates the container identity or captured leaf produced by an expression. */
+  function evaluateReplayExpression(
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): ReplayValue | undefined {
+    const expression = unwrapExpression(node);
+    if (!expression) return undefined;
+    if (expression.type === 'ThisExpression') {
+      return context.thisValue;
+    }
+    if (expression.type === 'Identifier') {
+      const binding = scope.getBinding(expression.name);
+      if (binding) {
+        const substituted = context.substitutions.get(binding);
+        if (substituted) return substituted;
+        if (context.values.has(binding)) return context.values.get(binding);
+      }
+      return createReplayLeaf(expression, scope, state);
+    }
+    if (
+      expression.type === 'ArrowFunctionExpression' ||
+      expression.type === 'FunctionExpression'
+    ) {
+      return {
+        type: 'function',
+        boundArguments: [],
+        callable: {
+          node: expression,
+          scope: state.scopes.get(expression) ?? scope,
+        },
+        substitutions: new Map(context.substitutions),
+      };
+    }
+    if (expression.type === 'ArrayExpression') {
+      return evaluateReplayArray(expression, scope, state, context);
+    }
+    if (expression.type === 'ObjectExpression') {
+      return evaluateReplayObject(expression, scope, state, context);
+    }
+    if (expression.type === 'NewExpression') {
+      return evaluateReplayNewExpression(expression, scope, state, context);
+    }
+    if (
+      expression.type === 'MemberExpression' ||
+      expression.type === 'OptionalMemberExpression'
+    ) {
+      return (
+        evaluateReplayMember(expression, scope, state, context) ??
+        createReplayLeaf(expression, scope, state)
+      );
+    }
+    if (
+      expression.type === 'CallExpression' ||
+      expression.type === 'OptionalCallExpression'
+    ) {
+      return evaluateReplayCall(expression, scope, state, context);
+    }
+    if (expression.type === 'SequenceExpression') {
+      const last = expression.expressions.at(-1);
+      return last
+        ? evaluateReplayExpression(last, scope, state, context)
+        : undefined;
+    }
+    if (expression.type === 'AssignmentExpression') {
+      return evaluateReplayExpression(expression.right, scope, state, context);
+    }
+    return createReplayLeaf(expression, scope, state);
+  }
+
+  /** Splits a static member target into its base expression and property path. */
+  function readReplayMemberTarget(
+    node: t.MemberExpression | t.OptionalMemberExpression,
+    scope: Scope,
+    state: ScriptState
+  ): { base: t.Expression | t.Super; properties: string[] } | undefined {
+    const properties: string[] = [];
+    let current: t.Expression | t.Super = node;
+    while (
+      current.type === 'MemberExpression' ||
+      current.type === 'OptionalMemberExpression'
+    ) {
+      const property = readResolvedMemberProperty(current, scope, state);
+      if (property === undefined) return undefined;
+      properties.unshift(property);
+      current = current.object;
+    }
+    return { base: current, properties };
+  }
+
+  /** Finds the accessor setter JavaScript would invoke for one property write. */
+  function readReplayContainerSetter(
+    value: ReplayContainerReference,
+    property: string,
+    receiver: ReplayContainerReference = value,
+    seen: Set<ReplayContainerIdentity> = new Set()
+  ): ReplayMethodReference | null | undefined {
+    if (
+      value.identity.escaped ||
+      value.identity.snapshot.kind !== 'object' ||
+      seen.has(value.identity)
+    ) {
+      return undefined;
+    }
+    const snapshot = value.identity.snapshot;
+    const setter = snapshot.setters?.get(property);
+    if (setter) return { ...setter, receiver };
+    if (snapshot.entries.has(property)) {
+      return snapshot.entries.get(property)?.type === 'getter'
+        ? undefined
+        : null;
+    }
+    return snapshot.prototype
+      ? readReplayContainerSetter(
+          snapshot.prototype,
+          property,
+          receiver,
+          new Set(seen).add(value.identity)
+        )
+      : null;
+  }
+
+  /** Applies one direct or nested member assignment to a replayed identity. */
+  function applyReplayMemberAssignment(
+    left: t.MemberExpression | t.OptionalMemberExpression,
+    right: t.Expression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): boolean {
+    const target = readReplayMemberTarget(left, scope, state);
+    if (!target || target.properties.length === 0) return false;
+    let value = evaluateReplayExpression(target.base, scope, state, context);
+    for (const property of target.properties.slice(0, -1)) {
+      const child =
+        value?.type === 'container'
+          ? readReplayContainerEntry(value, property, state, context)
+          : value?.type === 'ref' && property === 'value'
+            ? readReplayRefValue(value)
+            : value?.type === 'computed' && property === 'value'
+              ? evaluateReplayComputed(value, state, context)
+              : undefined;
+      if (!child) {
+        if (value?.type === 'container') markReplayContainerEscaped(value);
+        if (value?.type === 'ref') markReplayRefEscaped(value);
+        return false;
+      }
+      value = child;
+    }
+    const property = target.properties.at(-1)!;
+    if (value?.type === 'ref') {
+      if (property !== 'value') {
+        markReplayRefEscaped(value);
+        return false;
+      }
+      if (value.writePolicy !== 'forward') return true;
+      value.identity.value = evaluateReplayExpression(
+        right,
+        scope,
+        state,
+        context
+      );
+      return value.identity.value !== undefined;
+    }
+    if (value?.type !== 'container') return false;
+    if (value.writePolicy !== 'forward') return true;
+    const snapshot = value.identity.snapshot;
+    if (snapshot.kind === 'array' && property === 'length') {
+      const length = readStaticFromScope(
+        right,
+        scope,
+        new Set(),
+        right.end ?? Number.POSITIVE_INFINITY,
+        state.analysis,
+        true
+      );
+      if (
+        !length.ok ||
+        typeof length.value !== 'number' ||
+        !Number.isInteger(length.value) ||
+        length.value < 0
+      ) {
+        markReplayContainerEscaped(value);
+        return false;
+      }
+      snapshot.entries.length = length.value;
+      return true;
+    }
+    const replacement = evaluateReplayExpression(right, scope, state, context);
+    if (!replacement) {
+      markReplayContainerEscaped(value);
+      return false;
+    }
+    if (snapshot.kind === 'object') {
+      const setter = readReplayContainerSetter(value, property);
+      if (setter === undefined) {
+        markReplayContainerEscaped(value);
+        return false;
+      }
+      if (setter) {
+        const result = executeReplayFunction(
+          setter.callable,
+          [replacement],
+          state,
+          { ...context, substitutions: new Map(setter.substitutions) },
+          setter.receiver
+        );
+        if (!result.executed) {
+          markReplayContainerEscaped(value);
+          return false;
+        }
+        return true;
+      }
+    }
+    if (snapshot.kind === 'array') {
+      if (!/^(0|[1-9]\d*)$/.test(property)) {
+        markReplayContainerEscaped(value);
+        return false;
+      }
+      snapshot.entries[Number(property)] = replacement;
+    } else {
+      snapshot.entries.set(property, replacement);
+    }
+    return true;
+  }
+
+  /** Applies JavaScript delete semantics to one replayed own property. */
+  function applyReplayMemberDelete(
+    argument: t.MemberExpression | t.OptionalMemberExpression,
+    scope: Scope,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): boolean {
+    const target = readReplayMemberTarget(argument, scope, state);
+    if (!target || target.properties.length === 0) return false;
+    let value = evaluateReplayExpression(target.base, scope, state, context);
+    for (const property of target.properties.slice(0, -1)) {
+      value =
+        value?.type === 'container'
+          ? readReplayContainerEntry(value, property, state, context)
+          : value?.type === 'ref' && property === 'value'
+            ? readReplayRefValue(value)
+            : value?.type === 'computed' && property === 'value'
+              ? evaluateReplayComputed(value, state, context)
+              : undefined;
+      if (!value) return false;
+    }
+    if (value?.type !== 'container') return false;
+    if (value.writePolicy !== 'forward') return true;
+    const property = target.properties.at(-1)!;
+    const snapshot = value.identity.snapshot;
+    if (snapshot.kind === 'array') {
+      if (!/^(0|[1-9]\d*)$/.test(property)) return false;
+      snapshot.entries[Number(property)] = undefined;
+    } else {
+      snapshot.entries.delete(property);
+    }
+    return true;
+  }
+
+  /** Invalidates one replay binding and every identity reachable through it. */
+  function invalidateReplayBinding(
+    binding: Binding | undefined,
+    context: ReplayEvaluationContext
+  ): void {
+    if (!binding || !context.values.has(binding)) return;
+    const value = context.values.get(binding);
+    if (value?.type === 'container') markReplayContainerEscaped(value);
+    if (value?.type === 'ref') markReplayRefEscaped(value);
+    if (value?.type === 'collection') markReplayCollectionEscaped(value);
+    context.unsafeBindings.add(binding);
+    context.values.set(binding, undefined);
+  }
+
+  /** Invalidates identities captured by a local callback we cannot execute. */
+  function invalidateReplayFunctionCaptures(
+    fn: t.Function,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): void {
+    const path = state.paths.get(fn);
+    if (!path) return;
+    path.traverse({
+      Identifier(identifierPath) {
+        invalidateReplayBinding(
+          identifierPath.scope.getBinding(identifierPath.node.name),
+          context
+        );
+      },
+    });
+  }
+
+  /** Invalidates only identities referenced by unsupported control flow. */
+  function invalidateReplayStatement(
+    path: NodePath<t.Node>,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): void {
+    if (path.isIdentifier()) {
+      invalidateReplayBinding(path.scope.getBinding(path.node.name), context);
+    }
+    path.traverse({
+      CallExpression(callPath) {
+        const callable = resolveCalledFunction(
+          callPath.node.callee,
+          callPath.scope,
+          state,
+          new Set()
+        );
+        if (callable) {
+          invalidateReplayFunctionCaptures(callable.node, state, context);
+        }
+        for (const argument of callPath.node.arguments) {
+          if (
+            argument.type === 'ArgumentPlaceholder' ||
+            argument.type === 'SpreadElement'
+          ) {
+            continue;
+          }
+          markReplayValueEscaped(
+            evaluateReplayExpression(argument, callPath.scope, state, context)
+          );
+        }
+      },
+      OptionalCallExpression(callPath) {
+        const callable = resolveCalledFunction(
+          callPath.node.callee,
+          callPath.scope,
+          state,
+          new Set()
+        );
+        if (callable) {
+          invalidateReplayFunctionCaptures(callable.node, state, context);
+        }
+        for (const argument of callPath.node.arguments) {
+          if (
+            argument.type === 'ArgumentPlaceholder' ||
+            argument.type === 'SpreadElement'
+          ) {
+            continue;
+          }
+          markReplayValueEscaped(
+            evaluateReplayExpression(argument, callPath.scope, state, context)
+          );
+        }
+      },
+      Identifier(identifierPath) {
+        invalidateReplayBinding(
+          identifierPath.scope.getBinding(identifierPath.node.name),
+          context
+        );
+      },
+    });
+  }
+
+  /** Executes one direct sibling statement in the finite identity subset. */
+  function replayContainerStatement(
+    path: NodePath<t.Node>,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): void {
+    if (path.isImportDeclaration() || path.isFunctionDeclaration()) return;
+    if (path.isVariableDeclaration()) {
+      for (const declarator of path.get('declarations')) {
+        if (!declarator.isVariableDeclarator()) continue;
+        if (declarator.node.id.type !== 'Identifier') {
+          const source = declarator.node.init
+            ? evaluateReplayExpression(
+                declarator.node.init,
+                declarator.scope,
+                state,
+                context
+              )
+            : undefined;
+          const unsafe =
+            source?.type === 'unsafe' ||
+            (source?.type === 'container' && source.identity.escaped) ||
+            (source?.type === 'collection' && source.identity.escaped) ||
+            (source?.type === 'ref' && source.identity.escaped);
+          if (unsafe) {
+            for (const name of collectPatternBindingNames(declarator.node.id)) {
+              const binding = declarator.scope.getBinding(name);
+              if (!binding) continue;
+              context.unsafeBindings.add(binding);
+              context.values.set(binding, replayUnsafe);
+            }
+            continue;
+          }
+          invalidateReplayStatement(declarator, state, context);
+          continue;
+        }
+        const binding = declarator.scope.getBinding(declarator.node.id.name);
+        if (!binding) continue;
+        const value = declarator.node.init
+          ? evaluateReplayExpression(
+              declarator.node.init,
+              declarator.scope,
+              state,
+              context
+            )
+          : undefined;
+        if (value?.type === 'unsafe') context.unsafeBindings.add(binding);
+        else context.unsafeBindings.delete(binding);
+        context.values.set(binding, value);
+      }
+      return;
+    }
+    if (!path.isExpressionStatement()) {
+      invalidateReplayStatement(path, state, context);
+      return;
+    }
+    const expression = unwrapExpression(path.node.expression);
+    if (
+      expression?.type === 'UnaryExpression' &&
+      expression.operator === 'delete' &&
+      (expression.argument.type === 'MemberExpression' ||
+        expression.argument.type === 'OptionalMemberExpression')
+    ) {
+      if (
+        !applyReplayMemberDelete(
+          expression.argument,
+          path.scope,
+          state,
+          context
+        )
+      ) {
+        invalidateReplayStatement(path, state, context);
+      }
+      return;
+    }
+    if (expression?.type === 'AssignmentExpression') {
+      if (expression.operator !== '=') {
+        invalidateReplayStatement(path, state, context);
+        return;
+      }
+      if (expression.left.type === 'Identifier') {
+        const binding = path.scope.getBinding(expression.left.name);
+        if (!binding) return;
+        const value = evaluateReplayExpression(
+          expression.right,
+          path.scope,
+          state,
+          context
+        );
+        if (value?.type === 'unsafe') context.unsafeBindings.add(binding);
+        else context.unsafeBindings.delete(binding);
+        context.values.set(binding, value);
+        return;
+      }
+      if (
+        expression.left.type === 'MemberExpression' ||
+        expression.left.type === 'OptionalMemberExpression'
+      ) {
+        if (
+          !applyReplayMemberAssignment(
+            expression.left,
+            expression.right,
+            path.scope,
+            state,
+            context
+          )
+        ) {
+          invalidateReplayStatement(path, state, context);
+        }
+        return;
+      }
+      invalidateReplayStatement(path, state, context);
+      return;
+    }
+    if (
+      expression?.type === 'CallExpression' ||
+      expression?.type === 'OptionalCallExpression'
+    ) {
+      evaluateReplayCall(expression, path.scope, state, context);
+      return;
+    }
+    invalidateReplayStatement(path, state, context);
+  }
+
+  /** Replays one lexical statement list once and caches it for every binding. */
+  function readContainerIdentityReplay(
+    binding: Binding,
+    state: ScriptState
+  ): ContainerIdentityReplay | undefined {
+    const statement = binding.path.getStatementParent();
+    const bodyPath = statement?.parentPath;
+    if (
+      !statement ||
+      !bodyPath ||
+      (!bodyPath.isProgram() && !bodyPath.isBlockStatement())
+    ) {
+      return undefined;
+    }
+    const cached = state.containerIdentityReplays.get(bodyPath.node);
+    if (cached) return cached;
+    const context: ReplayEvaluationContext = {
+      allowGetterEffects: true,
+      substitutions: new Map(),
+      unsafeBindings: new Set(),
+      values: new Map(),
+    };
+    const body = bodyPath.get('body');
+    if (!Array.isArray(body)) return undefined;
+    for (const child of body) {
+      replayContainerStatement(child as NodePath<t.Node>, state, context);
+    }
+    const replay = {
+      unsafeBindings: context.unsafeBindings,
+      values: context.values,
+    };
+    state.containerIdentityReplays.set(bodyPath.node, replay);
+    return replay;
+  }
+
+  /** Replays earlier sibling statements and reads one call target in-place. */
+  function evaluateReplayAtPosition(
+    node: t.Node,
+    scope: Scope,
+    atPosition: number,
+    state: ScriptState
+  ): ReplayValue | undefined {
+    const expression = unwrapExpression(node) ?? node;
+    const nodePath = state.paths.get(expression) ?? state.paths.get(node);
+    const statement = nodePath?.getStatementParent();
+    const bodyPath = statement?.parentPath;
+    if (
+      !statement ||
+      !bodyPath ||
+      (!bodyPath.isProgram() && !bodyPath.isBlockStatement())
+    ) {
+      return undefined;
+    }
+    const body = bodyPath.get('body');
+    if (!Array.isArray(body)) return undefined;
+    const context: ReplayEvaluationContext = {
+      allowGetterEffects: true,
+      substitutions: new Map(),
+      unsafeBindings: new Set(),
+      values: new Map(),
+    };
+    for (const child of body) {
+      if (
+        child.node === statement.node ||
+        (child.node.start ?? Number.POSITIVE_INFINITY) >= atPosition
+      ) {
+        break;
+      }
+      replayContainerStatement(child as NodePath<t.Node>, state, context);
+    }
+    return evaluateReplayExpression(expression, scope, state, context);
+  }
+
+  /** Applies Vue template top-level ref/computed unwrapping to replayed bindings. */
+  function readReplayTemplateValue(
+    value: ReplayValue | undefined,
+    state: ScriptState,
+    replay: ContainerIdentityReplay
+  ): ReplayValue | undefined {
+    const context: ReplayEvaluationContext = {
+      substitutions: new Map(),
+      unsafeBindings: replay.unsafeBindings,
+      values: replay.values,
+    };
+    const seen = new Set<ReplayValue>();
+    let current = value;
+    while (
+      current &&
+      !seen.has(current) &&
+      (current.type === 'ref' || current.type === 'computed')
+    ) {
+      seen.add(current);
+      current =
+        current.type === 'ref'
+          ? readReplayRefValue(current)
+          : evaluateReplayComputed(current, state, context);
+    }
+    return current;
+  }
+
+  /** Reads a final scalar component identity without reviving stale sources. */
+  function readReplayLeafState(
+    binding: Binding,
+    state: ScriptState
+  ): ReplayLeafState | undefined {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay || !replay.values.has(binding)) return undefined;
+    const value = readReplayTemplateValue(
+      replay.values.get(binding),
+      state,
+      replay
+    );
+    if (value?.type === 'unsafe') return { status: 'unsafe' };
+    return value?.type === 'leaf' &&
+      value.exactSelection &&
+      value.hasGT !== undefined
+      ? { status: 'leaf', value }
+      : undefined;
+  }
+
+  /** Keeps exact replay from bypassing deliberate opaque-resolution boundaries. */
+  function readSafeReplayLeafOverride(
+    binding: Binding,
+    replayLeaf: ReplayLeafState | undefined,
+    state: ScriptState
+  ): Extract<ReplayLeafState, { status: 'leaf' }> | undefined {
+    if (replayLeaf?.status !== 'leaf') return undefined;
+    const { value } = replayLeaf;
+    if (bindingReadsUnsafeMutableImport(binding, state)) return undefined;
+    if (value.knownValue?.type === 'vue-builtin') return undefined;
+    if (
+      value.selectionKind === 'ref' &&
+      value.knownValue?.type === 'component'
+    ) {
+      return undefined;
+    }
+    return isReplayGetterStringLeaf(value) ? undefined : replayLeaf;
+  }
+
+  /** String translators selected through a getter remain intentionally opaque. */
+  function isReplayGetterStringLeaf(value: ReplayLeaf): boolean {
+    return (
+      value.selectionKind === 'getter' && value.knownValue?.type === 'string'
+    );
+  }
+
+  /** Detects unresolved mutable identities retained by one final replay value. */
+  function replayBindingRetainsUnsafeIdentity(
+    binding: Binding,
+    state: ScriptState
+  ): boolean {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay || replay.unsafeBindings.has(binding)) return Boolean(replay);
+    const seen = new Set<object>();
+    const visit = (value: ReplayValue | undefined): boolean => {
+      if (!value) return false;
+      if (value.type === 'unsafe') return true;
+      if (value.type === 'container') {
+        if (value.identity.escaped || seen.has(value.identity)) {
+          return value.identity.escaped;
+        }
+        seen.add(value.identity);
+        const snapshot = value.identity.snapshot;
+        const entries =
+          snapshot.kind === 'array'
+            ? snapshot.entries
+            : snapshot.entries.values();
+        for (const entry of entries) {
+          if (visit(entry)) return true;
+        }
+        return snapshot.kind === 'object' && snapshot.prototype
+          ? visit(snapshot.prototype)
+          : false;
+      }
+      if (value.type === 'ref') {
+        if (value.identity.escaped || seen.has(value.identity)) {
+          return value.identity.escaped;
+        }
+        seen.add(value.identity);
+        return visit(value.identity.value);
+      }
+      if (value.type === 'collection') {
+        if (value.identity.escaped || seen.has(value.identity)) {
+          return value.identity.escaped;
+        }
+        seen.add(value.identity);
+        return [...value.identity.entries.values()].some(visit);
+      }
+      if (value.type === 'function') {
+        return (
+          value.boundArguments.some(visit) ||
+          [...value.substitutions.values()].some(visit)
+        );
+      }
+      if (value.type === 'getter' || value.type === 'method') {
+        return [...value.substitutions.values()].some(visit);
+      }
+      return false;
+    };
+    return visit(replay.values.get(binding));
+  }
+
+  /** Collects exact tainted-container paths from one final runtime identity. */
+  function replayContainerIdentityHasGT(
+    value: ReplayContainerReference,
+    seen: Set<ReplayContainerIdentity>,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): boolean | undefined {
+    if (value.identity.escaped) return undefined;
+    if (seen.has(value.identity)) return false;
+    const nextSeen = new Set(seen).add(value.identity);
+    const visible = readReplayVisibleContainerEntries(value, state, context);
+    if (!visible) return undefined;
+    let unknown = false;
+    for (const [, entry] of visible) {
+      if (!entry) continue;
+      if (entry.type === 'leaf') {
+        if (entry.hasGT) return true;
+        if (entry.hasGT === undefined) unknown = true;
+        continue;
+      }
+      if (entry.type !== 'container') {
+        unknown = true;
+        continue;
+      }
+      const nested = replayContainerIdentityHasGT(
+        entry,
+        nextSeen,
+        state,
+        context
+      );
+      if (nested) return true;
+      if (nested === undefined) unknown = true;
+    }
+    return unknown ? undefined : false;
+  }
+
+  /** Collects exact tainted-container paths from one final runtime identity. */
+  function collectReplayGTContainerPaths(
+    value: ReplayContainerReference,
+    basePath: string,
+    seen: Set<ReplayContainerIdentity>,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): Set<string> | undefined {
+    if (value.identity.escaped) return new Set([basePath]);
+    if (seen.has(value.identity)) {
+      const hasGT = replayContainerIdentityHasGT(
+        value,
+        new Set(),
+        state,
+        context
+      );
+      return hasGT === undefined
+        ? undefined
+        : hasGT
+          ? new Set([
+              appendTemplatePath(basePath, recursiveTemplatePathSegment),
+            ])
+          : new Set();
+    }
+    const nextSeen = new Set(seen).add(value.identity);
+    const result = new Set<string>();
+    const entries = readReplayVisibleContainerEntries(value, state, context);
+    if (!entries) return undefined;
+    for (const [key, entry] of entries) {
+      if (!entry) continue;
+      if (entry.type === 'leaf') {
+        if (entry.hasGT === undefined) return undefined;
+        if (entry.hasGT) result.add(basePath);
+        continue;
+      }
+      if (entry.type !== 'container') return undefined;
+      const nested = collectReplayGTContainerPaths(
+        entry,
+        appendTemplatePath(basePath, key),
+        nextSeen,
+        state,
+        context
+      );
+      if (!nested) return undefined;
+      for (const path of nested) result.add(path);
+    }
+    return result;
+  }
+
+  /** Conservatively taints a finite Map/Set when any selected value can be T. */
+  function collectReplayCollectionGTContainerPaths(
+    value: ReplayCollectionReference,
+    basePath: string,
+    state: ScriptState,
+    context: ReplayEvaluationContext
+  ): Set<string> | undefined {
+    if (value.identity.escaped) return new Set([basePath]);
+    let nestedGT = false;
+    for (const entry of value.identity.entries.values()) {
+      if (entry.type === 'leaf') {
+        if (entry.hasGT === undefined) return undefined;
+        continue;
+      }
+      if (entry.type === 'container') {
+        const nested = collectReplayGTContainerPaths(
+          entry,
+          basePath,
+          new Set(),
+          state,
+          context
+        );
+        if (!nested) return undefined;
+        nestedGT ||= nested.size > 0;
+        continue;
+      }
+      return undefined;
+    }
+    return nestedGT ? new Set([basePath]) : new Set();
+  }
+
+  /** Reads exact final T-container paths when identity replay stayed finite. */
+  function readDefiniteReplayGTContainerPaths(
+    binding: Binding,
+    state: ScriptState
+  ): Set<string> | null | undefined {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay || !replay.values.has(binding)) return undefined;
+    const context: ReplayEvaluationContext = {
+      substitutions: new Map(),
+      unsafeBindings: replay.unsafeBindings,
+      values: replay.values,
+    };
+    const value = replay
+      ? readReplayTemplateValue(replay.values.get(binding), state, replay)
+      : undefined;
+    if (value?.type === 'container') {
+      return (
+        collectReplayGTContainerPaths(
+          value,
+          binding.identifier.name,
+          new Set(),
+          state,
+          context
+        ) ?? null
+      );
+    }
+    if (value?.type === 'collection') {
+      return (
+        collectReplayCollectionGTContainerPaths(
+          value,
+          binding.identifier.name,
+          state,
+          context
+        ) ?? null
+      );
+    }
+    if (value?.type === 'unsafe') return null;
+    return value === undefined && replay.unsafeBindings.has(binding)
+      ? null
+      : undefined;
+  }
+
+  /** Reads exact final array/object shape from the same identity replay. */
+  function readReplayContainerMetadata(
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ):
+    | {
+        arrayLengths: Map<string, number>;
+        kinds: Map<string, TemplateContainerKind>;
+      }
+    | undefined {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay) return undefined;
+    const context: ReplayEvaluationContext = {
+      substitutions: new Map(),
+      unsafeBindings: replay.unsafeBindings,
+      values: replay.values,
+    };
+    const root = replay
+      ? readReplayTemplateValue(replay.values.get(binding), state, replay)
+      : undefined;
+    if (root?.type === 'collection') {
+      return root.identity.escaped
+        ? undefined
+        : {
+            arrayLengths: new Map(),
+            kinds: new Map([[basePath, 'object']]),
+          };
+    }
+    if (root?.type !== 'container') return undefined;
+    const arrayLengths = new Map<string, number>();
+    const kinds = new Map<string, TemplateContainerKind>();
+    const visit = (
+      value: ReplayContainerReference,
+      path: string,
+      seen: Set<ReplayContainerIdentity>
+    ): boolean => {
+      if (value.identity.escaped) return false;
+      if (seen.has(value.identity)) return true;
+      const nextSeen = new Set(seen).add(value.identity);
+      const snapshot = value.identity.snapshot;
+      kinds.set(path, snapshot.kind);
+      if (snapshot.kind === 'array')
+        arrayLengths.set(path, snapshot.entries.length);
+      const entries = readReplayVisibleContainerEntries(value, state, context);
+      if (!entries) return false;
+      for (const [key, entry] of entries) {
+        if (
+          entry?.type === 'container' &&
+          !visit(entry, appendTemplatePath(path, key), nextSeen)
+        ) {
+          return false;
+        }
+      }
+      return true;
+    };
+    return visit(root, basePath, new Set())
+      ? { arrayLengths, kinds }
+      : undefined;
+  }
+
+  /** Exposes exact component leaves from a replayed final container. */
+  function readReplayComponentCandidates(
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ): ComponentMemberCandidate[] | undefined {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay) return undefined;
+    const context: ReplayEvaluationContext = {
+      substitutions: new Map(),
+      unsafeBindings: replay.unsafeBindings,
+      values: replay.values,
+    };
+    const root = replay
+      ? readReplayTemplateValue(replay.values.get(binding), state, replay)
+      : undefined;
+    if (root?.type === 'collection') {
+      if (root.identity.escaped) return undefined;
+      const result: ComponentMemberCandidate[] = [];
+      for (const [key, entry] of root.identity.entries) {
+        if (entry.type !== 'leaf' || entry.hasGT === undefined)
+          return undefined;
+        if (!entry.knownValue) continue;
+        const name = appendTemplatePath(
+          basePath,
+          root.identity.templateKeys.get(key) ?? unknownTemplatePathSegment
+        );
+        result.push({
+          certain: !isReplayGetterStringLeaf(entry),
+          name,
+          value: entry.knownValue,
+        });
+      }
+      return result;
+    }
+    if (root?.type !== 'container') return undefined;
+    const result: ComponentMemberCandidate[] = [];
+    const visit = (
+      value: ReplayContainerReference,
+      path: string,
+      seen: Set<ReplayContainerIdentity>
+    ): boolean => {
+      if (value.identity.escaped) return false;
+      if (seen.has(value.identity)) return true;
+      const nextSeen = new Set(seen).add(value.identity);
+      const entries = readReplayVisibleContainerEntries(value, state, context);
+      if (!entries) return false;
+      for (const [key, entry] of entries) {
+        if (!entry) continue;
+        const childPath = appendTemplatePath(path, key);
+        if (entry.type === 'container') {
+          if (!visit(entry, childPath, nextSeen)) return false;
+        } else if (entry.type === 'leaf') {
+          if (entry.hasGT === undefined) return false;
+          if (entry.knownValue) {
+            result.push({
+              certain: !isReplayGetterStringLeaf(entry),
+              name: childPath,
+              value: entry.knownValue,
+            });
+          }
+        } else {
+          return false;
+        }
+      }
+      return true;
+    };
+    return visit(root, basePath, new Set()) ? result : undefined;
+  }
+
+  /** Exposes pure receiver methods whose final return is a known component. */
+  function readReplayComponentFactoryCandidates(
+    binding: Binding,
+    basePath: string,
+    state: ScriptState
+  ): ComponentFactoryCandidate[] | undefined {
+    const replay = readContainerIdentityReplay(binding, state);
+    if (!replay) return undefined;
+    const context: ReplayEvaluationContext = {
+      substitutions: new Map(),
+      unsafeBindings: replay.unsafeBindings,
+      values: replay.values,
+    };
+    const root = readReplayTemplateValue(
+      replay.values.get(binding),
+      state,
+      replay
+    );
+    if (root?.type !== 'container') return undefined;
+    const result: ComponentFactoryCandidate[] = [];
+    const visit = (
+      value: ReplayContainerReference,
+      path: string,
+      seen: Set<ReplayContainerIdentity>
+    ): boolean => {
+      if (value.identity.escaped) return false;
+      if (seen.has(value.identity)) return true;
+      const entries = readReplayVisibleContainerEntries(value, state, context);
+      if (!entries) return false;
+      const nextSeen = new Set(seen).add(value.identity);
+      for (const [key, entry] of entries) {
+        if (!entry) continue;
+        const childPath = appendTemplatePath(path, key);
+        if (entry.type === 'container') {
+          if (!visit(entry, childPath, nextSeen)) return false;
+          continue;
+        }
+        if (entry.type === 'leaf') {
+          if (entry.hasGT === undefined) return false;
+          continue;
+        }
+        if (entry.type !== 'method' || !entry.receiver) return false;
+        const body = entry.callable.node.body;
+        if (
+          body.type === 'BlockStatement' &&
+          (body.body.length !== 1 || body.body[0]?.type !== 'ReturnStatement')
+        ) {
+          return false;
+        }
+        const returns = collectFunctionReturnExpressions(
+          entry.callable.node,
+          entry.callable.scope,
+          state
+        );
+        if (returns.length !== 1) return false;
+        const returned = evaluateReplayExpression(
+          returns[0]!.node,
+          returns[0]!.scope,
+          state,
+          {
+            ...context,
+            substitutions: new Map(entry.substitutions),
+            thisValue: entry.receiver,
+          }
+        );
+        if (returned?.type !== 'leaf' || returned.hasGT === undefined) {
+          return false;
+        }
+        if (
+          returned.knownValue?.type === 'component' ||
+          returned.knownValue?.type === 'vue-builtin'
+        ) {
+          result.push({
+            gt:
+              returned.knownValue.type === 'component' &&
+              returned.knownValue.name === 'T',
+            name: childPath,
+          });
+        }
+      }
+      return true;
+    };
+    return visit(root, basePath, new Set()) ? result : undefined;
+  }
+
+  return {
+    evaluateReplayAtPosition,
+    isReplayGetterStringLeaf,
+    readDefiniteReplayGTContainerPaths,
+    readReplayComponentCandidates,
+    readReplayComponentFactoryCandidates,
+    readReplayContainerMetadata,
+    readReplayLeafState,
+    readSafeReplayLeafOverride,
+    replayBindingRetainsUnsafeIdentity,
+  };
+}

--- a/packages/vue-extractor/src/internal/script/runtimeModules.ts
+++ b/packages/vue-extractor/src/internal/script/runtimeModules.ts
@@ -1,0 +1,26 @@
+/** Package roots that can expose GT-shaped names but never gt-vue values. */
+const KNOWN_NON_VUE_GT_RUNTIME_PACKAGES = [
+  '@generaltranslation/react-core',
+  'gt-i18n',
+  'gt-next',
+  'gt-node',
+  'gt-react',
+  'gt-react-native',
+  'gt-tanstack-start',
+] as const;
+
+/**
+ * Identifies an official GT runtime whose exports are ordinary to gt-vue.
+ *
+ * Package subpaths retain the identity of their package root. Explicitly
+ * classifying these imports prevents a mixed-framework scan from treating a
+ * React or server API named `T`, `msg`, or `useGT` as an unresolved gt-vue
+ * alias. Unknown packages and application aliases remain unresolved so the
+ * analyzer can continue to fail closed for custom gt-vue reexports.
+ */
+export function isKnownNonVueGTRuntime(source: string): boolean {
+  return KNOWN_NON_VUE_GT_RUNTIME_PACKAGES.some(
+    (packageName) =>
+      source === packageName || source.startsWith(`${packageName}/`)
+  );
+}

--- a/packages/vue-extractor/src/internal/script/snapshot.ts
+++ b/packages/vue-extractor/src/internal/script/snapshot.ts
@@ -1,0 +1,681 @@
+import type { Binding, NodePath, Scope } from '@babel/traverse';
+import type * as t from '@babel/types';
+import {
+  readStaticPrimitive,
+  unwrapExpression,
+  type StaticPrimitiveResult,
+} from '../utils.js';
+import type {
+  CollectedObjectEntries,
+  ContainerWritePolicy,
+  FinalContainerOperation,
+  FinalContainerSnapshot,
+  KnownValue,
+  ScopedExpression,
+  ScriptState,
+  VueScriptAnalysis,
+} from './model.js';
+
+/** Static-analysis operations consumed by finite snapshot evaluation. */
+export type SnapshotAnalysisDependencies = {
+  readonlyArrayTransforms: ReadonlySet<string>;
+  collectObjectEntries: (
+    node: t.Node,
+    scope: Scope,
+    seen: Set<t.Node>,
+    atPosition?: number,
+    state?: ScriptState
+  ) => CollectedObjectEntries;
+  collectTransformArrayEntries: (
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState,
+    seen: Set<t.Node>,
+    atPosition?: number
+  ) => Array<ScopedExpression | undefined> | undefined;
+  memberChainIsReadOnly: (
+    memberPath: NodePath<t.MemberExpression | t.OptionalMemberExpression>
+  ) => boolean;
+  readBindingContainerWritePolicy: (
+    binding: Binding,
+    state: ScriptState,
+    seen?: Set<Binding>
+  ) => ContainerWritePolicy | undefined;
+  readResolvedMemberPath: (
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ) => string | undefined;
+  readResolvedMemberProperty: (
+    node: t.MemberExpression | t.OptionalMemberExpression,
+    scope: Scope,
+    state: ScriptState
+  ) => string | undefined;
+  readStaticFromScope: (
+    node: t.Node | null | undefined,
+    scope: Scope,
+    seen: Set<Binding>,
+    atPosition: number,
+    analysis?: VueScriptAnalysis,
+    allowNumericGlobals?: boolean
+  ) => StaticPrimitiveResult;
+  resolveKnownExpression: (
+    node: t.Node | null | undefined,
+    scope: Scope,
+    state: ScriptState,
+    seen: Set<Binding>
+  ) => KnownValue | undefined;
+  resolveVueTemplateContainerSources: (
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ) => ScopedExpression[] | undefined;
+};
+
+/** Narrow snapshot queries used by replay and conservative provenance. */
+export type SnapshotAnalysis = {
+  readDefiniteArrayInteger: (
+    node: t.Node | undefined,
+    fallback: number,
+    scope: Scope,
+    state: ScriptState
+  ) => number | undefined;
+  readDefiniteFinalContainerHasGT: (
+    binding: Binding,
+    state: ScriptState
+  ) => boolean | undefined;
+  readDefiniteFinalContainerSnapshot: (
+    binding: Binding,
+    state: ScriptState
+  ) => FinalContainerSnapshot | undefined;
+};
+
+/** Creates the conservative finite-container snapshot analyzer. */
+export function createSnapshotAnalysis({
+  readonlyArrayTransforms: READONLY_ARRAY_TRANSFORMS,
+  collectObjectEntries,
+  collectTransformArrayEntries,
+  memberChainIsReadOnly,
+  readBindingContainerWritePolicy,
+  readResolvedMemberPath,
+  readResolvedMemberProperty,
+  readStaticFromScope,
+  resolveKnownExpression,
+  resolveVueTemplateContainerSources,
+}: SnapshotAnalysisDependencies): SnapshotAnalysis {
+  /** Copies a replay snapshot before another binding applies its own writes. */
+  function cloneFinalContainerSnapshot(
+    snapshot: FinalContainerSnapshot
+  ): FinalContainerSnapshot {
+    return snapshot.kind === 'array'
+      ? { kind: 'array', entries: [...snapshot.entries] }
+      : { kind: 'object', entries: new Map(snapshot.entries) };
+  }
+
+  /** Reads an exact finite container without assuming arbitrary calls are pure. */
+  function readFinalContainerSnapshot(
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState
+  ): FinalContainerSnapshot | undefined {
+    if (state.analysis.stats) {
+      state.analysis.stats.finalContainerSnapshotReads += 1;
+    }
+    // A resolved GT/Vue identity or string function is an exact scalar, not a
+    // finite container. This shortcut is especially important for immutable
+    // alias chains whose final value is later stored in a mutable registry.
+    if (resolveKnownExpression(node, scope, state, new Set())) return undefined;
+    const array = collectTransformArrayEntries(
+      node,
+      scope,
+      state,
+      new Set(),
+      Number.POSITIVE_INFINITY
+    );
+    if (array) return { kind: 'array', entries: [...array] };
+    const object = collectObjectEntries(
+      node,
+      scope,
+      new Set(),
+      Number.POSITIVE_INFINITY,
+      state
+    );
+    if (!object.unknownAll && object.unknownNames.size === 0) {
+      return { kind: 'object', entries: new Map(object.entries) };
+    }
+    const sources = resolveVueTemplateContainerSources(node, scope, state);
+    if (sources?.length !== 1) return undefined;
+    const sourceExpression = unwrapExpression(sources[0].node);
+    if (sourceExpression?.type === 'Identifier') {
+      const sourceBinding = sources[0].scope.getBinding(sourceExpression.name);
+      if (sourceBinding) {
+        const finalSource = readDefiniteFinalContainerSnapshot(
+          sourceBinding,
+          state
+        );
+        if (finalSource) return finalSource;
+      }
+    }
+    return readFinalContainerSnapshot(sources[0].node, sources[0].scope, state);
+  }
+
+  /** Determines whether a finite expression definitely contains T anywhere. */
+  function readDefiniteExpressionHasGT(
+    node: t.Node,
+    scope: Scope,
+    state: ScriptState,
+    seen: Set<t.Node>
+  ): boolean | undefined {
+    const expression = unwrapExpression(node);
+    if (!expression || seen.has(expression)) return undefined;
+    const nextSeen = new Set(seen).add(expression);
+    const known = resolveKnownExpression(expression, scope, state, new Set());
+    if (known) {
+      return known.type === 'component' ? known.name === 'T' : false;
+    }
+    const primitive = readStaticFromScope(
+      expression,
+      scope,
+      new Set(),
+      expression.end ?? Number.POSITIVE_INFINITY,
+      state.analysis
+    );
+    if (primitive.ok) return false;
+    if (
+      expression.type === 'Identifier' &&
+      !scope.getBinding(expression.name) &&
+      [
+        'Array',
+        'BigInt',
+        'Boolean',
+        'Date',
+        'Error',
+        'Map',
+        'Number',
+        'Object',
+        'RegExp',
+        'Set',
+        'String',
+        'Symbol',
+        'WeakMap',
+        'WeakSet',
+        'undefined',
+      ].includes(expression.name)
+    ) {
+      return false;
+    }
+    const snapshot = readFinalContainerSnapshot(expression, scope, state);
+    if (!snapshot) return undefined;
+    const values =
+      snapshot.kind === 'array'
+        ? snapshot.entries.filter(
+            (entry): entry is ScopedExpression => entry !== undefined
+          )
+        : [...snapshot.entries.values()];
+    let unknown = false;
+    for (const value of values) {
+      const hasGT = readDefiniteExpressionHasGT(
+        value.node,
+        value.scope,
+        state,
+        nextSeen
+      );
+      if (hasGT) return true;
+      if (hasGT === undefined) unknown = true;
+    }
+    return unknown ? undefined : false;
+  }
+
+  /** Coerces a statically known array index with JavaScript integer semantics. */
+  function readDefiniteArrayInteger(
+    node: t.Node | undefined,
+    fallback: number,
+    scope: Scope,
+    state: ScriptState
+  ): number | undefined {
+    if (!node) return fallback;
+    const expression = unwrapExpression(node);
+    if (
+      expression?.type === 'Identifier' &&
+      expression.name === 'undefined' &&
+      !scope.getBinding('undefined')
+    ) {
+      return 0;
+    }
+    const value = readStaticFromScope(
+      node,
+      scope,
+      new Set(),
+      node.end ?? Number.POSITIVE_INFINITY,
+      state.analysis,
+      true
+    );
+    if (!value.ok || typeof value.value === 'bigint') return undefined;
+    try {
+      const numeric = Number(value.value);
+      return Number.isNaN(numeric) ? 0 : Math.trunc(numeric);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /** Accepts only synchronous top-level operations that definitely run in order. */
+  function isUnconditionalSiblingOperation(
+    binding: Binding,
+    operation: NodePath<t.Node>
+  ): boolean {
+    const declarationStatement = binding.path.getStatementParent();
+    const operationStatement = operation.getStatementParent();
+    return Boolean(
+      declarationStatement &&
+      (operationStatement?.isExpressionStatement() ||
+        operationStatement?.isVariableDeclaration()) &&
+      declarationStatement.parentPath?.node ===
+        operationStatement.parentPath?.node &&
+      binding.referencePaths.every(
+        (reference) =>
+          reference.getFunctionParent()?.node ===
+          operation.getFunctionParent()?.node
+      )
+    );
+  }
+
+  /** Applies one direct member replacement to a finite container snapshot. */
+  function replaceFinalContainerMember(
+    snapshot: FinalContainerSnapshot,
+    property: string,
+    value: ScopedExpression
+  ): FinalContainerSnapshot | undefined {
+    if (snapshot.kind === 'object') {
+      snapshot.entries.set(property, value);
+      return snapshot;
+    }
+    if (property === 'length') {
+      const length = readStaticPrimitive(value.node, () => ({ ok: false }));
+      if (
+        !length.ok ||
+        typeof length.value !== 'number' ||
+        !Number.isInteger(length.value) ||
+        length.value < 0
+      ) {
+        return undefined;
+      }
+      snapshot.entries.length = length.value;
+      return snapshot;
+    }
+    if (!/^(0|[1-9]\d*)$/.test(property)) return undefined;
+    snapshot.entries[Number(property)] = value;
+    return snapshot;
+  }
+
+  /**
+   * Evaluates the final value of a directly mutated finite container.
+   * Unknown control flow, dynamic keys, callbacks, and escapes return unknown so
+   * the normal fail-closed provenance remains in place.
+   */
+  function readDefiniteFinalContainerSnapshot(
+    binding: Binding,
+    state: ScriptState
+  ): FinalContainerSnapshot | undefined {
+    const cached = state.finalContainerSnapshots.get(binding);
+    if (cached) return cloneFinalContainerSnapshot(cached);
+    if (state.finalContainerSnapshotsInProgress.has(binding)) return undefined;
+    state.finalContainerSnapshotsInProgress.add(binding);
+    try {
+      const replay = computeDefiniteFinalContainerSnapshot(binding, state);
+      if (!replay) return undefined;
+      for (const relatedBinding of replay.relatedBindings) {
+        state.finalContainerSnapshots.set(
+          relatedBinding,
+          cloneFinalContainerSnapshot(replay.snapshot)
+        );
+      }
+      return cloneFinalContainerSnapshot(replay.snapshot);
+    } finally {
+      state.finalContainerSnapshotsInProgress.delete(binding);
+    }
+  }
+
+  /** Replays exact writes and returns aliases that retain the same identity. */
+  function computeDefiniteFinalContainerSnapshot(
+    binding: Binding,
+    state: ScriptState
+  ):
+    | {
+        snapshot: FinalContainerSnapshot;
+        relatedBindings: Set<Binding>;
+      }
+    | undefined {
+    const declaration = binding.path.node;
+    if (
+      declaration.type !== 'VariableDeclarator' ||
+      declaration.id.type !== 'Identifier' ||
+      !declaration.init
+    ) {
+      return undefined;
+    }
+    let snapshot = readFinalContainerSnapshot(
+      declaration.init,
+      binding.path.scope,
+      state
+    );
+    if (!snapshot) return undefined;
+    const operations: FinalContainerOperation[] = [];
+    const addRootAssignment = (
+      assignment: NodePath<t.AssignmentExpression>
+    ): boolean => {
+      if (
+        assignment.node.operator !== '=' ||
+        assignment.node.left.type !== 'Identifier' ||
+        assignment.node.left.name !== binding.identifier.name ||
+        !isUnconditionalSiblingOperation(binding, assignment)
+      ) {
+        return false;
+      }
+      operations.push({
+        position: assignment.node.start ?? Number.POSITIVE_INFINITY,
+        apply: () =>
+          readFinalContainerSnapshot(
+            assignment.node.right,
+            assignment.scope,
+            state
+          ),
+      });
+      return true;
+    };
+    for (const violation of binding.constantViolations) {
+      if (
+        !violation.isAssignmentExpression() ||
+        !addRootAssignment(violation)
+      ) {
+        return undefined;
+      }
+    }
+
+    const pendingBindings = [binding];
+    const seenBindings = new Set<Binding>();
+    for (
+      let bindingIndex = 0;
+      bindingIndex < pendingBindings.length;
+      bindingIndex += 1
+    ) {
+      const currentBinding = pendingBindings[bindingIndex];
+      if (!currentBinding || seenBindings.has(currentBinding)) continue;
+      seenBindings.add(currentBinding);
+      if (
+        currentBinding !== binding &&
+        currentBinding.constantViolations.length > 0
+      ) {
+        return undefined;
+      }
+      const writePolicy = readBindingContainerWritePolicy(
+        currentBinding,
+        state
+      );
+      const blocksWriteAtDepth = (depth: number): boolean =>
+        writePolicy === 'readonly-deep' ||
+        (writePolicy === 'readonly-shallow' && depth <= 1);
+      for (const reference of currentBinding.referencePaths) {
+        const parent = reference.parentPath;
+        if (!parent) return undefined;
+        if (
+          parent.isAssignmentExpression() &&
+          parent.node.left === reference.node
+        ) {
+          continue;
+        }
+        if (
+          parent.isVariableDeclarator() &&
+          parent.node.init === reference.node &&
+          parent.node.id.type === 'Identifier'
+        ) {
+          if (binding.constantViolations.length > 0) return undefined;
+          if (!isUnconditionalSiblingOperation(binding, parent))
+            return undefined;
+          const alias = parent.scope.getBinding(parent.node.id.name);
+          if (!alias) return undefined;
+          pendingBindings.push(alias);
+          continue;
+        }
+        if (
+          parent.isCallExpression() &&
+          parent.node.arguments.includes(
+            reference.node as t.Expression | t.SpreadElement
+          )
+        ) {
+          const wrapper = resolveKnownExpression(
+            parent.node.callee,
+            parent.scope,
+            state,
+            new Set()
+          );
+          if (
+            wrapper?.type === 'container-wrapper' &&
+            wrapper.writePolicy !== 'forward'
+          ) {
+            continue;
+          }
+          const callee = readResolvedMemberPath(
+            parent.node.callee,
+            parent.scope,
+            state
+          );
+          const argumentIndex = parent.node.arguments.indexOf(
+            reference.node as t.Expression | t.SpreadElement
+          );
+          if (
+            callee !== 'Object.assign' ||
+            parent.scope.getBinding('Object') ||
+            argumentIndex !== 0 ||
+            !isUnconditionalSiblingOperation(binding, parent)
+          ) {
+            return undefined;
+          }
+          if (blocksWriteAtDepth(1)) continue;
+          const sources = parent.node.arguments.slice(1);
+          operations.push({
+            position: parent.node.start ?? Number.POSITIVE_INFINITY,
+            apply: (current) => {
+              if (current.kind !== 'object') return undefined;
+              for (const source of sources) {
+                if (
+                  source.type === 'ArgumentPlaceholder' ||
+                  source.type === 'SpreadElement'
+                ) {
+                  return undefined;
+                }
+                const entries = collectObjectEntries(
+                  source,
+                  parent.scope,
+                  new Set(),
+                  source.end ?? Number.POSITIVE_INFINITY,
+                  state
+                );
+                if (entries.unknownAll || entries.unknownNames.size > 0) {
+                  return undefined;
+                }
+                for (const [key, value] of entries.entries) {
+                  current.entries.set(key, value);
+                }
+              }
+              return current;
+            },
+          });
+          continue;
+        }
+        if (
+          !parent.isMemberExpression() &&
+          !parent.isOptionalMemberExpression()
+        ) {
+          return undefined;
+        }
+        const firstMember = parent;
+        let current: NodePath<t.Node> = firstMember;
+        let depth = 1;
+        while (
+          current.parentPath &&
+          (current.parentPath.isMemberExpression() ||
+            current.parentPath.isOptionalMemberExpression()) &&
+          current.parentPath.node.object === current.node
+        ) {
+          current = current.parentPath;
+          depth += 1;
+        }
+        const terminal = current.parentPath;
+        const property = readResolvedMemberProperty(
+          firstMember.node,
+          firstMember.scope,
+          state
+        );
+        if (
+          depth === 1 &&
+          property !== undefined &&
+          terminal?.isAssignmentExpression() &&
+          terminal.node.left === current.node &&
+          terminal.node.operator === '=' &&
+          isUnconditionalSiblingOperation(binding, terminal)
+        ) {
+          if (blocksWriteAtDepth(1)) continue;
+          operations.push({
+            position: terminal.node.start ?? Number.POSITIVE_INFINITY,
+            apply: (value) =>
+              replaceFinalContainerMember(value, property, {
+                node: terminal.node.right,
+                scope: terminal.scope,
+              }),
+          });
+          continue;
+        }
+        if (
+          depth === 1 &&
+          property !== undefined &&
+          terminal?.isCallExpression() &&
+          terminal.node.callee === current.node &&
+          isUnconditionalSiblingOperation(binding, terminal)
+        ) {
+          if (blocksWriteAtDepth(1)) continue;
+          const method = property;
+          const args = terminal.node.arguments;
+          if (
+            args.some(
+              (argument) =>
+                argument.type === 'ArgumentPlaceholder' ||
+                argument.type === 'SpreadElement'
+            )
+          ) {
+            return undefined;
+          }
+          operations.push({
+            position: terminal.node.start ?? Number.POSITIVE_INFINITY,
+            apply: (value) => {
+              if (value.kind !== 'array') return undefined;
+              const entries = value.entries;
+              const scoped = (index: number): ScopedExpression | undefined => {
+                const argument = args[index];
+                return argument && argument.type !== 'ArgumentPlaceholder'
+                  ? { node: argument, scope: terminal.scope }
+                  : undefined;
+              };
+              if (method === 'pop') entries.pop();
+              else if (method === 'shift') entries.shift();
+              else if (method === 'push') {
+                entries.push(
+                  ...args.map((argument) => ({
+                    node: argument as t.Expression,
+                    scope: terminal.scope,
+                  }))
+                );
+              } else if (method === 'unshift') {
+                entries.unshift(
+                  ...args.map((argument) => ({
+                    node: argument as t.Expression,
+                    scope: terminal.scope,
+                  }))
+                );
+              } else if (method === 'splice') {
+                const start = readDefiniteArrayInteger(
+                  scoped(0)?.node,
+                  0,
+                  terminal.scope,
+                  state
+                );
+                const deleteCount = readDefiniteArrayInteger(
+                  scoped(1)?.node,
+                  args.length < 2 ? Number.POSITIVE_INFINITY : 0,
+                  terminal.scope,
+                  state
+                );
+                if (start === undefined || deleteCount === undefined) {
+                  return undefined;
+                }
+                entries.splice(
+                  start,
+                  Math.max(0, deleteCount),
+                  ...args.slice(2).map((argument) => ({
+                    node: argument as t.Expression,
+                    scope: terminal.scope,
+                  }))
+                );
+              } else {
+                return READONLY_ARRAY_TRANSFORMS.has(method)
+                  ? value
+                  : undefined;
+              }
+              return value;
+            },
+          });
+          continue;
+        }
+        if (memberChainIsReadOnly(firstMember)) continue;
+        return undefined;
+      }
+    }
+
+    for (const operation of operations.sort(
+      (first, second) => first.position - second.position
+    )) {
+      snapshot = operation.apply(snapshot);
+      if (!snapshot) return undefined;
+    }
+    return { snapshot, relatedBindings: seenBindings };
+  }
+
+  /** Returns whether the exact final finite container contains T anywhere. */
+  function readDefiniteFinalContainerHasGT(
+    binding: Binding,
+    state: ScriptState
+  ): boolean | undefined {
+    const snapshot = readDefiniteFinalContainerSnapshot(binding, state);
+    if (!snapshot) return undefined;
+    const values = readFinalContainerValues(snapshot);
+    let unknown = false;
+    for (const value of values) {
+      const hasGT = readDefiniteExpressionHasGT(
+        value.node,
+        value.scope,
+        state,
+        new Set()
+      );
+      if (hasGT) return true;
+      if (hasGT === undefined) unknown = true;
+    }
+    return unknown ? undefined : false;
+  }
+
+  /** Lists the concrete values held by a finite container snapshot. */
+  function readFinalContainerValues(
+    snapshot: FinalContainerSnapshot
+  ): ScopedExpression[] {
+    return snapshot.kind === 'array'
+      ? snapshot.entries.filter(
+          (entry): entry is ScopedExpression => entry !== undefined
+        )
+      : [...snapshot.entries.values()];
+  }
+
+  return {
+    readDefiniteArrayInteger,
+    readDefiniteFinalContainerHasGT,
+    readDefiniteFinalContainerSnapshot,
+  };
+}

--- a/packages/vue-extractor/src/internal/script/syntax.ts
+++ b/packages/vue-extractor/src/internal/script/syntax.ts
@@ -1,0 +1,107 @@
+import type { NodePath, Scope } from '@babel/traverse';
+import type * as t from '@babel/types';
+import { unwrapExpression } from '../utils.js';
+
+/** Reads a member key that is already a static property literal. */
+export function readMemberProperty(
+  node: t.MemberExpression | t.OptionalMemberExpression
+): string | undefined {
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name;
+  }
+  return node.computed && node.property.type === 'StringLiteral'
+    ? node.property.value
+    : node.computed && node.property.type === 'NumericLiteral'
+      ? String(node.property.value)
+      : undefined;
+}
+
+/** Reads a direct identifier, string, or numeric object key. */
+export function readObjectKey(node: t.Node): string | undefined {
+  return node.type === 'Identifier'
+    ? node.name
+    : node.type === 'StringLiteral'
+      ? node.value
+      : node.type === 'NumericLiteral'
+        ? String(node.value)
+        : undefined;
+}
+
+/** Reads a property key without evaluating a computed expression. */
+export function readPropertyKey(property: {
+  computed: boolean;
+  key: t.Node;
+}): string | undefined {
+  return property.computed && property.key.type !== 'StringLiteral'
+    ? undefined
+    : readObjectKey(property.key);
+}
+
+/** Reads the identifier introduced by a direct or defaulted pattern. */
+export function readPatternIdentifier(node: t.Node): string | undefined {
+  if (node.type === 'Identifier') return node.name;
+  if (node.type === 'AssignmentPattern') {
+    return readPatternIdentifier(node.left);
+  }
+  return undefined;
+}
+
+/** Recognizes expressions that are statically JavaScript `undefined`. */
+export function isStaticallyUndefined(node: t.Node, scope: Scope): boolean {
+  const expression = unwrapExpression(node);
+  return (
+    (expression?.type === 'Identifier' &&
+      expression.name === 'undefined' &&
+      !scope.getBinding('undefined')) ||
+    (expression?.type === 'UnaryExpression' && expression.operator === 'void')
+  );
+}
+
+/** Returns whether a binding pattern introduces the requested name. */
+export function patternContains(node: t.Node, name: string): boolean {
+  if (node.type === 'Identifier') return node.name === name;
+  if (node.type === 'AssignmentPattern') {
+    return patternContains(node.left, name);
+  }
+  if (node.type === 'RestElement') return patternContains(node.argument, name);
+  if (node.type === 'ArrayPattern') {
+    return node.elements.some(
+      (element) => element && patternContains(element, name)
+    );
+  }
+  if (node.type === 'ObjectPattern') {
+    return node.properties.some((property) =>
+      property.type === 'RestElement'
+        ? patternContains(property.argument, name)
+        : patternContains(property.value, name)
+    );
+  }
+  return false;
+}
+
+/** Returns whether a node can introduce one or more lexical bindings. */
+export function isBindingPattern(node: t.Node): boolean {
+  return (
+    node.type === 'Identifier' ||
+    node.type === 'ObjectPattern' ||
+    node.type === 'ArrayPattern' ||
+    node.type === 'AssignmentPattern' ||
+    node.type === 'RestElement'
+  );
+}
+
+/** Identifies AST wrappers that can contain a nested assignment target. */
+export function isAssignmentTargetWrapper(
+  parent: NodePath<t.Node>,
+  child: NodePath<t.Node>
+): boolean {
+  return (
+    (parent.isObjectProperty() &&
+      parent.node.value === child.node &&
+      parent.parentPath?.isObjectPattern() === true) ||
+    parent.isObjectPattern() ||
+    parent.isArrayPattern() ||
+    (parent.isRestElement() && parent.node.argument === child.node) ||
+    (parent.isAssignmentPattern() && parent.node.left === child.node)
+  );
+}

--- a/packages/vue-extractor/src/internal/stringCalls.ts
+++ b/packages/vue-extractor/src/internal/stringCalls.ts
@@ -1,0 +1,181 @@
+import type * as t from '@babel/types';
+import type {
+  ExtractionLocation,
+  StringFunctionKind,
+  VueExtractionContext,
+} from './types.js';
+import {
+  addVueError,
+  createInlineMetadata,
+  readStaticPrimitive,
+  type StaticPrimitiveResult,
+  unwrapExpression,
+} from './utils.js';
+
+type VueStringCall = t.CallExpression | t.OptionalCallExpression;
+type StaticPrimitiveReader = (
+  input: t.Node | null | undefined
+) => StaticPrimitiveResult;
+
+export function processVueStringCall(
+  call: VueStringCall,
+  kind: StringFunctionKind,
+  location: ExtractionLocation | undefined,
+  context: VueExtractionContext,
+  readStatic: StaticPrimitiveReader = readStaticPrimitive
+): void {
+  const firstArgument = call.arguments[0];
+  const unwrappedFirstArgument = unwrapExpression(firstArgument);
+
+  if (kind === 'msg' && unwrappedFirstArgument?.type === 'ArrayExpression') {
+    const options = readContextOptions(
+      call.arguments[1],
+      location,
+      context,
+      readStatic
+    );
+    if (!options.ok) return;
+    if (call.arguments.length > 2) {
+      addUnsupportedArgumentsError(location, context);
+      return;
+    }
+
+    const messages: string[] = [];
+    for (const element of unwrappedFirstArgument.elements) {
+      const value = readStatic(element);
+      if (!value.ok || typeof value.value !== 'string') {
+        addVueError(
+          context,
+          location,
+          'Found a dynamic entry in a gt-vue msg() message list',
+          'Use only string literals or template literals without expressions'
+        );
+        return;
+      }
+      messages.push(value.value);
+    }
+    for (const message of messages) {
+      addStringUpdate(message, options.context, location, context);
+    }
+    return;
+  }
+
+  const value =
+    unwrappedFirstArgument?.type === 'SpreadElement' ||
+    unwrappedFirstArgument?.type === 'ArgumentPlaceholder'
+      ? { ok: false as const }
+      : readStatic(unwrappedFirstArgument);
+
+  // useMessages() can receive a previously encoded msg() value. Only direct
+  // literal calls register new source content.
+  if (!value.ok || typeof value.value !== 'string') {
+    if (kind === 'messages') return;
+    addVueError(
+      context,
+      location,
+      `Found dynamic content in a gt-vue ${kind === 'gt' ? 'gt()' : 'msg()'} call`,
+      'Use a string literal or a template literal without expressions'
+    );
+    return;
+  }
+
+  const options = readContextOptions(
+    call.arguments[1],
+    location,
+    context,
+    readStatic
+  );
+  if (!options.ok) return;
+  if (call.arguments.length > 2) {
+    addUnsupportedArgumentsError(location, context);
+    return;
+  }
+  addStringUpdate(value.value, options.context, location, context);
+}
+
+function addStringUpdate(
+  source: string,
+  translationContext: string | undefined,
+  location: ExtractionLocation | undefined,
+  context: VueExtractionContext
+): void {
+  context.results.push({
+    dataFormat: 'STRING',
+    source,
+    metadata: createInlineMetadata(context, location, translationContext),
+  });
+}
+
+function readContextOptions(
+  argument: VueStringCall['arguments'][number] | undefined,
+  location: ExtractionLocation | undefined,
+  context: VueExtractionContext,
+  readStatic: StaticPrimitiveReader
+): { ok: true; context?: string } | { ok: false } {
+  if (argument === undefined) return { ok: true };
+  const options = unwrapExpression(argument);
+  if (options?.type !== 'ObjectExpression') {
+    addVueError(
+      context,
+      location,
+      'Found dynamic options in a gt-vue string translation call',
+      'Pass a static object containing only a string $context field'
+    );
+    return { ok: false };
+  }
+
+  let translationContext: string | undefined;
+  for (const property of options.properties) {
+    if (
+      property.type !== 'ObjectProperty' ||
+      (property.computed && property.key.type !== 'StringLiteral')
+    ) {
+      addVueError(
+        context,
+        location,
+        'Found unsupported options in a gt-vue string translation call',
+        'Pass a static object containing only a string $context field'
+      );
+      return { ok: false };
+    }
+    const key =
+      property.key.type === 'Identifier'
+        ? property.key.name
+        : property.key.type === 'StringLiteral'
+          ? property.key.value
+          : undefined;
+    if (key !== '$context') {
+      addVueError(
+        context,
+        location,
+        `Found unsupported gt-vue string option ${key ? `"${key}"` : ''}`.trim(),
+        'gt-vue string translation currently supports only $context'
+      );
+      return { ok: false };
+    }
+    const value = readStatic(property.value);
+    if (!value.ok || typeof value.value !== 'string') {
+      addVueError(
+        context,
+        location,
+        'Found a dynamic $context in a gt-vue string translation call',
+        'Use a string literal or a template literal without expressions'
+      );
+      return { ok: false };
+    }
+    translationContext = value.value;
+  }
+  return { ok: true, context: translationContext };
+}
+
+function addUnsupportedArgumentsError(
+  location: ExtractionLocation | undefined,
+  context: VueExtractionContext
+): void {
+  addVueError(
+    context,
+    location,
+    'Found unsupported arguments in a gt-vue string translation call',
+    'Pass the source string and, optionally, an object containing only $context'
+  );
+}

--- a/packages/vue-extractor/src/internal/template.ts
+++ b/packages/vue-extractor/src/internal/template.ts
@@ -1,0 +1,5204 @@
+import { parseExpression, type ParserPlugin } from '@babel/parser';
+import traverseModule, { type Scope } from '@babel/traverse';
+import * as babel from '@babel/types';
+import type {
+  DirectiveNode,
+  ElementNode,
+  ExpressionNode,
+  RootNode,
+  SimpleExpressionNode,
+  TemplateChildNode,
+} from '@vue/compiler-dom';
+import {
+  HTML_CONTENT_PROPS,
+  type GTProp,
+  type JsxChild,
+  type JsxChildren,
+} from '@generaltranslation/format/types';
+import { isAcceptedPluralForm } from 'generaltranslation/internal';
+import { ElementTypes, NodeTypes } from './compilerAst.js';
+import { processVueStringCall } from './stringCalls.js';
+import {
+  appendTemplatePath,
+  recursiveTemplatePathSegment,
+  unknownTemplatePathSegment,
+} from './templatePath.js';
+import type {
+  ExtractionLocation,
+  GTComponentName,
+  TemplateBindings,
+  VueBuiltinName,
+  VueExtractionContext,
+} from './types.js';
+import {
+  addVueError,
+  createInlineMetadata,
+  readStaticPrimitive,
+  type StaticPrimitive,
+  unwrapExpression,
+} from './utils.js';
+
+const traverse = traverseModule.default || traverseModule;
+
+type Counter = { value: number };
+
+type SlotContent = {
+  children: TemplateChildNode[];
+  /** Number of VNode roots Vue produces before Suspense normalization. */
+  rootCount: number;
+  shadowed: Set<string>;
+};
+
+type SlotLayout = {
+  defaultSlot: SlotContent;
+  namedSlots: Map<string, SlotContent>;
+};
+
+type DynamicSelectorCandidate = {
+  kind: 'expression' | 'string';
+  name: string;
+};
+
+type DynamicSelectorContainer =
+  | {
+      kind: 'literal';
+      node: babel.ArrayExpression | babel.ObjectExpression;
+    }
+  | { kind: 'path'; path: string }
+  | {
+      /** A callback-created container whose children are abstract values. */
+      kind: 'analysis';
+      containerKind: 'array' | 'object';
+      members?: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>;
+      values: Omit<DynamicSelectorAnalysis, 'displayName'>;
+    };
+
+type DynamicSelectorAnalysis = {
+  candidates: DynamicSelectorCandidate[];
+  componentFactories: Set<string>;
+  containers: DynamicSelectorContainer[];
+  displayName: string;
+  gtComponentFactories: Set<string>;
+  possibleGT: boolean;
+  unknown: boolean;
+};
+
+const COMPONENT_SELECTING_ARRAY_METHODS = new Set([
+  'at',
+  'find',
+  'findLast',
+  'pop',
+  'shift',
+]);
+
+const COMPONENT_PRESERVING_ARRAY_METHODS = new Set([
+  'concat',
+  'filter',
+  'reverse',
+  'slice',
+  'sort',
+  'splice',
+  'toReversed',
+  'toSorted',
+  'toSpliced',
+]);
+
+// Vue 3.3 does not attach `forParseResult` to compiler-dom directive nodes.
+// These expressions match Vue's own stable v-for grammar and are used only as
+// a compatibility fallback when the consuming compiler omits that metadata.
+const FOR_ALIAS_EXPRESSION = /([\s\S]*?)\s+(?:in|of)\s+([\s\S]*)/;
+const FOR_ITERATOR_EXPRESSION = /,([^,}\]]*)(?:,([^,}\]]*))?$/;
+const FOR_STRIP_PARENS = /^\(|\)$/g;
+
+type ForParseResult = {
+  index?: SimpleExpressionNode;
+  key?: SimpleExpressionNode;
+  source?: SimpleExpressionNode;
+  value?: SimpleExpressionNode;
+};
+
+type TemplateBindingPattern =
+  | babel.ArrayPattern
+  | babel.AssignmentPattern
+  | babel.Identifier
+  | babel.ObjectPattern
+  | babel.RestElement;
+
+const NON_BRANCH_ATTRIBUTE_NAMES = new Set([
+  'branch',
+  'class',
+  'n',
+  'locales',
+  'key',
+  'ref',
+  'ref_for',
+  'ref_key',
+  'ref-for',
+  'ref-key',
+  'style',
+]);
+
+const RESERVED_T_PROPS = new Set([
+  'key',
+  'ref',
+  'ref_for',
+  'ref_key',
+  'ref-for',
+  'ref-key',
+]);
+
+const SOURCE_SHAPING_DIRECTIVES = new Set([
+  'if',
+  'else',
+  'else-if',
+  'for',
+  'html',
+  'text',
+]);
+
+export function parseVueTemplate(
+  root: RootNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): void {
+  visitTemplateChildren(
+    root.children,
+    new Set(),
+    bindings,
+    expressionPlugins,
+    context,
+    false
+  );
+}
+
+function visitTemplateChildren(
+  children: TemplateChildNode[],
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext,
+  insideTranslation: boolean
+): void {
+  for (const child of children) {
+    if (child.type === NodeTypes.INTERPOLATION) {
+      processTemplateExpression(
+        child.content,
+        shadowed,
+        bindings,
+        expressionPlugins,
+        context
+      );
+      continue;
+    }
+    if (child.type !== NodeTypes.ELEMENT) continue;
+
+    const localBindings = collectElementScopeBindings(child, expressionPlugins);
+    const possibleScopedComponents = collectPossibleScopedComponentAliases(
+      child,
+      bindings,
+      shadowed,
+      expressionPlugins
+    );
+    const possibleScopedContainers = collectPossibleScopedContainerAliases(
+      child,
+      bindings,
+      shadowed,
+      expressionPlugins
+    );
+    const componentBindings =
+      possibleScopedComponents.size > 0
+        ? createScopedComponentBindings(bindings, possibleScopedComponents)
+        : bindings;
+    const childBindings =
+      possibleScopedContainers.size > 0
+        ? createScopedContainerBindings(
+            componentBindings,
+            possibleScopedContainers,
+            shadowed
+          )
+        : componentBindings;
+    const childShadowed = unionSets(shadowed, localBindings);
+    for (const localName of [
+      ...possibleScopedComponents,
+      ...possibleScopedContainers.keys(),
+    ]) {
+      childShadowed.delete(localName);
+    }
+
+    for (const property of child.props) {
+      if (property.type !== NodeTypes.DIRECTIVE) continue;
+      if (property.name === 'for') {
+        const parseResult = readForParseResult(property);
+        for (const alias of [
+          parseResult?.value,
+          parseResult?.key,
+          parseResult?.index,
+        ]) {
+          processBindingDefaults(
+            alias,
+            childShadowed,
+            childBindings,
+            expressionPlugins,
+            context
+          );
+        }
+      } else if (property.name === 'slot') {
+        processBindingDefaults(
+          property.exp,
+          childShadowed,
+          childBindings,
+          expressionPlugins,
+          context
+        );
+      }
+    }
+
+    for (const property of child.props) {
+      if (property.type !== NodeTypes.DIRECTIVE) continue;
+      if (
+        property.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+        !property.arg.isStatic
+      ) {
+        processTemplateExpression(
+          property.arg,
+          childShadowed,
+          childBindings,
+          expressionPlugins,
+          context
+        );
+      }
+      if (property.name === 'slot' || !property.exp) continue;
+      if (property.name === 'for') {
+        const parseResult = readForParseResult(property);
+        if (parseResult?.source) {
+          processTemplateExpression(
+            parseResult.source,
+            shadowed,
+            bindings,
+            expressionPlugins,
+            context
+          );
+        }
+        continue;
+      }
+      processTemplateExpression(
+        property.exp,
+        property.name === 'if' || property.name === 'else-if'
+          ? shadowed
+          : childShadowed,
+        property.name === 'if' || property.name === 'else-if'
+          ? bindings
+          : childBindings,
+        expressionPlugins,
+        context
+      );
+    }
+
+    const component = resolveGTComponent(
+      child,
+      childBindings,
+      expressionPlugins,
+      childShadowed
+    );
+    const suspense = resolveSuspenseComponent(
+      child,
+      childBindings,
+      expressionPlugins,
+      childShadowed
+    );
+    const fragment = resolveFragmentComponent(
+      child,
+      childBindings,
+      expressionPlugins,
+      childShadowed
+    );
+    const uncertainGTComponent = resolveUncertainComponentBinding(
+      child,
+      childBindings,
+      childBindings.uncertainGTComponents,
+      childBindings.uncertainRegisteredGTComponents,
+      childBindings.gtComponentFactories,
+      expressionPlugins,
+      childShadowed
+    );
+    const possibleDynamicT = component
+      ? undefined
+      : resolvePossibleDynamicT(
+          child,
+          childBindings,
+          expressionPlugins,
+          childShadowed
+        );
+    const unresolvedGTComponent = uncertainGTComponent ?? possibleDynamicT;
+    if (!insideTranslation && !component && unresolvedGTComponent) {
+      addVueError(
+        context,
+        child.loc,
+        `Could not statically resolve possible gt-vue component alias "${unresolvedGTComponent}"`,
+        'Use a direct gt-vue import or an immutable alias that does not escape static analysis'
+      );
+    }
+    if (
+      component?.originalName === 'Var' ||
+      component?.originalName === 'Num' ||
+      component?.originalName === 'DateTime' ||
+      component?.originalName === 'Currency'
+    ) {
+      validateVariableComponentShape(child, component.originalName, context);
+    }
+    if (component?.originalName === 'T' && !insideTranslation) {
+      extractTranslationComponent(
+        child,
+        childShadowed,
+        childBindings,
+        expressionPlugins,
+        context
+      );
+    }
+
+    const childInsideTranslation =
+      component?.originalName === 'Var' ||
+      (insideTranslation &&
+        isOpaqueComponent(child, component, suspense ?? fragment))
+        ? false
+        : insideTranslation || component?.originalName === 'T';
+    if (childInsideTranslation && suspense) {
+      const suspenseElementIsFallback = hasStaticSlotName(child, 'fallback');
+      for (const suspenseChild of child.children) {
+        visitTemplateChildren(
+          [suspenseChild],
+          childShadowed,
+          childBindings,
+          expressionPlugins,
+          context,
+          suspenseElementIsFallback
+            ? false
+            : !isSuspenseFallbackTemplate(suspenseChild)
+        );
+      }
+    } else {
+      visitTemplateChildren(
+        child.children,
+        childShadowed,
+        childBindings,
+        expressionPlugins,
+        context,
+        childInsideTranslation
+      );
+    }
+  }
+}
+
+/** Finds local Vue aliases whose runtime value can be a GT component. */
+function collectPossibleScopedComponentAliases(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  expressionPlugins: ParserPlugin[]
+): Set<string> {
+  const aliases = new Set<string>();
+  for (const property of element.props) {
+    if (property.type !== NodeTypes.DIRECTIVE) continue;
+    if (property.name === 'for') {
+      const parseResult = readForParseResult(property);
+      const pattern = parseResult?.value
+        ? parseTemplateBindingPattern(parseResult.value, expressionPlugins)
+        : undefined;
+      const source = parseResult?.source
+        ? getExpressionNode(parseResult.source, expressionPlugins)
+        : undefined;
+      if (!pattern || !source) continue;
+      const values = collectTemplateContainerCandidates(
+        source,
+        bindings,
+        shadowed,
+        new Set()
+      );
+      collectPossiblePatternComponents(
+        pattern,
+        values,
+        bindings,
+        shadowed,
+        aliases
+      );
+      continue;
+    }
+    if (
+      property.name !== 'slot' ||
+      property.exp?.type !== NodeTypes.SIMPLE_EXPRESSION ||
+      !property.exp.content
+    ) {
+      continue;
+    }
+    try {
+      const arrow = parseExpression(`(${property.exp.content}) => 0`, {
+        plugins: expressionPlugins,
+      });
+      if (arrow.type !== 'ArrowFunctionExpression') continue;
+      for (const parameter of arrow.params) {
+        collectPossibleComponentDefaults(
+          parameter,
+          bindings,
+          shadowed,
+          aliases
+        );
+      }
+    } catch {
+      // Vue's compiler reports malformed slot patterns separately.
+    }
+  }
+  return aliases;
+}
+
+/** Collects v-for aliases whose runtime value can itself be a container. */
+function collectPossibleScopedContainerAliases(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  expressionPlugins: ParserPlugin[]
+): Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>> {
+  const aliases = new Map<
+    string,
+    Omit<DynamicSelectorAnalysis, 'displayName'>
+  >();
+  for (const property of element.props) {
+    if (property.type !== NodeTypes.DIRECTIVE || property.name !== 'for') {
+      continue;
+    }
+    const parseResult = readForParseResult(property);
+    const pattern = parseResult?.value
+      ? parseTemplateBindingPattern(parseResult.value, expressionPlugins)
+      : undefined;
+    const source = parseResult?.source
+      ? getExpressionNode(parseResult.source, expressionPlugins)
+      : undefined;
+    if (!pattern || !source) continue;
+    collectPossiblePatternContainers(
+      pattern,
+      collectTemplateContainerCandidates(source, bindings, shadowed, new Set()),
+      bindings,
+      shadowed,
+      aliases
+    );
+  }
+  return aliases;
+}
+
+/** Projects container alternatives through one v-for binding pattern. */
+function collectPossiblePatternContainers(
+  pattern: TemplateBindingPattern,
+  values: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  aliases: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>
+): void {
+  if (pattern.type === 'Identifier') {
+    if (values.containers.length === 0) return;
+    const existing = aliases.get(pattern.name);
+    aliases.set(
+      pattern.name,
+      existing ? mergeDynamicSelectorAnalyses([existing, values]) : values
+    );
+    return;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    if (!isTemplateBindingPattern(pattern.left)) return;
+    collectPossiblePatternContainers(
+      pattern.left,
+      values,
+      bindings,
+      shadowed,
+      aliases
+    );
+    collectPossiblePatternContainers(
+      pattern.left,
+      collectDynamicSelectorCandidates(
+        pattern.right,
+        bindings,
+        shadowed,
+        new Set()
+      ),
+      bindings,
+      shadowed,
+      aliases
+    );
+    return;
+  }
+  if (pattern.type === 'RestElement') {
+    if (isTemplateBindingPattern(pattern.argument)) {
+      collectPossiblePatternContainers(
+        pattern.argument,
+        values,
+        bindings,
+        shadowed,
+        aliases
+      );
+    }
+    return;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      const target =
+        property.type === 'RestElement' ? property.argument : property.value;
+      if (!isTemplateBindingPattern(target)) continue;
+      collectPossiblePatternContainers(
+        target,
+        property.type === 'RestElement'
+          ? values
+          : selectPossibleContainerChildren(
+              values,
+              readTemplateLiteralPropertyKey(property, bindings, shadowed),
+              bindings,
+              shadowed
+            ),
+        bindings,
+        shadowed,
+        aliases
+      );
+    }
+    return;
+  }
+  pattern.elements.forEach((element, index) => {
+    if (!element || !isTemplateBindingPattern(element)) return;
+    collectPossiblePatternContainers(
+      element,
+      selectPossibleContainerChildren(
+        values,
+        element.type === 'RestElement' ? undefined : String(index),
+        bindings,
+        shadowed
+      ),
+      bindings,
+      shadowed,
+      aliases
+    );
+  });
+}
+
+/** Parses a Vue alias expression as one JavaScript binding pattern. */
+function parseTemplateBindingPattern(
+  expression: SimpleExpressionNode,
+  expressionPlugins: ParserPlugin[]
+): TemplateBindingPattern | undefined {
+  try {
+    const arrow = parseExpression(`(${expression.content}) => 0`, {
+      plugins: expressionPlugins,
+    });
+    const parameter =
+      arrow.type === 'ArrowFunctionExpression' && arrow.params.length === 1
+        ? arrow.params[0]
+        : undefined;
+    return parameter && isTemplateBindingPattern(parameter)
+      ? parameter
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Projects possible iterable values through a v-for destructuring pattern. */
+function collectPossiblePatternComponents(
+  pattern: TemplateBindingPattern,
+  values: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  aliases: Set<string>
+): void {
+  if (pattern.type === 'Identifier') {
+    if (selectorAnalysisMayContainGT(values, bindings)) {
+      aliases.add(pattern.name);
+    }
+    return;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    if (!isTemplateBindingPattern(pattern.left)) return;
+    collectPossiblePatternComponents(
+      pattern.left,
+      values,
+      bindings,
+      shadowed,
+      aliases
+    );
+    const fallback = collectDynamicSelectorCandidates(
+      pattern.right,
+      bindings,
+      shadowed,
+      new Set()
+    );
+    collectPossiblePatternComponents(
+      pattern.left,
+      fallback,
+      bindings,
+      shadowed,
+      aliases
+    );
+    return;
+  }
+  if (pattern.type === 'RestElement') {
+    if (!isTemplateBindingPattern(pattern.argument)) return;
+    collectPossiblePatternComponents(
+      pattern.argument,
+      values,
+      bindings,
+      shadowed,
+      aliases
+    );
+    return;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type === 'RestElement') {
+        if (isTemplateBindingPattern(property.argument)) {
+          collectPossiblePatternComponents(
+            property.argument,
+            values,
+            bindings,
+            shadowed,
+            aliases
+          );
+        }
+        continue;
+      }
+      const key = readTemplateLiteralPropertyKey(property, bindings, shadowed);
+      const selected = selectPossibleContainerChildren(
+        values,
+        key,
+        bindings,
+        shadowed
+      );
+      if (isTemplateBindingPattern(property.value)) {
+        collectPossiblePatternComponents(
+          property.value,
+          selected,
+          bindings,
+          shadowed,
+          aliases
+        );
+      }
+    }
+    return;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    pattern.elements.forEach((element, index) => {
+      if (!element) return;
+      const selected = selectPossibleContainerChildren(
+        values,
+        element.type === 'RestElement' ? undefined : String(index),
+        bindings,
+        shadowed
+      );
+      if (isTemplateBindingPattern(element)) {
+        collectPossiblePatternComponents(
+          element,
+          selected,
+          bindings,
+          shadowed,
+          aliases
+        );
+      }
+    });
+  }
+}
+
+function isTemplateBindingPattern(
+  node: babel.Node
+): node is TemplateBindingPattern {
+  return (
+    node.type === 'ArrayPattern' ||
+    node.type === 'AssignmentPattern' ||
+    node.type === 'Identifier' ||
+    node.type === 'ObjectPattern' ||
+    node.type === 'RestElement'
+  );
+}
+
+/** Selects from every possible container carried by an abstract value. */
+function selectPossibleContainerChildren(
+  values: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  key: string | undefined,
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const selected = values.containers.map((container) =>
+    selectTemplateContainerReference(
+      container,
+      key,
+      bindings,
+      shadowed,
+      new Set()
+    )
+  );
+  return selected.length > 0
+    ? mergeDynamicSelectorAnalyses(selected)
+    : emptyDynamicSelectorAnalysis(true);
+}
+
+/** Walks one binding pattern and records GT-bearing default expressions. */
+function collectPossibleComponentDefaults(
+  pattern: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  aliases: Set<string>
+): void {
+  if (pattern.type === 'AssignmentPattern') {
+    if (pattern.left.type === 'Identifier') {
+      const analysis = collectDynamicSelectorCandidates(
+        pattern.right,
+        bindings,
+        shadowed,
+        new Set()
+      );
+      if (selectorAnalysisMayContainGT(analysis, bindings)) {
+        aliases.add(pattern.left.name);
+      }
+    }
+    collectPossibleComponentDefaults(pattern.left, bindings, shadowed, aliases);
+    return;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      collectPossibleComponentDefaults(
+        property.type === 'RestElement' ? property.argument : property.value,
+        bindings,
+        shadowed,
+        aliases
+      );
+    }
+    return;
+  }
+  if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements) {
+      if (element) {
+        collectPossibleComponentDefaults(element, bindings, shadowed, aliases);
+      }
+    }
+    return;
+  }
+  if (pattern.type === 'RestElement') {
+    collectPossibleComponentDefaults(
+      pattern.argument,
+      bindings,
+      shadowed,
+      aliases
+    );
+  }
+}
+
+/** Returns whether an abstract selector value can resolve to any GT component. */
+function selectorAnalysisMayContainGT(
+  analysis: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  bindings: TemplateBindings
+): boolean {
+  if (analysis.possibleGT || analysis.gtComponentFactories.size > 0) {
+    return true;
+  }
+  return analysis.candidates.some((candidate) => {
+    if (candidate.kind === 'expression') {
+      return (
+        bindings.components.get(candidate.name) === 'T' ||
+        bindings.uncertainGTComponents.has(candidate.name)
+      );
+    }
+    return [...normalizeTemplateBindingNames(candidate.name)].some(
+      (name) => bindings.registeredComponents.get(name) === 'T'
+    );
+  });
+}
+
+/** Shadows program bindings with one local alias of uncertain GT identity. */
+function createScopedComponentBindings(
+  bindings: TemplateBindings,
+  aliases: Set<string>
+): TemplateBindings {
+  const scoped: TemplateBindings = {
+    ...bindings,
+    arrayLengths: new Map(bindings.arrayLengths),
+    componentFactories: new Set(bindings.componentFactories),
+    components: new Map(bindings.components),
+    containerKinds: new Map(bindings.containerKinds),
+    possibleGTContainers: new Set(bindings.possibleGTContainers),
+    gtContainerFactories: new Set(bindings.gtContainerFactories),
+    directBindings: new Set(bindings.directBindings),
+    gtComponentFactories: new Set(bindings.gtComponentFactories),
+    identityFunctions: new Set(bindings.identityFunctions),
+    possibleStaticStrings: new Map(
+      [...bindings.possibleStaticStrings].map(([name, values]) => [
+        name,
+        new Set(values),
+      ])
+    ),
+    staticValues: new Map(bindings.staticValues),
+    stringFunctions: new Map(bindings.stringFunctions),
+    uncertainComponents: new Set(bindings.uncertainComponents),
+    uncertainGTComponents: new Set(bindings.uncertainGTComponents),
+    uncertainStringFunctions: new Set(bindings.uncertainStringFunctions),
+    vueBuiltins: new Map(bindings.vueBuiltins),
+  };
+  for (const alias of aliases) {
+    clearScopedPath(scoped.arrayLengths, alias);
+    clearScopedPath(scoped.componentFactories, alias);
+    clearScopedPath(scoped.components, alias);
+    clearScopedPath(scoped.containerKinds, alias);
+    clearScopedPath(scoped.possibleGTContainers, alias);
+    clearScopedPath(scoped.gtContainerFactories, alias);
+    clearScopedPath(scoped.gtComponentFactories, alias);
+    clearScopedPath(scoped.identityFunctions, alias);
+    clearScopedPath(scoped.possibleStaticStrings, alias);
+    clearScopedPath(scoped.staticValues, alias);
+    clearScopedPath(scoped.stringFunctions, alias);
+    clearScopedPath(scoped.uncertainComponents, alias);
+    clearScopedPath(scoped.uncertainGTComponents, alias);
+    clearScopedPath(scoped.uncertainStringFunctions, alias);
+    clearScopedPath(scoped.vueBuiltins, alias);
+    scoped.directBindings.add(alias);
+    scoped.uncertainComponents.add(alias);
+    scoped.uncertainGTComponents.add(alias);
+  }
+  return scoped;
+}
+
+/** Exposes container-valued v-for aliases to nested template scopes. */
+function createScopedContainerBindings(
+  bindings: TemplateBindings,
+  aliases: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>,
+  shadowed: Set<string>
+): TemplateBindings {
+  const scoped = createScopedComponentBindings(bindings, new Set());
+  for (const [alias, values] of aliases) {
+    clearScopedPath(scoped.arrayLengths, alias);
+    clearScopedPath(scoped.componentFactories, alias);
+    clearScopedPath(scoped.components, alias);
+    clearScopedPath(scoped.containerKinds, alias);
+    clearScopedPath(scoped.possibleGTContainers, alias);
+    clearScopedPath(scoped.gtContainerFactories, alias);
+    clearScopedPath(scoped.gtComponentFactories, alias);
+    clearScopedPath(scoped.identityFunctions, alias);
+    clearScopedPath(scoped.possibleStaticStrings, alias);
+    clearScopedPath(scoped.staticValues, alias);
+    clearScopedPath(scoped.stringFunctions, alias);
+    clearScopedPath(scoped.uncertainComponents, alias);
+    clearScopedPath(scoped.uncertainGTComponents, alias);
+    clearScopedPath(scoped.uncertainStringFunctions, alias);
+    clearScopedPath(scoped.vueBuiltins, alias);
+    scoped.directBindings.add(alias);
+
+    const expose = (
+      container: DynamicSelectorContainer,
+      path: string,
+      depth: number
+    ): void => {
+      if (depth > 32) return;
+      const kind =
+        container.kind === 'literal'
+          ? container.node.type === 'ArrayExpression'
+            ? 'array'
+            : 'object'
+          : container.kind === 'analysis'
+            ? container.containerKind
+            : scoped.containerKinds.get(container.path);
+      if (kind) scoped.containerKinds.set(path, kind);
+      const children = selectTemplateContainerReference(
+        container,
+        undefined,
+        scoped,
+        shadowed,
+        new Set()
+      );
+      if (selectorAnalysisMayContainGT(children, scoped)) {
+        scoped.possibleGTContainers.add(path);
+      }
+      const childPath = appendTemplatePath(path, unknownTemplatePathSegment);
+      for (const child of children.containers) {
+        expose(child, childPath, depth + 1);
+      }
+    };
+    for (const container of values.containers) expose(container, alias, 0);
+  }
+  return scoped;
+}
+
+function clearScopedPath(
+  collection: Map<string, unknown> | Set<string>,
+  path: string
+): void {
+  for (const key of collection.keys()) {
+    if (key === path || key.startsWith(`${path}.`)) collection.delete(key);
+  }
+}
+
+function processTemplateExpression(
+  expression: ExpressionNode,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): void {
+  const expressionNode = getExpressionNode(expression, expressionPlugins);
+  if (!expressionNode) return;
+
+  processTemplateExpressionNode(
+    expressionNode,
+    expression.loc,
+    shadowed,
+    bindings,
+    context
+  );
+}
+
+function processTemplateExpressionNode(
+  expression: babel.Node,
+  location: ExtractionLocation,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const file = wrapForTraversal(expression);
+  if (!file) return;
+
+  traverse(file, {
+    CallExpression(path) {
+      const kind = resolveTemplateStringFunction(
+        path.node.callee,
+        path.scope,
+        shadowed,
+        bindings
+      );
+      if (!kind) {
+        reportPossibleTemplateStringFunction(
+          path.node.callee,
+          path.scope,
+          location,
+          shadowed,
+          bindings,
+          context
+        );
+        return;
+      }
+      processVueStringCall(path.node, kind, location, context, (node) =>
+        readTemplatePrimitive(node, path.scope, shadowed, bindings)
+      );
+    },
+    OptionalCallExpression(path) {
+      const kind = resolveTemplateStringFunction(
+        path.node.callee,
+        path.scope,
+        shadowed,
+        bindings
+      );
+      if (!kind) {
+        reportPossibleTemplateStringFunction(
+          path.node.callee,
+          path.scope,
+          location,
+          shadowed,
+          bindings,
+          context
+        );
+        return;
+      }
+      processVueStringCall(path.node, kind, location, context, (node) =>
+        readTemplatePrimitive(node, path.scope, shadowed, bindings)
+      );
+    },
+    TaggedTemplateExpression(path) {
+      const kind = resolveTemplateStringFunction(
+        path.node.tag,
+        path.scope,
+        shadowed,
+        bindings
+      );
+      if (!kind) {
+        reportPossibleTemplateStringFunction(
+          path.node.tag,
+          path.scope,
+          location,
+          shadowed,
+          bindings,
+          context
+        );
+        return;
+      }
+      addVueError(
+        context,
+        location,
+        'Found an unsupported tagged template translation in gt-vue',
+        'Call the translation function with a string literal instead'
+      );
+    },
+  });
+}
+
+/** Reports a call whose binding may be a gt-vue string translator. */
+function reportPossibleTemplateStringFunction(
+  input: babel.Node,
+  scope: Scope,
+  location: ExtractionLocation,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  context: VueExtractionContext
+): void {
+  const displayName = resolvePossibleTemplateStringFunction(
+    input,
+    scope,
+    shadowed,
+    bindings
+  );
+  if (!displayName) return;
+  addVueError(
+    context,
+    location,
+    `Could not statically resolve possible gt-vue translation function alias "${displayName}"`,
+    'Use a direct gt-vue import or an immutable translator alias that does not escape static analysis'
+  );
+}
+
+/** Resolves direct or dynamically selected uncertain translator paths. */
+function resolvePossibleTemplateStringFunction(
+  input: babel.Node,
+  scope: Scope,
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+): string | undefined {
+  const node = unwrapExpression(input);
+  if (!node) return undefined;
+  const path = readStaticTemplateMemberPath(node, bindings, shadowed);
+  const root = path?.split('.', 1)[0];
+  if (
+    path &&
+    root &&
+    !scope.hasBinding(root) &&
+    bindings.uncertainStringFunctions.has(path)
+  ) {
+    return path;
+  }
+  if (
+    node.type !== 'MemberExpression' &&
+    node.type !== 'OptionalMemberExpression'
+  ) {
+    return undefined;
+  }
+  const objectPath = readStaticTemplateMemberPath(
+    node.object,
+    bindings,
+    shadowed
+  );
+  const objectRoot = objectPath?.split('.', 1)[0];
+  if (!objectPath || !objectRoot || scope.hasBinding(objectRoot)) {
+    return undefined;
+  }
+  const prefix = `${objectPath}.`;
+  const hasPossibleChild = [
+    ...bindings.stringFunctions.keys(),
+    ...bindings.uncertainStringFunctions,
+  ].some((name) => {
+    if (!name.startsWith(prefix)) return false;
+    const suffix = name.slice(prefix.length);
+    return !suffix.includes('.');
+  });
+  return hasPossibleChild ? objectPath : undefined;
+}
+
+/** Reads a script-exposed primitive unless a Vue or expression scope masks it. */
+function readTemplatePrimitive(
+  input: babel.Node | null | undefined,
+  scope: Scope,
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+) {
+  return readStaticPrimitive(input, (identifier) => {
+    if (shadowed.has(identifier.name) || scope.hasBinding(identifier.name)) {
+      return { ok: false };
+    }
+    const value = bindings.staticValues.get(identifier.name);
+    return bindings.staticValues.has(identifier.name)
+      ? { ok: true, value: value! }
+      : { ok: false };
+  });
+}
+
+/** Resolves a template call back to a statically imported gt-vue function. */
+function resolveTemplateStringFunction(
+  input: babel.Node,
+  scope: Scope,
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+) {
+  const node = unwrapExpression(input);
+  if (!node) return undefined;
+  const path = readStaticTemplateMemberPath(node, bindings, shadowed);
+  const root = path?.split('.', 1)[0];
+  return root && !scope.hasBinding(root)
+    ? bindings.stringFunctions.get(path)
+    : undefined;
+}
+
+/** Visits expressions that execute while Vue initializes binding patterns. */
+function processBindingDefaults(
+  expression: ExpressionNode | undefined,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): void {
+  if (
+    !expression ||
+    expression.type !== NodeTypes.SIMPLE_EXPRESSION ||
+    !expression.content
+  ) {
+    return;
+  }
+  try {
+    const arrow = parseExpression(`(${expression.content}) => 0`, {
+      plugins: expressionPlugins,
+    });
+    if (arrow.type !== 'ArrowFunctionExpression') return;
+    for (const parameter of arrow.params) {
+      visitBindingDefaultExpressions(parameter, (node) =>
+        processTemplateExpressionNode(
+          node,
+          expression.loc,
+          shadowed,
+          bindings,
+          context
+        )
+      );
+    }
+  } catch {
+    // The Vue compiler reports malformed v-for/v-slot bindings separately.
+  }
+}
+
+/** Recursively finds default and computed-key expressions in a binding. */
+function visitBindingDefaultExpressions(
+  pattern: babel.Node | null,
+  visit: (expression: babel.Expression) => void
+): void {
+  if (!pattern) return;
+  if (pattern.type === 'AssignmentPattern') {
+    visit(pattern.right);
+    visitBindingDefaultExpressions(pattern.left, visit);
+  } else if (pattern.type === 'RestElement') {
+    visitBindingDefaultExpressions(pattern.argument, visit);
+  } else if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements) {
+      if (element) visitBindingDefaultExpressions(element, visit);
+    }
+  } else if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type === 'RestElement') {
+        visitBindingDefaultExpressions(property.argument, visit);
+      } else {
+        if (property.computed && babel.isExpression(property.key)) {
+          visit(property.key);
+        }
+        visitBindingDefaultExpressions(property.value, visit);
+      }
+    }
+  } else if (pattern.type === 'TSParameterProperty') {
+    visitBindingDefaultExpressions(pattern.parameter, visit);
+  }
+}
+
+function extractTranslationComponent(
+  element: ElementNode,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): void {
+  const errorCount = context.errors.length;
+  const translationContext = readTContext(
+    element,
+    shadowed,
+    bindings,
+    expressionPlugins,
+    context
+  );
+  const slots = getSlotLayout(element, shadowed, expressionPlugins, context);
+  if (slots.namedSlots.size > 0) {
+    addVueError(
+      context,
+      element.loc,
+      'Found a named slot on a gt-vue <T> component',
+      'Place translatable content in the default slot'
+    );
+  }
+
+  const counter = { value: 0 };
+  const serialized = serializeChildren(
+    slots.defaultSlot.children,
+    counter,
+    slots.defaultSlot.shadowed,
+    bindings,
+    expressionPlugins,
+    context
+  );
+  if (context.errors.length !== errorCount) return;
+
+  context.results.push({
+    dataFormat: 'JSX',
+    source: collapseChildren(serialized),
+    metadata: createInlineMetadata(context, element.loc, translationContext),
+  });
+}
+
+function readTContext(
+  element: ElementNode,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): string | undefined {
+  let translationContext: string | undefined;
+  let hasContext = false;
+
+  for (const property of element.props) {
+    if (isDynamicComponentSelector(element, property)) continue;
+    if (property.type === NodeTypes.ATTRIBUTE) {
+      if (RESERVED_T_PROPS.has(property.name)) continue;
+      if (property.name !== 'context' && property.name !== '$context') {
+        addVueError(
+          context,
+          property.loc,
+          `Found unsupported prop "${property.name}" on a gt-vue <T> component`,
+          'gt-vue <T> currently supports only context'
+        );
+        continue;
+      }
+      if (hasContext) {
+        addDuplicateContextError(property.loc, context);
+        continue;
+      }
+      hasContext = true;
+      translationContext = property.value?.content ?? '';
+      continue;
+    }
+
+    if (property.name !== 'bind') continue;
+    if (property.modifiers.length > 0) {
+      const directive = property.rawName ?? 'v-bind';
+      addVueError(
+        context,
+        property.loc,
+        `Found unsupported directive ${directive} on a gt-vue <T> component`,
+        'Pass context without a v-bind modifier'
+      );
+      continue;
+    }
+    const key = readDirectiveKey(property);
+    if (key === undefined) {
+      addVueError(
+        context,
+        property.loc,
+        'Found a dynamic or spread binding on a gt-vue <T> component',
+        'Pass context as a static context or $context prop'
+      );
+      continue;
+    }
+    if (RESERVED_T_PROPS.has(key)) continue;
+    if (key !== 'context' && key !== '$context') {
+      addVueError(
+        context,
+        property.loc,
+        `Found unsupported prop "${key}" on a gt-vue <T> component`,
+        'gt-vue <T> currently supports only context'
+      );
+      continue;
+    }
+    if (hasContext) {
+      addDuplicateContextError(property.loc, context);
+      continue;
+    }
+    hasContext = true;
+    const value = readExpressionPrimitive(
+      property.exp,
+      expressionPlugins,
+      shadowed,
+      bindings
+    );
+    if (!value.ok || typeof value.value !== 'string') {
+      addVueError(
+        context,
+        property.loc,
+        'Found a dynamic context on a gt-vue <T> component',
+        'Use a string literal or a template literal without expressions'
+      );
+      continue;
+    }
+    translationContext = value.value;
+  }
+  return translationContext;
+}
+
+function addDuplicateContextError(
+  location: ExtractionLocation,
+  context: VueExtractionContext
+): void {
+  addVueError(
+    context,
+    location,
+    'Found duplicate context props on a gt-vue <T> component',
+    'Pass only one context prop'
+  );
+}
+
+function serializeChildren(
+  children: TemplateChildNode[],
+  counter: Counter,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): JsxChild[] {
+  validateCommentWhitespaceParity(children, context);
+  const result: JsxChild[] = [];
+  for (const child of children) {
+    const values = serializeChild(
+      child,
+      counter,
+      shadowed,
+      bindings,
+      expressionPlugins,
+      context
+    );
+    for (const value of values) appendSerializedChild(result, value);
+  }
+  return result;
+}
+
+/**
+ * Rejects comments whose removal can change Vue's surrounding whitespace.
+ *
+ * Vue keeps template comments in development and strips them in production.
+ * The compiler's whitespace transform can therefore produce different text
+ * VNodes, and consequently different persisted translation hashes, across
+ * Vue versions and build modes. Restrict this check to children that are
+ * actually serialized so comments in opaque or unused slots remain opaque.
+ */
+function validateCommentWhitespaceParity(
+  children: TemplateChildNode[],
+  context: VueExtractionContext
+): void {
+  for (const child of children) {
+    if (child.type !== NodeTypes.COMMENT) continue;
+    const before = context.source[child.loc.start.offset - 1];
+    const after = context.source[child.loc.end.offset];
+    if (!isHtmlWhitespace(before) && !isHtmlWhitespace(after)) continue;
+    addVueError(
+      context,
+      child.loc,
+      'Found a comment adjacent to translatable whitespace inside a gt-vue <T> component',
+      'Remove the adjacent whitespace or move the comment outside the translated content'
+    );
+  }
+}
+
+/** Matches the whitespace characters normalized by the Vue HTML compiler. */
+function isHtmlWhitespace(value: string | undefined): boolean {
+  return value !== undefined && /[\t\n\f\r ]/.test(value);
+}
+
+function serializeChild(
+  child: TemplateChildNode,
+  counter: Counter,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): JsxChild[] {
+  if (child.type === NodeTypes.COMMENT) return [];
+  if (child.type === NodeTypes.TEXT) return [child.content];
+  if (child.type === NodeTypes.INTERPOLATION) {
+    const value = readExpressionPrimitive(
+      child.content,
+      expressionPlugins,
+      shadowed,
+      bindings
+    );
+    if (!value.ok) {
+      addVueError(
+        context,
+        child.loc,
+        'Found dynamic template content inside a gt-vue <T> component',
+        'Wrap runtime values in <Var>, <Num>, <DateTime>, or <Currency>'
+      );
+      return [];
+    }
+    return [toDisplayString(value.value)];
+  }
+  if (child.type !== NodeTypes.ELEMENT) {
+    addVueError(
+      context,
+      child.loc,
+      'Found unsupported template syntax inside a gt-vue <T> component',
+      'Use static template content and gt-vue rich translation components'
+    );
+    return [];
+  }
+  const fragment = resolveFragmentComponent(
+    child,
+    bindings,
+    expressionPlugins,
+    shadowed
+  );
+  if (fragment) {
+    return serializeFragmentElement(
+      child,
+      counter,
+      shadowed,
+      bindings,
+      expressionPlugins,
+      context
+    );
+  }
+  return [
+    serializeElement(
+      child,
+      counter,
+      shadowed,
+      bindings,
+      expressionPlugins,
+      context
+    ),
+  ];
+}
+
+/** Flattens an exact Vue Fragment default slot without consuming an ID. */
+function serializeFragmentElement(
+  element: ElementNode,
+  counter: Counter,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): JsxChild[] {
+  validateRichElement(element, context, true);
+  const slots = getSlotLayout(element, shadowed, expressionPlugins, context);
+  if (slots.namedSlots.size > 0) {
+    addVueError(
+      context,
+      element.loc,
+      'Found a named slot on Vue Fragment inside a gt-vue <T> component',
+      'Keep Fragment content in its default slot'
+    );
+  }
+  return serializeChildren(
+    slots.defaultSlot.children,
+    counter,
+    slots.defaultSlot.shadowed,
+    bindings,
+    expressionPlugins,
+    context
+  );
+}
+
+function serializeElement(
+  element: ElementNode,
+  counter: Counter,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): JsxChild {
+  counter.value += 1;
+  const id = counter.value;
+  const component = resolveGTComponent(
+    element,
+    bindings,
+    expressionPlugins,
+    shadowed
+  );
+  const suspense = resolveSuspenseComponent(
+    element,
+    bindings,
+    expressionPlugins,
+    shadowed
+  );
+  const uncertainComponent =
+    !component && !suspense
+      ? resolveUncertainComponent(
+          element,
+          bindings,
+          expressionPlugins,
+          shadowed
+        )
+      : undefined;
+  if (uncertainComponent) {
+    addVueError(
+      context,
+      element.loc,
+      `Could not statically resolve component alias "${uncertainComponent}" inside a gt-vue <T> component`,
+      'Use a direct component import or an immutable alias that does not escape static analysis'
+    );
+  }
+  validateRichElement(
+    element,
+    context,
+    Boolean(component || suspense || uncertainComponent)
+  );
+  const originalName = component?.originalName;
+
+  if (originalName === 'T') {
+    addVueError(
+      context,
+      element.loc,
+      'Found a nested gt-vue <T> component inside another <T>',
+      'Split nested translations into sibling <T> components'
+    );
+  }
+
+  if (
+    originalName === 'Var' ||
+    originalName === 'Num' ||
+    originalName === 'DateTime' ||
+    originalName === 'Currency'
+  ) {
+    validateVariableComponentShape(element, originalName, context);
+    const variable =
+      originalName === 'Num'
+        ? { name: 'n', type: 'n' as const }
+        : originalName === 'DateTime'
+          ? { name: 'date', type: 'd' as const }
+          : originalName === 'Currency'
+            ? { name: 'cost', type: 'c' as const }
+            : { name: 'value', type: 'v' as const };
+    return {
+      i: id,
+      k: `_gt_${variable.name}_${id}`,
+      v: variable.type,
+    };
+  }
+
+  const data = readContentProps(
+    element,
+    shadowed,
+    bindings,
+    expressionPlugins,
+    context
+  );
+  if (isOpaqueComponent(element, component, suspense)) {
+    return {
+      t: element.tag,
+      i: id,
+      ...(Object.keys(data).length > 0 && { d: data }),
+    };
+  }
+
+  const slotLayout =
+    element.tagType === ElementTypes.COMPONENT
+      ? getSlotLayout(element, shadowed, expressionPlugins, context)
+      : {
+          defaultSlot: {
+            children: element.children,
+            rootCount: countVueSlotRoots(element.children),
+            shadowed,
+          },
+          namedSlots: new Map<string, SlotContent>(),
+        };
+
+  const children = serializeChildren(
+    slotLayout.defaultSlot.children,
+    counter,
+    slotLayout.defaultSlot.shadowed,
+    bindings,
+    expressionPlugins,
+    context
+  );
+  if (suspense && slotLayout.defaultSlot.rootCount > 1) {
+    addVueError(
+      context,
+      element.loc,
+      'Found more than one default root inside Vue <Suspense> within a gt-vue <T> component',
+      'Wrap the Suspense default content in a single element or move <T> inside <Suspense>'
+    );
+  }
+
+  const unsupportedNamedSlots = [...slotLayout.namedSlots].filter(
+    ([name]) => !suspense || name !== 'fallback'
+  );
+  if (
+    unsupportedNamedSlots.length > 0 &&
+    originalName !== 'Branch' &&
+    originalName !== 'Plural'
+  ) {
+    addVueError(
+      context,
+      element.loc,
+      `Found named slots on <${originalName ?? element.tag}> inside a gt-vue <T> component`,
+      'Move named-slot content outside <T> or use only the component default slot'
+    );
+  }
+
+  if (originalName === 'Branch' || originalName === 'Plural') {
+    const branches = readBranches(
+      element,
+      slotLayout,
+      id,
+      originalName,
+      shadowed,
+      bindings,
+      expressionPlugins,
+      context
+    );
+    if (Object.keys(branches).length > 0) {
+      data.b = branches;
+      data.t = originalName === 'Plural' ? 'p' : 'b';
+    }
+  }
+
+  return {
+    t: originalName ?? suspense?.originalName ?? element.tag,
+    i: id,
+    ...(Object.keys(data).length > 0 && { d: data }),
+    ...(children.length > 0 && { c: collapseChildren(children) }),
+  };
+}
+
+/** Returns true when the runtime preserves a component's slots as opaque. */
+function isOpaqueComponent(
+  element: ElementNode,
+  component?: { localName: string; originalName: GTComponentName },
+  vueBuiltin?: { localName: string; originalName: VueBuiltinName }
+): boolean {
+  return (
+    element.tagType === ElementTypes.COMPONENT && !component && !vueBuiltin
+  );
+}
+
+/** Resolves literal Suspense and statically proven aliases of Vue's builtin. */
+function resolveSuspenseComponent(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): { localName: string; originalName: 'Suspense' } | undefined {
+  if (
+    element.tagType === ElementTypes.COMPONENT &&
+    element.tag.toLowerCase() === 'suspense'
+  ) {
+    return { localName: element.tag, originalName: 'Suspense' };
+  }
+  const builtin = resolveVueBuiltinComponent(
+    element,
+    bindings,
+    expressionPlugins,
+    shadowed
+  );
+  return builtin?.originalName === 'Suspense'
+    ? { localName: builtin.localName, originalName: 'Suspense' }
+    : undefined;
+}
+
+/** Resolves an imported Vue Fragment alias without matching an ordinary tag. */
+function resolveFragmentComponent(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): { localName: string; originalName: 'Fragment' } | undefined {
+  const builtin = resolveVueBuiltinComponent(
+    element,
+    bindings,
+    expressionPlugins,
+    shadowed
+  );
+  return builtin?.originalName === 'Fragment'
+    ? { localName: builtin.localName, originalName: 'Fragment' }
+    : undefined;
+}
+
+/** Resolves a statically proven Vue builtin through direct or registered use. */
+function resolveVueBuiltinComponent(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): { localName: string; originalName: VueBuiltinName } | undefined {
+  return resolveComponentBinding(
+    element,
+    bindings,
+    bindings.vueBuiltins,
+    bindings.registeredVueBuiltins,
+    bindings.directBindings,
+    expressionPlugins,
+    shadowed
+  );
+}
+
+/** Resolves a component-shaped binding whose exact identity is uncertain. */
+function resolveUncertainComponent(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): string | undefined {
+  return resolveUncertainComponentBinding(
+    element,
+    bindings,
+    bindings.uncertainComponents,
+    bindings.uncertainRegisteredComponents,
+    bindings.componentFactories,
+    expressionPlugins,
+    shadowed
+  );
+}
+
+/** Resolves uncertainty while preserving direct versus registered precedence. */
+function resolveUncertainComponentBinding(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  uncertainDirectBindings: Set<string>,
+  uncertainRegisteredBindings: Set<string>,
+  uncertainFactories: Set<string>,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): string | undefined {
+  if (element.tagType !== ElementTypes.COMPONENT) return undefined;
+  const selector = readDynamicComponentSelector(
+    element,
+    expressionPlugins,
+    bindings,
+    shadowed
+  );
+  if (selector) {
+    if (
+      [...selector.componentFactories].some((name) =>
+        uncertainFactories.has(name)
+      ) ||
+      [...selector.gtComponentFactories].some((name) =>
+        uncertainFactories.has(name)
+      )
+    ) {
+      return selector.displayName;
+    }
+    for (const candidate of selector.candidates) {
+      for (const localName of normalizeTemplateBindingNames(candidate.name)) {
+        if (
+          candidate.kind === 'string'
+            ? uncertainRegisteredBindings.has(localName)
+            : uncertainDirectBindings.has(localName)
+        ) {
+          return localName;
+        }
+      }
+    }
+    return undefined;
+  }
+  for (const localName of normalizeTemplateBindingNames(element.tag)) {
+    const direct = uncertainDirectBindings.has(localName);
+    const registered = uncertainRegisteredBindings.has(localName);
+    if (isDirectTemplateBinding(localName, bindings.directBindings)) {
+      if (direct) return localName;
+    } else if (registered || direct) {
+      return localName;
+    }
+  }
+  return undefined;
+}
+
+/** Detects an unresolved dynamic selector whose possible result includes T. */
+function resolvePossibleDynamicT(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): string | undefined {
+  const selector = readDynamicComponentSelector(
+    element,
+    expressionPlugins,
+    bindings,
+    shadowed
+  );
+  if (!selector) return undefined;
+  if (selector.possibleGT || selector.gtComponentFactories.size > 0) {
+    return selector.displayName;
+  }
+  for (const candidate of selector.candidates) {
+    for (const localName of normalizeTemplateBindingNames(candidate.name)) {
+      const component =
+        candidate.kind === 'string'
+          ? bindings.registeredComponents.get(localName)
+          : bindings.components.get(localName);
+      if (component === 'T') return selector.displayName;
+    }
+  }
+  return undefined;
+}
+
+/** Identifies a statically named Suspense fallback slot during tree walking. */
+function isSuspenseFallbackTemplate(child: TemplateChildNode): boolean {
+  return (
+    child.type === NodeTypes.ELEMENT &&
+    child.tag === 'template' &&
+    hasStaticSlotName(child, 'fallback')
+  );
+}
+
+/** Matches one statically named slot directive without emitting diagnostics. */
+function hasStaticSlotName(element: ElementNode, name: string): boolean {
+  const directive = element.props.find(
+    (property): property is DirectiveNode =>
+      property.type === NodeTypes.DIRECTIVE && property.name === 'slot'
+  );
+  return (
+    directive?.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+    directive.arg.isStatic &&
+    directive.arg.content === name
+  );
+}
+
+function validateRichElement(
+  element: ElementNode,
+  context: VueExtractionContext,
+  resolvedDynamicComponent: boolean
+): void {
+  if (element.tagType === ElementTypes.SLOT || element.tag === 'slot') {
+    addVueError(
+      context,
+      element.loc,
+      'Found a <slot> inside a gt-vue <T> component',
+      'Move runtime slot content outside <T> or wrap a stable value in <Var>'
+    );
+  }
+  if (
+    element.tag === 'template' &&
+    !element.props.some(
+      (property) =>
+        property.type === NodeTypes.DIRECTIVE && property.name === 'slot'
+    )
+  ) {
+    addVueError(
+      context,
+      element.loc,
+      'Found a bare <template> inside a gt-vue <T> component',
+      'Use an ordinary element or a statically named slot template'
+    );
+  }
+  if (element.tag.toLowerCase() === 'component' && !resolvedDynamicComponent) {
+    addVueError(
+      context,
+      element.loc,
+      'Found a dynamic <component> inside a gt-vue <T> component',
+      'Use a statically named element or component'
+    );
+  }
+
+  for (const property of element.props) {
+    if (property.type !== NodeTypes.DIRECTIVE) continue;
+    if (SOURCE_SHAPING_DIRECTIVES.has(property.name)) {
+      addVueError(
+        context,
+        property.loc,
+        `Found source-shaping directive ${property.rawName ?? `v-${property.name}`} inside a gt-vue <T> component`,
+        'Move conditional or repeated content outside <T>, or use Branch/Plural'
+      );
+    } else if (property.name === 'bind' && !readDirectiveKey(property)) {
+      addVueError(
+        context,
+        property.loc,
+        'Found a dynamic or spread v-bind inside a gt-vue <T> component',
+        'Bind props by a static name so their effect on the translation source is known'
+      );
+    }
+  }
+}
+
+/** Enforces the one supported public shape for every variable component. */
+function validateVariableComponentShape(
+  element: ElementNode,
+  component: 'Currency' | 'DateTime' | 'Num' | 'Var',
+  context: VueExtractionContext
+): void {
+  if (context.validatedVariableComponents.has(element)) return;
+  context.validatedVariableComponents.add(element);
+
+  if (component !== 'Var') {
+    if (!hasTemplateProp(element, 'value')) {
+      addVueError(
+        context,
+        element.loc,
+        `Found a gt-vue <${component}> component without a value prop`,
+        `Pass the runtime value through <${component} :value="value" />`
+      );
+    }
+    if (hasMeaningfulSlotContent(element.children, context)) {
+      addVueError(
+        context,
+        element.loc,
+        `Found children on a gt-vue <${component}> component`,
+        `Use only the required value prop: <${component} :value="value" />`
+      );
+    }
+    return;
+  }
+
+  for (const property of element.props) {
+    const key =
+      property.type === NodeTypes.ATTRIBUTE
+        ? property.name
+        : property.name === 'bind'
+          ? readDirectiveKey(property)
+          : undefined;
+    if (key === 'name' || key === 'value') {
+      addVueError(
+        context,
+        property.loc,
+        `Found unsupported ${key} prop on a gt-vue <Var> component`,
+        'Pass the variable as the default child of <Var>'
+      );
+    } else if (
+      property.type === NodeTypes.DIRECTIVE &&
+      property.name === 'bind' &&
+      !property.arg
+    ) {
+      addVueError(
+        context,
+        property.loc,
+        'Found a spread v-bind on a gt-vue <Var> component',
+        'Pass the variable only as the default child of <Var>'
+      );
+    }
+  }
+}
+
+/** Returns whether a statically named template prop is explicitly present. */
+function hasTemplateProp(element: ElementNode, expected: string): boolean {
+  return element.props.some((property) => {
+    if (property.type === NodeTypes.ATTRIBUTE) {
+      return property.name === expected;
+    }
+    return property.name === 'bind' && readDirectiveKey(property) === expected;
+  });
+}
+
+function readContentProps(
+  element: ElementNode,
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): GTProp {
+  const data: GTProp = {};
+  for (const [shortName, propName] of Object.entries(HTML_CONTENT_PROPS)) {
+    const property = findElementProperty(
+      element,
+      propName,
+      expressionPlugins,
+      shadowed,
+      bindings
+    );
+    if (!property.present) continue;
+    if (!property.static) {
+      addVueError(
+        context,
+        property.location,
+        `Found dynamic translatable prop "${propName}" inside a gt-vue <T> component`,
+        'Use a string literal for translatable HTML props'
+      );
+      continue;
+    }
+    if (typeof property.value === 'string') {
+      (data as Record<string, unknown>)[shortName] = property.value;
+    }
+  }
+  return data;
+}
+
+function readBranches(
+  element: ElementNode,
+  slots: SlotLayout,
+  branchElementId: number,
+  component: 'Branch' | 'Plural',
+  shadowed: Set<string>,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): Record<string, JsxChildren> {
+  const branches: Record<string, JsxChildren> = {};
+
+  for (const [name, slot] of slots.namedSlots) {
+    if (name.startsWith('_')) continue;
+    if (component === 'Plural' && !isAcceptedPluralForm(name)) continue;
+    branches[name] = collapseChildren(
+      serializeChildren(
+        slot.children,
+        { value: branchElementId },
+        slot.shadowed,
+        bindings,
+        expressionPlugins,
+        context
+      )
+    );
+  }
+
+  for (const property of element.props) {
+    if (isDynamicComponentSelector(element, property)) continue;
+    if (property.type === NodeTypes.DIRECTIVE && property.name === 'slot') {
+      continue;
+    }
+    const key =
+      property.type === NodeTypes.ATTRIBUTE
+        ? property.name
+        : readDirectiveKey(property);
+
+    // Vue compiles v-on directives to listener props, which gt-vue always
+    // excludes from branch content regardless of the handler expression.
+    if (property.type === NodeTypes.DIRECTIVE && property.name === 'on') {
+      continue;
+    }
+    if (
+      key &&
+      (!isBranchAttributeName(key) ||
+        Object.prototype.hasOwnProperty.call(branches, key) ||
+        (component === 'Plural' && !isAcceptedPluralForm(key)))
+    ) {
+      continue;
+    }
+    if (
+      property.type === NodeTypes.DIRECTIVE &&
+      (property.name !== 'bind' || property.modifiers.length > 0)
+    ) {
+      const directive = property.rawName ?? `v-${property.name}`;
+      addVueError(
+        context,
+        property.loc,
+        `Found unsupported directive ${directive} on a gt-vue <${component}> component`,
+        `Move ${directive} to an element outside <${component}>`
+      );
+      continue;
+    }
+    if (key === undefined) continue;
+    const value = readPropertyValue(
+      property,
+      expressionPlugins,
+      shadowed,
+      bindings
+    );
+    if (!value.ok) {
+      if (
+        isStaticallyNonBranchValue(
+          property,
+          expressionPlugins,
+          shadowed,
+          bindings
+        )
+      ) {
+        continue;
+      }
+      addVueError(
+        context,
+        property.loc,
+        `Found dynamic branch prop "${key}" on a gt-vue <${component}> component`,
+        'Use a static branch prop or a named slot'
+      );
+      continue;
+    }
+    branches[key] = branchPropToChildren(value.value);
+  }
+  return branches;
+}
+
+function branchPropToChildren(value: StaticPrimitive): JsxChildren {
+  if (value == null || typeof value === 'boolean') return [];
+  return String(value);
+}
+
+/**
+ * Mirrors the attribute-name half of gt-vue's runtime branch predicate.
+ *
+ * Vue combines explicit component props, presentation attributes, and
+ * normalized listeners in one VNode prop record. The extractor must discard
+ * the same names before evaluating values so dynamic class/style/listener
+ * expressions cannot change a published translation hash.
+ */
+function isBranchAttributeName(name: string): boolean {
+  return !(
+    NON_BRANCH_ATTRIBUTE_NAMES.has(name) ||
+    name.startsWith('aria-') ||
+    name.startsWith('data-') ||
+    /^on[^a-z]/.test(name)
+  );
+}
+
+/**
+ * Identifies expressions whose top-level runtime type can never be branch
+ * content. Unknown identifiers and calls deliberately return false so an
+ * arbitrary prop whose runtime type may be primitive still fails closed.
+ */
+function isStaticallyNonBranchValue(
+  property: ElementNode['props'][number],
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+): boolean {
+  if (property.type !== NodeTypes.DIRECTIVE || property.name !== 'bind') {
+    return false;
+  }
+  const expression = property.exp
+    ? getExpressionNode(property.exp, expressionPlugins)
+    : undefined;
+  const node = unwrapExpression(expression);
+  if (!node) return false;
+
+  if (babel.isIdentifier(node, { name: 'undefined' })) {
+    return !shadowed.has(node.name) && !bindings.staticValues.has(node.name);
+  }
+  return (
+    babel.isArrayExpression(node) ||
+    babel.isArrowFunctionExpression(node) ||
+    babel.isClassExpression(node) ||
+    babel.isFunctionExpression(node) ||
+    babel.isNewExpression(node) ||
+    babel.isObjectExpression(node) ||
+    babel.isRegExpLiteral(node) ||
+    (babel.isUnaryExpression(node) && node.operator === 'void')
+  );
+}
+
+function getSlotLayout(
+  element: ElementNode,
+  shadowed: Set<string>,
+  expressionPlugins: ParserPlugin[],
+  context: VueExtractionContext
+): SlotLayout {
+  const namedSlots = new Map<string, SlotContent>();
+  let defaultSlot: SlotContent = { children: [], rootCount: 0, shadowed };
+  let hasTemplateSlots = false;
+  let hasExplicitDefaultSlot = false;
+  let reportedDefaultConflict = false;
+  const componentSlot = element.props.find(
+    (property): property is DirectiveNode =>
+      property.type === NodeTypes.DIRECTIVE && property.name === 'slot'
+  );
+
+  if (componentSlot) {
+    if (componentSlot.exp) addScopedSlotError(componentSlot.loc, context);
+    const slotName = readSlotName(componentSlot, context);
+    const slotShadowed = unionSets(
+      shadowed,
+      collectExpressionBindings(componentSlot.exp, expressionPlugins)
+    );
+    if (slotName === 'default') {
+      defaultSlot = {
+        children: element.children,
+        rootCount: countVueSlotRoots(element.children),
+        shadowed: slotShadowed,
+      };
+    } else if (slotName) {
+      namedSlots.set(slotName, {
+        children: element.children,
+        rootCount: countVueSlotRoots(element.children),
+        shadowed: slotShadowed,
+      });
+    }
+    return { defaultSlot, namedSlots };
+  }
+
+  const defaultChildren: TemplateChildNode[] = [];
+  for (const child of element.children) {
+    const slotDirective =
+      child.type === NodeTypes.ELEMENT && child.tag === 'template'
+        ? child.props.find(
+            (property): property is DirectiveNode =>
+              property.type === NodeTypes.DIRECTIVE && property.name === 'slot'
+          )
+        : undefined;
+    if (!slotDirective || child.type !== NodeTypes.ELEMENT) {
+      defaultChildren.push(child);
+      continue;
+    }
+    hasTemplateSlots = true;
+
+    for (const property of child.props) {
+      if (property.type === NodeTypes.DIRECTIVE && property.name !== 'slot') {
+        addVueError(
+          context,
+          property.loc,
+          'Found a conditional or dynamic named slot inside a gt-vue <T> component',
+          'Use an unconditional, statically named slot'
+        );
+      }
+    }
+
+    const slotName = readSlotName(slotDirective, context);
+    if (slotDirective.exp) addScopedSlotError(slotDirective.loc, context);
+    const slotShadowed = unionSets(
+      shadowed,
+      collectExpressionBindings(slotDirective.exp, expressionPlugins)
+    );
+    if (slotName === 'default') {
+      if (
+        hasMeaningfulSlotContent(defaultChildren, context) ||
+        hasExplicitDefaultSlot
+      ) {
+        addVueError(
+          context,
+          child.loc,
+          'Found more than one default slot definition inside a gt-vue translation',
+          'Use a single default slot'
+        );
+        reportedDefaultConflict = true;
+      }
+      hasExplicitDefaultSlot = true;
+      defaultSlot = {
+        children: child.children,
+        rootCount: countVueSlotRoots(child.children),
+        shadowed: slotShadowed,
+      };
+    } else if (slotName) {
+      if (namedSlots.has(slotName)) {
+        addVueError(
+          context,
+          child.loc,
+          `Found duplicate named slot "${slotName}" inside a gt-vue translation`,
+          'Define each named slot once'
+        );
+      }
+      namedSlots.set(slotName, {
+        children: child.children,
+        rootCount: countVueSlotRoots(child.children),
+        shadowed: slotShadowed,
+      });
+    }
+  }
+
+  const hasMeaningfulDefault = hasMeaningfulSlotContent(
+    defaultChildren,
+    context
+  );
+  if (
+    hasExplicitDefaultSlot &&
+    hasMeaningfulDefault &&
+    !reportedDefaultConflict
+  ) {
+    addVueError(
+      context,
+      defaultChildren[0].loc,
+      'Found more than one default slot definition inside a gt-vue translation',
+      'Use a single default slot'
+    );
+  } else if (
+    !hasExplicitDefaultSlot &&
+    defaultChildren.length > 0 &&
+    (!hasTemplateSlots || hasMeaningfulDefault)
+  ) {
+    defaultSlot = {
+      children: defaultChildren,
+      rootCount: countImplicitSlotRoots(element.children),
+      shadowed,
+    };
+  }
+  return { defaultSlot, namedSlots };
+}
+
+/** Matches Vue's test for an implicit slot containing more than separators. */
+function hasMeaningfulSlotContent(
+  children: TemplateChildNode[],
+  context: VueExtractionContext
+): boolean {
+  return children.some(
+    (child) =>
+      child.type !== NodeTypes.COMMENT &&
+      (child.type !== NodeTypes.TEXT ||
+        !isImplicitSlotWhitespace(
+          child.content,
+          context.implicitSlotWhitespace
+        ))
+  );
+}
+
+/** Mirrors the exact whitespace predicate detected from consumer compiler. */
+function isImplicitSlotWhitespace(
+  value: string,
+  semantics: VueExtractionContext['implicitSlotWhitespace']
+): boolean {
+  return semantics === 'ecmascript'
+    ? value.trim().length === 0
+    : /^[\t\n\f\r ]*$/.test(value);
+}
+
+/** Counts roots in a complete Vue slot before Suspense normalizes the array. */
+function countVueSlotRoots(children: TemplateChildNode[]): number {
+  return countSlotRoots(children, () => false);
+}
+
+/**
+ * Counts roots in an implicit slot while treating named-slot templates as
+ * barriers. Vue removes those templates from the default slot only after its
+ * text transform has run, so text on opposite sides remains separate VNodes.
+ */
+function countImplicitSlotRoots(children: TemplateChildNode[]): number {
+  return countSlotRoots(children, (child) => {
+    if (child.type !== NodeTypes.ELEMENT || child.tag !== 'template') {
+      return false;
+    }
+    return child.props.some(
+      (property) =>
+        property.type === NodeTypes.DIRECTIVE && property.name === 'slot'
+    );
+  });
+}
+
+function countSlotRoots(
+  children: TemplateChildNode[],
+  isExcluded: (child: TemplateChildNode) => boolean
+): number {
+  let roots = 0;
+  let previousWasText = false;
+  for (const child of children) {
+    if (child.type === NodeTypes.COMMENT || isExcluded(child)) {
+      previousWasText = false;
+      continue;
+    }
+    const isText =
+      child.type === NodeTypes.TEXT || child.type === NodeTypes.INTERPOLATION;
+    if (!isText || !previousWasText) roots += 1;
+    previousWasText = isText;
+  }
+  return roots;
+}
+
+function addScopedSlotError(
+  location: ExtractionLocation,
+  context: VueExtractionContext
+): void {
+  addVueError(
+    context,
+    location,
+    'Found a scoped slot inside a gt-vue <T> component',
+    'Use a slot without runtime slot props so the translation source is static'
+  );
+}
+
+function readSlotName(
+  directive: DirectiveNode,
+  context: VueExtractionContext
+): string | undefined {
+  if (!directive.arg) return 'default';
+  if (
+    directive.arg.type !== NodeTypes.SIMPLE_EXPRESSION ||
+    !directive.arg.isStatic
+  ) {
+    addVueError(
+      context,
+      directive.loc,
+      'Found a dynamic slot name inside a gt-vue translation',
+      'Use a static slot name'
+    );
+    return undefined;
+  }
+  return directive.arg.content;
+}
+
+function findElementProperty(
+  element: ElementNode,
+  name: string,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+):
+  | { present: false }
+  | {
+      location: ExtractionLocation;
+      present: true;
+      static: boolean;
+      value?: StaticPrimitive;
+    } {
+  for (const property of element.props) {
+    const key =
+      property.type === NodeTypes.ATTRIBUTE
+        ? property.name
+        : property.name === 'bind'
+          ? readDirectiveKey(property)
+          : undefined;
+    if (key !== name) continue;
+    const value = readPropertyValue(
+      property,
+      expressionPlugins,
+      shadowed,
+      bindings
+    );
+    return {
+      location: property.loc,
+      present: true,
+      static: value.ok,
+      ...(value.ok && { value: value.value }),
+    };
+  }
+  return { present: false };
+}
+
+function readPropertyValue(
+  property: ElementNode['props'][number],
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+): { ok: true; value: StaticPrimitive } | { ok: false } {
+  if (property.type === NodeTypes.ATTRIBUTE) {
+    return { ok: true, value: property.value?.content ?? '' };
+  }
+  if (property.name !== 'bind') return { ok: false };
+  return readExpressionPrimitive(
+    property.exp,
+    expressionPlugins,
+    shadowed,
+    bindings
+  );
+}
+
+function readExpressionPrimitive(
+  expression: ExpressionNode | undefined,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>,
+  bindings: TemplateBindings
+): { ok: true; value: StaticPrimitive } | { ok: false } {
+  const node = expression
+    ? getExpressionNode(expression, expressionPlugins)
+    : undefined;
+  return readStaticPrimitive(node, (identifier) => {
+    if (shadowed.has(identifier.name)) return { ok: false };
+    const value = bindings.staticValues.get(identifier.name);
+    return bindings.staticValues.has(identifier.name)
+      ? { ok: true, value: value! }
+      : { ok: false };
+  });
+}
+
+function getExpressionNode(
+  expression: ExpressionNode,
+  expressionPlugins: ParserPlugin[]
+): babel.Node | undefined {
+  if (expression.type !== NodeTypes.SIMPLE_EXPRESSION) return undefined;
+  if (expression.ast && typeof expression.ast === 'object') {
+    return expression.ast as babel.Node;
+  }
+  try {
+    return parseExpression(expression.content, {
+      plugins: expressionPlugins,
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+function wrapForTraversal(node: babel.Node): babel.File | undefined {
+  if (node.type === 'File') return node;
+  if (node.type === 'Program') return babel.file(node);
+  if (babel.isExpression(node)) {
+    return babel.file(
+      babel.program([babel.expressionStatement(node as babel.Expression)])
+    );
+  }
+  if (babel.isStatement(node)) {
+    return babel.file(babel.program([node]));
+  }
+  return undefined;
+}
+
+function collectElementScopeBindings(
+  element: ElementNode,
+  expressionPlugins: ParserPlugin[]
+): Set<string> {
+  const result = new Set<string>();
+  for (const property of element.props) {
+    if (property.type !== NodeTypes.DIRECTIVE) continue;
+    if (property.name === 'for') {
+      const parseResult = readForParseResult(property);
+      for (const alias of [
+        parseResult?.value,
+        parseResult?.key,
+        parseResult?.index,
+      ]) {
+        for (const name of collectExpressionBindings(
+          alias,
+          expressionPlugins
+        )) {
+          result.add(name);
+        }
+      }
+    } else if (property.name === 'slot') {
+      for (const name of collectExpressionBindings(
+        property.exp,
+        expressionPlugins
+      )) {
+        result.add(name);
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Reads Vue's normalized v-for fields across every supported Vue 3 release.
+ *
+ * Vue 3.4+ supplies `forParseResult`; Vue 3.3 exposes only the original
+ * directive expression. The fallback deliberately mirrors Vue's own alias,
+ * iterator, and parenthesis expressions so scope tracking sees the same value,
+ * key, index, and source fields without depending on a second compiler copy.
+ */
+function readForParseResult(
+  property: DirectiveNode
+): ForParseResult | undefined {
+  const compilerResult = (
+    property as DirectiveNode & { forParseResult?: ForParseResult }
+  ).forParseResult;
+  if (compilerResult) return compilerResult;
+  if (
+    property.exp?.type !== NodeTypes.SIMPLE_EXPRESSION ||
+    !property.exp.content
+  ) {
+    return undefined;
+  }
+
+  const match = property.exp.content.match(FOR_ALIAS_EXPRESSION);
+  if (!match) return undefined;
+  const source = match[2]?.trim();
+  const aliases = match[1]?.trim().replace(FOR_STRIP_PARENS, '').trim();
+  if (!source || !aliases) return undefined;
+
+  const iteratorMatch = aliases.match(FOR_ITERATOR_EXPRESSION);
+  const value = iteratorMatch
+    ? aliases.replace(FOR_ITERATOR_EXPRESSION, '').trim()
+    : aliases;
+  if (!value) return undefined;
+
+  return {
+    source: cloneForExpression(property.exp, source),
+    value: cloneForExpression(property.exp, value),
+    ...(iteratorMatch?.[1]?.trim() && {
+      key: cloneForExpression(property.exp, iteratorMatch[1].trim()),
+    }),
+    ...(iteratorMatch?.[2]?.trim() && {
+      index: cloneForExpression(property.exp, iteratorMatch[2].trim()),
+    }),
+  };
+}
+
+/** Creates one parser-neutral v-for field from Vue's original expression. */
+function cloneForExpression(
+  expression: SimpleExpressionNode,
+  content: string
+): SimpleExpressionNode {
+  return {
+    ...expression,
+    ast: undefined,
+    content,
+    loc: { ...expression.loc, source: content },
+  };
+}
+
+function collectExpressionBindings(
+  expression: ExpressionNode | undefined,
+  expressionPlugins: ParserPlugin[]
+): Set<string> {
+  const result = new Set<string>();
+  if (
+    !expression ||
+    expression.type !== NodeTypes.SIMPLE_EXPRESSION ||
+    !expression.content
+  ) {
+    return result;
+  }
+  try {
+    const arrow = parseExpression(`(${expression.content}) => 0`, {
+      plugins: expressionPlugins,
+    });
+    if (arrow.type === 'ArrowFunctionExpression') {
+      for (const parameter of arrow.params)
+        collectPatternNames(parameter, result);
+    }
+  } catch {
+    // The Vue compiler reports malformed v-for/v-slot bindings separately.
+  }
+  return result;
+}
+
+function collectPatternNames(
+  pattern: babel.Node | null,
+  result: Set<string>
+): void {
+  if (!pattern) return;
+  if (pattern.type === 'Identifier') {
+    result.add(pattern.name);
+  } else if (pattern.type === 'RestElement') {
+    collectPatternNames(pattern.argument, result);
+  } else if (pattern.type === 'AssignmentPattern') {
+    collectPatternNames(pattern.left, result);
+  } else if (pattern.type === 'ArrayPattern') {
+    for (const element of pattern.elements) {
+      if (element) collectPatternNames(element, result);
+    }
+  } else if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      if (property.type === 'RestElement') {
+        collectPatternNames(property.argument, result);
+      } else {
+        collectPatternNames(property.value, result);
+      }
+    }
+  } else if (pattern.type === 'TSParameterProperty') {
+    collectPatternNames(pattern.parameter, result);
+  }
+}
+
+function resolveGTComponent(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): { localName: string; originalName: GTComponentName } | undefined {
+  return resolveComponentBinding(
+    element,
+    bindings,
+    bindings.components,
+    bindings.registeredComponents,
+    bindings.directBindings,
+    expressionPlugins,
+    shadowed
+  );
+}
+
+/** Resolves a template tag or static dynamic selector through known bindings. */
+function resolveComponentBinding<Name extends string>(
+  element: ElementNode,
+  bindings: TemplateBindings,
+  directBindings: Map<string, Name>,
+  registeredBindings: Map<string, Name>,
+  directTemplateBindings: Set<string>,
+  expressionPlugins: ParserPlugin[],
+  shadowed: Set<string>
+): { localName: string; originalName: Name } | undefined {
+  if (element.tagType !== ElementTypes.COMPONENT) return undefined;
+  const selector = readDynamicComponentSelector(
+    element,
+    expressionPlugins,
+    bindings,
+    shadowed
+  );
+  if (selector) {
+    if (
+      selector.unknown ||
+      selector.possibleGT ||
+      selector.componentFactories.size > 0 ||
+      selector.gtComponentFactories.size > 0 ||
+      selector.candidates.length === 0
+    ) {
+      return undefined;
+    }
+    const resolved = selector.candidates.map((candidate) => {
+      for (const localName of normalizeTemplateBindingNames(candidate.name)) {
+        const originalName =
+          candidate.kind === 'string'
+            ? registeredBindings.get(localName)
+            : directBindings.get(localName);
+        if (originalName) return { localName, originalName };
+      }
+      return undefined;
+    });
+    const first = resolved[0];
+    return first &&
+      resolved.every(
+        (candidate) => candidate?.originalName === first.originalName
+      )
+      ? first
+      : undefined;
+  }
+  for (const localName of normalizeTemplateBindingNames(element.tag)) {
+    const originalName = isDirectTemplateBinding(
+      localName,
+      directTemplateBindings
+    )
+      ? directBindings.get(localName)
+      : registeredBindings.get(localName);
+    if (originalName) return { localName, originalName };
+  }
+  return undefined;
+}
+
+function normalizeTemplateBindingNames(sourceName: string): Set<string> {
+  const camelized = sourceName.replace(/-(\w)/g, (_match, letter: string) =>
+    letter.toUpperCase()
+  );
+  const pascalized = camelized
+    ? camelized[0].toUpperCase() + camelized.slice(1)
+    : camelized;
+  return new Set([sourceName, camelized, pascalized]);
+}
+
+/** Returns whether a program binding shadows an Options API registration. */
+function isDirectTemplateBinding(
+  localName: string,
+  directBindings: Set<string>
+): boolean {
+  return (
+    directBindings.has(localName) ||
+    directBindings.has(localName.split('.', 1)[0] ?? localName)
+  );
+}
+
+/** Resolves a statically knowable Vue dynamic-component selector. */
+function readDynamicComponentSelector(
+  element: ElementNode,
+  expressionPlugins: ParserPlugin[],
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): DynamicSelectorAnalysis | undefined {
+  if (element.tag.toLowerCase() !== 'component') return undefined;
+  const property = element.props.find((candidate) =>
+    isDynamicComponentSelector(element, candidate)
+  );
+  if (!property) return undefined;
+  if (property.type === NodeTypes.ATTRIBUTE) {
+    return property.value
+      ? {
+          candidates: [{ kind: 'string', name: property.value.content }],
+          componentFactories: new Set(),
+          containers: [],
+          displayName: property.value.content,
+          gtComponentFactories: new Set(),
+          possibleGT: false,
+          unknown: false,
+        }
+      : undefined;
+  }
+  const node = property.exp
+    ? getExpressionNode(property.exp, expressionPlugins)
+    : undefined;
+  if (!node) return undefined;
+  return {
+    ...collectDynamicSelectorCandidates(node, bindings, shadowed, new Set()),
+    displayName:
+      property.exp?.type === NodeTypes.SIMPLE_EXPRESSION
+        ? property.exp.content
+        : 'dynamic component',
+  };
+}
+
+/** Collects every statically visible result of a dynamic selector expression. */
+function collectDynamicSelectorCandidates(
+  node: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) {
+    return emptyDynamicSelectorAnalysis(true);
+  }
+  const nextSeen = new Set(seen).add(expression);
+  if (
+    expression.type === 'ArrayExpression' ||
+    expression.type === 'ObjectExpression'
+  ) {
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'literal', node: expression }],
+    };
+  }
+  if (
+    expression.type === 'ArrowFunctionExpression' ||
+    expression.type === 'FunctionExpression' ||
+    expression.type === 'ObjectMethod'
+  ) {
+    const result = collectTemplateCallableReturnAnalysis(
+      expression,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    return { ...result, unknown: true };
+  }
+  if (expression.type === 'Identifier') {
+    if (shadowed.has(expression.name)) {
+      return emptyDynamicSelectorAnalysis(true);
+    }
+    if (bindings.containerKinds.has(expression.name)) {
+      return {
+        ...emptyDynamicSelectorAnalysis(false),
+        containers: [{ kind: 'path', path: expression.name }],
+      };
+    }
+    if (bindings.staticValues.has(expression.name)) {
+      const value = bindings.staticValues.get(expression.name);
+      return typeof value === 'string'
+        ? selectorCandidate('string', value)
+        : emptyDynamicSelectorAnalysis(false);
+    }
+    const possibleStrings = bindings.possibleStaticStrings.get(expression.name);
+    if (possibleStrings && possibleStrings.size > 0) {
+      const result = mergeDynamicSelectorAnalyses(
+        [...possibleStrings].map((value) => selectorCandidate('string', value))
+      );
+      return { ...result, unknown: true };
+    }
+    return selectorCandidate('expression', expression.name);
+  }
+  if (expression.type === 'StringLiteral') {
+    return selectorCandidate('string', expression.value);
+  }
+  const staticValue = readTemplateStaticPrimitive(
+    expression,
+    bindings,
+    shadowed
+  );
+  if (staticValue.ok) {
+    return typeof staticValue.value === 'string'
+      ? selectorCandidate('string', staticValue.value)
+      : emptyDynamicSelectorAnalysis(false);
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const property = readStaticTemplateMemberProperty(
+      expression,
+      bindings,
+      shadowed
+    );
+    if (property !== undefined) {
+      const selected = selectTemplateStaticMemberExpression(
+        expression.object,
+        property,
+        bindings,
+        shadowed,
+        new Set()
+      );
+      if (selected) {
+        return collectDynamicSelectorCandidates(
+          selected,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+      }
+      const objectAnalysis = collectDynamicSelectorCandidates(
+        expression.object,
+        bindings,
+        shadowed,
+        nextSeen
+      );
+      if (objectAnalysis.containers.length > 0) {
+        const memberAnalysis = mergeDynamicSelectorAnalyses(
+          objectAnalysis.containers.map((container) =>
+            selectTemplateContainerReference(
+              container,
+              property,
+              bindings,
+              shadowed,
+              nextSeen
+            )
+          )
+        );
+        return {
+          ...memberAnalysis,
+          unknown: memberAnalysis.unknown || objectAnalysis.unknown,
+        };
+      }
+    }
+    const memberPath = readStaticTemplateMemberPath(
+      expression,
+      bindings,
+      shadowed
+    );
+    if (memberPath) {
+      const staticMember = bindings.staticValues.get(memberPath);
+      if (typeof staticMember === 'string') {
+        return selectorCandidate('string', staticMember);
+      }
+      if (bindings.containerKinds.has(memberPath)) {
+        return {
+          ...emptyDynamicSelectorAnalysis(false),
+          containers: [{ kind: 'path', path: memberPath }],
+        };
+      }
+      const possibleStrings = bindings.possibleStaticStrings.get(memberPath);
+      if (possibleStrings && possibleStrings.size > 0) {
+        const result = mergeDynamicSelectorAnalyses(
+          [...possibleStrings].map((value) =>
+            selectorCandidate('string', value)
+          )
+        );
+        return { ...result, unknown: true };
+      }
+      const possibleContainer = findPossibleGTContainerPath(
+        memberPath,
+        bindings
+      );
+      if (possibleContainer) {
+        return {
+          ...emptyDynamicSelectorAnalysis(true),
+          containers: [{ kind: 'path', path: possibleContainer }],
+        };
+      }
+      if (templatePathSelectsPossibleGT(memberPath, bindings)) {
+        return {
+          ...emptyDynamicSelectorAnalysis(true),
+          possibleGT: true,
+        };
+      }
+      return selectorCandidate('expression', memberPath);
+    }
+    const container = collectTemplateContainerCandidates(
+      expression.object,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    if (
+      container.candidates.length > 0 ||
+      container.componentFactories.size > 0 ||
+      container.containers.length > 0 ||
+      container.gtComponentFactories.size > 0 ||
+      container.possibleGT
+    ) {
+      return { ...container, unknown: true };
+    }
+    return emptyDynamicSelectorAnalysis(true);
+  }
+  if (expression.type === 'ConditionalExpression') {
+    const test = readTemplateStaticPrimitive(
+      expression.test,
+      bindings,
+      shadowed
+    );
+    if (test.ok) {
+      return collectDynamicSelectorCandidates(
+        test.value ? expression.consequent : expression.alternate,
+        bindings,
+        shadowed,
+        nextSeen
+      );
+    }
+    return mergeDynamicSelectorAnalyses([
+      collectDynamicSelectorCandidates(
+        expression.consequent,
+        bindings,
+        shadowed,
+        nextSeen
+      ),
+      collectDynamicSelectorCandidates(
+        expression.alternate,
+        bindings,
+        shadowed,
+        nextSeen
+      ),
+    ]);
+  }
+  if (expression.type === 'LogicalExpression') {
+    const leftCandidates = collectDynamicSelectorCandidates(
+      expression.left,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    if (selectorAnalysisIsKnownComponent(leftCandidates, bindings)) {
+      return expression.operator === '&&'
+        ? collectDynamicSelectorCandidates(
+            expression.right,
+            bindings,
+            shadowed,
+            nextSeen
+          )
+        : leftCandidates;
+    }
+    const left = readTemplateStaticPrimitive(
+      expression.left,
+      bindings,
+      shadowed
+    );
+    if (left.ok) {
+      const selectsRight =
+        expression.operator === '??'
+          ? left.value == null
+          : expression.operator === '||'
+            ? !left.value
+            : Boolean(left.value);
+      return selectsRight
+        ? collectDynamicSelectorCandidates(
+            expression.right,
+            bindings,
+            shadowed,
+            nextSeen
+          )
+        : emptyDynamicSelectorAnalysis(false);
+    }
+    const merged = mergeDynamicSelectorAnalyses([
+      leftCandidates,
+      collectDynamicSelectorCandidates(
+        expression.right,
+        bindings,
+        shadowed,
+        nextSeen
+      ),
+    ]);
+    return { ...merged, unknown: true };
+  }
+  if (expression.type === 'SequenceExpression') {
+    const last = expression.expressions.at(-1);
+    return last
+      ? collectDynamicSelectorCandidates(last, bindings, shadowed, nextSeen)
+      : emptyDynamicSelectorAnalysis(true);
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const reduction = collectTemplateReductionResult(
+      expression,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    if (reduction) return reduction;
+    const directCallable = unwrapExpression(expression.callee);
+    if (
+      directCallable &&
+      (directCallable.type === 'ArrowFunctionExpression' ||
+        directCallable.type === 'FunctionExpression')
+    ) {
+      const returned = collectTemplateCallableReturnAnalysis(
+        directCallable,
+        bindings,
+        shadowed,
+        nextSeen
+      );
+      return { ...returned, unknown: true };
+    }
+    const memberCallee = unwrapExpression(expression.callee);
+    if (
+      memberCallee &&
+      (memberCallee.type === 'MemberExpression' ||
+        memberCallee.type === 'OptionalMemberExpression')
+    ) {
+      const method = readStaticTemplateMemberProperty(
+        memberCallee,
+        bindings,
+        shadowed
+      );
+      const literalMethod = method
+        ? selectTemplateStaticMemberExpression(
+            memberCallee.object,
+            method,
+            bindings,
+            shadowed,
+            new Set()
+          )
+        : undefined;
+      if (literalMethod?.type === 'ObjectMethod') {
+        const returned = collectTemplateCallableReturnAnalysis(
+          literalMethod,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+        return { ...returned, unknown: true };
+      }
+      if (method === 'call' || method === 'apply' || method === 'bind') {
+        const receiver = collectDynamicSelectorCandidates(
+          memberCallee.object,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+        const receiverPath = readStaticTemplateMemberPath(
+          memberCallee.object,
+          bindings,
+          shadowed
+        );
+        if (receiverPath && bindings.componentFactories.has(receiverPath)) {
+          receiver.componentFactories.add(receiverPath);
+        }
+        if (receiverPath && bindings.gtComponentFactories.has(receiverPath)) {
+          receiver.gtComponentFactories.add(receiverPath);
+        }
+        if (
+          receiver.componentFactories.size > 0 ||
+          receiver.gtComponentFactories.size > 0
+        ) {
+          return { ...receiver, unknown: true };
+        }
+      }
+      if (
+        method &&
+        (COMPONENT_SELECTING_ARRAY_METHODS.has(method) ||
+          COMPONENT_PRESERVING_ARRAY_METHODS.has(method))
+      ) {
+        const references = collectTemplateContainerReferences(
+          memberCallee.object,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+        const arrays = references.containers.filter(
+          (container) =>
+            isKnownTemplateArray(container, bindings) &&
+            !templateContainerHasOwnMember(container, method, bindings)
+        );
+        if (arrays.length > 0) {
+          if (COMPONENT_PRESERVING_ARRAY_METHODS.has(method)) {
+            const argumentAnalyses =
+              method === 'concat'
+                ? expression.arguments.flatMap((argument) =>
+                    argument.type === 'ArgumentPlaceholder'
+                      ? []
+                      : [
+                          collectDynamicSelectorCandidates(
+                            argument.type === 'SpreadElement'
+                              ? argument.argument
+                              : argument,
+                            bindings,
+                            shadowed,
+                            nextSeen
+                          ),
+                        ]
+                  )
+                : [];
+            const argumentContainers =
+              method === 'concat'
+                ? argumentAnalyses.flatMap((analysis) => analysis.containers)
+                : [];
+            return {
+              ...emptyDynamicSelectorAnalysis(true),
+              containers: [...arrays, ...argumentContainers],
+              possibleGT: argumentAnalyses.some((analysis) =>
+                selectorAnalysisMayContainGT(analysis, bindings)
+              ),
+            };
+          }
+
+          let hasUnknownSelection = false;
+          const analyses = arrays.flatMap((container) => {
+            const key = readSelectingArrayMethodKey(
+              method,
+              expression.arguments[0],
+              container,
+              bindings,
+              shadowed
+            );
+            if (key === null) return [];
+            hasUnknownSelection ||= key === undefined;
+            return [
+              selectTemplateContainerReference(
+                container,
+                key,
+                bindings,
+                shadowed,
+                nextSeen
+              ),
+            ];
+          });
+          if (analyses.length === 0) {
+            return emptyDynamicSelectorAnalysis(false);
+          }
+          const selected = mergeDynamicSelectorAnalyses(analyses);
+          return {
+            ...selected,
+            unknown: selected.unknown || hasUnknownSelection,
+          };
+        }
+      }
+      if (method === 'get') {
+        const receiverPath = readStaticTemplateMemberPath(
+          memberCallee.object,
+          bindings,
+          shadowed
+        );
+        if (
+          receiverPath &&
+          findPossibleGTContainerPath(receiverPath, bindings)
+        ) {
+          return {
+            ...emptyDynamicSelectorAnalysis(true),
+            possibleGT: true,
+          };
+        }
+        const references = collectTemplateContainerReferences(
+          memberCallee.object,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+        if (references.containers.length > 0) {
+          const argument = expression.arguments[0];
+          const staticKey =
+            argument &&
+            argument.type !== 'ArgumentPlaceholder' &&
+            argument.type !== 'SpreadElement'
+              ? readTemplateStaticPrimitive(argument, bindings, shadowed)
+              : undefined;
+          const key =
+            staticKey?.ok &&
+            (typeof staticKey.value === 'string' ||
+              typeof staticKey.value === 'number')
+              ? String(staticKey.value)
+              : argument &&
+                  argument.type !== 'ArgumentPlaceholder' &&
+                  argument.type !== 'SpreadElement'
+                ? (() => {
+                    const argumentPath = readStaticTemplateMemberPath(
+                      argument,
+                      bindings,
+                      shadowed
+                    );
+                    return argumentPath &&
+                      bindings.containerKinds.has(argumentPath)
+                      ? argumentPath
+                      : undefined;
+                  })()
+                : undefined;
+          const selected = mergeDynamicSelectorAnalyses(
+            references.containers.map((container) =>
+              selectTemplateContainerReference(
+                container,
+                key,
+                bindings,
+                shadowed,
+                nextSeen
+              )
+            )
+          );
+          return {
+            ...selected,
+            unknown: selected.unknown || key === undefined,
+          };
+        }
+      }
+    }
+    const callee = readStaticTemplateMemberPath(
+      expression.callee,
+      bindings,
+      shadowed
+    );
+    if (callee === 'Reflect.get' && expression.arguments.length >= 2) {
+      const target = expression.arguments[0];
+      const keyNode = expression.arguments[1];
+      if (
+        target &&
+        target.type !== 'ArgumentPlaceholder' &&
+        target.type !== 'SpreadElement' &&
+        keyNode &&
+        keyNode.type !== 'ArgumentPlaceholder' &&
+        keyNode.type !== 'SpreadElement'
+      ) {
+        const references = collectTemplateContainerReferences(
+          target,
+          bindings,
+          shadowed,
+          nextSeen
+        );
+        const staticKey = readTemplateStaticPrimitive(
+          keyNode,
+          bindings,
+          shadowed
+        );
+        const key =
+          staticKey.ok &&
+          (typeof staticKey.value === 'string' ||
+            typeof staticKey.value === 'number')
+            ? String(staticKey.value)
+            : undefined;
+        const selected = mergeDynamicSelectorAnalyses(
+          references.containers.map((container) =>
+            selectTemplateContainerReference(
+              container,
+              key,
+              bindings,
+              shadowed,
+              nextSeen
+            )
+          )
+        );
+        if (references.containers.length > 0) {
+          return {
+            ...selected,
+            unknown: selected.unknown || key === undefined,
+          };
+        }
+      }
+    }
+    const first = expression.arguments[0];
+    if (
+      callee &&
+      bindings.identityFunctions.has(callee) &&
+      expression.arguments.length === 1 &&
+      first &&
+      first.type !== 'ArgumentPlaceholder' &&
+      first.type !== 'SpreadElement'
+    ) {
+      return collectDynamicSelectorCandidates(
+        first,
+        bindings,
+        shadowed,
+        nextSeen
+      );
+    }
+    const argumentsAnalysis = mergeDynamicSelectorAnalyses(
+      expression.arguments
+        .filter(
+          (
+            argument
+          ): argument is Exclude<typeof argument, babel.ArgumentPlaceholder> =>
+            argument.type !== 'ArgumentPlaceholder'
+        )
+        .map((argument) =>
+          collectDynamicSelectorCandidates(
+            argument.type === 'SpreadElement' ? argument.argument : argument,
+            bindings,
+            shadowed,
+            nextSeen
+          )
+        )
+    );
+    const calleeAnalysis = collectDynamicSelectorCandidates(
+      expression.callee,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    for (const candidate of calleeAnalysis.candidates) {
+      if (candidate.kind !== 'expression') continue;
+      if (bindings.componentFactories.has(candidate.name)) {
+        argumentsAnalysis.componentFactories.add(candidate.name);
+      }
+      if (bindings.gtComponentFactories.has(candidate.name)) {
+        argumentsAnalysis.gtComponentFactories.add(candidate.name);
+      }
+    }
+    for (const name of calleeAnalysis.componentFactories) {
+      argumentsAnalysis.componentFactories.add(name);
+    }
+    for (const name of calleeAnalysis.gtComponentFactories) {
+      argumentsAnalysis.gtComponentFactories.add(name);
+    }
+    if (callee && bindings.componentFactories.has(callee)) {
+      argumentsAnalysis.componentFactories.add(callee);
+    }
+    if (callee && bindings.gtComponentFactories.has(callee)) {
+      argumentsAnalysis.gtComponentFactories.add(callee);
+    }
+    return { ...argumentsAnalysis, unknown: true };
+  }
+  if (expression.type === 'AssignmentExpression') {
+    return collectDynamicSelectorCandidates(
+      expression.right,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+  }
+  if (
+    expression.type === 'AwaitExpression' ||
+    expression.type === 'YieldExpression'
+  ) {
+    return expression.argument
+      ? collectDynamicSelectorCandidates(
+          expression.argument,
+          bindings,
+          shadowed,
+          nextSeen
+        )
+      : emptyDynamicSelectorAnalysis(true);
+  }
+  return emptyDynamicSelectorAnalysis(false);
+}
+
+/** Finds component-bearing values that a dynamic container index may select. */
+function collectTemplateContainerCandidates(
+  node: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) {
+    return emptyDynamicSelectorAnalysis(true);
+  }
+  const nextSeen = new Set(seen).add(expression);
+  if (
+    expression.type === 'ArrayExpression' ||
+    expression.type === 'ObjectExpression'
+  ) {
+    return collectLiteralContainerCandidates(
+      expression,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const transformed = collectTemplateTransformCandidates(
+      expression,
+      bindings,
+      shadowed,
+      nextSeen
+    );
+    if (transformed) return transformed;
+  }
+  const path = readStaticTemplateMemberPath(expression, bindings, shadowed);
+  if (
+    path &&
+    (bindings.containerKinds.has(path) ||
+      findPossibleGTContainerPath(path, bindings) !== undefined ||
+      hasImmediatePossibleGTContainerChild(path, bindings) ||
+      hasPossibleStaticStringChild(path, bindings))
+  ) {
+    const result =
+      bindings.containerKinds.has(path) ||
+      hasImmediatePossibleGTContainerChild(path, bindings) ||
+      hasPossibleStaticStringChild(path, bindings)
+        ? collectExposedContainerCandidates(path, bindings)
+        : emptyDynamicSelectorAnalysis(true);
+    return {
+      ...result,
+      possibleGT:
+        result.possibleGT ||
+        findPossibleGTContainerPath(path, bindings) !== undefined,
+    };
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = readStaticTemplateMemberPath(
+      expression.callee,
+      bindings,
+      shadowed
+    );
+    if (callee && bindings.gtContainerFactories.has(callee)) {
+      return {
+        ...emptyDynamicSelectorAnalysis(true),
+        possibleGT: true,
+      };
+    }
+  }
+  const selected = collectDynamicSelectorCandidates(
+    expression,
+    bindings,
+    shadowed,
+    seen
+  );
+  const analyses = selected.containers.map((container) =>
+    selectTemplateContainerReference(
+      container,
+      undefined,
+      bindings,
+      shadowed,
+      nextSeen
+    )
+  );
+  if (analyses.length === 0) {
+    return {
+      ...emptyDynamicSelectorAnalysis(true),
+      possibleGT: false,
+    };
+  }
+  const result = mergeDynamicSelectorAnalyses(analyses);
+  return {
+    ...result,
+    possibleGT: result.possibleGT,
+    unknown: result.unknown || selected.unknown,
+  };
+}
+
+/** Models built-in transforms whose result is immediately selected or iterated. */
+function collectTemplateTransformCandidates(
+  call: babel.CallExpression | babel.OptionalCallExpression,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> | undefined {
+  const callee = unwrapExpression(call.callee);
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'OptionalMemberExpression')
+  ) {
+    return undefined;
+  }
+  const method = readStaticTemplateMemberProperty(callee, bindings, shadowed);
+  if (!method) return undefined;
+  const receiverPath = readStaticTemplateMemberPath(
+    callee.object,
+    bindings,
+    shadowed
+  );
+  const readArgument = (index: number): babel.Node | undefined => {
+    const argument = call.arguments[index];
+    return argument && argument.type !== 'ArgumentPlaceholder'
+      ? argument.type === 'SpreadElement'
+        ? argument.argument
+        : argument
+      : undefined;
+  };
+  const receiver = (): Omit<DynamicSelectorAnalysis, 'displayName'> =>
+    collectTemplateContainerCandidates(callee.object, bindings, shadowed, seen);
+  const mapValues = (
+    source: Omit<DynamicSelectorAnalysis, 'displayName'>,
+    callbackNode: babel.Node | undefined,
+    includeSourceParameter = true,
+    thisNode?: babel.Node
+  ): Omit<DynamicSelectorAnalysis, 'displayName'> => {
+    const callback = unwrapExpression(callbackNode);
+    if (
+      !callback ||
+      (callback.type !== 'ArrowFunctionExpression' &&
+        callback.type !== 'FunctionExpression')
+    ) {
+      return { ...source, unknown: true };
+    }
+    const parameters = new Map<
+      string,
+      Omit<DynamicSelectorAnalysis, 'displayName'>
+    >();
+    const sourceArray: Omit<DynamicSelectorAnalysis, 'displayName'> = {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [
+        { kind: 'analysis', containerKind: 'array', values: source },
+      ],
+    };
+    const callbackArguments = [
+      source,
+      emptyDynamicSelectorAnalysis(false),
+      ...(includeSourceParameter ? [sourceArray] : []),
+    ];
+    bindTemplateCallbackParameters(
+      callback,
+      callbackArguments,
+      bindings,
+      shadowed,
+      parameters
+    );
+    if (callback.type !== 'ArrowFunctionExpression' && thisNode) {
+      parameters.set(
+        'this',
+        collectTemplateSelectorValue(thisNode, bindings, shadowed, seen)
+      );
+    }
+    const analyses = collectTemplateFunctionReturns(callback).map((value) =>
+      collectTemplateCallbackReturnValue(
+        value,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      )
+    );
+    const mapped = mergeDynamicSelectorAnalyses(analyses);
+    return { ...mapped, unknown: mapped.unknown || analyses.length === 0 };
+  };
+
+  if (
+    receiverPath === 'Array' &&
+    method === 'from' &&
+    !bindings.directBindings.has('Array') &&
+    !shadowed.has('Array')
+  ) {
+    const sourceNode = readArgument(0);
+    if (!sourceNode) return emptyDynamicSelectorAnalysis(true);
+    const source = collectTemplateContainerCandidates(
+      sourceNode,
+      bindings,
+      shadowed,
+      seen
+    );
+    return call.arguments.length > 1
+      ? mapValues(source, readArgument(1), false, readArgument(2))
+      : source;
+  }
+
+  if (
+    receiverPath === 'Object' &&
+    (method === 'values' || method === 'entries') &&
+    !bindings.directBindings.has('Object') &&
+    !shadowed.has('Object')
+  ) {
+    const sourceNode = readArgument(0);
+    if (!sourceNode) return emptyDynamicSelectorAnalysis(true);
+    if (method === 'values') {
+      return collectTemplateContainerCandidates(
+        sourceNode,
+        bindings,
+        shadowed,
+        seen
+      );
+    }
+    const sourceValues = collectTemplateContainerCandidates(
+      sourceNode,
+      bindings,
+      shadowed,
+      seen
+    );
+    const source = unwrapExpression(sourceNode);
+    if (source?.type !== 'ObjectExpression') {
+      return {
+        ...emptyDynamicSelectorAnalysis(false),
+        containers: [
+          {
+            kind: 'analysis',
+            containerKind: 'array',
+            members: new Map([
+              ['0', emptyDynamicSelectorAnalysis(false)],
+              ['1', sourceValues],
+            ]),
+            values: sourceValues,
+          },
+        ],
+      };
+    }
+    const properties = flattenTemplateLiteralObject(source, new Set());
+    if (!properties) return emptyDynamicSelectorAnalysis(true);
+    const tuples: DynamicSelectorContainer[] = [];
+    let unknown = false;
+    for (const property of properties) {
+      if (property.type === 'SpreadElement') {
+        unknown = true;
+        continue;
+      }
+      const key = readTemplateLiteralPropertyKey(property, bindings, shadowed);
+      if (
+        property.type !== 'ObjectProperty' ||
+        !babel.isExpression(property.value)
+      ) {
+        unknown = true;
+        continue;
+      }
+      tuples.push({
+        kind: 'literal',
+        node: babel.arrayExpression([
+          babel.stringLiteral(key ?? ''),
+          property.value,
+        ]),
+      });
+      unknown ||= key === undefined;
+    }
+    return {
+      ...emptyDynamicSelectorAnalysis(unknown),
+      containers: tuples,
+    };
+  }
+
+  const source = receiver();
+  if (method === 'concat') {
+    const argumentsAnalysis = call.arguments.flatMap((_, index) => {
+      const argument = readArgument(index);
+      if (!argument) return [];
+      return [
+        flattenTemplateTransformAnalysis(
+          collectDynamicSelectorCandidates(argument, bindings, shadowed, seen),
+          1,
+          bindings,
+          shadowed,
+          seen
+        ),
+      ];
+    });
+    return mergeDynamicSelectorAnalyses([source, ...argumentsAnalysis]);
+  }
+  if (method === 'map') {
+    return mapValues(source, readArgument(0), true, readArgument(1));
+  }
+  if (method === 'flatMap') {
+    return flattenTemplateTransformAnalysis(
+      mapValues(source, readArgument(0), true, readArgument(1)),
+      1,
+      bindings,
+      shadowed,
+      seen
+    );
+  }
+  if (method === 'flat') {
+    const depthNode = readArgument(0);
+    const depthValue = depthNode
+      ? readTemplateStaticPrimitive(depthNode, bindings, shadowed, true)
+      : { ok: true as const, value: 1 };
+    if (!depthValue.ok) {
+      const possibilities = [source];
+      let current = source;
+      for (
+        let depth = 0;
+        depth < 32 && current.containers.length > 0;
+        depth += 1
+      ) {
+        current = flattenTemplateTransformAnalysis(
+          current,
+          1,
+          bindings,
+          shadowed,
+          seen
+        );
+        possibilities.push(current);
+      }
+      const merged = mergeDynamicSelectorAnalyses(possibilities);
+      return { ...merged, unknown: true };
+    }
+    if (typeof depthValue.value === 'bigint') {
+      return emptyDynamicSelectorAnalysis(false);
+    }
+    const numericDepth = Number(depthValue.value);
+    const depth = Number.isNaN(numericDepth)
+      ? 0
+      : numericDepth === Number.POSITIVE_INFINITY
+        ? 32
+        : Math.max(0, Math.trunc(numericDepth));
+    return flattenTemplateTransformAnalysis(
+      source,
+      depth,
+      bindings,
+      shadowed,
+      seen
+    );
+  }
+  if (method === 'with' || method === 'toSpliced') {
+    const inserted =
+      method === 'with'
+        ? [readArgument(1)]
+        : call.arguments.slice(2).map((_, index) => readArgument(index + 2));
+    return mergeDynamicSelectorAnalyses([
+      source,
+      ...inserted.flatMap((value) =>
+        value
+          ? [collectTemplateSelectorValue(value, bindings, shadowed, seen)]
+          : []
+      ),
+    ]);
+  }
+  if (method === 'copyWithin') return source;
+  if (method === 'fill') {
+    const value = readArgument(0);
+    return value
+      ? collectTemplateSelectorValue(value, bindings, shadowed, seen)
+      : emptyDynamicSelectorAnalysis(false);
+  }
+  if (method === 'reduce' || method === 'reduceRight') {
+    const reduction = collectTemplateReductionResult(
+      call,
+      bindings,
+      shadowed,
+      seen
+    );
+    if (reduction) {
+      const scalar = { ...reduction, containers: [] };
+      return mergeDynamicSelectorAnalyses([
+        scalar,
+        ...reduction.containers.map((container) =>
+          selectTemplateContainerReference(
+            container,
+            undefined,
+            bindings,
+            shadowed,
+            seen
+          )
+        ),
+      ]);
+    }
+    const flattened = flattenTemplateTransformAnalysis(
+      source,
+      1,
+      bindings,
+      shadowed,
+      seen
+    );
+    const initial = readArgument(1);
+    return mergeDynamicSelectorAnalyses([
+      source,
+      flattened,
+      ...(initial
+        ? [collectTemplateSelectorValue(initial, bindings, shadowed, seen)]
+        : []),
+    ]);
+  }
+  return undefined;
+}
+
+/** Evaluates a finite literal reduce/reduceRight without executing user code. */
+function collectTemplateReductionResult(
+  call: babel.CallExpression | babel.OptionalCallExpression,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> | undefined {
+  const callee = unwrapExpression(call.callee);
+  if (
+    !callee ||
+    (callee.type !== 'MemberExpression' &&
+      callee.type !== 'OptionalMemberExpression')
+  ) {
+    return undefined;
+  }
+  const method = readStaticTemplateMemberProperty(callee, bindings, shadowed);
+  if (method !== 'reduce' && method !== 'reduceRight') return undefined;
+  const receiver = unwrapExpression(callee.object);
+  if (receiver?.type !== 'ArrayExpression') return undefined;
+  const elements = flattenTemplateLiteralArray(receiver, new Set());
+  if (!elements) return undefined;
+  const callbackArgument = call.arguments[0];
+  const callback =
+    callbackArgument &&
+    callbackArgument.type !== 'ArgumentPlaceholder' &&
+    callbackArgument.type !== 'SpreadElement'
+      ? unwrapExpression(callbackArgument)
+      : undefined;
+  if (
+    !callback ||
+    (callback.type !== 'ArrowFunctionExpression' &&
+      callback.type !== 'FunctionExpression')
+  ) {
+    return undefined;
+  }
+  const entries = elements
+    .filter((element): element is babel.Node => Boolean(element))
+    .map((element) =>
+      collectTemplateSelectorValue(element, bindings, shadowed, seen)
+    );
+  const initialArgument = call.arguments[1];
+  const initial =
+    initialArgument &&
+    initialArgument.type !== 'ArgumentPlaceholder' &&
+    initialArgument.type !== 'SpreadElement'
+      ? collectTemplateSelectorValue(initialArgument, bindings, shadowed, seen)
+      : undefined;
+  if (entries.length === 0)
+    return initial ?? emptyDynamicSelectorAnalysis(false);
+  const ordered = method === 'reduceRight' ? [...entries].reverse() : entries;
+  let accumulator = initial ?? ordered.shift();
+  if (!accumulator) return emptyDynamicSelectorAnalysis(false);
+  const sourceArray = collectTemplateSelectorValue(
+    receiver,
+    bindings,
+    shadowed,
+    seen
+  );
+  for (const current of ordered) {
+    const parameters = new Map<
+      string,
+      Omit<DynamicSelectorAnalysis, 'displayName'>
+    >();
+    bindTemplateCallbackParameters(
+      callback,
+      [accumulator, current, emptyDynamicSelectorAnalysis(false), sourceArray],
+      bindings,
+      shadowed,
+      parameters
+    );
+    const returned = collectTemplateFunctionReturns(callback).map((value) =>
+      collectTemplateCallbackReturnValue(
+        value,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      )
+    );
+    accumulator =
+      returned.length > 0
+        ? mergeDynamicSelectorAnalyses(returned)
+        : emptyDynamicSelectorAnalysis(true);
+  }
+  return accumulator;
+}
+
+/** Flattens only container alternatives while retaining non-array values. */
+function flattenTemplateTransformAnalysis(
+  analysis: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  depth: number,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  let current = analysis;
+  for (
+    let index = 0;
+    index < depth && current.containers.length > 0;
+    index += 1
+  ) {
+    const retained = { ...current, containers: [] };
+    const children = current.containers.map((container) =>
+      selectTemplateContainerReference(
+        container,
+        undefined,
+        bindings,
+        shadowed,
+        seen
+      )
+    );
+    current = mergeDynamicSelectorAnalyses([retained, ...children]);
+  }
+  return current;
+}
+
+/** Binds positional callback values, including a precise rest-argument tuple. */
+function bindTemplateCallbackParameters(
+  callback: babel.ArrowFunctionExpression | babel.FunctionExpression,
+  callbackArguments: Array<Omit<DynamicSelectorAnalysis, 'displayName'>>,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  parameters: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>
+): void {
+  callback.params.forEach((parameter, index) => {
+    if (!isTemplateBindingPattern(parameter)) return;
+    if (parameter.type === 'RestElement') {
+      if (!isTemplateBindingPattern(parameter.argument)) return;
+      const restValues = callbackArguments.slice(index);
+      collectTemplateCallbackParameterValues(
+        parameter.argument,
+        {
+          ...emptyDynamicSelectorAnalysis(false),
+          containers: [
+            {
+              kind: 'analysis',
+              containerKind: 'array',
+              members: new Map(
+                restValues.map((value, memberIndex) => [
+                  String(memberIndex),
+                  value,
+                ])
+              ),
+              values: mergeDynamicSelectorAnalyses(restValues),
+            },
+          ],
+        },
+        bindings,
+        shadowed,
+        parameters
+      );
+      return;
+    }
+    collectTemplateCallbackParameterValues(
+      parameter,
+      callbackArguments[index] ?? emptyDynamicSelectorAnalysis(true),
+      bindings,
+      shadowed,
+      parameters
+    );
+  });
+}
+
+/** Projects one mapper input through its callback parameter pattern. */
+function collectTemplateCallbackParameterValues(
+  pattern: TemplateBindingPattern,
+  values: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  parameters: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>
+): void {
+  if (pattern.type === 'Identifier') {
+    parameters.set(pattern.name, values);
+    return;
+  }
+  if (pattern.type === 'AssignmentPattern') {
+    if (isTemplateBindingPattern(pattern.left)) {
+      collectTemplateCallbackParameterValues(
+        pattern.left,
+        mergeDynamicSelectorAnalyses([
+          values,
+          collectDynamicSelectorCandidates(
+            pattern.right,
+            bindings,
+            shadowed,
+            new Set()
+          ),
+        ]),
+        bindings,
+        shadowed,
+        parameters
+      );
+    }
+    return;
+  }
+  if (pattern.type === 'RestElement') {
+    if (isTemplateBindingPattern(pattern.argument)) {
+      collectTemplateCallbackParameterValues(
+        pattern.argument,
+        {
+          ...emptyDynamicSelectorAnalysis(false),
+          containers: [{ kind: 'analysis', containerKind: 'array', values }],
+        },
+        bindings,
+        shadowed,
+        parameters
+      );
+    }
+    return;
+  }
+  if (pattern.type === 'ObjectPattern') {
+    for (const property of pattern.properties) {
+      const target =
+        property.type === 'RestElement' ? property.argument : property.value;
+      if (!isTemplateBindingPattern(target)) continue;
+      collectTemplateCallbackParameterValues(
+        target,
+        property.type === 'RestElement'
+          ? values
+          : selectPossibleContainerChildren(
+              values,
+              readTemplateLiteralPropertyKey(property, bindings, shadowed),
+              bindings,
+              shadowed
+            ),
+        bindings,
+        shadowed,
+        parameters
+      );
+    }
+    return;
+  }
+  pattern.elements.forEach((element, index) => {
+    if (!element || !isTemplateBindingPattern(element)) return;
+    collectTemplateCallbackParameterValues(
+      element,
+      selectPossibleContainerChildren(
+        values,
+        element.type === 'RestElement' ? undefined : String(index),
+        bindings,
+        shadowed
+      ),
+      bindings,
+      shadowed,
+      parameters
+    );
+  });
+}
+
+/** Evaluates a callback return against abstract parameter values. */
+function collectTemplateCallbackReturnValue(
+  node: babel.Node,
+  parameters: Map<string, Omit<DynamicSelectorAnalysis, 'displayName'>>,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const expression = unwrapExpression(node);
+  if (!expression) return emptyDynamicSelectorAnalysis(true);
+  if (expression.type === 'Identifier') {
+    const parameter = parameters.get(expression.name);
+    if (parameter) return parameter;
+  }
+  if (
+    expression.type === 'CallExpression' ||
+    expression.type === 'OptionalCallExpression'
+  ) {
+    const callee = unwrapExpression(expression.callee);
+    if (
+      callee &&
+      (callee.type === 'MemberExpression' ||
+        callee.type === 'OptionalMemberExpression') &&
+      readStaticTemplateMemberProperty(callee, bindings, shadowed) === 'concat'
+    ) {
+      const objectValue = collectTemplateCallbackReturnValue(
+        callee.object,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      );
+      if (objectValue.containers.length > 0) {
+        const flattenOne = (
+          value: Omit<DynamicSelectorAnalysis, 'displayName'>
+        ): Omit<DynamicSelectorAnalysis, 'displayName'> =>
+          mergeDynamicSelectorAnalyses([
+            { ...value, containers: [] },
+            ...value.containers.map((container) =>
+              selectTemplateContainerReference(
+                container,
+                undefined,
+                bindings,
+                shadowed,
+                seen
+              )
+            ),
+          ]);
+        const values = mergeDynamicSelectorAnalyses([
+          flattenOne(objectValue),
+          ...expression.arguments.flatMap((argument) =>
+            argument.type === 'ArgumentPlaceholder'
+              ? []
+              : [
+                  flattenOne(
+                    collectTemplateCallbackReturnValue(
+                      argument.type === 'SpreadElement'
+                        ? argument.argument
+                        : argument,
+                      parameters,
+                      bindings,
+                      shadowed,
+                      seen
+                    )
+                  ),
+                ]
+          ),
+        ]);
+        return {
+          ...emptyDynamicSelectorAnalysis(false),
+          containers: [{ kind: 'analysis', containerKind: 'array', values }],
+        };
+      }
+    }
+  }
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const objectValue = collectTemplateCallbackReturnValue(
+      expression.object,
+      parameters,
+      bindings,
+      shadowed,
+      seen
+    );
+    if (objectValue.containers.length > 0) {
+      return selectPossibleContainerChildren(
+        objectValue,
+        readStaticTemplateMemberProperty(expression, bindings, shadowed),
+        bindings,
+        shadowed
+      );
+    }
+  }
+  if (expression.type === 'ThisExpression') {
+    return parameters.get('this') ?? emptyDynamicSelectorAnalysis(true);
+  }
+  if (expression.type === 'ArrayExpression') {
+    const elementValues = expression.elements.map((element) =>
+      element
+        ? collectTemplateCallbackReturnValue(
+            element.type === 'SpreadElement' ? element.argument : element,
+            parameters,
+            bindings,
+            shadowed,
+            seen
+          )
+        : emptyDynamicSelectorAnalysis(false)
+    );
+    const values = mergeDynamicSelectorAnalyses(elementValues);
+    const hasSpread = expression.elements.some(
+      (element) => element?.type === 'SpreadElement'
+    );
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [
+        {
+          kind: 'analysis',
+          containerKind: 'array',
+          members: hasSpread
+            ? undefined
+            : new Map(
+                elementValues.map((value, index) => [String(index), value])
+              ),
+          values,
+        },
+      ],
+    };
+  }
+  if (expression.type === 'ObjectExpression') {
+    const values = mergeDynamicSelectorAnalyses(
+      expression.properties.map((property) =>
+        collectTemplateCallbackReturnValue(
+          property.type === 'SpreadElement'
+            ? property.argument
+            : property.type === 'ObjectProperty'
+              ? property.value
+              : property,
+          parameters,
+          bindings,
+          shadowed,
+          seen
+        )
+      )
+    );
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'analysis', containerKind: 'object', values }],
+    };
+  }
+  if (expression.type === 'ConditionalExpression') {
+    return mergeDynamicSelectorAnalyses([
+      collectTemplateCallbackReturnValue(
+        expression.consequent,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      ),
+      collectTemplateCallbackReturnValue(
+        expression.alternate,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      ),
+    ]);
+  }
+  if (expression.type === 'LogicalExpression') {
+    return mergeDynamicSelectorAnalyses([
+      collectTemplateCallbackReturnValue(
+        expression.left,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      ),
+      collectTemplateCallbackReturnValue(
+        expression.right,
+        parameters,
+        bindings,
+        shadowed,
+        seen
+      ),
+    ]);
+  }
+  if (expression.type === 'SequenceExpression') {
+    const last = expression.expressions.at(-1);
+    return last
+      ? collectTemplateCallbackReturnValue(
+          last,
+          parameters,
+          bindings,
+          shadowed,
+          seen
+        )
+      : emptyDynamicSelectorAnalysis(true);
+  }
+  return collectTemplateSelectorValue(expression, bindings, shadowed, seen);
+}
+
+/** Resolves an expression to container identities without selecting a child. */
+function collectTemplateContainerReferences(
+  node: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) {
+    return emptyDynamicSelectorAnalysis(true);
+  }
+  if (
+    expression.type === 'ArrayExpression' ||
+    expression.type === 'ObjectExpression'
+  ) {
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'literal', node: expression }],
+    };
+  }
+  const path = readStaticTemplateMemberPath(expression, bindings, shadowed);
+  if (path && bindings.containerKinds.has(path)) {
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'path', path }],
+    };
+  }
+  const selected = collectDynamicSelectorCandidates(
+    expression,
+    bindings,
+    shadowed,
+    seen
+  );
+  return {
+    ...emptyDynamicSelectorAnalysis(selected.unknown),
+    containers: selected.containers,
+  };
+}
+
+/** Selects one exact child, or every immediate child, from a container. */
+function selectTemplateContainerReference(
+  container: DynamicSelectorContainer,
+  key: string | undefined,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  if (container.kind === 'path') {
+    return key === undefined
+      ? collectExposedContainerCandidates(container.path, bindings)
+      : collectExposedPathCandidate(
+          appendTemplatePath(container.path, key),
+          bindings
+        );
+  }
+  if (container.kind === 'analysis') {
+    const selected =
+      key === undefined ? container.values : container.members?.get(key);
+    return selected
+      ? { ...selected, unknown: selected.unknown || key === undefined }
+      : emptyDynamicSelectorAnalysis(true);
+  }
+  if (key === undefined) {
+    return collectLiteralContainerCandidates(
+      container.node,
+      bindings,
+      shadowed,
+      seen
+    );
+  }
+  const selected = selectTemplateLiteralMember(container.node, key);
+  return selected
+    ? collectTemplateSelectorValue(selected, bindings, shadowed, seen)
+    : templateLiteralMemberIsUncertain(container.node, key)
+      ? collectLiteralContainerCandidates(
+          container.node,
+          bindings,
+          shadowed,
+          seen
+        )
+      : emptyDynamicSelectorAnalysis(false);
+}
+
+/** Reads one exact flattened script path, retaining its value category. */
+function collectExposedPathCandidate(
+  path: string,
+  bindings: TemplateBindings
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const result = emptyDynamicSelectorAnalysis(false);
+  const value = bindings.staticValues.get(path);
+  if (typeof value === 'string') {
+    result.candidates.push({ kind: 'string', name: value });
+  }
+  const possibleStrings = bindings.possibleStaticStrings.get(path);
+  if (possibleStrings) {
+    for (const possible of possibleStrings) {
+      result.candidates.push({ kind: 'string', name: possible });
+    }
+    result.unknown = possibleStrings.size > 0;
+  }
+  if (
+    bindings.components.has(path) ||
+    bindings.vueBuiltins.has(path) ||
+    bindings.uncertainComponents.has(path)
+  ) {
+    result.candidates.push({ kind: 'expression', name: path });
+  }
+  if (bindings.componentFactories.has(path)) {
+    result.componentFactories.add(path);
+    result.candidates.push({ kind: 'expression', name: path });
+  }
+  if (bindings.gtComponentFactories.has(path)) {
+    result.gtComponentFactories.add(path);
+  }
+  if (bindings.containerKinds.has(path)) {
+    result.containers.push({ kind: 'path', path });
+  }
+  const possibleContainer = findPossibleGTContainerPath(path, bindings);
+  if (possibleContainer) {
+    result.containers.push({ kind: 'path', path: possibleContainer });
+  }
+  result.possibleGT ||= templatePathSelectsPossibleGT(path, bindings);
+  result.unknown =
+    result.unknown ||
+    bindings.uncertainComponents.has(path) ||
+    (result.candidates.length === 0 &&
+      result.componentFactories.size === 0 &&
+      result.containers.length === 0);
+  return result;
+}
+
+/** Returns true only for arrays whose shape was proven by static analysis. */
+function isKnownTemplateArray(
+  container: DynamicSelectorContainer,
+  bindings: TemplateBindings
+): boolean {
+  return container.kind === 'literal'
+    ? container.node.type === 'ArrayExpression'
+    : container.kind === 'analysis'
+      ? container.containerKind === 'array'
+      : bindings.containerKinds.get(container.path) === 'array';
+}
+
+/** Detects a statically defined own property that overrides an array method. */
+function templateContainerHasOwnMember(
+  container: DynamicSelectorContainer,
+  member: string,
+  bindings: TemplateBindings
+): boolean {
+  if (container.kind !== 'path') return false;
+  const path = appendTemplatePath(container.path, member);
+  return (
+    bindings.components.has(path) ||
+    bindings.componentFactories.has(path) ||
+    bindings.containerKinds.has(path) ||
+    bindings.gtComponentFactories.has(path) ||
+    bindings.staticValues.has(path) ||
+    bindings.uncertainComponents.has(path) ||
+    bindings.vueBuiltins.has(path)
+  );
+}
+
+/** Resolves the exact child selected by an array method when it is static. */
+function readSelectingArrayMethodKey(
+  method: string,
+  argument: babel.CallExpression['arguments'][number] | undefined,
+  container: DynamicSelectorContainer,
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): string | null | undefined {
+  if (templateContainerHasOwnMember(container, method, bindings)) {
+    return null;
+  }
+  const length =
+    container.kind === 'literal'
+      ? container.node.type === 'ArrayExpression'
+        ? flattenTemplateLiteralArray(container.node, new Set())?.length
+        : undefined
+      : container.kind === 'path'
+        ? bindings.arrayLengths.get(container.path)
+        : undefined;
+  if (method === 'shift') return length === 0 ? null : '0';
+  if (method === 'pop') {
+    return length === undefined
+      ? undefined
+      : length === 0
+        ? null
+        : `${length - 1}`;
+  }
+  if (method !== 'at') return undefined;
+
+  if (
+    argument?.type === 'ArgumentPlaceholder' ||
+    argument?.type === 'SpreadElement'
+  ) {
+    return undefined;
+  }
+  const indexValue = argument
+    ? readTemplateStaticPrimitive(argument, bindings, shadowed)
+    : { ok: true as const, value: 0 };
+  if (!indexValue.ok) return undefined;
+  if (typeof indexValue.value === 'bigint') return null;
+  let index: number;
+  try {
+    index = Number(indexValue.value);
+  } catch {
+    return null;
+  }
+  if (Number.isNaN(index)) index = 0;
+  else if (!Number.isFinite(index)) return null;
+  index = Math.trunc(index);
+  if (index < 0) {
+    if (length === undefined) return undefined;
+    index += length;
+  }
+  if (index < 0 || (length !== undefined && index >= length)) return null;
+  return String(index);
+}
+
+/** Collects only the immediate values that one literal selection may return. */
+function collectLiteralContainerCandidates(
+  container: babel.ArrayExpression | babel.ObjectExpression,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  if (container.type === 'ArrayExpression') {
+    const flattened = flattenTemplateLiteralArray(container, new Set());
+    const values = flattened
+      ? flattened.filter((value): value is babel.Node => Boolean(value))
+      : container.elements.flatMap((element) =>
+          !element ? [] : element.type === 'SpreadElement' ? [] : [element]
+        );
+    const analyses = values.map((value) =>
+      collectTemplateSelectorValue(value, bindings, shadowed, seen)
+    );
+    if (!flattened) {
+      for (const element of container.elements) {
+        if (element?.type !== 'SpreadElement') continue;
+        analyses.push(
+          collectTemplateContainerCandidates(
+            element.argument,
+            bindings,
+            shadowed,
+            seen
+          )
+        );
+      }
+    }
+    const result = mergeDynamicSelectorAnalyses(analyses);
+    return { ...result, unknown: result.unknown || !flattened };
+  }
+
+  const properties = flattenTemplateLiteralObject(container, new Set());
+  const finalValues = new Map<string, babel.Node>();
+  const uncertainValues: babel.Node[] = [];
+  const spreadAnalyses: Array<Omit<DynamicSelectorAnalysis, 'displayName'>> =
+    [];
+  for (const property of properties ?? container.properties) {
+    if (property.type === 'SpreadElement') {
+      spreadAnalyses.push(
+        collectTemplateContainerCandidates(
+          property.argument,
+          bindings,
+          shadowed,
+          seen
+        )
+      );
+      continue;
+    }
+    const key = readTemplateLiteralPropertyKey(property, bindings, shadowed);
+    const value =
+      property.type === 'ObjectProperty'
+        ? property.value
+        : property.type === 'ObjectMethod' && property.kind === 'get'
+          ? property
+          : undefined;
+    if (!value) continue;
+    if (key === undefined) uncertainValues.push(value);
+    else finalValues.set(key, value);
+  }
+  const analyses = [...finalValues.values(), ...uncertainValues].map((value) =>
+    collectTemplateSelectorValue(value, bindings, shadowed, seen)
+  );
+  analyses.push(...spreadAnalyses);
+  const result = mergeDynamicSelectorAnalyses(analyses);
+  return {
+    ...result,
+    unknown:
+      result.unknown || properties === undefined || uncertainValues.length > 0,
+  };
+}
+
+/** Preserves a nested literal as a container instead of flattening its leaves. */
+function collectTemplateSelectorValue(
+  node: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  if (node.type === 'ObjectMethod' && node.kind === 'get') {
+    const returns = collectTemplateFunctionReturns(node);
+    const result = mergeDynamicSelectorAnalyses(
+      returns.map((value) =>
+        collectTemplateSelectorValue(value, bindings, shadowed, seen)
+      )
+    );
+    return { ...result, unknown: true };
+  }
+  const expression = unwrapExpression(node);
+  if (
+    expression?.type === 'ArrayExpression' ||
+    expression?.type === 'ObjectExpression'
+  ) {
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'literal', node: expression }],
+    };
+  }
+  const path = readStaticTemplateMemberPath(expression, bindings, shadowed);
+  if (path && bindings.containerKinds.has(path)) {
+    return {
+      ...emptyDynamicSelectorAnalysis(false),
+      containers: [{ kind: 'path', path }],
+    };
+  }
+  return expression
+    ? collectDynamicSelectorCandidates(expression, bindings, shadowed, seen)
+    : emptyDynamicSelectorAnalysis(true);
+}
+
+/** Collects returns from one function body without entering nested functions. */
+function collectTemplateCallableReturnAnalysis(
+  fn:
+    | babel.ArrowFunctionExpression
+    | babel.FunctionExpression
+    | babel.ObjectMethod,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  return mergeDynamicSelectorAnalyses(
+    collectTemplateFunctionReturns(fn).map((value) =>
+      collectTemplateSelectorValue(value, bindings, shadowed, seen)
+    )
+  );
+}
+
+function collectTemplateFunctionReturns(
+  fn:
+    | babel.ArrowFunctionExpression
+    | babel.FunctionExpression
+    | babel.ObjectMethod
+): babel.Expression[] {
+  if (
+    fn.type === 'ArrowFunctionExpression' &&
+    fn.body.type !== 'BlockStatement'
+  ) {
+    return [fn.body];
+  }
+  const returns: babel.Expression[] = [];
+  const visit = (node: babel.Node): void => {
+    if (node !== fn && babel.isFunction(node)) return;
+    if (node.type === 'ReturnStatement') {
+      if (node.argument && babel.isExpression(node.argument)) {
+        returns.push(node.argument);
+      }
+      return;
+    }
+    for (const key of babel.VISITOR_KEYS[node.type] ?? []) {
+      const child = (node as unknown as Record<string, unknown>)[key];
+      if (Array.isArray(child)) {
+        for (const entry of child) {
+          if (entry && typeof entry === 'object' && 'type' in entry) {
+            visit(entry as babel.Node);
+          }
+        }
+      } else if (child && typeof child === 'object' && 'type' in child) {
+        visit(child as babel.Node);
+      }
+    }
+  };
+  visit(fn);
+  return returns;
+}
+
+/** Expands literal-only object spreads while preserving property write order. */
+function flattenTemplateLiteralObject(
+  object: babel.ObjectExpression,
+  seen: Set<babel.Node>
+): babel.ObjectExpression['properties'] | undefined {
+  if (seen.has(object)) return undefined;
+  const nextSeen = new Set(seen).add(object);
+  const properties: babel.ObjectExpression['properties'] = [];
+  for (const property of object.properties) {
+    if (property.type !== 'SpreadElement') {
+      properties.push(property);
+      continue;
+    }
+    const argument = unwrapExpression(property.argument);
+    if (argument?.type !== 'ObjectExpression') return undefined;
+    const spread = flattenTemplateLiteralObject(argument, nextSeen);
+    if (!spread) return undefined;
+    properties.push(...spread);
+  }
+  return properties;
+}
+
+/** Resolves a literal object key without executing user code. */
+function readTemplateLiteralPropertyKey(
+  property: babel.ObjectExpression['properties'][number],
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): string | undefined {
+  if (property.type === 'SpreadElement') return undefined;
+  if (!property.computed && property.key.type === 'Identifier') {
+    return property.key.name;
+  }
+  if (property.key.type === 'StringLiteral') return property.key.value;
+  if (property.key.type === 'NumericLiteral') return String(property.key.value);
+  if (!property.computed) return undefined;
+  const key = readTemplateStaticPrimitive(property.key, bindings, shadowed);
+  return key.ok &&
+    (typeof key.value === 'string' || typeof key.value === 'number')
+    ? String(key.value)
+    : undefined;
+}
+
+/** Collects exact component-bearing descendants exposed by script analysis. */
+function collectExposedContainerCandidates(
+  path: string,
+  bindings: TemplateBindings
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const candidates = new Map<string, DynamicSelectorCandidate>();
+  const componentFactories = new Set<string>();
+  const containers: DynamicSelectorContainer[] = [];
+  const gtComponentFactories = new Set<string>();
+  const prefix = `${path}.`;
+  const isImmediateChild = (name: string) => {
+    if (!name.startsWith(prefix)) return false;
+    const suffix = name.slice(prefix.length);
+    return !suffix.includes('.');
+  };
+  const addExpression = (name: string) => {
+    if (!isImmediateChild(name)) return;
+    candidates.set(`expression:${name}`, { kind: 'expression', name });
+  };
+
+  for (const name of bindings.components.keys()) addExpression(name);
+  for (const name of bindings.vueBuiltins.keys()) addExpression(name);
+  for (const name of bindings.uncertainComponents) addExpression(name);
+  for (const [name, value] of bindings.staticValues) {
+    if (isImmediateChild(name) && typeof value === 'string') {
+      candidates.set(`string:${value}`, { kind: 'string', name: value });
+    }
+  }
+  for (const [name, values] of bindings.possibleStaticStrings) {
+    if (!isImmediateChild(name)) continue;
+    for (const value of values) {
+      candidates.set(`string:${value}`, { kind: 'string', name: value });
+    }
+  }
+  for (const name of bindings.componentFactories) {
+    if (!isImmediateChild(name)) continue;
+    componentFactories.add(name);
+    addExpression(name);
+  }
+  for (const name of bindings.gtComponentFactories) {
+    if (!isImmediateChild(name)) continue;
+    gtComponentFactories.add(name);
+    addExpression(name);
+  }
+  for (const [name] of bindings.containerKinds) {
+    if (isImmediateChild(name)) containers.push({ kind: 'path', path: name });
+  }
+  const addNestedContainer = (
+    name: string,
+    requireNestedChild: boolean
+  ): void => {
+    if (!name.startsWith(prefix)) return;
+    const suffix = name.slice(prefix.length);
+    if (requireNestedChild && !suffix.includes('.')) return;
+    const firstSegment = suffix.split('.', 1)[0];
+    if (!firstSegment) return;
+    const childPath = `${prefix}${firstSegment}`;
+    if (
+      !containers.some(
+        (container) => container.kind === 'path' && container.path === childPath
+      )
+    ) {
+      containers.push({ kind: 'path', path: childPath });
+    }
+  };
+  for (const name of bindings.possibleGTContainers) {
+    addNestedContainer(name, false);
+  }
+  for (const name of bindings.possibleStaticStrings.keys()) {
+    addNestedContainer(name, true);
+  }
+
+  return {
+    candidates: [...candidates.values()],
+    componentFactories,
+    containers,
+    gtComponentFactories,
+    possibleGT: findPossibleGTContainerPath(path, bindings) !== undefined,
+    unknown: true,
+  };
+}
+
+/** Returns whether selecting one direct child of a tainted path can yield T. */
+function templatePathSelectsPossibleGT(
+  path: string,
+  bindings: TemplateBindings
+): boolean {
+  const separator = path.lastIndexOf('.');
+  return (
+    separator > 0 &&
+    findPossibleGTContainerPath(path.slice(0, separator), bindings) !==
+      undefined
+  );
+}
+
+/** Finds an exact or wildcard tainted-container path. */
+function findPossibleGTContainerPath(
+  path: string,
+  bindings: TemplateBindings
+): string | undefined {
+  if (bindings.possibleGTContainers.has(path)) return path;
+  const wildcard = appendTemplatePath('', unknownTemplatePathSegment).slice(1);
+  const recursiveSuffix = appendTemplatePath('', recursiveTemplatePathSegment);
+  const segments = path.split('.');
+  for (const candidate of bindings.possibleGTContainers) {
+    if (candidate.endsWith(recursiveSuffix)) {
+      const recursiveRoot = candidate.slice(0, -recursiveSuffix.length);
+      if (path === recursiveRoot || path.startsWith(`${recursiveRoot}.`)) {
+        return candidate;
+      }
+    }
+    const candidateSegments = candidate.split('.');
+    if (
+      candidateSegments.length === segments.length &&
+      candidateSegments.every(
+        (segment, index) => segment === wildcard || segment === segments[index]
+      )
+    ) {
+      return candidate;
+    }
+  }
+  return undefined;
+}
+
+/** Returns whether one selected child contains a tainted container path. */
+function hasImmediatePossibleGTContainerChild(
+  path: string,
+  bindings: TemplateBindings
+): boolean {
+  const prefix = `${path}.`;
+  return [...bindings.possibleGTContainers].some((candidate) =>
+    candidate.startsWith(prefix)
+  );
+}
+
+/** Returns whether one selected child can expose a known selector string. */
+function hasPossibleStaticStringChild(
+  path: string,
+  bindings: TemplateBindings
+): boolean {
+  const prefix = `${path}.`;
+  return [...bindings.possibleStaticStrings].some(
+    ([candidate, values]) => candidate.startsWith(prefix) && values.size > 0
+  );
+}
+
+/** Selects through nested literal member chains in a template expression. */
+function selectTemplateStaticMemberExpression(
+  node: babel.Node,
+  key: string,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  seen: Set<babel.Node>
+): babel.Node | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression || seen.has(expression)) return undefined;
+  const nextSeen = new Set(seen).add(expression);
+  if (
+    expression.type === 'MemberExpression' ||
+    expression.type === 'OptionalMemberExpression'
+  ) {
+    const parentKey = readStaticTemplateMemberProperty(
+      expression,
+      bindings,
+      shadowed
+    );
+    const parent =
+      parentKey === undefined
+        ? undefined
+        : selectTemplateStaticMemberExpression(
+            expression.object,
+            parentKey,
+            bindings,
+            shadowed,
+            nextSeen
+          );
+    return parent
+      ? selectTemplateStaticMemberExpression(
+          parent,
+          key,
+          bindings,
+          shadowed,
+          nextSeen
+        )
+      : undefined;
+  }
+  return selectTemplateLiteralMember(expression, key);
+}
+
+function selectorAnalysisIsKnownComponent(
+  analysis: Omit<DynamicSelectorAnalysis, 'displayName'>,
+  bindings: TemplateBindings
+): boolean {
+  return (
+    !analysis.unknown &&
+    analysis.componentFactories.size === 0 &&
+    analysis.candidates.length > 0 &&
+    analysis.candidates.every((candidate) =>
+      [...normalizeTemplateBindingNames(candidate.name)].some((name) =>
+        candidate.kind === 'string'
+          ? bindings.registeredComponents.has(name) ||
+            bindings.registeredVueBuiltins.has(name)
+          : bindings.components.has(name) || bindings.vueBuiltins.has(name)
+      )
+    )
+  );
+}
+
+function selectorCandidate(
+  kind: DynamicSelectorCandidate['kind'],
+  name: string
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  return {
+    candidates: [{ kind, name }],
+    componentFactories: new Set(),
+    containers: [],
+    gtComponentFactories: new Set(),
+    possibleGT: false,
+    unknown: false,
+  };
+}
+
+function emptyDynamicSelectorAnalysis(
+  unknown: boolean
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  return {
+    candidates: [],
+    componentFactories: new Set(),
+    containers: [],
+    gtComponentFactories: new Set(),
+    possibleGT: false,
+    unknown,
+  };
+}
+
+function mergeDynamicSelectorAnalyses(
+  analyses: Array<Omit<DynamicSelectorAnalysis, 'displayName'>>
+): Omit<DynamicSelectorAnalysis, 'displayName'> {
+  const candidates = new Map<string, DynamicSelectorCandidate>();
+  const componentFactories = new Set<string>();
+  const containers: DynamicSelectorContainer[] = [];
+  const containerPaths = new Set<string>();
+  const literalContainers = new Set<babel.Node>();
+  const abstractContainers = new Set<DynamicSelectorContainer>();
+  const gtComponentFactories = new Set<string>();
+  let possibleGT = false;
+  let unknown = false;
+  for (const analysis of analyses) {
+    possibleGT ||= analysis.possibleGT;
+    unknown ||= analysis.unknown;
+    for (const candidate of analysis.candidates) {
+      candidates.set(`${candidate.kind}:${candidate.name}`, candidate);
+    }
+    for (const name of analysis.componentFactories) {
+      componentFactories.add(name);
+    }
+    for (const container of analysis.containers) {
+      if (container.kind === 'path') {
+        if (containerPaths.has(container.path)) continue;
+        containerPaths.add(container.path);
+      } else if (container.kind === 'literal') {
+        if (literalContainers.has(container.node)) continue;
+        literalContainers.add(container.node);
+      } else {
+        if (abstractContainers.has(container)) continue;
+        abstractContainers.add(container);
+      }
+      containers.push(container);
+    }
+    for (const name of analysis.gtComponentFactories) {
+      gtComponentFactories.add(name);
+    }
+  }
+  return {
+    candidates: [...candidates.values()],
+    componentFactories,
+    containers,
+    gtComponentFactories,
+    possibleGT,
+    unknown,
+  };
+}
+
+/** Selects a literal array/object member used directly in a template. */
+function selectTemplateLiteralMember(
+  node: babel.Node,
+  key: string
+): babel.Node | undefined {
+  const expression = unwrapExpression(node);
+  if (expression?.type === 'ArrayExpression') {
+    const index = key.match(/^(0|[1-9]\d*)$/) ? Number(key) : undefined;
+    const elements = flattenTemplateLiteralArray(expression, new Set());
+    return index === undefined ? undefined : elements?.[index];
+  }
+  if (expression?.type !== 'ObjectExpression') return undefined;
+  const properties =
+    flattenTemplateLiteralObject(expression, new Set()) ??
+    expression.properties;
+  let selected: babel.Node | undefined;
+  let uncertainWriteAfterSelection = false;
+  for (const property of properties) {
+    if (property.type === 'SpreadElement') {
+      uncertainWriteAfterSelection = true;
+      continue;
+    }
+    const propertyKey =
+      !property.computed && property.key.type === 'Identifier'
+        ? property.key.name
+        : property.key.type === 'StringLiteral'
+          ? property.key.value
+          : property.key.type === 'NumericLiteral'
+            ? String(property.key.value)
+            : undefined;
+    if (propertyKey === undefined) {
+      uncertainWriteAfterSelection = true;
+      continue;
+    }
+    if (propertyKey === key) {
+      selected =
+        property.type === 'ObjectProperty' || property.type === 'ObjectMethod'
+          ? property.type === 'ObjectProperty'
+            ? property.value
+            : property
+          : undefined;
+      uncertainWriteAfterSelection = false;
+    }
+  }
+  return uncertainWriteAfterSelection ? undefined : selected;
+}
+
+/** Returns whether an unresolved literal member can be supplied by a spread. */
+function templateLiteralMemberIsUncertain(
+  node: babel.ArrayExpression | babel.ObjectExpression,
+  key: string
+): boolean {
+  if (node.type === 'ArrayExpression') {
+    return (
+      /^(0|[1-9]\d*)$/.test(key) &&
+      flattenTemplateLiteralArray(node, new Set()) === undefined
+    );
+  }
+  if (flattenTemplateLiteralObject(node, new Set())) return false;
+  let uncertain = false;
+  for (const property of node.properties) {
+    if (property.type === 'SpreadElement') {
+      uncertain = true;
+      continue;
+    }
+    const propertyKey =
+      !property.computed && property.key.type === 'Identifier'
+        ? property.key.name
+        : property.key.type === 'StringLiteral'
+          ? property.key.value
+          : property.key.type === 'NumericLiteral'
+            ? String(property.key.value)
+            : undefined;
+    if (propertyKey === undefined) uncertain = true;
+    else if (propertyKey === key) uncertain = false;
+  }
+  return uncertain;
+}
+
+/** Flattens array spreads only when every spread operand is another literal. */
+function flattenTemplateLiteralArray(
+  array: babel.ArrayExpression,
+  seen: Set<babel.Node>
+): Array<babel.Node | undefined> | undefined {
+  if (seen.has(array)) return undefined;
+  const nextSeen = new Set(seen).add(array);
+  const elements: Array<babel.Node | undefined> = [];
+  for (const element of array.elements) {
+    if (!element) {
+      elements.push(undefined);
+      continue;
+    }
+    if (element.type !== 'SpreadElement') {
+      elements.push(element);
+      continue;
+    }
+    const argument = unwrapExpression(element.argument);
+    if (argument?.type !== 'ArrayExpression') return undefined;
+    const spread = flattenTemplateLiteralArray(argument, nextSeen);
+    if (!spread) return undefined;
+    elements.push(...spread);
+  }
+  return elements;
+}
+
+/** Resolves a computed member key from literals or exposed static bindings. */
+function readStaticTemplateMemberProperty(
+  node: babel.MemberExpression | babel.OptionalMemberExpression,
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): string | undefined {
+  if (!node.computed && node.property.type === 'Identifier') {
+    return node.property.name;
+  }
+  if (!node.computed) return undefined;
+  const property = readTemplateStaticPrimitive(
+    node.property,
+    bindings,
+    shadowed
+  );
+  return property.ok &&
+    (typeof property.value === 'string' || typeof property.value === 'number')
+    ? String(property.value)
+    : undefined;
+}
+
+function readTemplateStaticPrimitive(
+  node: babel.Node,
+  bindings: TemplateBindings,
+  shadowed: Set<string>,
+  allowNumericGlobals = false
+) {
+  return readStaticPrimitive(node, (identifier) => {
+    if (shadowed.has(identifier.name)) {
+      return { ok: false };
+    }
+    if (bindings.staticValues.has(identifier.name)) {
+      return { ok: true, value: bindings.staticValues.get(identifier.name)! };
+    }
+    if (
+      allowNumericGlobals &&
+      !bindings.directBindings.has(identifier.name) &&
+      identifier.name === 'Infinity'
+    ) {
+      return { ok: true, value: Number.POSITIVE_INFINITY };
+    }
+    if (
+      allowNumericGlobals &&
+      !bindings.directBindings.has(identifier.name) &&
+      identifier.name === 'NaN'
+    ) {
+      return { ok: true, value: Number.NaN };
+    }
+    return { ok: false };
+  });
+}
+
+/** Reads a dotted template member chain without evaluating runtime code. */
+function readStaticTemplateMemberPath(
+  node: babel.Node | undefined,
+  bindings: TemplateBindings,
+  shadowed: Set<string>
+): string | undefined {
+  const expression = unwrapExpression(node);
+  if (!expression) return undefined;
+  if (expression.type === 'Identifier') {
+    return shadowed.has(expression.name) ? undefined : expression.name;
+  }
+  if (
+    expression.type !== 'MemberExpression' &&
+    expression.type !== 'OptionalMemberExpression'
+  ) {
+    return undefined;
+  }
+  const object = readStaticTemplateMemberPath(
+    expression.object,
+    bindings,
+    shadowed
+  );
+  const property = readStaticTemplateMemberProperty(
+    expression,
+    bindings,
+    shadowed
+  );
+  return object && property !== undefined
+    ? appendTemplatePath(object, property)
+    : undefined;
+}
+
+/** Identifies the selector prop that Vue consumes for `<component>`. */
+function isDynamicComponentSelector(
+  element: ElementNode,
+  property: ElementNode['props'][number]
+): boolean {
+  if (element.tag.toLowerCase() !== 'component') return false;
+  if (property.type === NodeTypes.ATTRIBUTE) return property.name === 'is';
+  return property.name === 'bind' && readDirectiveKey(property) === 'is';
+}
+
+function readDirectiveKey(directive: DirectiveNode): string | undefined {
+  return directive.arg?.type === NodeTypes.SIMPLE_EXPRESSION &&
+    directive.arg.isStatic
+    ? directive.arg.content
+    : undefined;
+}
+
+function toDisplayString(value: StaticPrimitive): string {
+  return value == null ? '' : String(value);
+}
+
+function appendSerializedChild(result: JsxChild[], value: JsxChild): void {
+  const previous = result[result.length - 1];
+  if (typeof previous === 'string' && typeof value === 'string') {
+    result[result.length - 1] = previous + value;
+  } else {
+    result.push(value);
+  }
+}
+
+function collapseChildren(children: JsxChild[]): JsxChildren {
+  return children.length === 1 ? children[0] : children;
+}
+
+function unionSets(first: Set<string>, second: Set<string>): Set<string> {
+  return second.size === 0 ? first : new Set([...first, ...second]);
+}

--- a/packages/vue-extractor/src/internal/templatePath.ts
+++ b/packages/vue-extractor/src/internal/templatePath.ts
@@ -1,0 +1,21 @@
+/** Internal segment reserved for an unresolved object key. */
+export const unknownTemplatePathSegment = '%GT_UNKNOWN%';
+
+/** Internal segment marking a GT-bearing identity reachable through a cycle. */
+export const recursiveTemplatePathSegment = '%GT_RECURSIVE%';
+
+/**
+ * Appends one property to a flattened template-binding path.
+ *
+ * Dots delimit JavaScript member segments internally, so literal dots and
+ * percent escapes in property names must be encoded before concatenation.
+ * This keeps `value.a.b` distinct from `value['a.b']`.
+ */
+export function appendTemplatePath(path: string, property: string): string {
+  return `${path}.${encodeTemplatePathSegment(property)}`;
+}
+
+/** Encodes the only characters that can collide with the path wire format. */
+function encodeTemplatePathSegment(segment: string): string {
+  return segment.replace(/%/g, '%25').replace(/\./g, '%2E');
+}

--- a/packages/vue-extractor/src/internal/types.ts
+++ b/packages/vue-extractor/src/internal/types.ts
@@ -1,0 +1,83 @@
+import type { VueExtractionResult } from '../types.js';
+import type { ImplicitSlotWhitespace } from './vueCompiler.js';
+
+export type GTComponentName =
+  | 'T'
+  | 'Var'
+  | 'Num'
+  | 'DateTime'
+  | 'Currency'
+  | 'Plural'
+  | 'Branch';
+
+/** Vue builtins whose runtime identity changes rich-content traversal. */
+export type VueBuiltinName = 'Fragment' | 'Suspense';
+
+export type StringFunctionKind = 'gt' | 'messages' | 'msg';
+export type TemplateContainerKind = 'array' | 'object';
+
+export type TemplateBindings = {
+  /** Lengths of statically known, non-mutated array paths. */
+  arrayLengths: Map<string, number>;
+  /** Callable bindings that may return a GT or Vue component identity. */
+  componentFactories: Set<string>;
+  components: Map<string, GTComponentName>;
+  /** Statically known container paths available to template expressions. */
+  containerKinds: Map<string, TemplateContainerKind>;
+  /** Container paths whose immediate runtime value may be a GT component. */
+  possibleGTContainers: Set<string>;
+  /** Callable paths whose returned container may directly contain `<T>`. */
+  gtContainerFactories: Set<string>;
+  /** Program bindings whose identity takes precedence over registrations. */
+  directBindings: Set<string>;
+  /** GT identities registered through an Options API `components` object. */
+  registeredComponents: Map<string, GTComponentName>;
+  /** Vue builtin identities registered through an Options API object. */
+  registeredVueBuiltins: Map<string, VueBuiltinName>;
+  staticValues: Map<string, string | number | bigint | boolean | null>;
+  /** Vue identity helpers such as `markRaw`. */
+  identityFunctions: Set<string>;
+  /** Statically visible string alternatives for non-singleton expressions. */
+  possibleStaticStrings: Map<string, Set<string>>;
+  stringFunctions: Map<string, StringFunctionKind>;
+  /** Callable aliases that may resolve to a gt-vue string function. */
+  uncertainStringFunctions: Set<string>;
+  /** Component aliases whose runtime identity escaped static analysis. */
+  uncertainComponents: Set<string>;
+  /** Direct aliases that can specifically resolve to a GT component. */
+  uncertainGTComponents: Set<string>;
+  /** Callable bindings that may specifically return a GT component. */
+  gtComponentFactories: Set<string>;
+  /** Uncertain identities originating in an Options API registration. */
+  uncertainRegisteredComponents: Set<string>;
+  /** Uncertain GT identities originating in an Options API registration. */
+  uncertainRegisteredGTComponents: Set<string>;
+  /** Statically proven local aliases of Vue builtins. */
+  vueBuiltins: Map<string, VueBuiltinName>;
+};
+
+export type ExtractionPosition = {
+  line: number;
+  column: number;
+  offset: number;
+};
+
+export type ExtractionLocation = {
+  start: ExtractionPosition;
+  end: ExtractionPosition;
+};
+
+export type VueExtractionContext = {
+  errors: string[];
+  file: string;
+  /** Whitespace predicate used by the resolved consumer Vue compiler. */
+  implicitSlotWhitespace: ImplicitSlotWhitespace;
+  includeSourceCodeContext: boolean;
+  relativeFile: string;
+  results: VueExtractionResult[];
+  source: string;
+  surroundingLineCount: number;
+  /** Variable component nodes whose public shape was already validated. */
+  validatedVariableComponents: WeakSet<object>;
+  warnings: Set<string>;
+};

--- a/packages/vue-extractor/src/internal/utils.ts
+++ b/packages/vue-extractor/src/internal/utils.ts
@@ -1,0 +1,234 @@
+import path from 'node:path';
+import type * as t from '@babel/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import type { VueExtractionResult, VueSourceCode } from '../types.js';
+import type { ExtractionLocation, VueExtractionContext } from './types.js';
+
+export function createVueExtractionContext(
+  file: string,
+  source: string,
+  projectRoot: string,
+  includeSourceCodeContext: boolean,
+  surroundingLineCount: number,
+  results: VueExtractionResult[],
+  errors: string[],
+  warnings: Set<string>
+): VueExtractionContext {
+  return {
+    errors,
+    file,
+    // Script-only extraction never reads this field. Vue SFC extraction
+    // replaces it with the resolved consumer compiler's behavior before
+    // traversing the template.
+    implicitSlotWhitespace: 'ecmascript',
+    includeSourceCodeContext,
+    relativeFile: path.relative(projectRoot, file),
+    results,
+    source,
+    surroundingLineCount,
+    validatedVariableComponents: new WeakSet(),
+    warnings,
+  };
+}
+
+export function addVueError(
+  context: VueExtractionContext,
+  location: ExtractionLocation | undefined,
+  whatHappened: string,
+  fix?: string
+): void {
+  const position = location
+    ? ` (${location.start.line}:${location.start.column})`
+    : '';
+  context.errors.push(
+    `${context.file}${position}: ${createDiagnosticMessage({ whatHappened, fix })}`
+  );
+}
+
+export function babelLocation(
+  location: t.SourceLocation | null | undefined
+): ExtractionLocation | undefined {
+  if (!location) return undefined;
+  return {
+    start: {
+      line: location.start.line,
+      column: location.start.column + 1,
+      offset: location.start.index ?? 0,
+    },
+    end: {
+      line: location.end.line,
+      column: location.end.column + 1,
+      offset: location.end.index ?? 0,
+    },
+  };
+}
+
+export function createInlineMetadata(
+  context: VueExtractionContext,
+  location: ExtractionLocation | undefined,
+  translationContext?: string
+): VueExtractionResult['metadata'] {
+  const metadata: VueExtractionResult['metadata'] = {
+    ...(translationContext !== undefined && { context: translationContext }),
+    ...(context.relativeFile && { filePaths: [context.relativeFile] }),
+  };
+
+  if (
+    context.includeSourceCodeContext &&
+    context.relativeFile &&
+    location?.start.line &&
+    location.end.line
+  ) {
+    const sourceCode = extractSourceCode(
+      context.source,
+      location.start.line,
+      location.end.line,
+      context.surroundingLineCount
+    );
+    if (sourceCode) {
+      metadata.sourceCode = { [context.relativeFile]: [sourceCode] };
+    }
+  }
+
+  return metadata;
+}
+
+/** Extracts source lines around a 1-based line range. */
+function extractSourceCode(
+  source: string,
+  startLine: number,
+  endLine: number,
+  surroundingLineCount: number
+): VueSourceCode | undefined {
+  const lines = source.split('\n');
+  if (lines.length === 0) return undefined;
+
+  const targetStart = Math.max(0, startLine - 1);
+  const targetEnd = Math.min(lines.length - 1, endLine - 1);
+  if (targetStart > targetEnd) return undefined;
+
+  return {
+    before: lines
+      .slice(Math.max(0, targetStart - surroundingLineCount), targetStart)
+      .join('\n'),
+    target: lines.slice(targetStart, targetEnd + 1).join('\n'),
+    after: lines
+      .slice(targetEnd + 1, targetEnd + 1 + surroundingLineCount)
+      .join('\n'),
+  };
+}
+
+export type StaticPrimitive = string | number | bigint | boolean | null;
+export type StaticPrimitiveResult =
+  | { ok: true; value: StaticPrimitive }
+  | { ok: false };
+export type StaticIdentifierResolver = (
+  identifier: t.Identifier
+) => StaticPrimitiveResult;
+
+/** Removes syntax-only TypeScript, Flow, and parenthesis wrappers. */
+export function unwrapExpression(
+  input: t.Node | null | undefined
+): t.Node | undefined {
+  let current = input ?? undefined;
+  while (
+    current &&
+    (current.type === 'TSAsExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSInstantiationExpression' ||
+      current.type === 'TypeCastExpression' ||
+      current.type === 'ParenthesizedExpression')
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
+/** Evaluates the side-effect-free primitive subset supported by extraction. */
+export function readStaticPrimitive(
+  input: t.Node | null | undefined,
+  resolveIdentifier?: StaticIdentifierResolver
+): StaticPrimitiveResult {
+  const expression = unwrapExpression(input);
+  if (!expression) return { ok: false };
+  if (expression.type === 'Identifier' && resolveIdentifier) {
+    return resolveIdentifier(expression);
+  }
+  if (expression.type === 'StringLiteral') {
+    return { ok: true, value: expression.value };
+  }
+  if (expression.type === 'NumericLiteral') {
+    return { ok: true, value: expression.value };
+  }
+  if (expression.type === 'BigIntLiteral') {
+    try {
+      return { ok: true, value: BigInt(expression.value) };
+    } catch {
+      return { ok: false };
+    }
+  }
+  if (expression.type === 'BooleanLiteral') {
+    return { ok: true, value: expression.value };
+  }
+  if (expression.type === 'NullLiteral') {
+    return { ok: true, value: null };
+  }
+  if (expression.type === 'TemplateLiteral') {
+    const firstQuasi = expression.quasis[0]?.value.cooked;
+    // Executable, untagged template literals always have cooked values.
+    // Missing cooked data belongs to malformed or tagged-template ASTs and
+    // must fail closed instead of being interpreted with different raw-text
+    // semantics.
+    if (firstQuasi == null) return { ok: false };
+    let value = firstQuasi;
+    for (let index = 0; index < expression.expressions.length; index += 1) {
+      const interpolation = readStaticPrimitive(
+        expression.expressions[index],
+        resolveIdentifier
+      );
+      if (!interpolation.ok) return { ok: false };
+      value += String(interpolation.value);
+      const quasi = expression.quasis[index + 1]?.value.cooked;
+      if (quasi == null) return { ok: false };
+      value += quasi;
+    }
+    return { ok: true, value };
+  }
+  if (expression.type === 'BinaryExpression' && expression.operator === '+') {
+    const left = readStaticPrimitive(expression.left, resolveIdentifier);
+    const right = readStaticPrimitive(expression.right, resolveIdentifier);
+    if (!left.ok || !right.ok) return { ok: false };
+    if (typeof left.value === 'string' || typeof right.value === 'string') {
+      return { ok: true, value: String(left.value) + String(right.value) };
+    }
+    if (typeof left.value === 'bigint' || typeof right.value === 'bigint') {
+      return typeof left.value === 'bigint' && typeof right.value === 'bigint'
+        ? { ok: true, value: left.value + right.value }
+        : { ok: false };
+    }
+    return { ok: true, value: Number(left.value) + Number(right.value) };
+  }
+  if (
+    expression.type === 'UnaryExpression' &&
+    (expression.operator === '+' || expression.operator === '-')
+  ) {
+    const argument = readStaticPrimitive(
+      expression.argument,
+      resolveIdentifier
+    );
+    if (argument.ok && typeof argument.value === 'number') {
+      return {
+        ok: true,
+        value: expression.operator === '-' ? -argument.value : argument.value,
+      };
+    }
+    if (argument.ok && typeof argument.value === 'bigint') {
+      return expression.operator === '-'
+        ? { ok: true, value: -argument.value }
+        : { ok: false };
+    }
+  }
+  return { ok: false };
+}

--- a/packages/vue-extractor/src/internal/vueCompiler.ts
+++ b/packages/vue-extractor/src/internal/vueCompiler.ts
@@ -1,0 +1,546 @@
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+import type { parse as parseVueTemplate } from '@vue/compiler-dom';
+import type * as VueCompilerModule from '@vue/compiler-sfc';
+import type { TemplateCompiler } from '@vue/compiler-sfc';
+import type { VueCompiler } from '../types.js';
+
+/** Whitespace test used by Vue when it constructs an implicit default slot. */
+export type ImplicitSlotWhitespace = 'ecmascript' | 'html';
+
+export type ResolvedVueCompiler = {
+  compiler: ExactVueCompiler;
+  implicitSlotWhitespace: ImplicitSlotWhitespace;
+  parseTemplate?: typeof parseVueTemplate;
+  templateCompiler?: TemplateCompiler;
+  templateParseOptionsSupported: boolean;
+  version: string;
+};
+
+type CompilerResolution =
+  | { ok: true; value: ResolvedVueCompiler }
+  | { ok: false; details: string };
+
+const resolvedCompilers = new Map<string, CompilerResolution>();
+const inspectedCompilers = new WeakMap<object, CompilerResolution>();
+
+type ExactVueCompiler = Pick<
+  typeof VueCompilerModule,
+  'compileTemplate' | 'parse' | 'version'
+> & {
+  parseTemplate?: typeof parseVueTemplate;
+};
+
+/**
+ * Resolves the exact Vue compiler selected by the consuming source file.
+ *
+ * The `vue/compiler-sfc` export is version-locked to that installation's Vue
+ * runtime. Resolving from the SFC first is important in workspaces where apps
+ * intentionally use different Vue versions.
+ */
+export function resolveVueCompiler(
+  file: string,
+  projectRoot: string
+): CompilerResolution {
+  const absoluteFile = path.isAbsolute(file)
+    ? file
+    : path.resolve(projectRoot, file);
+  const anchors = [absoluteFile, path.join(projectRoot, 'package.json')];
+
+  for (const anchor of anchors) {
+    const requireFromConsumer = createRequire(anchor);
+    let vueManifestPath: string;
+    try {
+      vueManifestPath = requireFromConsumer.resolve('vue/package.json');
+    } catch (error) {
+      if (isMissingModule(error)) continue;
+      return {
+        ok: false,
+        details: formatResolutionError(error),
+      };
+    }
+
+    let compilerPath: string;
+    try {
+      compilerPath = requireFromConsumer.resolve('vue/compiler-sfc');
+    } catch (error) {
+      return {
+        ok: false,
+        details: `Resolved the app's Vue package at ${vueManifestPath}, but its compiler-sfc export could not be loaded: ${formatResolutionError(error)}`,
+      };
+    }
+
+    const cached = resolvedCompilers.get(compilerPath);
+    if (cached) return cached;
+
+    const resolution = loadCompiler(
+      requireFromConsumer,
+      compilerPath,
+      vueManifestPath,
+      readVueVersion(requireFromConsumer, vueManifestPath)
+    );
+    resolvedCompilers.set(compilerPath, resolution);
+    return resolution;
+  }
+
+  const declaredVersion = findDeclaredVueVersion(absoluteFile, projectRoot);
+  if (declaredVersion) {
+    return {
+      ok: false,
+      details: `The project declares Vue ${JSON.stringify(declaredVersion)} but vue/compiler-sfc could not be resolved from ${absoluteFile}.`,
+    };
+  }
+
+  return {
+    ok: false,
+    details: `Could not resolve vue/compiler-sfc from ${absoluteFile}.`,
+  };
+}
+
+/** Validates an explicitly supplied compiler before extraction uses it. */
+export function inspectVueCompiler(compiler: VueCompiler): CompilerResolution {
+  if (!compiler || typeof compiler !== 'object') {
+    return {
+      ok: false,
+      details: 'The supplied Vue compiler is not an object.',
+    };
+  }
+  const cached = inspectedCompilers.get(compiler);
+  if (cached) return cached;
+  const exactCompiler = compiler as ExactVueCompiler;
+  const resolution = isVueCompiler(compiler)
+    ? inspectCompiler(exactCompiler, exactCompiler.parseTemplate)
+    : {
+        ok: false as const,
+        details:
+          'The supplied object does not expose the Vue compiler-sfc API.',
+      };
+  inspectedCompilers.set(compiler, resolution);
+  return resolution;
+}
+
+function loadCompiler(
+  requireFromConsumer: NodeRequire,
+  compilerPath: string,
+  vueManifestPath: string,
+  vueVersion: string | undefined
+): CompilerResolution {
+  try {
+    const loaded = requireFromConsumer(compilerPath) as unknown;
+    const defaultExport = readDefaultExport(loaded);
+    const compiler = isVueCompiler(loaded)
+      ? (loaded as ExactVueCompiler)
+      : isVueCompiler(defaultExport)
+        ? (defaultExport as ExactVueCompiler)
+        : undefined;
+    if (!compiler) {
+      return {
+        ok: false,
+        details: `The module at ${compilerPath} does not expose the Vue compiler-sfc API.`,
+      };
+    }
+    if (vueVersion && compiler.version !== vueVersion) {
+      return {
+        ok: false,
+        details: `The app resolves Vue ${vueVersion} but vue/compiler-sfc ${compiler.version}. Install one matching Vue package version.`,
+      };
+    }
+    if (!isSupportedVueVersion(compiler.version)) {
+      return {
+        ok: false,
+        details: `Resolved Vue compiler version ${JSON.stringify(compiler.version)}; gt-vue supports Vue 3.3 through Vue 3.x.`,
+      };
+    }
+    const requireFromCompiler = createRequire(compilerPath);
+    const compilerDomPath = requireFromCompiler.resolve('@vue/compiler-dom');
+    const compilerDom = requireFromCompiler(compilerDomPath) as {
+      compile?: TemplateCompiler['compile'];
+      parse?: typeof parseVueTemplate;
+    };
+    const compilerDomVersion = readVueVersion(
+      requireFromCompiler,
+      requireFromCompiler.resolve('@vue/compiler-dom/package.json')
+    );
+    if (compilerDomVersion !== compiler.version) {
+      return {
+        ok: false,
+        details: `vue/compiler-sfc ${compiler.version} resolves @vue/compiler-dom ${String(compilerDomVersion)}. Install matching Vue compiler packages.`,
+      };
+    }
+    if (typeof compilerDom.parse !== 'function') {
+      return {
+        ok: false,
+        details: `The template compiler at ${compilerDomPath} does not expose parse().`,
+      };
+    }
+    if (typeof compilerDom.compile !== 'function') {
+      return {
+        ok: false,
+        details: `The template compiler at ${compilerDomPath} does not expose compile().`,
+      };
+    }
+    return inspectCompiler(compiler, compilerDom.parse, {
+      compile: compilerDom.compile,
+      parse: compilerDom.parse,
+    });
+  } catch (error) {
+    const bunResolution = loadBunCompiler(
+      requireFromConsumer,
+      vueManifestPath,
+      vueVersion
+    );
+    if (bunResolution) return bunResolution;
+    return { ok: false, details: formatResolutionError(error) };
+  }
+}
+
+/** Loads exact, self-contained Vue browser compilers in a compiled Bun CLI. */
+function loadBunCompiler(
+  requireFromConsumer: NodeRequire,
+  vueManifestPath: string,
+  vueVersion: string | undefined
+): CompilerResolution | undefined {
+  if (typeof process.versions.bun !== 'string') return undefined;
+
+  try {
+    const compilerSfcRoot = findInstalledPackageRoot(
+      vueManifestPath,
+      '@vue/compiler-sfc'
+    );
+    const compilerDomRoot = findInstalledPackageRoot(
+      vueManifestPath,
+      '@vue/compiler-dom'
+    );
+    if (!compilerSfcRoot || !compilerDomRoot) {
+      return {
+        ok: false,
+        details:
+          'The Vue installation does not contain its compiler-sfc and compiler-dom dependencies.',
+      };
+    }
+
+    const compilerPath = path.join(
+      compilerSfcRoot,
+      'dist/compiler-sfc.esm-browser.js'
+    );
+    const compilerDomPath = path.join(
+      compilerDomRoot,
+      'dist/compiler-dom.esm-browser.js'
+    );
+    const loaded = requireFromConsumer(compilerPath) as unknown;
+    const defaultExport = readDefaultExport(loaded);
+    const compiler = isVueCompiler(loaded)
+      ? (loaded as ExactVueCompiler)
+      : isVueCompiler(defaultExport)
+        ? (defaultExport as ExactVueCompiler)
+        : undefined;
+    if (!compiler) {
+      return {
+        ok: false,
+        details: `The module at ${compilerPath} does not expose the Vue compiler-sfc API.`,
+      };
+    }
+    if (vueVersion && compiler.version !== vueVersion) {
+      return {
+        ok: false,
+        details: `The app resolves Vue ${vueVersion} but vue/compiler-sfc ${compiler.version}. Install one matching Vue package version.`,
+      };
+    }
+    if (!isSupportedVueVersion(compiler.version)) {
+      return {
+        ok: false,
+        details: `Resolved Vue compiler version ${JSON.stringify(compiler.version)}; gt-vue supports Vue 3.3 through Vue 3.x.`,
+      };
+    }
+
+    const compilerDom = requireFromConsumer(compilerDomPath) as {
+      compile?: TemplateCompiler['compile'];
+      parse?: typeof parseVueTemplate;
+    };
+    const compilerDomVersion = readPackageVersion(compilerDomRoot);
+    if (compilerDomVersion !== compiler.version) {
+      return {
+        ok: false,
+        details: `vue/compiler-sfc ${compiler.version} resolves @vue/compiler-dom ${String(compilerDomVersion)}. Install matching Vue compiler packages.`,
+      };
+    }
+    if (typeof compilerDom.parse !== 'function') {
+      return {
+        ok: false,
+        details: `The template compiler at ${compilerDomPath} does not expose parse().`,
+      };
+    }
+    if (typeof compilerDom.compile !== 'function') {
+      return {
+        ok: false,
+        details: `The template compiler at ${compilerDomPath} does not expose compile().`,
+      };
+    }
+    return inspectCompiler(compiler, compilerDom.parse, {
+      compile: compilerDom.compile,
+      parse: compilerDom.parse,
+    });
+  } catch (error) {
+    return { ok: false, details: formatResolutionError(error) };
+  }
+}
+
+/** Finds one dependency relative to the physical Vue installation on disk. */
+function findInstalledPackageRoot(
+  vueManifestPath: string,
+  packageName: string
+): string | undefined {
+  const packageSegments = packageName.split('/');
+  let directory = path.dirname(vueManifestPath);
+  while (true) {
+    const candidate =
+      path.basename(directory) === 'node_modules'
+        ? path.join(directory, ...packageSegments)
+        : path.join(directory, 'node_modules', ...packageSegments);
+    if (fs.existsSync(path.join(candidate, 'package.json'))) return candidate;
+    const parent = path.dirname(directory);
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+function readPackageVersion(packageRoot: string): string | undefined {
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf8')
+    ) as { version?: unknown };
+    return typeof manifest.version === 'string' ? manifest.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readVueVersion(
+  requireFromConsumer: NodeRequire,
+  manifestPath: string
+): string | undefined {
+  try {
+    const manifest = requireFromConsumer(manifestPath) as { version?: unknown };
+    return typeof manifest.version === 'string' ? manifest.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Finds an installed-but-missing declaration that bundled fallback could hide. */
+function findDeclaredVueVersion(
+  absoluteFile: string,
+  projectRoot: string
+): string | undefined {
+  const stop = path.resolve(projectRoot);
+  let directory = path.dirname(absoluteFile);
+  while (true) {
+    const version = readDeclaredVueVersion(
+      path.join(directory, 'package.json')
+    );
+    if (version) return version;
+    if (directory === stop || directory === path.dirname(directory)) break;
+    directory = path.dirname(directory);
+  }
+  return readDeclaredVueVersion(path.join(stop, 'package.json'));
+}
+
+function readDeclaredVueVersion(manifestPath: string): string | undefined {
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(manifestPath, 'utf8')
+    ) as Record<string, unknown>;
+    for (const section of [
+      'dependencies',
+      'devDependencies',
+      'peerDependencies',
+      'optionalDependencies',
+    ]) {
+      const dependencies = manifest[section];
+      if (
+        dependencies &&
+        typeof dependencies === 'object' &&
+        'vue' in dependencies
+      ) {
+        const version = (dependencies as Record<string, unknown>).vue;
+        return typeof version === 'string' ? version : 'an unknown version';
+      }
+    }
+  } catch (error) {
+    if (
+      !error ||
+      typeof error !== 'object' ||
+      !('code' in error) ||
+      error.code !== 'ENOENT'
+    ) {
+      throw error;
+    }
+  }
+  return undefined;
+}
+
+function inspectCompiler(
+  compiler: ExactVueCompiler,
+  parseTemplate?: typeof parseVueTemplate,
+  templateCompiler?: TemplateCompiler
+): CompilerResolution {
+  const version = compiler.version;
+  if (!isSupportedVueVersion(version)) {
+    return {
+      ok: false,
+      details: `Resolved Vue compiler version ${JSON.stringify(version)}; gt-vue supports Vue 3.3 through Vue 3.x.`,
+    };
+  }
+
+  try {
+    const templateParseOptionsSupported =
+      supportsTemplateParseOptions(compiler);
+    if (!parseTemplate && !templateParseOptionsSupported) {
+      return {
+        ok: false,
+        details:
+          'The supplied compiler does not expose exact template parser options. Let the extractor resolve vue/compiler-sfc from the consuming app instead.',
+      };
+    }
+    return {
+      ok: true,
+      value: {
+        compiler,
+        implicitSlotWhitespace: detectImplicitSlotWhitespace(compiler),
+        parseTemplate,
+        templateCompiler,
+        templateParseOptionsSupported,
+        version,
+      },
+    };
+  } catch (error) {
+    return { ok: false, details: formatResolutionError(error) };
+  }
+}
+
+/** Detects the SFC parser option added after Vue 3.4. */
+function supportsTemplateParseOptions(compiler: ExactVueCompiler): boolean {
+  const source = '<template><Probe>First\n  second</Probe></template>';
+  const parseText = (whitespace: 'condense' | 'preserve') => {
+    const result = compiler.parse(source, {
+      templateParseOptions: { whitespace },
+    });
+    return collectText(result.descriptor.template?.ast);
+  };
+  return parseText('condense') !== parseText('preserve');
+}
+
+function collectText(value: unknown): string {
+  if (!value || typeof value !== 'object') return '';
+  let output = '';
+  if ('type' in value && value.type === 2 && 'content' in value) {
+    output += String(value.content);
+  }
+  if ('children' in value && Array.isArray(value.children)) {
+    for (const child of value.children) output += collectText(child);
+  }
+  return output;
+}
+
+/**
+ * Detects the compiler's slot-whitespace semantics instead of inferring them
+ * from a semver range. Vue 3.3/3.4 use ECMAScript `trim()`, while Vue 3.5 uses
+ * the HTML parser's ASCII whitespace set. A behavior probe remains exact if a
+ * later Vue 3.x release backports or revises that implementation.
+ */
+function detectImplicitSlotWhitespace(
+  compiler: ExactVueCompiler
+): ImplicitSlotWhitespace {
+  const result = compiler.compileTemplate({
+    filename: 'gt-vue-compiler-probe.vue',
+    id: 'gt-vue-compiler-probe',
+    source: '<Probe><template #named>x</template>&nbsp;</Probe>',
+  });
+  if (result.errors.length > 0) {
+    throw new Error(
+      `The Vue compiler compatibility probe failed: ${result.errors.map(String).join('; ')}`
+    );
+  }
+
+  const component = result.ast?.children.find(
+    (node) =>
+      typeof node === 'object' &&
+      node !== null &&
+      'tag' in node &&
+      node.tag === 'Probe'
+  );
+  const codegen =
+    component && 'codegenNode' in component ? component.codegenNode : undefined;
+  const children =
+    codegen &&
+    typeof codegen === 'object' &&
+    'children' in codegen &&
+    codegen.children &&
+    typeof codegen.children === 'object'
+      ? codegen.children
+      : undefined;
+  const properties =
+    children && 'properties' in children && Array.isArray(children.properties)
+      ? children.properties
+      : undefined;
+  if (!properties) {
+    throw new Error(
+      'The Vue compiler compatibility probe returned an unknown slot AST.'
+    );
+  }
+
+  const hasImplicitDefault = properties.some((property) => {
+    if (!property || typeof property !== 'object' || !('key' in property)) {
+      return false;
+    }
+    const key = property.key;
+    return (
+      key != null &&
+      typeof key === 'object' &&
+      'content' in key &&
+      key.content === 'default'
+    );
+  });
+  return hasImplicitDefault ? 'html' : 'ecmascript';
+}
+
+function isVueCompiler(value: unknown): value is VueCompiler {
+  if (!value || typeof value !== 'object') return false;
+  return (
+    'compileTemplate' in value &&
+    typeof value.compileTemplate === 'function' &&
+    'parse' in value &&
+    typeof value.parse === 'function' &&
+    'version' in value &&
+    typeof value.version === 'string'
+  );
+}
+
+/** Reads a possible CommonJS-interoperability default export. */
+function readDefaultExport(value: unknown): unknown {
+  return value && typeof value === 'object' && 'default' in value
+    ? value.default
+    : undefined;
+}
+
+function isSupportedVueVersion(version: string): boolean {
+  const match = /^(\d+)\.(\d+)(?:\.|$)/.exec(version);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major === 3 && minor >= 3;
+}
+
+function isMissingModule(error: unknown): boolean {
+  return (
+    !!error &&
+    typeof error === 'object' &&
+    'code' in error &&
+    error.code === 'MODULE_NOT_FOUND'
+  );
+}
+
+function formatResolutionError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/vue-extractor/src/project.ts
+++ b/packages/vue-extractor/src/project.ts
@@ -1,0 +1,13 @@
+/**
+ * Extracts all statically discoverable gt-vue messages owned by a project.
+ *
+ * The project boundary owns workspace discovery, Vue compiler configuration,
+ * Vite aliases, local-module resolution, file matching, hashing, and atomic
+ * diagnostics so callers do not need any Vue-specific orchestration.
+ */
+export { extractFromVueProject } from './internal/project/extractFromVueProject.js';
+export type {
+  VueProjectExtractionOptions,
+  VueProjectExtractionOutput,
+  VueProjectExtractionResult,
+} from './types.js';

--- a/packages/vue-extractor/src/project.ts
+++ b/packages/vue-extractor/src/project.ts
@@ -6,8 +6,11 @@
  * diagnostics so callers do not need any Vue-specific orchestration.
  */
 export { extractFromVueProject } from './internal/project/extractFromVueProject.js';
+export { mergeVueProjectExtraction } from './internal/project/mergeVueProjectExtraction.js';
 export type {
   VueProjectExtractionOptions,
+  VueProjectInspection,
   VueProjectExtractionOutput,
   VueProjectExtractionResult,
 } from './types.js';
+export type { InlineExtractionOutput } from './internal/project/mergeVueProjectExtraction.js';

--- a/packages/vue-extractor/src/types.ts
+++ b/packages/vue-extractor/src/types.ts
@@ -1,0 +1,132 @@
+import type { JsxChildren } from '@generaltranslation/format/types';
+
+/**
+ * Version-neutral Vue compiler surface accepted by programmatic extraction.
+ *
+ * Vue's compiler AST types are nominally incompatible across even patch
+ * releases. Keeping the callable members opaque lets an app pass its exact
+ * `vue/compiler-sfc` module while runtime validation protects the boundary.
+ */
+export type VueCompiler = {
+  /** Compiles one Vue SFC template. */
+  compileTemplate: (...args: never[]) => unknown;
+  /** Parses one Vue single-file component. */
+  parse: (...args: never[]) => unknown;
+  /** Optional exact compiler-dom parser for older Vue 3 releases. */
+  parseTemplate?: (...args: never[]) => unknown;
+  /** Exact Vue compiler release. */
+  version: string;
+};
+
+/** Vue template compiler options that can change extracted source hashes. */
+export type VueCompilerOptions = {
+  /** Controls how Vue normalizes whitespace between template children. */
+  whitespace?: 'condense' | 'preserve';
+  /** Replaces Vue's default `{{` and `}}` interpolation delimiters. */
+  delimiters?: [string, string];
+};
+
+/** Source lines captured around an extracted translation. */
+export type VueSourceCode = {
+  before: string;
+  target: string;
+  after: string;
+};
+
+/** Metadata attached to an extracted Vue translation. */
+export type VueExtractionMetadata = {
+  context?: string;
+  filePaths?: string[];
+  /** Stable catalog key calculated by project-level extraction. */
+  hash?: string;
+  sourceCode?: Record<string, VueSourceCode[]>;
+};
+
+/** A translation extracted from Vue source code before CLI post-processing. */
+export type VueExtractionResult =
+  | {
+      dataFormat: 'JSX';
+      source: JsxChildren;
+      metadata: VueExtractionMetadata;
+    }
+  | {
+      dataFormat: 'STRING';
+      source: string;
+      metadata: VueExtractionMetadata;
+    };
+
+/** Options that control extraction from one Vue source file. */
+export type VueExtractionOptions = {
+  /** Exact compiler used by the consuming Vue application. */
+  compiler?: VueCompiler;
+  /** Vue compiler options used by the consuming application. */
+  compilerOptions?: VueCompilerOptions;
+  /** Includes surrounding source lines in result metadata. */
+  includeSourceCodeContext?: boolean;
+  /** Root used to make metadata file paths relative. Defaults to `process.cwd()`. */
+  projectRoot?: string;
+  /**
+   * Skips standalone script files that have no statically proven gt-vue
+   * provenance. Vue single-file components are always parsed.
+   *
+   * This is useful when a framework dispatcher sends the same JavaScript and
+   * TypeScript files to multiple extractors. A permissive, read-only preflight
+   * recognizes gt-vue imports through local barrels before the normal parser
+   * applies the source file's declared language.
+   */
+  requireGTProvenance?: boolean;
+  /**
+   * Resolves a static module specifier to a source file without loading or
+   * executing that module. Relative source files and index barrels are
+   * resolved automatically; provide this hook for aliases or workspace
+   * package exports that use application-specific resolution rules.
+   *
+   * The hook is consulted first for every specifier, including relative ones,
+   * so a project can preserve its compiler's source-over-build precedence.
+   *
+   * Returning `undefined` leaves the import unresolved. GT-shaped uses fail
+   * closed only inside Vue SFCs or standalone files with separate proven
+   * gt-vue provenance. The returned path must identify a readable local source
+   * file.
+   */
+  resolveModule?: (specifier: string, importer: string) => string | undefined;
+  /** Number of source lines captured before and after a translation. */
+  surroundingLineCount?: number;
+};
+
+/** Extraction output for one Vue single-file component or script. */
+export type VueExtractionOutput = {
+  results: VueExtractionResult[];
+  errors: string[];
+  warnings: string[];
+};
+
+/** Options for extracting every gt-vue source owned by one project. */
+export type VueProjectExtractionOptions = {
+  /** Project root. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Optional project-root-relative globs that replace framework defaults. */
+  filePatterns?: string[];
+  /** Includes surrounding source lines in result metadata. */
+  includeSourceCodeContext?: boolean;
+  /** Package export conditions used by static local-module resolution. */
+  conditionNames?: string[];
+  /** Explicit hash-affecting Vue compiler options from project configuration. */
+  vueCompilerOptions?: VueCompilerOptions;
+  /** Explicit Vite config path relative to the project root. */
+  viteConfigPath?: string;
+  /** Number of source lines captured before and after a translation. */
+  surroundingLineCount?: number;
+};
+
+/** A project result whose stable catalog hash has been calculated. */
+export type VueProjectExtractionResult = VueExtractionResult & {
+  metadata: VueExtractionMetadata & { hash: string };
+};
+
+/** Complete output from atomic project-level Vue extraction. */
+export type VueProjectExtractionOutput = {
+  updates: VueProjectExtractionResult[];
+  errors: string[];
+  warnings: string[];
+};

--- a/packages/vue-extractor/src/types.ts
+++ b/packages/vue-extractor/src/types.ts
@@ -105,6 +105,8 @@ export type VueExtractionOutput = {
 export type VueProjectExtractionOptions = {
   /** Project root. Defaults to `process.cwd()`. */
   cwd?: string;
+  /** Reusable package-owned workspace inspection for this project root. */
+  inspection?: VueProjectInspection;
   /** Optional project-root-relative globs that replace framework defaults. */
   filePatterns?: string[];
   /** Includes surrounding source lines in result metadata. */
@@ -117,6 +119,16 @@ export type VueProjectExtractionOptions = {
   viteConfigPath?: string;
   /** Number of source lines captured before and after a translation. */
   surroundingLineCount?: number;
+};
+
+/** Opaque summary returned by package-owned Vue workspace inspection. */
+export type VueProjectInspection = {
+  /** Absolute root inspected for Vue-owned source scopes. */
+  readonly projectRoot: string;
+  /** Whether the root package itself activates the Vue command surface. */
+  readonly rootOwnsVue: boolean;
+  /** Whether the root or any declared workspace owns Vue source. */
+  readonly hasVueScopes: boolean;
 };
 
 /** A project result whose stable catalog hash has been calculated. */

--- a/packages/vue-extractor/tsconfig.json
+++ b/packages/vue-extractor/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"],
+  "exclude": ["**/__tests__/**/*"]
+}

--- a/packages/vue-extractor/tsdown.config.mts
+++ b/packages/vue-extractor/tsdown.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'tsdown';
+import { createTsdownUnbundleConfig } from '../../tsdown.preset.mts';
+
+export default defineConfig(
+  createTsdownUnbundleConfig({
+    format: 'esm',
+  })
+);

--- a/packages/vue-extractor/vitest.config.ts
+++ b/packages/vue-extractor/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1694,6 +1694,9 @@ importers:
       generaltranslation:
         specifier: workspace:*
         version: link:../core
+      semver:
+        specifier: ^7.8.5
+        version: 7.8.5
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1707,6 +1710,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 22.13.10
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
       '@vue/compiler-dom':
         specifier: ^3.5.0
         version: 3.5.40

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
       '@generaltranslation/supported-locales':
         specifier: workspace:*
         version: link:../supported-locales
+      '@generaltranslation/vue-extractor':
+        specifier: workspace:*
+        version: link:../vue-extractor
       chalk:
         specifier: ^5.4.1
         version: 5.6.2
@@ -955,6 +958,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
 
   packages/compiler:
     dependencies:
@@ -1652,6 +1658,70 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
+      vitest:
+        specifier: 'catalog:'
+        version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
+      vue:
+        specifier: ^3.5.0
+        version: 3.5.40(typescript@5.9.3)
+
+  packages/vue-extractor:
+    dependencies:
+      '@babel/parser':
+        specifier: ^7.25.7
+        version: 7.29.7
+      '@babel/traverse':
+        specifier: ^7.25.7
+        version: 7.29.0
+      '@babel/types':
+        specifier: ^7.25.7
+        version: 7.29.7
+      '@generaltranslation/format':
+        specifier: workspace:*
+        version: link:../format
+      '@vue/shared':
+        specifier: ^3.5.0
+        version: 3.5.40
+      enhanced-resolve:
+        specifier: ^5.18.3
+        version: 5.24.2
+      es-module-lexer:
+        specifier: ^2.3.1
+        version: 2.3.1
+      fast-glob:
+        specifier: ^3.3.3
+        version: 3.3.3
+      generaltranslation:
+        specifier: workspace:*
+        version: link:../core
+      tsconfig-paths:
+        specifier: ^4.2.0
+        version: 4.2.0
+      yaml:
+        specifier: ^2.8.0
+        version: 2.8.3
+    devDependencies:
+      '@types/babel__traverse':
+        specifier: ^7.20.6
+        version: 7.28.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.13.10
+      '@vue/compiler-dom':
+        specifier: ^3.5.0
+        version: 3.5.40
+      '@vue/compiler-sfc':
+        specifier: ^3.5.0
+        version: 3.5.40
+      tsdown:
+        specifier: 'catalog:'
+        version: 0.21.10(synckit@0.11.11)(typescript@5.9.3)
+      typescript:
+        specifier: 'catalog:'
+        version: 5.9.3
+      vite:
+        specifier: ^7.1.7
+        version: 7.3.1(@types/node@22.13.10)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)
       vitest:
         specifier: 'catalog:'
         version: 3.2.4(@edge-runtime/vm@4.0.4)(@types/debug@4.1.12)(@types/node@22.13.10)(jiti@2.7.0)(jsdom@29.0.1(@noble/hashes@2.2.0))(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

- add `@generaltranslation/vue-extractor` as the sole owner of Vue project discovery, compiler configuration, source resolution, static analysis, hashing, and diagnostics
- integrate Vue through a thin CLI adapter while preserving the existing React, Next.js, React Native, TanStack Start, Node.js, and Python extraction paths
- add Vue command routing, config schema support, CI coverage, and a minor changeset for both the extractor and `gt`

## Regression boundary

- existing React, Next.js, Python, API, workflow, and shared catalog post-processing source trees are unchanged
- non-Vue projects call their historical extractor with the same arguments and return the original result object
- Vue ownership is established before Vue parsing or compiler/config resolution, including in mixed workspaces
- the heavy Vue project graph is loaded dynamically only after lightweight package-owned detection

## Verification

- `@generaltranslation/vue-extractor`: 44 files, 1,418 tests; typecheck and build pass
- `gt`: 115 files, 2,190 tests; typecheck and build pass
- repository lint and formatting pass
- 54 exact parser-output comparisons across React, Next.js, React Native, TanStack Start, and Node.js
- 18 generated React-family catalogs are byte-identical to `iris`; Python output is exact across 26 messages
- packed-package smoke covers every exported subpath, TypeScript declarations, pure Vue and mixed React/Vue catalogs, `gt validate`, transitive installation, and a Vite production build
- Vue 3.3 and 3.5 compatibility remains in the CI matrix
- frozen offline lockfile validation passes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes Vue project discovery, configuration, source analysis, extraction, and diagnostics in a new `@generaltranslation/vue-extractor` package, with the CLI acting as a thin adapter.
- Adds Vue-aware CLI routing, initialization, validation, and extraction orchestration.
- Preserves explicit React, Next.js, React Native, TanStack Start, Node.js, and Python routing ahead of Vue detection.
- Adds configuration schema support, standalone-binary coverage, workspace handling, and extensive extraction regression tests.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the eligible follow-up review scope.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/cli/src/index.ts | Adds Vue CLI selection after all explicit framework routes, preserving existing framework precedence. |
| packages/cli/src/translation/extractInline.ts | Adds project-level Vue inspection, source partitioning, extraction dispatch, and result merging around historical extractors. |
| packages/cli/src/cli/vue.ts | Introduces a thin Vue-specific command adapter with Vue initialization and inline setup flags. |
| packages/vue-extractor/src/internal/project/detectVueProject.ts | Implements package- and workspace-aware Vue ownership detection used by CLI routing. |
| packages/vue-extractor/src/internal/project/extractFromVueProject.ts | Orchestrates Vue scope discovery, configuration resolution, source extraction, and project result construction. |
| packages/vue-extractor/src/internal/config/resolveVueCompilerOptions.ts | Resolves explicit and project-derived Vue compiler options across Vite, Nuxt, and workspace configurations. |
| packages/vue-extractor/src/internal/project/viteAliases.ts | Adds static Vite alias discovery for resolving Vue project modules during extraction. |
| assets/config-schema.json | Exposes Vue compiler and Vite configuration under inline parsing flags. |
| packages/vue-extractor/package.json | Defines the new extractor package, its public subpaths, dependencies, and build/test entry points. |
| .github/workflows/ci.yml | Extends Vue compatibility and compiled CLI testing to cover the new extractor package. |

</details>

<sub>Reviews (9): Last reviewed commit: ["fix(cli): match Vue component ownership"](https://github.com/generaltranslation/gt/commit/c97da288d69c53289c7c7894512ce526b51f4ee7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51066037)</sub>

**Context used:**

- Knowledge Base — [CLI package (`gt`)](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-package.md)

<!-- /greptile_comment -->