### PR TITLE
docs: update README license badge to MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 <a href="https://generaltranslation.com"><img alt="General Translation" src="https://img.shields.io/badge/MADE%20BY%20General%20Translation-000000.svg?style=for-the-badge&labelColor=ffffff&color=000000"></a>
 <a href="https://www.npmjs.com/package/gt-next"><img alt="NPM version" src="https://img.shields.io/npm/v/gt-next.svg?style=for-the-badge&labelColor=000000&color=CB3837"></a>
-<a href="https://github.com/generaltranslation/gt/blob/main/LICENSE.md"><img alt="License" src="https://img.shields.io/npm/l/gt-next.svg?style=for-the-badge&labelColor=000000&color=FAEBD7"></a>
+<a href="https://github.com/generaltranslation/gt/blob/main/LICENSE.md"><img alt="MIT License" src="https://img.shields.io/badge/license-MIT-FAEBD7.svg?style=for-the-badge&labelColor=000000"></a>
 <a href="https://discord.gg/W99K6fchSu"><img alt="Join the community on Discord" src="https://img.shields.io/badge/Join%20the%20community-5865F2.svg?style=for-the-badge&logo=discord&labelColor=23272A&logoWidth=20"></a>
 
 </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- replace the package-derived license badge with an explicit MIT license badge
- keep the badge linked to the repository's MIT license file

## Testing
- `git diff --check`
- confirmed README contains MIT and no FSL references
- formatting command unavailable because workspace dependencies are not installed
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://generaltranslation.slack.com/archives/C0BJA1M93QC/p1786494609216329?thread_ts=1786494609.216329&cid=C0BJA1M93QC)

<div><a href="https://cursor.com/agents/bc-5c42e12e-3f07-5111-8956-f97bf384470a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c42e12e-3f07-5111-8956-f97bf384470a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the README license badge from package-derived metadata to an explicit MIT badge while preserving the link to the repository license.
- Replaces the dynamic npm license badge with a static Shields.io MIT badge.
- Updates the badge alternative text to “MIT License.”

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The README badge, linked LICENSE.md, and package license metadata consistently identify the project as MIT licensed.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces the npm-derived license badge with an accurate explicit MIT badge linked to the MIT license file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: update README license badge to MIT"](https://github.com/generaltranslation/gt/commit/8b9839ea4e964f829fafb4e997de69d1e033dff7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52431382)</sub>

<!-- /greptile_comment -->