### PR TITLE
fix(vue): align branch runtime parity

### DIFF
--- a/.changeset/calm-branches-align.md
+++ b/.changeset/calm-branches-align.md
@@ -1,0 +1,7 @@
+---
+'gt-vue': patch
+---
+
+Preserve direct primitive `Branch` and `Plural` values in the source wire
+format, and align branch rendering and Plural locale selection with the React
+runtime.

--- a/packages/vue/src/__tests__/branches.test.ts
+++ b/packages/vue/src/__tests__/branches.test.ts
@@ -1,10 +1,77 @@
+import {
+  Branch as ReactBranch,
+  Plural as ReactPlural,
+  Var as ReactVar,
+  prepareT as prepareReactT,
+  renderTranslatedChildren as renderReactTranslatedChildren,
+} from '@generaltranslation/react-core/components-rsc';
 import { hashSource } from 'generaltranslation/id';
 import type { JsxChildren } from 'generaltranslation/types';
-import { compile, createSSRApp, defineComponent, type Component } from 'vue';
+import * as React from 'react';
+import {
+  compile,
+  createSSRApp,
+  defineComponent,
+  h,
+  type Component,
+  type VNode,
+  type VNodeChild,
+} from 'vue';
 import { renderToString } from 'vue/server-renderer';
 import { describe, expect, it } from 'vitest';
 import { isBranchAttribute } from '../components/utils';
