### PR TITLE
fix(vue): translate static component children

### DIFF
--- a/.changeset/bright-static-slots.md
+++ b/.changeset/bright-static-slots.md
@@ -1,0 +1,5 @@
+---
+'gt-vue': patch
+---
+
+Translate statically authored default-slot content inside custom components.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -84,22 +84,35 @@ const setLocale = useSetLocale();
 `$context`; braces are literal text and no ICU formatting or interpolation is
 applied.
 
-Arbitrary component slots are opaque when placed inside `<T>`. Vue does not
-expose a reliable way to inspect a component slot without executing user code,
-so the component and its real runtime slots are preserved, but their content is
-not part of the surrounding rich translation. To translate slot content, place
-`<T>` inside the slot and wrap runtime values in `<Var>`. Native elements and
-the slots owned by GT's `<Branch>` and `<Plural>` components remain part of the
-surrounding translation. Component tags inside `<T>` must resolve at runtime;
-an unresolved component warning from Vue is a configuration error and is not a
-supported translation source.
+Statically authored default-slot content inside a custom component participates
+in the surrounding translation. The component itself, its props, and its
+listeners are preserved while the translated content replaces its default
+slot:
 
-Vue `<Suspense>` is the one built-in whose default content participates in an
-outer `<T>`. Prefer literal `<Suspense>` and use a single default root. Immutable
-aliases that the extractor can trace directly to `vue` are also supported; the
-fallback slot is preserved but excluded from the outer translation. Re-exported,
-globally registered, ref/computed-held, and other runtime-wrapped Suspense
-aliases are not supported inside an outer `<T>`. Put `<T>` inside those
+```vue
+<T>
+  <DocsLink to="/docs">Read the documentation</DocsLink>
+</T>
+```
+
+Content created inside `DocsLink`'s implementation is not visible to the outer
+`<T>`. Runtime values still belong in `<Var>`, and conditional alternatives
+belong in `<Branch>` or `<Plural>`. Scoped and arbitrary named slots depend on
+the child component's runtime behavior, so place `<T>` inside those slots or
+enclose the dynamic component boundary in `<Var>`. Component tags inside `<T>`
+must resolve at runtime; an unresolved component warning from Vue is a
+configuration error and is not a supported translation source. Use direct
+component tags inside an outer `<T>`: Vue's `<component :is>` and
+`is="vue:..."` selector forms are intentionally rejected by extraction because
+global runtime registration can change their component identity after build.
+
+Vue built-ins with statically authored default content follow the same rule.
+`<Suspense>` needs one additional distinction: its default content participates
+in an outer `<T>`, while its fallback slot is preserved but excluded from that
+translation. Prefer literal `<Suspense>` with a single default root. Immutable
+aliases that the extractor can trace directly to `vue` are also supported.
+Re-exported, globally registered, ref/computed-held, and other runtime-wrapped
+Suspense aliases are not supported inside an outer `<T>`. Put `<T>` inside those
 boundaries instead:
 
 ```vue

--- a/packages/vue/src/__tests__/runtime.test.ts
+++ b/packages/vue/src/__tests__/runtime.test.ts
@@ -3,10 +3,12 @@ import { hashSource } from 'generaltranslation/id';
 import * as Vue from 'vue';
 import {
   Fragment,
+  KeepAlive,
   Suspense,
   createCommentVNode,
   createRenderer,
   createSSRApp,
+  createStaticVNode,
   defineComponent,
   h,
   nextTick,
@@ -260,7 +262,7 @@ describe('gt-vue runtime', () => {
     expect(html).not.toContain('Formal');
   });
 
-  it('translates supported component props while preserving opaque slots', async () => {
+  it('translates supported component props and static slot children', async () => {
     const onNavigate = vi.fn();
     const Link = defineComponent({
       emits: ['navigate'],
@@ -327,7 +329,7 @@ describe('gt-vue runtime', () => {
       id: 'docs-link',
       title: 'Titre traduit',
     });
-    expect(textContent(mounted.root)).toBe('Source link');
+    expect(textContent(mounted.root)).toBe('Lien traduit');
     const onClick = anchor?.props.onClick;
     expect(onClick).toBeTypeOf('function');
     (onClick as () => void)();
@@ -335,7 +337,40 @@ describe('gt-vue runtime', () => {
     mounted.app.unmount();
   });
 
-  it('keeps Vue-compiled scoped slots opaque and supplies real props in SSR', async () => {
+  it('normalizes translated text for compiler-generated slot outlets', async () => {
+    const CompiledLink = defineComponent({
+      name: 'CompiledLink',
+      render: compileSfcTemplate('<a><slot /></a>'),
+    });
+    const plugin = createGT({
+      loadTranslations: async () => ({
+        compiledSlot: {
+          t: 'CompiledLink',
+          i: 1,
+          c: 'Translated compiler slot',
+        },
+      }),
+    });
+    await plugin.setLocale('fr');
+    const Root = defineComponent({
+      components: { CompiledLink, T },
+      render: compileSfcTemplate(
+        '<T _hash="compiledSlot"><CompiledLink>Source compiler slot</CompiledLink></T>'
+      ),
+    });
+
+    const html = await renderWithPlugin(Root, plugin);
+
+    expect(html).toContain('<a>');
+    expect(html).toContain('Translated compiler slot');
+    expect(html).not.toContain('Source compiler slot');
+
+    const mounted = mount(Root, plugin);
+    expect(textContent(mounted.root)).toBe('Translated compiler slot');
+    mounted.app.unmount();
+  });
+
+  it('keeps Vue-compiled scoped slots dynamic when enclosed by Var', async () => {
     const ScopedCard = defineComponent({
       name: 'ScopedCard',
       setup(_props, { slots }) {
@@ -345,42 +380,33 @@ describe('gt-vue runtime', () => {
     const plugin = createGT({
       loadTranslations: async () => ({
         scoped: {
-          t: 'ScopedCard',
           i: 1,
-          c: 'A translated replacement must not consume a scoped slot',
+          k: '_gt_value_1',
+          v: 'v',
         },
       }),
     });
     await plugin.setLocale('fr');
     const Root = defineComponent({
-      components: { Card: ScopedCard, T },
+      components: { Card: ScopedCard, T, Var },
       render: compileSfcTemplate(
-        '<T _hash="scoped"><Card v-slot="{ label }"><span>{{ label }}</span></Card></T>'
+        '<T _hash="scoped"><Var><Card v-slot="{ label }"><span>{{ label }}</span></Card></Var></T>'
       ),
     });
 
     const html = await renderWithPlugin(Root, plugin);
 
     expect(html).toContain('<article><span>Runtime label</span></article>');
-    expect(html).not.toContain('translated replacement');
   });
 
-  it('never probes direct, ignored, or forwarded custom component slots', async () => {
+  it('materializes each authored custom-component slot once', async () => {
     const directCalls = vi.fn();
     const ignoredCalls = vi.fn();
     const forwardedCalls = vi.fn();
-    const scope = { label: 'Runtime label' };
-    const DeferredReader = defineComponent({
-      name: 'DeferredReader',
-      props: { payload: { required: true, type: Object } },
-      setup(props) {
-        return () => h('span', String(props.payload.label));
-      },
-    });
     const DirectOwner = defineComponent({
       name: 'DirectOwner',
       setup(_props, { slots }) {
-        return () => h('section', slots.default?.(scope));
+        return () => h('section', slots.default?.());
       },
     });
     const IgnoredOwner = defineComponent({
@@ -392,15 +418,15 @@ describe('gt-vue runtime', () => {
     const ForwardingOwner = defineComponent({
       name: 'ForwardingOwner',
       setup(_props, { slots }) {
-        return () => h('div', slots.default?.(scope));
+        return () => h('div', slots.default?.());
       },
     });
     const plugin = createGT({
       loadTranslations: async () => ({
         opaqueSlots: [
-          { t: 'DirectOwner', i: 1, c: 'Wrong direct replacement' },
-          { t: 'IgnoredOwner', i: 2, c: 'Wrong ignored replacement' },
-          { t: 'ForwardingOwner', i: 3, c: 'Wrong forwarded replacement' },
+          { t: 'DirectOwner', i: 1, c: 'Translated direct child' },
+          { t: 'IgnoredOwner', i: 2, c: 'Translated ignored child' },
+          { t: 'ForwardingOwner', i: 3, c: 'Translated forwarded child' },
         ],
       }),
     });
@@ -414,11 +440,9 @@ describe('gt-vue runtime', () => {
             {
               default: () => [
                 h(DirectOwner, null, {
-                  default: (slotScope: typeof scope) => {
-                    directCalls(slotScope);
-                    return slotScope === scope
-                      ? 'Exact scope object'
-                      : 'Synthetic scope object';
+                  default: () => {
+                    directCalls();
+                    return 'Source direct child';
                   },
                 }),
                 h(IgnoredOwner, null, {
@@ -428,9 +452,9 @@ describe('gt-vue runtime', () => {
                   },
                 }),
                 h(ForwardingOwner, null, {
-                  default: (slotScope: typeof scope) => {
-                    forwardedCalls(slotScope);
-                    return h(DeferredReader, { payload: slotScope });
+                  default: () => {
+                    forwardedCalls();
+                    return 'Source forwarded child';
                   },
                 }),
               ],
@@ -441,18 +465,17 @@ describe('gt-vue runtime', () => {
 
     const html = await renderWithPlugin(Root, plugin);
 
-    expect(html).toContain('Exact scope object');
+    expect(html).toContain('Translated direct child');
     expect(html).toContain('Ignored safely');
-    expect(html).toContain('Runtime label');
-    expect(html).not.toContain('Wrong');
+    expect(html).toContain('Translated forwarded child');
+    expect(html).not.toContain('Source direct child');
+    expect(html).not.toContain('Source forwarded child');
     expect(directCalls).toHaveBeenCalledOnce();
-    expect(directCalls).toHaveBeenCalledWith(scope);
-    expect(ignoredCalls).not.toHaveBeenCalled();
+    expect(ignoredCalls).toHaveBeenCalledOnce();
     expect(forwardedCalls).toHaveBeenCalledOnce();
-    expect(forwardedCalls).toHaveBeenCalledWith(scope);
   });
 
-  it('preserves arbitrary scoped named slots without invoking them', async () => {
+  it('keeps arbitrary scoped named slots dynamic when enclosed by Var', async () => {
     const ScopedBranch = defineComponent({
       name: 'ScopedBranch',
       setup(_props, { slots }) {
@@ -462,24 +485,83 @@ describe('gt-vue runtime', () => {
     const plugin = createGT({
       loadTranslations: async () => ({
         scopedBranch: {
-          t: 'ScopedBranch',
           i: 1,
-          c: 'Translated replacement',
+          k: '_gt_value_1',
+          v: 'v',
         },
       }),
     });
     await plugin.setLocale('fr');
     const Root = defineComponent({
-      components: { ScopedBranch, T },
+      components: { ScopedBranch, T, Var },
       render: compileSfcTemplate(
-        '<T _hash="scopedBranch"><ScopedBranch><template #one="{ label }"><span>{{ label }}</span></template></ScopedBranch></T>'
+        '<T _hash="scopedBranch"><Var><ScopedBranch><template #one="{ label }"><span>{{ label }}</span></template></ScopedBranch></Var></T>'
       ),
     });
 
     const html = await renderWithPlugin(Root, plugin);
 
     expect(html).toContain('<span>Runtime label</span>');
-    expect(html).not.toContain('Translated replacement');
+  });
+
+  it('does not translate component-owned implementation content', async () => {
+    const ImplementationCopy = defineComponent({
+      name: 'ImplementationCopy',
+      setup() {
+        return () => h('p', 'Component-owned copy');
+      },
+    });
+    const plugin = createGT({
+      loadTranslations: async () => ({
+        implementation: {
+          t: 'ImplementationCopy',
+          i: 1,
+          c: 'Catalog content was not authored inside T',
+        },
+      }),
+    });
+    await plugin.setLocale('fr');
+    const Root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            T,
+            { _hash: 'implementation' },
+            { default: () => h(ImplementationCopy) }
+          );
+      },
+    });
+
+    const html = await renderWithPlugin(Root, plugin);
+
+    expect(html).toContain('Component-owned copy');
+    expect(html).not.toContain('Catalog content was not authored inside T');
+  });
+
+  it('preserves opaque Static VNodes in source and translated locales', async () => {
+    const plugin = createGT({
+      loadTranslations: async () => ({
+        staticVNode: { t: 'Static', i: 1, c: 'Ignored target' },
+      }),
+    });
+    const Root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            T,
+            { _hash: 'staticVNode' },
+            { default: () => createStaticVNode('<p>Static source</p>', 1) }
+          );
+      },
+    });
+
+    expect(await renderWithPlugin(Root, plugin)).toContain(
+      '<p>Static source</p>'
+    );
+    await plugin.setLocale('fr');
+    const translatedHtml = await renderWithPlugin(Root, plugin);
+    expect(translatedHtml).toContain('<p>Static source</p>');
+    expect(translatedHtml).not.toContain('Ignored target');
   });
 
   it('reuses explicit source element IDs repeated by a translation', async () => {
@@ -518,10 +600,15 @@ describe('gt-vue runtime', () => {
     const Stateful = defineComponent({
       name: 'Stateful',
       props: { label: { required: true, type: String } },
-      setup(props) {
+      setup(props, { slots }) {
         const initialLabel = props.label;
         const instance = ++setupCount;
-        return () => h('span', `${props.label}:${initialLabel}:${instance}|`);
+        return () =>
+          h('span', [
+            `${props.label}:${initialLabel}:${instance}:`,
+            slots.default?.(),
+            '|',
+          ]);
       },
     });
     const plugin = createGT({
@@ -529,13 +616,13 @@ describe('gt-vue runtime', () => {
         identity:
           locale === 'fr'
             ? [
-                { t: 'Stateful', i: 2 },
-                { t: 'Stateful', i: 1 },
+                { t: 'Stateful', i: 2, c: 'B-fr' },
+                { t: 'Stateful', i: 1, c: 'A-fr' },
               ]
             : [
-                { t: 'Stateful', i: 1 },
-                { t: 'Stateful', i: 1 },
-                { t: 'Stateful', i: 2 },
+                { t: 'Stateful', i: 1, c: 'A-de-1' },
+                { t: 'Stateful', i: 1, c: 'A-de-2' },
+                { t: 'Stateful', i: 2, c: 'B-de' },
               ],
       }),
     });
@@ -547,8 +634,8 @@ describe('gt-vue runtime', () => {
             { _hash: 'identity' },
             {
               default: () => [
-                h(Stateful, { label: 'a' }),
-                h(Stateful, { label: 'b' }),
+                h(Stateful, { label: 'a' }, { default: () => 'A' }),
+                h(Stateful, { label: 'b' }, { default: () => 'B' }),
               ],
             }
           );
@@ -556,24 +643,82 @@ describe('gt-vue runtime', () => {
     });
     const mounted = mount(Root, plugin);
 
-    expect(textContent(mounted.root)).toBe('a:a:1|b:b:2|');
+    expect(textContent(mounted.root)).toBe('a:a:1:A|b:b:2:B|');
     await plugin.setLocale('fr');
     await nextTick();
-    expect(textContent(mounted.root)).toBe('b:b:2|a:a:1|');
+    expect(textContent(mounted.root)).toBe('b:b:2:B-fr|a:a:1:A-fr|');
     expect(setupCount).toBe(2);
 
     await plugin.setLocale('de');
     await nextTick();
-    expect(textContent(mounted.root)).toBe('a:a:1|a:a:3|b:b:2|');
+    expect(textContent(mounted.root)).toBe(
+      'a:a:1:A-de-1|a:a:3:A-de-2|b:b:2:B-de|'
+    );
     expect(setupCount).toBe(3);
 
     await plugin.setLocale('fr');
     await nextTick();
-    expect(textContent(mounted.root)).toBe('b:b:2|a:a:1|');
+    expect(textContent(mounted.root)).toBe('b:b:2:B-fr|a:a:1:A-fr|');
 
     await plugin.setLocale('en');
     await nextTick();
-    expect(textContent(mounted.root)).toBe('a:a:1|b:b:2|');
+    expect(textContent(mounted.root)).toBe('a:a:1:A|b:b:2:B|');
+    mounted.app.unmount();
+  });
+
+  it('preserves generated keys through KeepAlive locale updates', async () => {
+    let setupCount = 0;
+    const Stateful = defineComponent({
+      name: 'Stateful',
+      setup(_props, { slots }) {
+        setupCount += 1;
+        return () => h('span', slots.default?.());
+      },
+    });
+    const plugin = createGT({
+      loadTranslations: async (locale) =>
+        locale === 'fr'
+          ? {
+              keepAlive: {
+                t: 'KeepAlive',
+                i: 1,
+                c: {
+                  t: 'Stateful',
+                  i: 2,
+                  c: 'Contenu traduit',
+                },
+              },
+            }
+          : {},
+    });
+    const Root = defineComponent({
+      setup() {
+        return () =>
+          h(
+            T,
+            { _hash: 'keepAlive' },
+            {
+              default: () =>
+                h(KeepAlive, null, {
+                  default: () =>
+                    h(Stateful, null, { default: () => 'Source content' }),
+                }),
+            }
+          );
+      },
+    });
+    const mounted = mount(Root, plugin);
+
+    expect(textContent(mounted.root)).toBe('Source content');
+    await plugin.setLocale('fr');
+    await nextTick();
+    expect(textContent(mounted.root)).toBe('Contenu traduit');
+    expect(setupCount).toBe(1);
+
+    await plugin.setLocale('en');
+    await nextTick();
+    expect(textContent(mounted.root)).toBe('Source content');
+    expect(setupCount).toBe(1);
     mounted.app.unmount();
   });
 
@@ -1505,8 +1650,8 @@ describe('gt-vue runtime', () => {
     mounted.app.unmount();
   });
 
-  it('coalesces text around comments and fragments for stable rich hashes', async () => {
-    const source = 'Hello world';
+  it('preserves React-compatible text boundaries around comments', async () => {
+    const source = ['Hello', ' world'];
     const plugin = createGT({
       loadTranslations: async () => ({
         [jsxHash(source)]: 'Bonjour le monde',

--- a/packages/vue/src/rendering/translateVueChildren.ts
+++ b/packages/vue/src/rendering/translateVueChildren.ts
@@ -16,9 +16,12 @@ import { hashSource } from 'generaltranslation/id';
 import {
   Comment,
   Fragment,
+  Static,
   Suspense,
   Text,
   cloneVNode,
+  createCommentVNode,
+  createTextVNode,
   h,
   isVNode,
   mergeProps,
@@ -39,20 +42,23 @@ const variableTypes = {
 
 type Transformation = 'branch' | 'fragment' | 'plural' | 'variable' | undefined;
 
+/** Prevents text on opposite sides of an ignored Vue comment from merging. */
+const textBoundary = Symbol('gt-vue-text-boundary');
+
 type SourceElement = {
   branches: Record<string, SourceNode[]>;
   children: SourceNode[];
   id: number;
   identity: string;
-  opaque: boolean;
   preserveExplicitKey: boolean;
+  replaceDefaultSlot: boolean;
   transformation: Transformation;
   variableName?: string;
   variableType?: VariableType;
   vnode: VNode;
 };
 
-type SourceNode = SourceElement | string;
+type SourceNode = SourceElement | string | typeof textBoundary;
 
 type ComponentWithGTMetadata = Component & {
   _gtt?: string;
@@ -241,22 +247,20 @@ function visitChildren(
   transparentKeyScope = false
 ): SourceNode[] {
   if (Array.isArray(children)) {
-    return mergeAdjacentStrings(
-      children.flatMap((child) =>
-        visitChildren(
-          child,
-          index,
-          identityScope,
-          identityRender,
-          identityOccurrences,
-          transparentKeyScope
-        )
+    return children.flatMap((child) =>
+      visitChildren(
+        child,
+        index,
+        identityScope,
+        identityRender,
+        identityOccurrences,
+        transparentKeyScope
       )
     );
   }
   if (children == null || typeof children === 'boolean') return [];
   if (!isVNode(children)) return [String(children)];
-  if (children.type === Comment) return [];
+  if (children.type === Comment) return [textBoundary];
   if (children.type === Text) return [String(children.children ?? '')];
   if (children.type === Fragment) {
     const fragmentChildren = isSlots(children.children)
@@ -302,25 +306,24 @@ function visitChildren(
   const variable =
     transformation === 'variable' ? getVariable(metadata, id) : undefined;
   const defaultSlot = variable
-    ? { children: undefined, opaque: false }
-    : readDefaultSlot(children, transformation);
+    ? { children: undefined, replace: false }
+    : readDefaultSlot(children);
   const source: SourceElement = {
     branches: {},
-    children:
-      variable || defaultSlot.opaque
-        ? []
-        : visitChildren(
-            defaultSlot.children,
-            index,
-            transformation === 'branch' || transformation === 'plural'
-              ? `${identity}/default`
-              : identity,
-            identityRender
-          ),
+    children: variable
+      ? []
+      : visitChildren(
+          defaultSlot.children,
+          index,
+          transformation === 'branch' || transformation === 'plural'
+            ? `${identity}/default`
+            : identity,
+          identityRender
+        ),
     id,
     identity,
-    opaque: defaultSlot.opaque,
     preserveExplicitKey: !transparentKeyScope,
+    replaceDefaultSlot: defaultSlot.replace,
     transformation,
     variableName: variable?.name,
     variableType: variable?.type,
@@ -405,35 +408,39 @@ function getVariable(
 }
 
 /**
- * Reads source-owned content without speculatively invoking user components.
+ * Materializes the authored default slot that React receives as `children`.
  *
- * Vue represents both scoped and unscoped component slots as indistinguishable
- * functions. Calling an arbitrary slot to discover which kind it is can run
- * ignored slots, duplicate side effects, or let synthetic props escape. Keep
- * custom component slots opaque and traverse only GT-owned slots whose
- * no-argument contract is known. Suspense is read from Vue's already-normalized
- * content so its slot is not invoked a second time.
+ * GT rich content is static by contract: runtime values belong in a variable
+ * component and alternatives belong in Branch or Plural. Vue represents even
+ * a static custom component child as a lazy, zero-argument slot, so T invokes
+ * that authored slot once and later replaces it with the translated children.
+ * Scoped or otherwise dynamic slots are rejected by extraction instead of
+ * changing this runtime wire format.
  */
-function readDefaultSlot(
-  vnode: VNode,
-  transformation: Transformation
-): {
+function readDefaultSlot(vnode: VNode): {
   children: unknown;
-  opaque: boolean;
+  replace: boolean;
 } {
+  // A Static VNode stores pre-rendered HTML in `children`, not translatable
+  // text children. Preserve it as an opaque source node rather than treating
+  // its Symbol type as a component and dropping its HTML during cloning.
+  if (vnode.type === Static) {
+    return { children: undefined, replace: false };
+  }
   if (vnode.type === Suspense) {
     return {
       children: (vnode as VNodeWithRenderMetadata).ssContent,
-      opaque: false,
+      replace: true,
     };
   }
-  if (transformation === undefined && typeof vnode.type !== 'string') {
-    return { children: undefined, opaque: true };
-  }
   if (!isSlots(vnode.children)) {
-    return { children: vnode.children, opaque: false };
+    return { children: vnode.children, replace: false };
   }
-  return { children: vnode.children.default?.(), opaque: false };
+  const defaultSlot = vnode.children.default;
+  return {
+    children: typeof defaultSlot === 'function' ? defaultSlot() : undefined,
+    replace: typeof defaultSlot === 'function',
+  };
 }
 
 function getBranches(
@@ -489,11 +496,11 @@ function isSlots(children: unknown): children is Slots {
 }
 
 function serializeNodes(nodes: SourceNode[]): JsxChildren {
-  const serialized = nodes.map(serializeNode);
+  const serialized = nodes.filter(isContentNode).map(serializeNode);
   return serialized.length === 1 ? serialized[0] : serialized;
 }
 
-function serializeNode(node: SourceNode): JsxChild {
+function serializeNode(node: SourceElement | string): JsxChild {
   if (typeof node === 'string') return node;
   if (node.transformation === 'variable') {
     return {
@@ -527,7 +534,7 @@ function serializeNode(node: SourceNode): JsxChild {
     t: getElementName(node.vnode, node.id),
     i: node.id,
     ...(Object.keys(data).length && { d: data }),
-    ...(node.children.length && { c: serializeNodes(node.children) }),
+    ...(hasContentNodes(node.children) && { c: serializeNodes(node.children) }),
   };
 }
 
@@ -562,7 +569,8 @@ function renderNodes(
 
   const targets = Array.isArray(target) ? target : [target];
   const sourceElements = source.filter(
-    (node): node is SourceElement => typeof node !== 'string'
+    (node): node is SourceElement =>
+      typeof node !== 'string' && node !== textBoundary
   );
   const variables = new Map(
     sourceElements
@@ -649,9 +657,9 @@ function keySourceResult(
 
   if (isVNode(rendered)) {
     if (rendered.key === key) return rendered;
-    const cloned = cloneVNode(rendered);
-    cloned.key = key;
-    return cloned;
+    // Persist the key in props as well as `VNode.key`. Vue built-ins such as
+    // KeepAlive clone cached children and recompute their key from props.
+    return cloneVNode(rendered, { key });
   }
 
   const children =
@@ -709,15 +717,11 @@ function renderElement(
   if (source.transformation === 'fragment') {
     return renderNodes(source.children, target.c, state, identityRender);
   }
-  if (source.opaque) {
-    const translatedProps = getTranslatedProps(target);
-    return Object.keys(translatedProps).length
-      ? cloneWithProps(source.vnode, translatedProps)
-      : source.vnode;
-  }
   const translatedProps = getTranslatedProps(target);
-  if (target.c == null) {
-    return source.children.length
+  const hasAuthoredChildren =
+    hasContentNodes(source.children) || source.replaceDefaultSlot;
+  if (target.c == null || !hasAuthoredChildren) {
+    return hasAuthoredChildren
       ? cloneWithChildren(
           source.vnode,
           renderDefaultNodes(
@@ -790,17 +794,12 @@ function getSelectedTargetBranch(
     : target.c;
 }
 
-function mergeAdjacentStrings(nodes: SourceNode[]): SourceNode[] {
-  const result: SourceNode[] = [];
-  for (const node of nodes) {
-    const previous = result.at(-1);
-    if (typeof previous === 'string' && typeof node === 'string') {
-      result[result.length - 1] = previous + node;
-    } else {
-      result.push(node);
-    }
-  }
-  return result;
+function isContentNode(node: SourceNode): node is SourceElement | string {
+  return node !== textBoundary;
+}
+
+function hasContentNodes(nodes: SourceNode[]): boolean {
+  return nodes.some(isContentNode);
 }
 
 function getTranslatedProps(target: JsxElement): Record<string, string> {
@@ -819,20 +818,22 @@ function renderDefaultNodes(
   locale: string
 ): VNodeChild[] {
   const occurrences = new Map<SourceElement, number>();
-  return nodes.map((node) =>
-    typeof node === 'string'
-      ? node
-      : keySourceResult(
-          node,
-          renderDefaultNode(node, state, identityRender, locale),
-          occurrences,
-          identityRender
-        )
-  );
+  return nodes
+    .filter(isContentNode)
+    .map((node) =>
+      typeof node === 'string'
+        ? node
+        : keySourceResult(
+            node,
+            renderDefaultNode(node, state, identityRender, locale),
+            occurrences,
+            identityRender
+          )
+    );
 }
 
 function renderDefaultNode(
-  node: SourceNode,
+  node: SourceElement | string,
   state: GTState,
   identityRender: TranslationIdentityRender,
   locale: string
@@ -874,7 +875,9 @@ function renderDefaultNode(
       locale
     );
   }
-  if (!node.children.length) return node.vnode;
+  if (!hasContentNodes(node.children) && !node.replaceDefaultSlot) {
+    return node.vnode;
+  }
   return cloneWithChildren(
     node.vnode,
     renderDefaultNodes(node.children, state, identityRender, locale)
@@ -931,9 +934,32 @@ function cloneWithChildren(
   const type = vnode as unknown as Component;
   const props = Object.keys(extraProps).length ? extraProps : null;
   const slots = isSlots(vnode.children) ? vnode.children : {};
+  const runtimeSlots = Object.fromEntries(
+    Object.entries(slots).filter(([name]) => name !== '_' && name !== '$stable')
+  );
   return h(type, props, {
-    ...slots,
-    default: () => children,
+    // The compiler's stable-slot marker describes the source slot function,
+    // not the translated VNodes assembled here. Keeping it lets Vue take a
+    // block-optimized path that can skip runtime-created descendants.
+    ...runtimeSlots,
+    // Compiler-generated slot outlets consume normalized VNode arrays. A
+    // programmatic component can happen to accept a primitive here, which hid
+    // this distinction in unit fixtures, but a production-compiled `<slot />`
+    // drops an unnormalized translated string.
+    default: () => normalizeComponentSlotValue(children),
+  });
+}
+
+/** Normalizes a replacement default slot the same way Vue normalizes raw slots. */
+function normalizeComponentSlotValue(value: VNodeChild): VNode[] {
+  const values = Array.isArray(value) ? value : [value];
+  return values.map((child) => {
+    if (isVNode(child)) return child;
+    if (Array.isArray(child)) return h(Fragment, null, child);
+    if (child == null || typeof child === 'boolean') {
+      return createCommentVNode();
+    }
+    return createTextVNode(String(child));
   });
 }
 


### PR DESCRIPTION
## Summary

- translate statically authored default-slot content inside arbitrary custom components, matching React's `<T>` contract
- keep dynamic/scoped default slots behind `<Var>` and preserve named slots as outer-opaque
- preserve adjacent Vue JSX text boundaries and reconciliation identity through component reordering and `KeepAlive`
- normalize compiler-generated replacement slots without exposing component implementation content
- document selector forms that must fail closed because global component registration can change runtime identity

## Testing

- `pnpm --filter gt-vue test` — 8 files, 153/153 tests
- package typecheck and build
- production Vite SPA/SSR/browser checks on Vue 3.3.13 and Vue 3.5
- 1,000 generated React/Vue rich trees and 512 stateful locale transitions
- lint, formatting, and diff checks

## Stack

1. #2064 — lock the contract
2. this PR — align the runtime
3. #2054 — align the standalone extractor
4. #2055 — add the minimal CLI adapter

Includes a patch changeset for `gt-vue`.