### PR TITLE
feat(cli): allow disabling the translation wait timeout with --timeout none

### DIFF
--- a/.changeset/timeout-none-flag.md
+++ b/.changeset/timeout-none-flag.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+Accept `--timeout none` to disable the timeout when waiting for translations.

--- a/packages/cli/src/cli/__tests__/flags.test.ts
+++ b/packages/cli/src/cli/__tests__/flags.test.ts
@@ -24,4 +24,28 @@ describe('attachTranslateFlags', () => {
   it('allows saving local edits to be disabled', () => {
     expect(parseTranslateFlags(['--no-save-local']).saveLocal).toBe(false);
   });
+
+  it('defaults the timeout to 900 seconds', () => {
+    expect(parseTranslateFlags().timeout).toBe(900);
+  });
+
+  it('parses a numeric timeout', () => {
+    expect(parseTranslateFlags(['--timeout', '300']).timeout).toBe(300);
+  });
+
+  it('disables the timeout when set to none', () => {
+    expect(parseTranslateFlags(['--timeout', 'none']).timeout).toBe(Infinity);
+  });
+
+  it('rejects a non-numeric timeout', () => {
+    expect(() => parseTranslateFlags(['--timeout', 'abc'])).toThrow(
+      'Invalid timeout: not a number.'
+    );
+  });
+
+  it('rejects a negative timeout', () => {
+    expect(() => parseTranslateFlags(['--timeout', '-5'])).toThrow(
+      'Invalid timeout: must be a positive number.'
+    );
+  });
 });

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -34,8 +34,11 @@ export function attachTranslateFlags(command: Command) {
     )
     .option(
       '--timeout <seconds>',
-      'Translation wait timeout in seconds',
+      'Translation wait timeout in seconds, or "none" to wait indefinitely',
       (value) => {
+        if (value === 'none') {
+          return Infinity;
+        }
         const parsedValue = parseInt(value, 10);
         if (isNaN(parsedValue)) {
           throw new Error('Invalid timeout: not a number.');

--- a/packages/cli/src/utils/__tests__/calculateTimeoutMs.test.ts
+++ b/packages/cli/src/utils/__tests__/calculateTimeoutMs.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { calculateTimeoutMs } from '../calculateTimeoutMs.js';
+
+describe('calculateTimeoutMs', () => {
+  it('converts seconds to milliseconds', () => {
+    expect(calculateTimeoutMs(300)).toBe(300_000);
+  });
+
+  it('falls back to the default when undefined', () => {
+    expect(calculateTimeoutMs(undefined)).toBe(900_000);
+  });
+
+  it('falls back to the default when not a number', () => {
+    expect(calculateTimeoutMs('abc')).toBe(900_000);
+  });
+
+  it('keeps Infinity so the timeout stays disabled', () => {
+    expect(calculateTimeoutMs(Infinity)).toBe(Infinity);
+  });
+});

--- a/packages/cli/src/utils/calculateTimeoutMs.ts
+++ b/packages/cli/src/utils/calculateTimeoutMs.ts
@@ -8,5 +8,5 @@ export function calculateTimeoutMs(
 ): number {
   const value =
     timeout !== undefined ? Number(timeout) : DEFAULT_TIMEOUT_SECONDS;
-  return (Number.isFinite(value) ? value : DEFAULT_TIMEOUT_SECONDS) * 1000;
+  return (Number.isNaN(value) ? DEFAULT_TIMEOUT_SECONDS : value) * 1000;
 }


### PR DESCRIPTION
## Summary

- Closes #481: adds `none` as an accepted value for `--timeout`, so translation waits can run without a time limit; `--timeout none` parses to an unlimited duration and both polling loops (`awaitJobs` deadline math and the download poll's elapsed comparison) already handle it without arming a raw timer.
- Removes the silent clamp in `calculateTimeoutMs()` that converted any non-finite timeout back to the default, which made an unlimited timeout impossible to express.
- Adds a patch changeset for `gt`.

## Validation

- `npx vitest run` in `packages/cli`: 112 files, 2169 tests passed on 15185e6b0; the 2 new timeout tests fail against the base revision's files.
- `npx tsc --noEmit` in `packages/cli`, `npx oxlint`, and `npx oxfmt --check` on touched paths: clean.
- Not run: a live long-poll against the translation API.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds `--timeout none` for translation commands that need to wait indefinitely, while preserving the existing 900-second default and numeric timeout values. The timeout failure hypothesis was disproved by an executed parser-to-polling test: `none` remained `Infinity` through timeout conversion and both setup and translation polling paths, while default and numeric values continued to work. No defects were found.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge based on focused execution coverage of the new timeout behavior and its two waiting consumers.

The executed harness exercised `--timeout none` through parsing, conversion, setup waiting, and translation polling without a timeout firing; directly targeted regression tests also passed for disabled, default, and numeric timeout behavior.

**Files Needing Attention:** None.
</details>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the timeout-none flow harness and all three tests passed, covering parsing --timeout none, preserving Infinity during conversion, and keeping both setup and translation polling active.
- Executed targeted tests across CLI flags, timeout calculation utilities, and SetupStep, and all 18 tests passed.
- Observed that timeout 'none' is delivered as an unbounded timeout to both polling consumers, while default and numeric timeouts retain their configured values.
- Validated the key implementation paths in CLI flags, timeout calculation, SetupStep, and PollJobsStep were exercised.

<a href="https://app.greptile.com/trex/runs/19957703/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): allow disabling the translati..."](https://github.com/generaltranslation/gt/commit/15185e6b00ca935cbd44b2f1918c3aa9a55dead3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55444569)</sub>

<!-- /greptile_comment -->