-import { Branch, Plural, T, createGT } from '../index';
+import { Branch, Plural, T, Var, createGT } from '../index';
+import { serializeVueChildren } from '../rendering/translateVueChildren';
+
+type BranchTransformation = 'branch' | 'plural';
+type BranchSourceValue =
+  | 'rich'
+  | 'rich siblings'
+  | boolean
+  | null
+  | number
+  | string;
+type BranchTargetValue = JsxChildren | boolean | null;
+
+const BRANCH_SOURCE_CASES = [
+  { label: 'rich node', value: 'rich' },
+  { label: 'two rich siblings', value: 'rich siblings' },
+  { label: 'true', value: true },
+  { label: 'positive number', value: 1 },
+  { label: 'nonempty string', value: 'SOURCE TEXT' },
+  { label: 'false', value: false },
+  { label: 'null', value: null },
+  { label: 'zero', value: 0 },
+  { label: 'negative zero', value: -0 },
+  { label: 'empty string', value: '' },
+  { label: 'NaN', value: Number.NaN },
+] as const satisfies ReadonlyArray<{
+  label: string;
+  value: BranchSourceValue;
+}>;
+
+const BRANCH_TARGET_CASES = [
+  { label: 'true', value: true },
+  { label: 'false', value: false },
+  { label: 'null', value: null },
+  { label: 'string', value: 'TARGET STRING' },
+  { label: 'string array', value: ['TARGET A', 'TARGET B'] },
+  {
+    label: 'single element',
+    value: { t: 'span', i: 2, c: 'TARGET ELEMENT' },
+  },
+  {
+    label: 'single variable',
+    value: { i: 3, k: '_gt_value_3', v: 'v' },
+  },
+] as const satisfies ReadonlyArray<{
+  label: string;
+  value: BranchTargetValue;
+}>;
+
+const BRANCH_RENDER_MATRIX = BRANCH_SOURCE_CASES.flatMap((source) =>
+  BRANCH_TARGET_CASES.map((target) => ({ source, target }))
+);
 
 describe('Branch and Plural attributes', () => {
   it.each([
@@ -17,6 +84,99 @@ describe('Branch and Plural attributes', () => {
     ['one', 'Singular'],
   ])('accepts the primitive branch attribute %s', (name, value) => {
     expect(isBranchAttribute(name, value)).toBe(true);
+  });
+
+  it('preserves direct boolean and null Branch attributes in the rich wire source', () => {
+    const source = serializeVueChildren([
+      h(Branch, {
+        active: true,
+        branch: 'active',
+        inactive: false,
+        pending: '',
+        unknown: null,
+      }),
+    ]);
+
+    expect(source).toEqual({
+      t: 'Branch',
+      i: 1,
+      d: {
+        b: {
+          active: true,
+          inactive: false,
+          pending: '',
+          unknown: null,
+        },
+        t: 'b',
+      },
+    });
+  });
+
+  it('preserves primitive accepted Plural forms and rejects other attributes in the rich wire source', () => {
+    const source = serializeVueChildren([
+      h(Plural, {
+        few: '',
+        ignored: true,
+        many: 0,
+        n: 1,
+        one: true,
+        other: 'false',
+        two: null,
+        zero: false,
+      }),
+    ]);
+
+    expect(source).toEqual({
+      t: 'Plural',
+      i: 1,
+      d: {
+        b: {
+          few: '',
+          many: '0',
+          one: true,
+          other: 'false',
+          two: null,
+          zero: false,
+        },
+        t: 'p',
+      },
+    });
+  });
+
+  it('serializes Branch and Plural named slots before same-name primitive attributes', () => {
+    const source = serializeVueChildren([
+      h(
+        Branch,
+        { branch: 'formal', formal: false },
+        {
+          default: () => 'Fallback',
+          formal: () => 'Named slot',
+        }
+      ),
+      h(
+        Plural,
+        { n: 1, one: null },
+        {
+          default: () => 'Plural fallback',
+          one: () => 'Named plural slot',
+        }
+      ),
+    ]);
+
+    expect(source).toEqual([
+      {
+        t: 'Branch',
+        i: 1,
+        d: { b: { formal: 'Named slot' }, t: 'b' },
+        c: 'Fallback',
+      },
+      {
+        t: 'Plural',
+        i: 2,
+        d: { b: { one: 'Named plural slot' }, t: 'p' },
+        c: 'Plural fallback',
+      },
+    ]);
   });
 
   it.each([
@@ -198,8 +358,8 @@ describe('Branch and Plural attributes', () => {
           formal: 'Slot source',
           count: '12',
           large: '12',
-          flag: [],
-          empty: [],
+          flag: false,
+          empty: null,
         },
         t: 'b',
       },
@@ -213,8 +373,8 @@ describe('Branch and Plural attributes', () => {
           formal: 'Slot traduit',
           count: 'douze',
           large: 'grand',
-          flag: [],
-          empty: [],
+          flag: false,
+          empty: null,
         },
         t: 'b',
       },
@@ -251,21 +411,24 @@ describe('Branch and Plural attributes', () => {
     expect(html).not.toContain('[object Object]');
   });
 
-  it.each([
-    ['false', ':one="false"'],
-    ['null', ':one="null"'],
-  ])(
-    'treats a standalone Plural %s form as present and empty',
-    async (label, attribute) => {
-      const html = await renderTemplate(
-        `<div>before<Plural :n="1" ${attribute}>Fallback</Plural>after</div>`
-      );
+  it('treats a standalone Plural false form as present and empty', async () => {
+    const html = await renderTemplate(
+      '<div>before<Plural :n="1" :one="false">Fallback</Plural>after</div>'
+    );
 
-      expect(html).toContain('beforeafter');
-      expect(html).not.toContain('Fallback');
-      expect(html).not.toContain(`>${label}<`);
-    }
-  );
+    expect(html).toContain('beforeafter');
+    expect(html).not.toContain('Fallback');
+    expect(html).not.toContain('>false<');
+  });
+
+  it('uses the standalone Plural default for a null form', async () => {
+    const html = await renderTemplate(
+      '<div>before<Plural :n="1" :one="null">Fallback</Plural>after</div>'
+    );
+
+    expect(html).toContain('beforeFallbackafter');
+    expect(html).not.toContain('>null<');
+  });
 
   it('prefers a named Plural slot over an attribute with the same name', async () => {
     const html = await renderTemplate(
@@ -333,6 +496,106 @@ describe('Branch and Plural attributes', () => {
     expect(html).not.toContain('secret');
     expect(html).not.toContain('[object Object]');
   });
+
+  it('uses a React-canonical boolean/null branch hash and renders both source and target values as empty', async () => {
+    // React's persisted wire format keeps boolean and null branch values as
+    // primitives even though they render no visible content.
+    const source = [
+      'before',
+      {
+        t: 'Branch',
+        i: 1,
+        d: { b: { active: true }, t: 'b' },
+      },
+      {
+        t: 'Branch',
+        i: 2,
+        d: { b: { inactive: false }, t: 'b' },
+      },
+      {
+        t: 'Branch',
+        i: 3,
+        d: { b: { unknown: null }, t: 'b' },
+      },
+      'after',
+    ] as unknown as JsxChildren;
+    const target = [
+      'avant',
+      {
+        t: 'Branch',
+        i: 1,
+        d: { b: { active: false }, t: 'b' },
+      },
+      {
+        t: 'Branch',
+        i: 2,
+        d: { b: { inactive: true }, t: 'b' },
+      },
+      {
+        t: 'Branch',
+        i: 3,
+        d: { b: { unknown: null }, t: 'b' },
+      },
+      'après',
+    ] as unknown as JsxChildren;
+    const Root = defineComponent({
+      setup() {
+        return () =>
+          h(T, null, {
+            default: () => [
+              'before',
+              h(Branch, { active: true, branch: 'active' }),
+              h(Branch, { branch: 'inactive', inactive: false }),
+              h(Branch, { branch: 'unknown', unknown: null }),
+              'after',
+            ],
+          });
+      },
+    });
+
+    const defaultHtml = stripFragmentMarkers(
+      await renderWithRoot(Root, createGT())
+    );
+    expect(defaultHtml).toContain('beforeafter');
+    expect(defaultHtml).not.toContain('true');
+    expect(defaultHtml).not.toContain('null');
+
+    const translatedPlugin = createGT({
+      loadTranslations: async () => ({ [jsxHash(source)]: target }),
+    });
+    await translatedPlugin.setLocale('fr');
+    const translatedHtml = stripFragmentMarkers(
+      await renderWithRoot(Root, translatedPlugin)
+    );
+
+    expect(translatedHtml).toContain('avantaprès');
+    expect(translatedHtml).not.toContain('before');
+    expect(translatedHtml).not.toContain('false');
+    expect(translatedHtml).not.toContain('null');
+  });
+
+  describe.each(['branch', 'plural'] as const)(
+    '%s rich translation parity with React',
+    (transformation) => {
+      it.each(BRANCH_RENDER_MATRIX)(
+        '$source.label source with $target.label target',
+        async ({ source, target }) => {
+          const reactOutput = renderReactMatrixCase(
+            transformation,
+            source.value,
+            target.value
+          );
+          const vueOutput = await renderVueMatrixCase(
+            transformation,
+            source.value,
+            target.value
+          );
+
+          expect(vueOutput).toBe(reactOutput);
+        }
+      );
+    }
+  );
 });
 
 /** Renders a compiled Vue template through the server renderer. */
@@ -349,6 +612,163 @@ async function renderTemplate(
   const app = createSSRApp(Root);
   app.use(plugin);
   return stripFragmentMarkers(await renderToString(app));
+}
+
+/** Renders a component through the server renderer with a GT plugin. */
+async function renderWithRoot(
+  Root: Component,
+  plugin: ReturnType<typeof createGT>
+): Promise<string> {
+  const app = createSSRApp(Root);
+  app.use(plugin);
+  return renderToString(app);
+}
+
+/** Renders one matrix case through React's canonical rich-content pipeline. */
+function renderReactMatrixCase(
+  transformation: BranchTransformation,
+  sourceValue: BranchSourceValue,
+  targetValue: BranchTargetValue
+): string {
+  const prepared = prepareReactT({
+    locale: 'en',
+    params: {},
+    sourceChildren: createReactMatrixSource(transformation, sourceValue),
+  });
+  const target = createMatrixTarget(transformation, targetValue);
+  const rendered = renderReactTranslatedChildren({
+    enableI18n: true,
+    locales: ['fr'],
+    source: prepared.taggedSourceChildren,
+    target,
+  });
+  return serializeReactResult(rendered);
+}
+
+/** Renders the equivalent matrix case through the gt-vue T component. */
+async function renderVueMatrixCase(
+  transformation: BranchTransformation,
+  sourceValue: BranchSourceValue,
+  targetValue: BranchTargetValue
+): Promise<string> {
+  const source = serializeVueChildren([
+    createVueMatrixSource(transformation, sourceValue),
+  ]);
+  const target = createMatrixTarget(transformation, targetValue);
+  const plugin = createGT({
+    loadTranslations: async () => ({ [jsxHash(source)]: target }),
+  });
+  await plugin.setLocale('fr');
+  const Root = defineComponent({
+    setup() {
+      return () =>
+        h(T, null, {
+          default: () => createVueMatrixSource(transformation, sourceValue),
+        });
+    },
+  });
+
+  return stripFragmentMarkers(await renderWithRoot(Root, plugin)).replaceAll(
+    '<!---->',
+    ''
+  );
+}
+
+/** Creates a React Branch or Plural with an explicit rich default. */
+function createReactMatrixSource(
+  transformation: BranchTransformation,
+  sourceValue: BranchSourceValue
+): React.ReactElement {
+  const branchName = transformation === 'branch' ? 'selected' : 'other';
+  const props: Record<string, unknown> = {
+    children: React.createElement('em', null, 'SOURCE DEFAULT'),
+    ...(transformation === 'branch'
+      ? { branch: branchName }
+      : {
+          _enableI18n: true,
+          _locale: 'en',
+          n: 2,
+        }),
+    [branchName]:
+      sourceValue === 'rich'
+        ? React.createElement('strong', null, 'SOURCE BRANCH')
+        : sourceValue === 'rich siblings'
+          ? [
+              React.createElement('strong', { key: 'element' }, 'SOURCE FIRST'),
+              React.createElement(
+                ReactVar,
+                { key: 'variable' },
+                'SOURCE VARIABLE'
+              ),
+            ]
+          : sourceValue,
+  };
+  const component = transformation === 'branch' ? ReactBranch : ReactPlural;
+  return React.createElement(
+    component as React.ComponentType<Record<string, unknown>>,
+    props
+  );
+}
+
+/** Creates a Vue Branch or Plural with the same explicit rich default. */
+function createVueMatrixSource(
+  transformation: BranchTransformation,
+  sourceValue: BranchSourceValue
+): VNode {
+  const branchName = transformation === 'branch' ? 'selected' : 'other';
+  const props: Record<string, unknown> =
+    transformation === 'branch' ? { branch: branchName } : { n: 2 };
+  const slots: Record<string, () => VNodeChild> = {
+    default: () => h('em', null, 'SOURCE DEFAULT'),
+  };
+  if (sourceValue === 'rich') {
+    slots[branchName] = () => h('strong', null, 'SOURCE BRANCH');
+  } else if (sourceValue === 'rich siblings') {
+    slots[branchName] = () => [
+      h('strong', null, 'SOURCE FIRST'),
+      h(Var, { key: 'variable' }, { default: () => 'SOURCE VARIABLE' }),
+    ];
+  } else {
+    props[branchName] = sourceValue;
+  }
+  return h(transformation === 'branch' ? Branch : Plural, props, slots);
+}
+
+/** Builds a translated transform record with an explicit target default. */
+function createMatrixTarget(
+  transformation: BranchTransformation,
+  value: BranchTargetValue
+): JsxChildren {
+  const branchName = transformation === 'branch' ? 'selected' : 'other';
+  return {
+    t: transformation === 'branch' ? 'Branch' : 'Plural',
+    i: 1,
+    d: {
+      b: { [branchName]: value } as unknown as Record<string, JsxChildren>,
+      t: transformation === 'branch' ? 'b' : 'p',
+    },
+    c: 'TARGET DEFAULT',
+  };
+}
+
+/** Serializes the small React result grammar used by the parity matrix. */
+function serializeReactResult(node: React.ReactNode): string {
+  if (node == null || typeof node === 'boolean') return '';
+  if (
+    typeof node === 'string' ||
+    typeof node === 'number' ||
+    typeof node === 'bigint'
+  ) {
+    return String(node);
+  }
+  if (Array.isArray(node)) return node.map(serializeReactResult).join('');
+  if (!React.isValidElement(node)) return '';
+
+  const children = (node.props as { children?: React.ReactNode }).children;
+  const content = serializeReactResult(children);
+  return typeof node.type === 'string'
+    ? `<${node.type}>${content}</${node.type}>`
+    : content;
 }
 
 function jsxHash(source: JsxChildren): string {

--- a/packages/vue/src/__tests__/runtime.test.ts
+++ b/packages/vue/src/__tests__/runtime.test.ts
@@ -1413,7 +1413,7 @@ describe('gt-vue runtime', () => {
     mounted.app.unmount();
   });
 
-  it('selects source plural values with the source locale and target branches with the active locale', async () => {
+  it('selects source and target plural values with the active locale', async () => {
     const variable = { i: 2, k: '_gt_value_2', v: 'v' } as const;
     const target: JsxChildren = {
       t: 'Plural',
@@ -1454,8 +1454,8 @@ describe('gt-vue runtime', () => {
 
     const html = stripFragmentMarkers(await renderWithPlugin(Root, plugin));
 
-    expect(html).toContain('Cible OTHER');
-    expect(html).not.toContain('Cible ONE');
+    expect(html).toContain('Cible ONE');
+    expect(html).not.toContain('Cible OTHER');
   });
 
   it('updates multi-root rich children from arrays to scalar text on the client', async () => {

--- a/packages/vue/src/components/branches.ts
+++ b/packages/vue/src/components/branches.ts
@@ -59,7 +59,15 @@ export const Plural = withGTMetadata<PluralProps>(
             state.defaultLocale
           )
         );
-        return asFragmentRoot(getBranchContent(branch, attrs, slots));
+        const namedSlot = branch && slots[branch];
+        // React treats a null plural form as absent and renders the default,
+        // while false and true remain selected branches that render empty.
+        // A Vue named slot still wins over an attribute with the same name.
+        const content =
+          branch && attrs[branch] === null && typeof namedSlot !== 'function'
+            ? (slots.default?.() ?? null)
+            : getBranchContent(branch, attrs, slots);
+        return asFragmentRoot(content);
       };
     },
   }),

--- a/packages/vue/src/rendering/translateVueChildren.ts
+++ b/packages/vue/src/rendering/translateVueChildren.ts
@@ -39,8 +39,39 @@ const variableTypes = {
 
 type Transformation = 'branch' | 'fragment' | 'plural' | 'variable' | undefined;
 
+/**
+ * Empty-rendering primitives that React preserves verbatim in branch source.
+ *
+ * These values cannot be part of `SourceNode`: Vue renders them as no child,
+ * while the persisted GT wire format distinguishes `true`, `false`, and
+ * `null`. Keeping them beside the render nodes preserves both contracts.
+ */
+type BranchWireLiteral = boolean | null;
+type SourceCardinality = 'array' | 'scalar';
+
+type BranchSourceInput = {
+  /** Original JavaScript truthiness for a direct primitive attribute. */
+  scalarTruthy?: boolean;
+  value: unknown;
+  /** Persisted primitive that differs from its empty Vue render shape. */
+  wireLiteral?: BranchWireLiteral;
+};
+
+type SelectedBranchSource = {
+  cardinality: SourceCardinality;
+  nodes: SourceNode[];
+  /** Absent for named slots and defaults, which are already node collections. */
+  scalarTruthy?: boolean;
+};
+
 type SourceElement = {
   branches: Record<string, SourceNode[]>;
+  /** Semantic wire shape for each branch, independent from Vue slot arrays. */
+  branchCardinalities: Record<string, SourceCardinality>;
+  /** Truthiness before Vue normalizes primitive attributes into text nodes. */
+  branchScalarTruthiness: Record<string, boolean>;
+  /** Boolean/null values preserved independently from empty render nodes. */
+  branchWireLiterals: Record<string, BranchWireLiteral>;
   children: SourceNode[];
   id: number;
   identity: string;
@@ -306,6 +337,9 @@ function visitChildren(
     : readDefaultSlot(children, transformation);
   const source: SourceElement = {
     branches: {},
+    branchCardinalities: {},
+    branchScalarTruthiness: {},
+    branchWireLiterals: {},
     children:
       variable || defaultSlot.opaque
         ? []
@@ -328,13 +362,17 @@ function visitChildren(
   };
 
   if (transformation === 'branch' || transformation === 'plural') {
-    source.branches = getBranches(
+    const branches = getBranches(
       children,
       transformation,
       id,
       identity,
       identityRender
     );
+    source.branches = branches.nodes;
+    source.branchCardinalities = branches.cardinalities;
+    source.branchScalarTruthiness = branches.scalarTruthiness;
+    source.branchWireLiterals = branches.wireLiterals;
   }
   return [source];
 }
@@ -442,8 +480,13 @@ function getBranches(
   branchElementId: number,
   identity: string,
   identityRender: TranslationIdentityRender
-): Record<string, SourceNode[]> {
-  const inputs = Object.create(null) as Record<string, unknown>;
+): {
+  cardinalities: Record<string, SourceCardinality>;
+  nodes: Record<string, SourceNode[]>;
+  scalarTruthiness: Record<string, boolean>;
+  wireLiterals: Record<string, BranchWireLiteral>;
+} {
+  const inputs = Object.create(null) as Record<string, BranchSourceInput>;
   if (isSlots(vnode.children)) {
     for (const [key, slot] of Object.entries(vnode.children)) {
       if (
@@ -451,7 +494,7 @@ function getBranches(
         !key.startsWith('_') &&
         typeof slot === 'function'
       ) {
-        inputs[key] = slot();
+        inputs[key] = { value: slot() };
       }
     }
   }
@@ -460,28 +503,78 @@ function getBranches(
       isBranchAttribute(key, value) &&
       !Object.prototype.hasOwnProperty.call(inputs, key)
     ) {
-      inputs[key] = value;
+      inputs[key] = {
+        scalarTruthy: Boolean(value),
+        value,
+        ...(isBranchWireLiteral(value) && { wireLiteral: value }),
+      };
     }
   }
 
-  return Object.fromEntries(
-    Object.entries(inputs)
-      .filter(
-        ([key]) => transformation === 'branch' || isAcceptedPluralForm(key)
-      )
-      // Branches are mutually exclusive. Number each one independently from
-      // the parent so they share stable variable names and do not shift later
-      // siblings, matching the React renderer.
-      .map(([key, value]) => [
-        key,
-        visitChildren(
-          value,
-          { value: branchElementId },
-          `${identity}/branch:${key.length}:${key}`,
-          identityRender
-        ),
-      ])
+  const acceptedInputs = Object.entries(inputs).filter(
+    ([key]) => transformation === 'branch' || isAcceptedPluralForm(key)
   );
+  const nodes: Record<string, SourceNode[]> = Object.fromEntries(
+    acceptedInputs.map(([key, input]) => [
+      key,
+      getBranchRenderNodes(
+        input,
+        branchElementId,
+        identity,
+        key,
+        identityRender
+      ),
+    ])
+  );
+  return {
+    cardinalities: Object.fromEntries(
+      acceptedInputs.map(([key, input]) => [
+        key,
+        input.scalarTruthy === undefined
+          ? getSourceCardinality(nodes[key])
+          : 'scalar',
+      ])
+    ),
+    nodes,
+    scalarTruthiness: Object.fromEntries(
+      acceptedInputs.flatMap(([key, input]) =>
+        input.scalarTruthy === undefined ? [] : [[key, input.scalarTruthy]]
+      )
+    ),
+    wireLiterals: Object.fromEntries(
+      acceptedInputs.flatMap(([key, input]) =>
+        input.wireLiteral === undefined ? [] : [[key, input.wireLiteral]]
+      )
+    ),
+  };
+}
+
+/**
+ * Builds the render model for one branch independently from its wire model.
+ *
+ * Direct boolean/null attributes render no node, so they must not enter the
+ * recursive VNode visitor. Other mutually exclusive branches start numbering
+ * from their parent to preserve React-compatible variable and element IDs.
+ */
+function getBranchRenderNodes(
+  input: BranchSourceInput,
+  branchElementId: number,
+  identity: string,
+  key: string,
+  identityRender: TranslationIdentityRender
+): SourceNode[] {
+  if (input.wireLiteral !== undefined) return [];
+  return visitChildren(
+    input.value,
+    { value: branchElementId },
+    `${identity}/branch:${key.length}:${key}`,
+    identityRender
+  );
+}
+
+/** True when Vue renders a direct branch attribute empty but GT persists it. */
+function isBranchWireLiteral(value: unknown): value is BranchWireLiteral {
+  return value === null || typeof value === 'boolean';
 }
 
 function isSlots(children: unknown): children is Slots {
@@ -517,7 +610,7 @@ function serializeNode(node: SourceNode): JsxChild {
     data.b = Object.fromEntries(
       Object.entries(node.branches).map(([key, branch]) => [
         key,
-        serializeNodes(branch),
+        serializeBranch(node, key, branch),
       ])
     );
     data.t = node.transformation === 'plural' ? 'p' : 'b';
@@ -529,6 +622,23 @@ function serializeNode(node: SourceNode): JsxChild {
     ...(Object.keys(data).length && { d: data }),
     ...(node.children.length && { c: serializeNodes(node.children) }),
   };
+}
+
+/**
+ * Serializes a branch without conflating its render shape with its wire value.
+ *
+ * `JsxChildren` predates React's persisted boolean/null branch values, so the
+ * cast is confined to the exact literal crossing that shared type boundary.
+ */
+function serializeBranch(
+  node: SourceElement,
+  key: string,
+  branch: SourceNode[]
+): JsxChildren {
+  if (Object.hasOwn(node.branchWireLiterals, key)) {
+    return node.branchWireLiterals[key] as unknown as JsxChildren;
+  }
+  return serializeNodes(branch);
 }
 
 /**
@@ -549,18 +659,33 @@ function getElementName(vnode: VNode, id: number): string {
 
 function renderNodes(
   source: SourceNode[],
-  target: JsxChildren | undefined,
+  target: JsxChildren | boolean | null | undefined,
   state: GTState,
-  identityRender: TranslationIdentityRender
+  identityRender: TranslationIdentityRender,
+  sourceCardinality: SourceCardinality = getSourceCardinality(source),
+  sourceScalarTruthy?: boolean
 ): VNodeChild {
-  if (target == null) {
+  if (target == null || typeof target === 'boolean') {
     // A partial translated tree falls back within the active locale. A wholly
     // missing catalog entry is handled above using the source/default locale.
     return renderDefaultNodes(source, state, identityRender, state.getLocale());
   }
   if (typeof target === 'string') return target;
+  const targetIsArray = Array.isArray(target);
+  if (!targetIsArray && sourceCardinality === 'array') {
+    // A scalar element/variable target cannot reconcile against React's array
+    // source shape. React falls back to the complete source instead of
+    // selecting the first compatible child and dropping its siblings.
+    return renderDefaultNodes(source, state, identityRender, state.getLocale());
+  }
+  if (targetIsArray && sourceScalarTruthy === false) {
+    // React only coerces a truthy scalar source to an array before rendering
+    // an array target. Preserve that asymmetry for every falsy primitive,
+    // including zero, empty strings, false, null, NaN, and zero bigint.
+    return renderDefaultNodes(source, state, identityRender, state.getLocale());
+  }
 
-  const targets = Array.isArray(target) ? target : [target];
+  const targets = targetIsArray ? target : [target];
   const sourceElements = source.filter(
     (node): node is SourceElement => typeof node !== 'string'
   );
@@ -575,6 +700,23 @@ function renderNodes(
   const ordinaryById = new Map(ordinary.map((node) => [node.id, node]));
   const fallback = [...ordinary];
   const occurrences = new Map<SourceElement, number>();
+
+  // React falls back to the complete scalar source when a scalar target has
+  // no compatible element or variable. Array targets instead drop unmatched
+  // records one by one, so this check must remain limited to scalar targets.
+  if (!targetIsArray) {
+    const hasCompatibleSource = isVariable(target)
+      ? variables.has(target.k)
+      : ordinary.length > 0;
+    if (!hasCompatibleSource) {
+      return renderDefaultNodes(
+        source,
+        state,
+        identityRender,
+        state.getLocale()
+      );
+    }
+  }
 
   return targets.map((targetNode) => {
     if (typeof targetNode === 'string') return targetNode;
@@ -667,11 +809,14 @@ function renderElement(
 ): VNodeChild {
   if (source.transformation === 'branch') {
     const branch = getBranchKey(source.vnode);
+    const selectedSource = getSelectedSourceBranch(source, branch);
     return renderNodes(
-      getSelectedSourceBranch(source, branch),
+      selectedSource.nodes,
       getSelectedTargetBranch(target, branch),
       state,
-      identityRender
+      identityRender,
+      selectedSource.cardinality,
+      selectedSource.scalarTruthy
     );
   }
   if (source.transformation === 'plural') {
@@ -684,26 +829,17 @@ function renderElement(
         state.getLocale()
       );
     }
-    const sourceBranch = getPluralKey(
-      n,
-      Object.keys(source.branches),
-      source,
-      state,
-      state.defaultLocale,
-      true
-    );
+    const sourceBranch = getPluralKey(n, Object.keys(source.branches), state);
     const targetBranches = target.d?.b ?? {};
-    const targetBranch = getPluralKey(
-      n,
-      Object.keys(targetBranches),
-      source,
-      state
-    );
+    const targetBranch = getPluralKey(n, Object.keys(targetBranches), state);
+    const selectedSource = getSelectedSourceBranch(source, sourceBranch);
     return renderNodes(
-      getSelectedSourceBranch(source, sourceBranch),
+      selectedSource.nodes,
       (targetBranch && targetBranches[targetBranch]) ?? target.c,
       state,
-      identityRender
+      identityRender,
+      selectedSource.cardinality,
+      selectedSource.scalarTruthy
     );
   }
   if (source.transformation === 'fragment') {
@@ -750,24 +886,16 @@ function getBranchKey(source: VNode): string | undefined {
 function getPluralKey(
   n: number,
   branches: string[],
-  source: SourceElement,
   state: GTState,
-  locale = state.getLocale(),
-  includeSourceLocales = false
+  locale = state.getLocale()
 ): string | undefined {
   const forms = branches.filter(isAcceptedPluralForm);
   if (!forms.length) return undefined;
-  const sourceLocales =
-    includeSourceLocales && Array.isArray(source.vnode.props?.locales)
-      ? source.vnode.props.locales.filter(
-          (locale): locale is string => typeof locale === 'string'
-        )
-      : [];
   return (
     getPluralForm(
       n,
       forms,
-      getFormatLocales(sourceLocales, locale, state.defaultLocale)
+      getFormatLocales(undefined, locale, state.defaultLocale)
     ) || undefined
   );
 }
@@ -775,19 +903,45 @@ function getPluralKey(
 function getSelectedSourceBranch(
   source: SourceElement,
   branch?: string
-): SourceNode[] {
-  return branch && Object.hasOwn(source.branches, branch)
-    ? source.branches[branch]
-    : source.children;
+): SelectedBranchSource {
+  if (!branch || !Object.hasOwn(source.branches, branch)) {
+    return {
+      cardinality: getSourceCardinality(source.children),
+      nodes: source.children,
+    };
+  }
+
+  const wireLiteral = source.branchWireLiterals[branch];
+  // React treats a null plural form as missing and renders the default branch,
+  // while a null Branch value remains a selected, empty branch.
+  if (source.transformation === 'plural' && wireLiteral === null) {
+    return {
+      cardinality: getSourceCardinality(source.children),
+      nodes: source.children,
+    };
+  }
+  return {
+    cardinality: source.branchCardinalities[branch],
+    nodes: source.branches[branch],
+    scalarTruthy: source.branchScalarTruthiness[branch],
+  };
+}
+
+/** Returns the scalar/array shape produced by `serializeNodes()`. */
+function getSourceCardinality(nodes: SourceNode[]): SourceCardinality {
+  return nodes.length === 1 ? 'scalar' : 'array';
 }
 
 function getSelectedTargetBranch(
   target: JsxElement,
   branch?: string
-): JsxChildren | undefined {
-  return branch && target.d?.b && Object.hasOwn(target.d.b, branch)
-    ? target.d.b[branch]
-    : target.c;
+): JsxChildren | boolean | null | undefined {
+  if (branch && target.d?.b && Object.hasOwn(target.d.b, branch)) {
+    // React catalogs can persist boolean/null branch values even though the
+    // shared public type has not yet widened to describe that wire reality.
+    return target.d.b[branch] as JsxChildren | boolean | null;
+  }
+  return target.c;
 }
 
 function mergeAdjacentStrings(nodes: SourceNode[]): SourceNode[] {
@@ -848,7 +1002,7 @@ function renderDefaultNode(
   }
   if (node.transformation === 'branch') {
     return renderDefaultNodes(
-      getSelectedSourceBranch(node, getBranchKey(node.vnode)),
+      getSelectedSourceBranch(node, getBranchKey(node.vnode)).nodes,
       state,
       identityRender,
       locale
@@ -859,16 +1013,9 @@ function renderDefaultNode(
     if (typeof n !== 'number') {
       return renderDefaultNodes(node.children, state, identityRender, locale);
     }
-    const branch = getPluralKey(
-      n,
-      Object.keys(node.branches),
-      node,
-      state,
-      locale,
-      true
-    );
+    const branch = getPluralKey(n, Object.keys(node.branches), state, locale);
     return renderDefaultNodes(
-      getSelectedSourceBranch(node, branch),
+      getSelectedSourceBranch(node, branch).nodes,
       state,
       identityRender,
       locale
@@ -983,6 +1130,11 @@ function cloneWithProps(
   return cloneVNode(vnode, extraProps);
 }
 
-function isVariable(value: JsxElement | Variable): value is Variable {
-  return 'k' in value && typeof value.k === 'string';
+function isVariable(value: unknown): value is Variable {
+  return (
+    value != null &&
+    typeof value === 'object' &&
+    'k' in value &&
+    typeof value.k === 'string'
+  );
 }

--- a/test-fixtures/react-vue-runtime-parity.json
+++ b/test-fixtures/react-vue-runtime-parity.json
@@ -134,26 +134,8 @@
   {
     "id": "complex-cases/different-number-formats",
     "hash": "4d68f22fc6e97b8f",
-    "mode": "expected-failure",
-    "reason": "The only runtime mismatch is direct Branch props true, false, and null being normalized to empty children; their typed values remain available on the compiled VNode, so gt-vue can preserve them in source serialization.",
-    "brokenVueHash": "4c9ba22391e5f1dc",
-    "repairs": [
-      {
-        "path": [1, "d", "b", "active"],
-        "before": [],
-        "after": true
-      },
-      {
-        "path": [1, "d", "b", "inactive"],
-        "before": [],
-        "after": false
-      },
-      {
-        "path": [1, "d", "b", "unknown"],
-        "before": [],
-        "after": null
-      }
-    ]
+    "mode": "semantic-wire-exact",
+    "reason": "Both runtimes preserve direct Branch props true, false, and null as typed source values, producing identical semantic wire data and the locked React hash."
   },
   {
     "id": "complex-cases/duplicate-branches",


### PR DESCRIPTION
## Summary

- preserve React's boolean and null `Branch`/`Plural` values in Vue's persisted rich-content wire format
- retain source truthiness and scalar/array shape so translated branches reconcile without dropping or inventing content
- align null/default and active-locale Plural selection with the React runtime
- promote the locked runtime seed from an expected mismatch to exact semantic-wire and hash parity

## Testing

- `pnpm --filter gt-vue test` — 506 tests passed, including 210 locked seed assertions and 154 direct React/Vue Branch/Plural rendering comparisons
- `pnpm --filter @generaltranslation/react-core test` — 50 tests passed
- `pnpm --filter gt-vue typecheck`
- `pnpm --filter gt-vue build`
- `pnpm lint`
- `pnpm exec changeset status` — `gt-vue` patch recognized
- isolated Vue 3.3.13 gate at commit `c7ad7efff`: dependency build, gt-vue typecheck, and all 506 tests passed

## Notes

- stacked on #2061 (`e/multi/lock-react-runtime-parity`)
- includes a patch changeset for `gt-vue`
- React production code and the locked parity assertions/hashes are unchanged
- the initial portable contract excludes raw bigint branch wire values and falsy default-slot primitives supplied through render functions

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns Vue `Branch` and `Plural` serialization and rendering with the corresponding React runtime behavior.
- Preserves boolean and null branch values in the persisted rich-content wire format.
- Tracks source cardinality and primitive truthiness during translated-tree reconciliation.
- Aligns plural fallback and active-locale selection semantics.
- Expands direct React/Vue parity coverage and promotes the locked fixture to exact semantic-wire parity.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/vue/src/rendering/translateVueChildren.ts | Adds semantic branch metadata, preserves boolean/null wire literals, and aligns translated-tree reconciliation and plural selection with React. |
| packages/vue/src/components/branches.ts | Makes a null standalone Plural form render its default while preserving named-slot precedence. |
| packages/vue/src/__tests__/branches.test.ts | Adds serialization assertions and a broad direct React/Vue Branch and Plural rendering matrix. |
| packages/vue/src/__tests__/runtime.test.ts | Updates runtime coverage to assert active-locale plural selection. |
| test-fixtures/react-vue-runtime-parity.json | Promotes the branch primitive fixture from an expected mismatch to exact semantic-wire and hash parity. |
| .changeset/calm-branches-align.md | Records the Vue runtime parity correction as a patch release. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Source[Vue Branch or Plural source] --> Serialize[Capture wire literals, cardinality, and truthiness]
  Serialize --> Hash[Generate canonical source hash]
  Hash --> Catalog[Load translated rich-content target]
  Catalog --> Select[Select Branch or active-locale Plural form]
  Select --> Reconcile[Reconcile target with source shape]
  Reconcile --> Render[Render translated content or source fallback]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(vue): align branch runtime parity"](https://github.com/generaltranslation/gt/commit/c5cb5dc85cab1337d3b9f0b54de20d717f5d35fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51932379)</sub>

<!-- /greptile_comment -->