### PR TITLE
fix(cli): make upload --force bypass the gt-lock.json unchanged-file skip

### DIFF
--- a/.changeset/upload-force-bypasses-lockfile.md
+++ b/.changeset/upload-force-bypasses-lockfile.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+`gt upload --force` now re-uploads translation files even when gt-lock.json marks them unchanged, overwriting existing remote translations. Previously the flag was accepted but the lockfile skip ignored it. The `--force` help text now states the overwrite behavior.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -120,6 +120,7 @@ export type UploadOptions = {
   apiKey?: string;
   projectId?: string;
   defaultLocale?: string;
+  force?: boolean;
 };
 
 export type LoginOptions = {

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -599,3 +599,30 @@ describe('upload - composite JSON', () => {
     expect(plainFile?.translations[0].content).toBe(translatedPlain);
   });
 });
+
+describe('upload - force flag', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(false);
+    vi.mocked(readFileSync).mockReturnValue('');
+    vi.mocked(createFileMapping).mockReturnValue({});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('forwards the force flag to the upload workflow', async () => {
+    const content = JSON.stringify({ title: 'Hello' });
+    setMockFiles({ 'plain.json': content });
+
+    const filePaths: ResolvedFiles = { json: ['plain.json'] };
+    const settings = makeSettings({ options: {}, force: true });
+
+    await uploadWithFiles(filePaths, settings);
+
+    expect(runUploadFilesWorkflow).toHaveBeenCalledTimes(1);
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.force).toBe(true);
+  });
+});

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -147,6 +147,7 @@ export async function upload(
     const { branchData } = await runUploadFilesWorkflow({
       files: uploadData,
       options: settings,
+      force: settings.force,
     });
 
     // Publish files to CDN if publish config exists

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -84,7 +84,7 @@ export function attachTranslateFlags(command: Command) {
     )
     .option(
       '--force',
-      'Force a retranslation, invalidating all existing cached translations if they exist.',
+      'Force a retranslation, invalidating all existing cached translations if they exist. With upload, re-uploads translation files even if gt-lock.json marks them unchanged, overwriting existing remote translations.',
       false
     )
     .option(

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -61,7 +61,8 @@ export class UploadTranslationsStep {
 
   constructor(
     private gt: GT,
-    private settings: Settings
+    private settings: Settings,
+    private force?: boolean
   ) {}
 
   async run({ files }: UploadTranslationsInput): Promise<FileReference[]> {
@@ -79,12 +80,12 @@ export class UploadTranslationsStep {
     // uploaded (the endpoint is an upsert, so existing translations are
     // overwritten). The one optimization is the lockfile: files whose content
     // hash still matches gt-lock.json are unchanged since the last sync and
-    // can be skipped. Without a lockfile, everything uploads.
+    // can be skipped. Without a lockfile, everything uploads, and --force
+    // uploads everything regardless of the lockfile.
     const lockfile = readLockfile(this.settings);
-    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
-      withTranslations,
-      lockfile.entryMap
-    );
+    const { filesToUpload, skippedCount } = this.force
+      ? { filesToUpload: withTranslations, skippedCount: 0 }
+      : partitionTranslationsByLockfile(withTranslations, lockfile.entryMap);
 
     if (filesToUpload.length === 0) {
       logger.info(

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -278,6 +278,41 @@ describe('UploadTranslationsStep', () => {
     );
   });
 
+  it('uploads translations matching the lockfile hash when force is set', async () => {
+    const translation = makeTranslation('file-1', 'es');
+    mockLockfile([
+      {
+        fileId: 'file-1',
+        versionId: 'version-file-1',
+        translations: {
+          es: { postProcessHash: hashStringSync(translation.content) },
+        },
+      },
+    ]);
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [{ fileId: 'file-1', locale: 'es' }],
+    });
+
+    const files = [
+      { source: makeSource('file-1'), translations: [translation] },
+    ];
+    const step = new UploadTranslationsStep(
+      mockGt as unknown as GT,
+      mockSettings,
+      true
+    );
+    await step.run({ files });
+
+    expect(mockGt.uploadTranslations).toHaveBeenCalledTimes(1);
+    expect(mockGt.uploadTranslations).toHaveBeenCalledWith(
+      files,
+      expect.any(Object)
+    );
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining('unchanged since the last sync')
+    );
+  });
+
   it('records content hashes for server-confirmed uploads in the lockfile', async () => {
     const es = makeTranslation('file-1', 'es');
     const fr = makeTranslation('file-1', 'fr');

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -20,12 +20,14 @@ import { BranchData } from '../types/branch.js';
 export async function runUploadFilesWorkflow({
   files,
   options,
+  force,
 }: {
   files: {
     source: FileToUpload;
     translations: FileToUpload[];
   }[];
   options: Settings;
+  force?: boolean;
 }): Promise<{ branchData: BranchData }> {
   try {
     logger.message(
@@ -46,7 +48,11 @@ export async function runUploadFilesWorkflow({
     // Create workflow steps
     const branchStep = new BranchStep(gt, options);
     const uploadStep = new UploadSourcesStep(gt, options);
-    const uploadTranslationsStep = new UploadTranslationsStep(gt, options);
+    const uploadTranslationsStep = new UploadTranslationsStep(
+      gt,
+      options,
+      force
+    );
 
     // Step 1: Resolve branch information
     const branchData = await branchStep.run();


### PR DESCRIPTION
## Summary

- Fixes the residual `gt upload --force` gap from #1666: the upload path accepted `--force` but never read it, so files whose content hash matched `gt-lock.json` were skipped even when forced; `--force` now bypasses the lockfile partition and re-uploads every local translation, while the skip stays byte-for-byte unchanged without the flag.
- Updates the `--force` help text to state that, with upload, it re-uploads files `gt-lock.json` marks unchanged and overwrites existing remote translations.
- Adds a patch changeset for `gt`.

## Validation

- `npx vitest run` in `packages/cli`: 111 files, 2162 tests passed on dd97da709; the 2 new tests (step-level force bypass, command-level flag forwarding) fail against the base revision.
- `npx tsc --noEmit` in `packages/cli`, `npx oxlint`, and `npx oxfmt --check` on touched paths: clean.
- Not run: an end-to-end upload against the live API; behavior is pinned at the step and command seams.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary
This change makes `gt upload --force` re-upload translations even when `gt-lock.json` marks them unchanged, while ordinary uploads retain the unchanged-file optimization.

Focused checks exercised both matching-lockfile paths: the default upload did not call the upload API, and forced upload sent the translation. The force option was also confirmed to travel from the CLI command through the workflow into `UploadTranslationsStep`. The affected test suite completed with 25 passing tests, and CLI typechecking passed.

No defects were found.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge: forced and ordinary upload behavior both behaved as intended in focused execution.

The relevant lockfile filtering paths, command-to-workflow propagation, workflow-to-step propagation, focused regression tests, and CLI typechecking all completed successfully without exposing a defect.

**Files Needing Attention:** No files require follow-up attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Installed locked workspace dependencies and ran focused CLI validation.
- Ran matching-lockfile tests for both modes, confirming that without force the upload API was not invoked and with force the upload API received the translation.
- Ran command and workflow propagation checks showing that settings.force reaches UploadTranslationsStep and the focused regression suite passed with 25 tests.
- Ran CLI typechecking successfully.
- Concluded that forced uploads bypass the lockfile filter, while ordinary uploads retain the unchanged-file skip.

<a href="https://app.greptile.com/trex/runs/19962001/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): make upload --force bypass the..."](https://github.com/generaltranslation/gt/commit/dd97da709c75e745acd1c279c7697f302620d342) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55446068)</sub>

<!-- /greptile_comment -->