### PR TITLE
fix: overwriting published content

### DIFF
--- a/.changeset/spotty-donkeys-repeat.md
+++ b/.changeset/spotty-donkeys-repeat.md
@@ -1,0 +1,17 @@
+---
+'gt-sanity': patch
+---
+
+Stop document-level import from overwriting published translations.
+
+When a translation document already existed as a published document with no
+draft, importing a translation patched that published document directly, so
+translated content went live immediately with no draft to review, no publish
+step, and no regard for the auto-publish switch. Studios that already had
+localized documents — including ones set up with
+`@sanity/document-internationalization` before installing this plugin — hit
+this on their first import, because the existing `translation.metadata` is
+adopted and already points at published translations.
+
+Imports now seed a draft from the published state and patch the draft, matching
+what `internationalizedArrayPatch` and `commitResolvedRefs` already do.

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.test.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.test.ts
@@ -50,4 +50,56 @@ describe('patchI18nDoc', () => {
       }),
     });
   });
+
+  test('seeds a draft instead of writing to a published translation', async () => {
+    vi.spyOn(pluginConfig, 'getIgnoreFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getSkipFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getDedupeFields').mockReturnValue([]);
+
+    const commit = vi.fn().mockResolvedValue({});
+    const transactionPatch = vi.fn().mockReturnThis();
+    const createIfNotExists = vi.fn().mockReturnThis();
+    const transaction = { createIfNotExists, patch: transactionPatch, commit };
+    const directPatch = vi.fn();
+    const client = {
+      transaction: () => transaction,
+      patch: directPatch,
+    } as unknown as SanityClient;
+
+    const publishedTranslation = {
+      _id: 'doc-1-de',
+      _type: 'article',
+      title: 'Alte Übersetzung',
+    };
+
+    await patchI18nDoc(
+      'doc-1',
+      'doc-1-de',
+      { _id: 'doc-1', _type: 'article', title: 'About' },
+      { _id: 'doc-1', _type: 'article', title: 'Über uns' },
+      { title: 'Über uns' },
+      client,
+      publishedTranslation
+    );
+
+    // The live document must not be touched.
+    expect(directPatch).not.toHaveBeenCalled();
+
+    expect(createIfNotExists).toHaveBeenCalledWith({
+      ...publishedTranslation,
+      _id: 'drafts.doc-1-de',
+    });
+    expect(transactionPatch).toHaveBeenCalledWith(
+      'drafts.doc-1-de',
+      expect.any(Function)
+    );
+
+    // The patch builder should set the translated fields on the draft.
+    const set = vi.fn().mockReturnThis();
+    transactionPatch.mock.calls[0]![1]({ set });
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Über uns' })
+    );
+    expect(commit).toHaveBeenCalled();
+  });
 });

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts
@@ -8,6 +8,7 @@ import {
   forEachMatchingField,
 } from '../../../utils/applyDocuments';
 import { pluginConfig } from '../../../adapter/core';
+import { getPublishedId } from '../../../utils/documentIds';
 
 const SYSTEM_FIELDS = ['_id', '_rev', '_updatedAt', 'language'];
 
@@ -61,5 +62,31 @@ export async function patchI18nDoc(
       }
     );
   }
-  await client.patch(i18nDocId, { set: appliedDocument }).commit();
+  if (i18nDocId.startsWith('drafts.')) {
+    await client.patch(i18nDocId, { set: appliedDocument }).commit();
+    return;
+  }
+
+  // A draft in Sanity is just a document whose id carries a `drafts.` prefix,
+  // and the client writes to whatever id it is handed — it will not redirect a
+  // write to the draft on your behalf. A published id here is therefore the
+  // copy readers are served. Copy it into a draft and patch that, so the
+  // translation lands somewhere reviewable and the live document only changes
+  // when someone publishes.
+  const seed = existingDocument ?? (await client.getDocument(i18nDocId));
+  if (!seed) {
+    // References in `translation.metadata` are weak, so they outlive the
+    // documents they point at: deleting a translation leaves its entry behind.
+    // With no document to copy there is nothing to seed a draft from, so patch
+    // the id directly and let the missing document surface as an error.
+    await client.patch(i18nDocId, { set: appliedDocument }).commit();
+    return;
+  }
+
+  const draftId = `drafts.${getPublishedId(i18nDocId)}`;
+  await client
+    .transaction()
+    .createIfNotExists({ ...seed, _id: draftId })
+    .patch(draftId, (patch) => patch.set(appliedDocument))
+    .commit();
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents document-level translation imports from modifying published Sanity documents directly.
- Published translations are copied into a draft before translated fields are applied.
- Existing draft IDs continue to use the direct patch path.
- Tests verify that published content remains untouched and the draft transaction is committed.
- A patch changeset documents the corrected import behavior.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the changed path consistently directing published-document imports into reviewable drafts.

The implementation preserves direct patching for existing draft IDs, seeds a draft when the referenced target is published, and adds focused tests for the transaction and translated-field update without introducing a concrete blocking failure.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.ts | Redirects imports targeting published documents into a transaction that seeds and patches the corresponding draft while retaining existing draft and missing-document behavior. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/helpers/patchI18nDoc.test.ts | Adds focused coverage confirming that a published translation is not patched directly and that translated fields are written to its draft. |
| .changeset/spotty-donkeys-repeat.md | Records the user-visible fix as a patch release for gt-sanity. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Import[Document-level translation import] --> Check{Target ID is a draft?}
  Check -->|Yes| PatchDraft[Patch existing draft]
  Check -->|No| Seed{Published document exists?}
  Seed -->|Yes| CreateDraft[Create draft from published state if absent]
  CreateDraft --> Apply[Patch translated fields onto draft]
  Seed -->|No| ExistingError[Preserve missing-document error path]
  PatchDraft --> Review[Review and publish explicitly]
  Apply --> Review
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix: overwriting published content"](https://github.com/generaltranslation/gt/commit/9ccd6ede0881417918fdea61e637403fa5fcc9fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52083064)</sub>

**Context used:**

- Knowledge Base — [Sanity plugin (`gt-sanity`)](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/sanity-package.md)

<!-- /greptile_comment -->