### PR TITLE
feat(cli): integrate Vue source extraction

### DIFF
--- a/.changeset/calm-vue-config.md
+++ b/.changeset/calm-vue-config.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Accept Vue compiler settings in the shared GT configuration type.

--- a/.changeset/warm-vue-cli.md
+++ b/.changeset/warm-vue-cli.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Add Vue source extraction through the standalone `@generaltranslation/vue-extractor` package.

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -113,6 +113,75 @@
                 "translations/[locale].json"
               ]
             },
+            "parsingFlags": {
+              "type": "object",
+              "description": "Options controlling inline source extraction",
+              "properties": {
+                "autoderive": {
+                  "oneOf": [
+                    { "type": "boolean" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "jsx": { "type": "boolean" },
+                        "strings": { "type": "boolean" }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "includeSourceCodeContext": {
+                  "type": "boolean"
+                },
+                "enableAutoJsxInjection": {
+                  "type": "boolean"
+                },
+                "legacyGtReactImportSource": {
+                  "type": "boolean"
+                },
+                "devHotReload": {
+                  "oneOf": [
+                    { "type": "boolean" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "strings": { "type": "boolean" },
+                        "jsx": { "type": "boolean" }
+                      },
+                      "additionalProperties": false
+                    }
+                  ]
+                },
+                "viteConfigPath": {
+                  "type": "string",
+                  "minLength": 1,
+                  "pattern": "\\S",
+                  "description": "Vite config path relative to the project root"
+                },
+                "vueCompilerOptions": {
+                  "type": "object",
+                  "description": "Hash-affecting Vue template compiler options",
+                  "properties": {
+                    "whitespace": {
+                      "type": "string",
+                      "enum": ["condense", "preserve"]
+                    },
+                    "delimiters": {
+                      "type": "array",
+                      "items": [
+                        { "type": "string", "minLength": 1 },
+                        { "type": "string", "minLength": 1 }
+                      ],
+                      "additionalItems": false,
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
             "includeSourceCodeContext": {
               "type": "boolean",
               "description": "Include surrounding source code lines as context for translations. Only applies to library users that send GT JSON for translation.",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -118,6 +118,7 @@
     "@generaltranslation/format": "workspace:*",
     "@generaltranslation/python-extractor": "workspace:*",
     "@generaltranslation/supported-locales": "workspace:*",
+    "@generaltranslation/vue-extractor": "workspace:*",
     "chalk": "^5.4.1",
     "commander": "^12.1.0",
     "dotenv": "^16.4.5",

--- a/packages/cli/src/cli/inline.ts
+++ b/packages/cli/src/cli/inline.ts
@@ -195,6 +195,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
     Libraries.GT_TANSTACK_START,
     Libraries.GT_FLASK,
     Libraries.GT_FASTAPI,
+    Libraries.GT_VUE,
   ].includes(library as Libraries)
     ? (library as
         | typeof Libraries.GT_NEXT
@@ -202,6 +203,7 @@ function fallbackToGtReact(library: SupportedLibraries): InlineLibrary {
         | typeof Libraries.GT_REACT_NATIVE
         | typeof Libraries.GT_TANSTACK_START
         | typeof Libraries.GT_FLASK
-        | typeof Libraries.GT_FASTAPI)
+        | typeof Libraries.GT_FASTAPI
+        | typeof Libraries.GT_VUE)
     : Libraries.GT_REACT;
 }

--- a/packages/cli/src/formats/files/__tests__/collectFilesVueAdapter.test.ts
+++ b/packages/cli/src/formats/files/__tests__/collectFilesVueAdapter.test.ts
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Settings, TranslateFlags } from '../../../types/index.js';
+import { Libraries } from '../../../types/libraries.js';
+import { TEMPLATE_FILE_ID } from '../../../utils/constants.js';
+
+vi.mock('../../../translation/stage.js', () => ({
+  aggregateInlineTranslations: vi.fn(),
+}));
+
+import { aggregateInlineTranslations } from '../../../translation/stage.js';
+import { collectFiles } from '../collectFiles.js';
+
+const initialCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(aggregateInlineTranslations).mockResolvedValue([
+    {
+      dataFormat: 'STRING',
+      source: 'Vue message',
+      metadata: { hash: 'vue-hash' },
+    },
+  ]);
+});
+
+afterEach(() => {
+  process.chdir(initialCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('collectFiles Vue adapter', () => {
+  it.each([
+    ['next-intl', 'ICU'],
+    ['i18next', 'I18NEXT'],
+  ] as const)(
+    'keeps %s JSON semantics while collecting direct gt-vue content',
+    async (fileLibrary, expectedDataFormat) => {
+      const root = createFixture(fileLibrary);
+      const sourcePath = path.join(root, 'messages.json');
+      const settings = createSettings(sourcePath);
+      const options = {} as TranslateFlags;
+      process.chdir(root);
+
+      const result = await collectFiles(options, settings, fileLibrary);
+
+      const sourceFile = result.files.find(
+        ({ fileFormat }) => fileFormat === 'JSON'
+      );
+      expect(sourceFile?.dataFormat).toBe(expectedDataFormat);
+      expect(
+        result.files.some(({ fileId }) => fileId === TEMPLATE_FILE_ID)
+      ).toBe(true);
+      expect(result.reactComponents).toBe(1);
+      expect(aggregateInlineTranslations).toHaveBeenCalledOnce();
+      expect(aggregateInlineTranslations).toHaveBeenCalledWith(
+        options,
+        settings,
+        Libraries.GT_VUE
+      );
+    }
+  );
+});
+
+function createFixture(fileLibrary: 'next-intl' | 'i18next'): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-cli-vue-files-'));
+  temporaryDirectories.push(root);
+  fs.writeFileSync(
+    path.join(root, 'package.json'),
+    JSON.stringify({
+      dependencies: { [fileLibrary]: '*', 'gt-vue': '*' },
+    })
+  );
+  fs.writeFileSync(
+    path.join(root, 'messages.json'),
+    JSON.stringify({ greeting: 'Hello' })
+  );
+  return root;
+}
+
+function createSettings(sourcePath: string): Settings {
+  return {
+    defaultLocale: 'en',
+    locales: ['fr'],
+    publish: true,
+    options: {},
+    files: {
+      resolvedPaths: { json: [sourcePath] },
+      placeholderPaths: {},
+      transformPaths: {},
+      transformFormats: {},
+      publishPaths: new Set<string>(),
+      unpublishPaths: new Set<string>(),
+      requiresReviewPaths: new Set<string>(),
+      parsingFlags: {},
+      gtJson: { parsingFlags: {} },
+    },
+  } as Settings;
+}

--- a/packages/cli/src/formats/files/collectFiles.ts
+++ b/packages/cli/src/formats/files/collectFiles.ts
@@ -11,8 +11,9 @@ import type { JsxChildren } from '@generaltranslation/format/types';
 import type { FileToUpload } from 'generaltranslation/types';
 import { hashStringSync } from '../../utils/hash.js';
 import { TEMPLATE_FILE_NAME, TEMPLATE_FILE_ID } from '../../utils/constants.js';
-import { isInlineLibrary } from '../../types/libraries.js';
+import { isInlineLibrary, Libraries } from '../../types/libraries.js';
 import { shouldPublishGt } from '../../utils/resolvePublish.js';
+import { planVueExtraction } from '@generaltranslation/vue-extractor/integration';
 
 export async function collectFiles(
   options: TranslateFlags,
@@ -28,11 +29,19 @@ export async function collectFiles(
 
   // Parse for React components
   let reactComponents = 0;
-  if (isInlineLibrary(library)) {
+  const inlineLibrary = isInlineLibrary(library)
+    ? library
+    : planVueExtraction({
+          library,
+          projectRoot: process.cwd(),
+        }).handled
+      ? Libraries.GT_VUE
+      : undefined;
+  if (inlineLibrary) {
     const updates = await aggregateInlineTranslations(
       options,
       settings,
-      library
+      inlineLibrary
     );
     if (updates.length > 0) {
       if (!settings.publish && !settings.files?.placeholderPaths.gt) {

--- a/packages/cli/src/fs/determineFramework/__tests__/determineLibraryVueAdapter.test.ts
+++ b/packages/cli/src/fs/determineFramework/__tests__/determineLibraryVueAdapter.test.ts
@@ -1,0 +1,124 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Libraries } from '../../../types/libraries.js';
+import { determineLibrary } from '../index.js';
+
+const initialCwd = process.cwd();
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  process.chdir(initialCwd);
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('determineLibrary Vue adapter', () => {
+  it.each([
+    ['Next', Libraries.GT_NEXT, Libraries.GT_NEXT],
+    [
+      'TanStack Start',
+      Libraries.GT_TANSTACK_START,
+      Libraries.GT_TANSTACK_START,
+    ],
+    ['React', Libraries.GT_REACT, Libraries.GT_REACT],
+    ['React Native', Libraries.GT_REACT_NATIVE, Libraries.GT_REACT_NATIVE],
+    ['Node', Libraries.GT_NODE, Libraries.GT_NODE],
+    ['next-intl', 'next-intl', 'next-intl'],
+    ['i18next', 'i18next', 'i18next'],
+  ] as const)(
+    'keeps the historical %s priority over a direct gt-vue dependency',
+    (_name, dependency, expected) => {
+      const root = createFixture({
+        'package.json': JSON.stringify({
+          dependencies: { [dependency]: '*', 'gt-vue': '*' },
+        }),
+      });
+      process.chdir(root);
+
+      expect(determineLibrary()).toEqual({
+        library: expected,
+        additionalModules: [],
+      });
+    }
+  );
+
+  it('keeps Python priority over a direct gt-vue dependency', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        dependencies: { 'gt-vue': '*' },
+      }),
+      'requirements.txt': 'gt-fastapi>=1.0.0\n',
+    });
+    process.chdir(root);
+
+    expect(determineLibrary().library).toBe(Libraries.GT_FASTAPI);
+  });
+
+  it('selects gt-vue when it is the only direct supported runtime', () => {
+    const root = createFixture({
+      'package.json': JSON.stringify({
+        devDependencies: { 'gt-vue': '*' },
+      }),
+    });
+    process.chdir(root);
+
+    expect(determineLibrary()).toEqual({
+      library: Libraries.GT_VUE,
+      additionalModules: [],
+    });
+  });
+
+  it.each([
+    [
+      'optional declaration',
+      {
+        'package.json': JSON.stringify({
+          optionalDependencies: { 'gt-vue': '*' },
+        }),
+      },
+    ],
+    [
+      'peer declaration',
+      {
+        'package.json': JSON.stringify({
+          peerDependencies: { 'gt-vue': '*' },
+        }),
+      },
+    ],
+    [
+      'descendant-only declaration',
+      {
+        'package.json': JSON.stringify({
+          private: true,
+          workspaces: ['packages/*'],
+        }),
+        'packages/vue-app/package.json': JSON.stringify({
+          name: '@fixture/vue-app',
+          dependencies: { 'gt-vue': '*' },
+        }),
+      },
+    ],
+  ])('leaves %s Vue evidence inert', (_name, files) => {
+    const root = createFixture(files);
+    process.chdir(root);
+
+    expect(determineLibrary()).toEqual({
+      library: 'base',
+      additionalModules: [],
+    });
+  });
+});
+
+function createFixture(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-cli-vue-routing-'));
+  temporaryDirectories.push(root);
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  return root;
+}

--- a/packages/cli/src/fs/determineFramework/index.ts
+++ b/packages/cli/src/fs/determineFramework/index.ts
@@ -4,6 +4,7 @@ import { SupportedLibraries } from '../../types/index.js';
 import { logger } from '../../console/logger.js';
 import { Libraries } from '../../types/libraries.js';
 import { detectPythonLibrary } from './detectPythonLibrary.js';
+import { manifestDirectlyDeclaresGTVue } from '@generaltranslation/vue-extractor/integration';
 
 export function determineLibrary(): {
   library: SupportedLibraries;
@@ -11,6 +12,7 @@ export function determineLibrary(): {
 } {
   let library: SupportedLibraries = 'base';
   const additionalModules: SupportedLibraries[] = [];
+  let directlyDeclaresVue = false;
   try {
     // Get the current working directory (where the CLI is being run)
     const cwd = process.cwd();
@@ -20,6 +22,7 @@ export function determineLibrary(): {
     if (fs.existsSync(packageJsonPath)) {
       // Read and parse package.json
       const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+      directlyDeclaresVue = manifestDirectlyDeclaresGTVue(packageJson);
       const dependencies = {
         ...packageJson.dependencies,
         ...packageJson.devDependencies,
@@ -53,6 +56,12 @@ export function determineLibrary(): {
       if (pythonLibrary) {
         library = pythonLibrary;
       }
+    }
+
+    // Vue is intentionally the final fallback so every existing framework
+    // keeps its historical command surface and priority in mixed projects.
+    if (library === 'base' && directlyDeclaresVue) {
+      library = Libraries.GT_VUE;
     }
 
     // Fallback to base if neither is found

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,7 @@ import { determineLibrary } from './fs/determineFramework/index.js';
 import { Command } from 'commander';
 import { NodeCLI } from './cli/node.js';
 import { Libraries, isPythonLibrary } from './types/libraries.js';
+import { InlineCLI } from './cli/inline.js';
 
 export function main(program: Command) {
   program.name('gt');
@@ -22,6 +23,8 @@ export function main(program: Command) {
     cli = new ReactCLI(program, library, additionalModules);
   } else if (library === Libraries.GT_NODE) {
     cli = new NodeCLI(program, library, additionalModules);
+  } else if (library === Libraries.GT_VUE) {
+    cli = new InlineCLI(program, library, additionalModules);
   } else if (isPythonLibrary(library)) {
     cli = new PythonCLI(program, library, additionalModules);
   } else {

--- a/packages/cli/src/translation/__tests__/extractInline.test.ts
+++ b/packages/cli/src/translation/__tests__/extractInline.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Libraries, type InlineLibrary } from '../../types/libraries.js';
+import type {
+  GTParsingFlags,
+  ParsingConfigOptions,
+} from '../../types/parsing.js';
+import type { PrimaryInlineExtractor } from '@generaltranslation/vue-extractor/integration';
+
+const mocks = vi.hoisted(() => ({
+  planVueExtraction: vi.fn(),
+}));
+
+vi.mock('@generaltranslation/vue-extractor/integration', () => ({
+  planVueExtraction: mocks.planVueExtraction,
+}));
+
+import { extractInlineFromProject } from '../extractInline.js';
+
+const projectRoot = '/project';
+const parsingFlags = {
+  includeSourceCodeContext: true,
+  viteConfigPath: 'vite.config.ts',
+  vueCompilerOptions: {
+    whitespace: 'preserve' as const,
+  },
+} as GTParsingFlags;
+const parsingOptions = {
+  conditionNames: ['source', 'import'],
+} as ParsingConfigOptions;
+const emptyOutput = { updates: [], errors: [], warnings: [] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(process, 'cwd').mockReturnValue(projectRoot);
+  mocks.planVueExtraction.mockReturnValue({ handled: false });
+});
+
+describe('extractInlineFromProject', () => {
+  it.each([
+    Libraries.GT_REACT,
+    Libraries.GT_NEXT,
+    Libraries.GT_REACT_NATIVE,
+    Libraries.GT_TANSTACK_START,
+    Libraries.GT_NODE,
+    Libraries.GT_FLASK,
+    Libraries.GT_FASTAPI,
+  ] satisfies InlineLibrary[])(
+    'preserves the historical %s extractor invocation when Vue is inert',
+    async (library) => {
+      const patterns = Object.freeze([
+        'src/**/*.{js,jsx,ts,tsx}',
+      ]) as unknown as string[];
+      const primaryOutput = {
+        updates: [],
+        errors: [`${library} error`],
+        warnings: [`${library} warning`],
+      };
+      const extractPrimary = vi.fn(() => Promise.resolve(primaryOutput));
+
+      const result = extractInlineFromProject(
+        library,
+        patterns,
+        parsingFlags,
+        parsingOptions,
+        extractPrimary
+      );
+
+      expect(extractPrimary).toHaveBeenCalledOnce();
+      expect(extractPrimary).toHaveBeenCalledWith(patterns);
+      expect(await result).toBe(primaryOutput);
+      expect(mocks.planVueExtraction).toHaveBeenCalledWith({
+        library,
+        projectRoot,
+        filePatterns: patterns,
+        includeSourceCodeContext: true,
+        conditionNames: parsingOptions.conditionNames,
+        vueCompilerOptions: parsingFlags.vueCompilerOptions,
+        viteConfigPath: parsingFlags.viteConfigPath,
+      });
+    }
+  );
+
+  it('delegates mixed React and Vue merging to the handled package plan', async () => {
+    const primaryOutput = {
+      updates: [
+        {
+          dataFormat: 'STRING' as const,
+          source: 'React message',
+          metadata: { hash: 'react-hash' },
+        },
+      ],
+      errors: [],
+      warnings: [],
+    };
+    const mergedOutput = {
+      updates: [
+        ...primaryOutput.updates,
+        {
+          dataFormat: 'STRING' as const,
+          source: 'Vue message',
+          metadata: { hash: 'vue-hash' },
+        },
+      ],
+      errors: [],
+      warnings: [],
+    };
+    const extractPrimary = vi.fn(() => Promise.resolve(primaryOutput));
+    const run = vi.fn(
+      async ({
+        extractPrimary: delegatedPrimary = undefined,
+      }: { extractPrimary?: PrimaryInlineExtractor } = {}) => {
+        expect(delegatedPrimary).toBe(extractPrimary);
+        await delegatedPrimary?.(undefined);
+        return mergedOutput;
+      }
+    );
+    mocks.planVueExtraction.mockReturnValue({ handled: true, run });
+
+    const result = await extractInlineFromProject(
+      Libraries.GT_REACT,
+      undefined,
+      parsingFlags,
+      parsingOptions,
+      extractPrimary
+    );
+
+    expect(run).toHaveBeenCalledOnce();
+    expect(extractPrimary).toHaveBeenCalledWith(undefined);
+    expect(result).toBe(mergedOutput);
+  });
+
+  it('lets the package-owned plan partition explicit targeted files', async () => {
+    const requestedPatterns = ['src/App.tsx', 'src/App.vue'];
+    const partitionedPrimaryPatterns = [
+      ...requestedPatterns,
+      '!/project/src/App.vue',
+    ];
+    const extractPrimary = vi.fn(() => Promise.resolve(emptyOutput));
+    const run = vi.fn(
+      async ({
+        extractPrimary: delegatedPrimary = undefined,
+      }: { extractPrimary?: PrimaryInlineExtractor } = {}) => {
+        await delegatedPrimary?.(partitionedPrimaryPatterns);
+        return emptyOutput;
+      }
+    );
+    mocks.planVueExtraction.mockReturnValue({ handled: true, run });
+
+    await extractInlineFromProject(
+      Libraries.GT_REACT,
+      requestedPatterns,
+      parsingFlags,
+      parsingOptions,
+      extractPrimary
+    );
+
+    expect(mocks.planVueExtraction).toHaveBeenCalledWith(
+      expect.objectContaining({ filePatterns: requestedPatterns })
+    );
+    expect(extractPrimary).toHaveBeenCalledOnce();
+    expect(extractPrimary).toHaveBeenCalledWith(partitionedPrimaryPatterns);
+  });
+
+  it('preserves a synchronous historical extractor throw when Vue is inert', () => {
+    const primaryError = new Error('synchronous primary failure');
+
+    expect(() =>
+      extractInlineFromProject(
+        Libraries.GT_REACT,
+        undefined,
+        parsingFlags,
+        parsingOptions,
+        () => {
+          throw primaryError;
+        }
+      )
+    ).toThrow(primaryError);
+  });
+
+  it('returns the handled plan early-rejection promise unchanged', async () => {
+    const primaryError = new Error('early primary failure');
+    const rejection = Promise.reject(primaryError);
+    const run = vi.fn(() => rejection);
+    mocks.planVueExtraction.mockReturnValue({ handled: true, run });
+
+    const result = extractInlineFromProject(
+      Libraries.GT_REACT,
+      undefined,
+      parsingFlags,
+      parsingOptions,
+      vi.fn()
+    );
+
+    expect(result).toBe(rejection);
+    await expect(result).rejects.toBe(primaryError);
+  });
+});

--- a/packages/cli/src/translation/__tests__/parse.test.ts
+++ b/packages/cli/src/translation/__tests__/parse.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createUpdates } from '../parse.js';
 import { createInlineUpdates } from '../../react/parse/createInlineUpdates.js';
+import { createPythonInlineUpdates } from '../../python/parse/createPythonInlineUpdates.js';
 import { Libraries } from '../../types/libraries.js';
-import type { ParsingConfigOptions } from '../../types/parsing.js';
+import type {
+  GTParsingFlags,
+  ParsingConfigOptions,
+} from '../../types/parsing.js';
 import type { TranslateFlags } from '../../types/index.js';
 
 vi.mock('../../react/parse/createInlineUpdates.js', () => ({
@@ -87,4 +91,72 @@ describe('createUpdates', () => {
       'shared-id',
     ]);
   });
+
+  it.each([
+    Libraries.GT_REACT,
+    Libraries.GT_NEXT,
+    Libraries.GT_REACT_NATIVE,
+    Libraries.GT_TANSTACK_START,
+    Libraries.GT_NODE,
+  ])('preserves the historical %s extractor arguments', async (library) => {
+    const patterns = ['src/entry.tsx'];
+    const parsingFlags = {
+      includeSourceCodeContext: true,
+      legacyGtReactImportSource: 'custom-gt-react',
+    } as GTParsingFlags;
+    const parsingOptions = {
+      conditionNames: ['source', 'import'],
+    } as ParsingConfigOptions;
+    vi.mocked(createInlineUpdates).mockResolvedValue({
+      updates: [],
+      errors: [],
+      warnings: [],
+    });
+
+    await createUpdates(
+      {} as TranslateFlags,
+      patterns,
+      undefined,
+      library,
+      true,
+      parsingFlags,
+      parsingOptions
+    );
+
+    expect(createInlineUpdates).toHaveBeenCalledOnce();
+    expect(createInlineUpdates).toHaveBeenCalledWith(
+      library,
+      true,
+      patterns,
+      parsingFlags,
+      parsingOptions
+    );
+    expect(createPythonInlineUpdates).not.toHaveBeenCalled();
+  });
+
+  it.each([Libraries.GT_FLASK, Libraries.GT_FASTAPI])(
+    'preserves the historical %s extractor arguments',
+    async (library) => {
+      const patterns = ['src/**/*.py'];
+      vi.mocked(createPythonInlineUpdates).mockResolvedValue({
+        updates: [],
+        errors: [],
+        warnings: [],
+      });
+
+      await createUpdates(
+        {} as TranslateFlags,
+        patterns,
+        undefined,
+        library,
+        true,
+        {},
+        {} as ParsingConfigOptions
+      );
+
+      expect(createPythonInlineUpdates).toHaveBeenCalledOnce();
+      expect(createPythonInlineUpdates).toHaveBeenCalledWith(patterns);
+      expect(createInlineUpdates).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/packages/cli/src/translation/extractInline.ts
+++ b/packages/cli/src/translation/extractInline.ts
@@ -1,0 +1,51 @@
+import {
+  planVueExtraction,
+  type InlineExtractionOutput,
+  type PrimaryInlineExtractor,
+} from '@generaltranslation/vue-extractor/integration';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import type { InlineLibrary } from '../types/libraries.js';
+import type { GTParsingFlags, ParsingConfigOptions } from '../types/parsing.js';
+
+export type { PrimaryInlineExtractor } from '@generaltranslation/vue-extractor/integration';
+
+const missingVueExtractorDiagnostic = createDiagnosticMessage({
+  source: 'gt',
+  severity: 'Error',
+  whatHappened: 'The gt-vue extractor did not claim this project',
+  fix: 'Install compatible versions of gt and @generaltranslation/vue-extractor',
+});
+
+/**
+ * Adds package-owned Vue extraction around the existing inline extractor.
+ *
+ * Non-Vue projects immediately call the historical extractor with the same
+ * arguments. The standalone Vue package owns activation, source partitioning,
+ * compiler resolution, extraction, and cross-framework result merging.
+ */
+export function extractInlineFromProject(
+  library: InlineLibrary,
+  filePatterns: string[] | undefined,
+  parsingFlags: GTParsingFlags,
+  parsingOptions: ParsingConfigOptions,
+  extractPrimary?: PrimaryInlineExtractor
+): Promise<InlineExtractionOutput> {
+  const plan = planVueExtraction({
+    library,
+    projectRoot: process.cwd(),
+    filePatterns,
+    includeSourceCodeContext: parsingFlags.includeSourceCodeContext,
+    conditionNames: parsingOptions.conditionNames,
+    vueCompilerOptions: parsingFlags.vueCompilerOptions,
+    viteConfigPath: parsingFlags.viteConfigPath,
+  });
+
+  if (!plan.handled) {
+    if (!extractPrimary) {
+      throw new Error(missingVueExtractorDiagnostic);
+    }
+    return extractPrimary(filePatterns);
+  }
+
+  return plan.run({ extractPrimary });
+}

--- a/packages/cli/src/translation/parse.ts
+++ b/packages/cli/src/translation/parse.ts
@@ -9,7 +9,15 @@ import createESBuildConfig from '../react/config/createESBuildConfig.js';
 import chalk from 'chalk';
 import type { ParsingConfigOptions, GTParsingFlags } from '../types/parsing.js';
 import { exitSync } from '../console/logging.js';
-import { InlineLibrary, isPythonLibrary } from '../types/libraries.js';
+import {
+  InlineLibrary,
+  isPythonLibrary,
+  Libraries,
+} from '../types/libraries.js';
+import {
+  extractInlineFromProject,
+  type PrimaryInlineExtractor,
+} from './extractInline.js';
 
 /**
  * Searches for gt-react or gt-next dictionary files and creates updates for them,
@@ -70,19 +78,30 @@ export async function createUpdates(
     }
   }
   // Scan through project for translatable content
+  const extractPrimary: PrimaryInlineExtractor | undefined =
+    pkg === Libraries.GT_VUE
+      ? undefined
+      : (primaryPatterns) =>
+          isPythonLibrary(pkg)
+            ? createPythonInlineUpdates(primaryPatterns)
+            : createInlineUpdates(
+                pkg,
+                validate,
+                primaryPatterns,
+                parsingFlags,
+                parsingOptions
+              );
   const {
     updates: newUpdates,
     errors: newErrors,
     warnings: newWarnings,
-  } = isPythonLibrary(pkg)
-    ? await createPythonInlineUpdates(src)
-    : await createInlineUpdates(
-        pkg,
-        validate,
-        src,
-        parsingFlags,
-        parsingOptions
-      );
+  } = await extractInlineFromProject(
+    pkg,
+    src,
+    parsingFlags,
+    parsingOptions,
+    extractPrimary
+  );
 
   errors = [...errors, ...newErrors];
   warnings = [...warnings, ...newWarnings];

--- a/packages/cli/src/translation/validate.ts
+++ b/packages/cli/src/translation/validate.ts
@@ -1,12 +1,16 @@
 import { logErrorAndExit, stripAnsi } from '../console/logging.js';
 import chalk from 'chalk';
 import findFilepath from '../fs/findFilepath.js';
-import { Framework, Options, Settings, Updates } from '../types/index.js';
+import { Options, Settings, Updates } from '../types/index.js';
 import { logger } from '../console/logger.js';
 
 import { createUpdates } from './parse.js';
 import { createInlineUpdates } from '../react/parse/createInlineUpdates.js';
 import { InlineLibrary, Libraries } from '../types/libraries.js';
+import {
+  extractInlineFromProject,
+  type PrimaryInlineExtractor,
+} from './extractInline.js';
 
 // Types for programmatic validation API
 export type ValidationLevel = 'error' | 'warning';
@@ -27,12 +31,23 @@ async function runValidation(
   files?: string[]
 ): Promise<{ updates: Updates; errors: string[]; warnings: string[] }> {
   if (files && files.length > 0) {
-    return createInlineUpdates(
+    const extractPrimary: PrimaryInlineExtractor | undefined =
+      pkg === Libraries.GT_VUE
+        ? undefined
+        : (primaryFiles) =>
+            createInlineUpdates(
+              pkg,
+              true,
+              primaryFiles,
+              settings.files.gtJson.parsingFlags,
+              settings.parsingOptions
+            );
+    return extractInlineFromProject(
       pkg,
-      true,
       files,
       settings.files.gtJson.parsingFlags,
-      settings.parsingOptions
+      settings.parsingOptions,
+      extractPrimary
     );
   }
 
@@ -94,15 +109,18 @@ export async function getValidateJson(
   pkg:
     | `${typeof Libraries.GT_REACT}`
     | `${typeof Libraries.GT_NEXT}`
-    | `${typeof Libraries.GT_REACT_NATIVE}`,
+    | `${typeof Libraries.GT_REACT_NATIVE}`
+    | `${typeof Libraries.GT_VUE}`,
   files?: string[]
 ): Promise<ValidationResult> {
-  const validatedPkg: Framework =
-    pkg === Libraries.GT_NEXT
-      ? Libraries.GT_NEXT
-      : pkg === Libraries.GT_REACT_NATIVE
-        ? Libraries.GT_REACT_NATIVE
-        : Libraries.GT_REACT;
+  const validatedPkg: InlineLibrary =
+    pkg === Libraries.GT_VUE
+      ? Libraries.GT_VUE
+      : pkg === Libraries.GT_NEXT
+        ? Libraries.GT_NEXT
+        : pkg === Libraries.GT_REACT_NATIVE
+          ? Libraries.GT_REACT_NATIVE
+          : Libraries.GT_REACT;
   const { errors, warnings } = await runValidation(
     settings,
     validatedPkg,

--- a/packages/cli/src/types/__tests__/configSchema.test.ts
+++ b/packages/cli/src/types/__tests__/configSchema.test.ts
@@ -1,0 +1,93 @@
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+type JsonSchema = {
+  additionalItems?: boolean;
+  additionalProperties?: boolean;
+  enum?: unknown[];
+  items?: JsonSchema[];
+  maxItems?: number;
+  minItems?: number;
+  oneOf?: JsonSchema[];
+  pattern?: string;
+  properties?: Record<string, JsonSchema>;
+  type?: string;
+};
+
+const schemaPath = fileURLToPath(
+  new URL('../../../../../assets/config-schema.json', import.meta.url)
+);
+const schema = JSON.parse(fs.readFileSync(schemaPath, 'utf8')) as JsonSchema;
+
+function getParsingFlagProperties(): Record<string, JsonSchema> {
+  const parsingFlagProperties =
+    schema.properties?.files?.properties?.gt?.properties?.parsingFlags
+      ?.properties;
+
+  expect(parsingFlagProperties).toBeDefined();
+  return parsingFlagProperties ?? {};
+}
+
+describe('GT config schema parsing flags', () => {
+  it('retains the complete canonical parsing flag surface', () => {
+    expect(Object.keys(getParsingFlagProperties()).sort()).toEqual([
+      'autoderive',
+      'devHotReload',
+      'enableAutoJsxInjection',
+      'includeSourceCodeContext',
+      'legacyGtReactImportSource',
+      'viteConfigPath',
+      'vueCompilerOptions',
+    ]);
+  });
+
+  it('accepts the existing boolean and granular dev hot reload forms', () => {
+    expect(getParsingFlagProperties().devHotReload).toEqual({
+      oneOf: [
+        { type: 'boolean' },
+        {
+          type: 'object',
+          properties: {
+            strings: { type: 'boolean' },
+            jsx: { type: 'boolean' },
+          },
+          additionalProperties: false,
+        },
+      ],
+    });
+  });
+
+  it('matches the exact Vue compiler option contract', () => {
+    expect(getParsingFlagProperties().vueCompilerOptions).toEqual({
+      type: 'object',
+      description: 'Hash-affecting Vue template compiler options',
+      properties: {
+        whitespace: {
+          type: 'string',
+          enum: ['condense', 'preserve'],
+        },
+        delimiters: {
+          type: 'array',
+          items: [
+            { type: 'string', minLength: 1 },
+            { type: 'string', minLength: 1 },
+          ],
+          additionalItems: false,
+          minItems: 2,
+          maxItems: 2,
+        },
+      },
+      additionalProperties: false,
+    });
+  });
+
+  it('requires a meaningful Vite config path', () => {
+    expect(getParsingFlagProperties().viteConfigPath).toEqual({
+      type: 'string',
+      minLength: 1,
+      pattern: '\\S',
+      description: 'Vite config path relative to the project root',
+    });
+  });
+});

--- a/packages/cli/src/types/__tests__/libraries.test.ts
+++ b/packages/cli/src/types/__tests__/libraries.test.ts
@@ -3,6 +3,7 @@ import {
   Libraries,
   isPythonLibrary,
   INLINE_LIBRARIES,
+  GT_LIBRARIES,
   GT_LIBRARIES_UPSTREAM,
   PYTHON_LIBRARIES,
 } from '../libraries.js';
@@ -49,5 +50,12 @@ describe('Python library types', () => {
     expect(PYTHON_LIBRARIES).toContain(Libraries.GT_FLASK);
     expect(PYTHON_LIBRARIES).toContain(Libraries.GT_FASTAPI);
     expect(PYTHON_LIBRARIES).toHaveLength(2);
+  });
+});
+
+describe('Vue library boundary', () => {
+  it('supports Vue inline extraction without changing React import tracking', () => {
+    expect(INLINE_LIBRARIES).toContain(Libraries.GT_VUE);
+    expect(GT_LIBRARIES).not.toContain(Libraries.GT_VUE);
   });
 });

--- a/packages/cli/src/types/libraries.ts
+++ b/packages/cli/src/types/libraries.ts
@@ -9,6 +9,7 @@ export enum Libraries {
   GT_I18N = 'gt-i18n',
   GT_REACT_CORE = '@generaltranslation/react-core',
   GT_TANSTACK_START = 'gt-tanstack-start',
+  GT_VUE = 'gt-vue',
   GT_FLASK = 'gt-flask',
   GT_FASTAPI = 'gt-fastapi',
 }
@@ -39,6 +40,7 @@ export const INLINE_LIBRARIES = [
   Libraries.GT_REACT_NATIVE,
   Libraries.GT_REACT_CORE,
   Libraries.GT_TANSTACK_START,
+  Libraries.GT_VUE,
   Libraries.GT_I18N,
   Libraries.GT_FLASK,
   Libraries.GT_FASTAPI,

--- a/packages/cli/src/types/parsing.ts
+++ b/packages/cli/src/types/parsing.ts
@@ -1,3 +1,4 @@
+import type { VueCompilerOptions } from '@generaltranslation/vue-extractor/types';
 import type { SupportedFileExtension } from './index.js';
 
 /**
@@ -37,12 +38,16 @@ export type BaseParsingFlags = Record<string, unknown>;
  * @property {boolean} includeSourceCodeContext - Include surrounding source code lines as context for translations.
  * @property {boolean} enableAutoJsxInjection - Whether to enable auto-jsx injection for the internal <_T> and <_Var> components.
  * @property {boolean} legacyGtReactImportSource - Whether compiler-injected gt-react imports should use gt-react/browser.
+ * @property {string} viteConfigPath - Vite config used to resolve hash-affecting Vue compiler behavior.
+ * @property {VueCompilerOptions} vueCompilerOptions - Hash-affecting Vue template compiler options.
  */
 export type GTParsingFlags = BaseParsingFlags & {
   autoderive: boolean | { jsx?: boolean; strings?: boolean };
   includeSourceCodeContext: boolean;
   enableAutoJsxInjection: boolean;
   legacyGtReactImportSource: boolean;
+  viteConfigPath?: string;
+  vueCompilerOptions?: VueCompilerOptions;
 };
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,7 @@
     "release:alpha": "pnpm run build:clean && pnpm publish --tag alpha",
     "release:beta": "pnpm run build:clean && pnpm publish --tag beta",
     "release:latest": "pnpm run build:clean && pnpm publish --tag latest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.type-tests.json"
   },
   "repository": {
     "type": "git",

--- a/packages/core/src/types-dir/config.ts
+++ b/packages/core/src/types-dir/config.ts
@@ -10,6 +10,13 @@ export type GTParsingFlags = {
   enableAutoJsxInjection?: boolean;
   legacyGtReactImportSource?: boolean;
   devHotReload?: boolean | { strings?: boolean; jsx?: boolean };
+  /** Vite config used to resolve hash-affecting Vue compiler behavior. */
+  viteConfigPath?: string;
+  /** Hash-affecting Vue template compiler options. */
+  vueCompilerOptions?: {
+    whitespace?: 'condense' | 'preserve';
+    delimiters?: [string, string];
+  };
 };
 
 /** Configuration for generated GT translation files. */

--- a/packages/core/tsconfig.type-tests.json
+++ b/packages/core/tsconfig.type-tests.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["type-tests/**/*.ts"],
+  "exclude": []
+}

--- a/packages/core/type-tests/config.ts
+++ b/packages/core/type-tests/config.ts
@@ -1,0 +1,75 @@
+import type { GTConfig, GTParsingFlags } from '../src/types.js';
+
+type Equal<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type Expect<Value extends true> = Value;
+
+type VueCompilerOptions = NonNullable<GTParsingFlags['vueCompilerOptions']>;
+type ExpectedVueCompilerOptions = {
+  whitespace?: 'condense' | 'preserve';
+  delimiters?: [string, string];
+};
+
+type _VueCompilerOptionsMatch = Expect<
+  Equal<VueCompilerOptions, ExpectedVueCompilerOptions>
+>;
+
+const validConfig = {
+  files: {
+    gt: {
+      parsingFlags: {
+        viteConfigPath: 'vite.config.ts',
+        vueCompilerOptions: {
+          whitespace: 'preserve',
+          delimiters: ['[[', ']]'],
+        },
+      },
+    },
+  },
+} satisfies GTConfig;
+
+const invalidWhitespace: GTConfig = {
+  files: {
+    gt: {
+      parsingFlags: {
+        vueCompilerOptions: {
+          // @ts-expect-error Vue only accepts its two documented modes.
+          whitespace: 'collapse',
+        },
+      },
+    },
+  },
+};
+
+const invalidViteConfigPath: GTConfig = {
+  files: {
+    gt: {
+      parsingFlags: {
+        // @ts-expect-error Vite config paths must be strings.
+        viteConfigPath: 42,
+      },
+    },
+  },
+};
+
+const invalidDelimiters: GTConfig = {
+  files: {
+    gt: {
+      parsingFlags: {
+        vueCompilerOptions: {
+          // @ts-expect-error Vue delimiters are exactly an opening/closing pair.
+          delimiters: ['[['],
+        },
+      },
+    },
+  },
+};
+
+void validConfig;
+void invalidWhitespace;
+void invalidViteConfigPath;
+void invalidDelimiters;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -798,6 +798,9 @@ importers:
       '@generaltranslation/supported-locales':
         specifier: workspace:*
         version: link:../supported-locales
+      '@generaltranslation/vue-extractor':
+        specifier: workspace:*
+        version: link:../vue-extractor
       chalk:
         specifier: ^5.4.1
         version: 5.6.2


### PR DESCRIPTION
## Summary

- connect `gt` to the package-owned `@generaltranslation/vue-extractor` planner through one small adapter
- preserve every historical framework's detection priority and command class
- select the existing `InlineCLI` only for direct gt-vue-only roots
- keep optional, peer, descendant-only, wrapper, transitive, and source-code evidence inert
- preserve next-intl/i18next JSON semantics while adding directly owned Vue content
- expose exact Vue compiler options through the canonical public config type and schema
- keep `packages/cli/src/react` byte-for-byte unchanged and deliberately exclude gt-vue from React import tracking

## Testing

- full CLI suite: 114 files, 2,186/2,186 tests
- full Vue extractor suite: 59 files, 1,937/1,937 tests
- 28/28 exact Iris differentials across React, Next, React Native, TanStack, Node, Flask, and FastAPI
- optional/peer/descendant inertness 6/6; framework priority 9/9
- callback arguments, Promise identity, synchronous throws, and rejection identity preserved
- warm inert-adapter overhead approximately 0.0124 ms per call with no workspace/source scan
- packed `gt`, `gt-vue`, and extractor imports on Node 20/24
- production Bun catalog byte-identical to Node
- real Vite production build and Chromium preview translated rich `<T>` and `useGT()` content without console errors
- CLI/core builds, typechecks, schema tests, lint, formatting, size, benchmark, binaries, and CodeQL

## Stack

1. #2064 — lock the contract
2. #2065 — align the gt-vue runtime
3. #2054 — implement the standalone extractor
4. this PR — add the minimal CLI adapter

## Release

- minor changeset for `gt`
- patch changeset for `generaltranslation` public config types