### PR TITLE
fix(react-core): degrade to source content when a runtime translation request fails during an RSC render

### DIFF
--- a/.changeset/rsc-runtime-translation-failure.md
+++ b/.changeset/rsc-runtime-translation-failure.md
@@ -1,0 +1,5 @@
+---
+'@generaltranslation/react-core': patch
+---
+
+Render source content and log one deduplicated error, instead of crashing the server render, when a runtime translation request fails during a React Server Component render of `<T>` or `<Tx>` in development (for example a 401 from an invalid dev API key). Production behavior is unchanged: failed lookups already logged and fell back to source content.

--- a/packages/react-core/src/components/translation/T.rsc.tsx
+++ b/packages/react-core/src/components/translation/T.rsc.tsx
@@ -7,6 +7,7 @@ import {
   type ResolvedTProps,
 } from '../../utils/translation/prepareT.shared';
 import { JsxChildren } from '@generaltranslation/format/types';
+import { logRuntimeTranslationRenderError } from '../../utils/errors/logRuntimeTranslationError';
 
 // RSC implementation: request conditions are passed explicitly instead of
 // being read from hooks. This module must stay free of hook/context imports
@@ -45,21 +46,28 @@ async function RscT({
 
   let targetJsxChildren: JsxChildren | undefined;
   const i18nCache = getReactI18nCache();
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled()
-  ) {
-    targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
-      locale,
-      prepared.sourceJsxChildren,
-      prepared.targetOptions
-    );
-  } else {
-    const lookupTranslation = await i18nCache.getLookupTranslation(locale);
-    targetJsxChildren = lookupTranslation(
-      prepared.sourceJsxChildren,
-      prepared.targetOptions
-    );
+  // In development the cache rethrows lookup failures (for example a 401 from
+  // an invalid dev API key); degrade to source content instead of letting the
+  // rejection crash the server render.
+  try {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      getI18nConfig().isDevHotReloadEnabled()
+    ) {
+      targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
+        locale,
+        prepared.sourceJsxChildren,
+        prepared.targetOptions
+      );
+    } else {
+      const lookupTranslation = await i18nCache.getLookupTranslation(locale);
+      targetJsxChildren = lookupTranslation(
+        prepared.sourceJsxChildren,
+        prepared.targetOptions
+      );
+    }
+  } catch (error) {
+    logRuntimeTranslationRenderError(error);
   }
 
   return _renderPreparedT({

--- a/packages/react-core/src/components/translation/Tx.rsc.tsx
+++ b/packages/react-core/src/components/translation/Tx.rsc.tsx
@@ -6,6 +6,8 @@ import {
   prepareT,
   type ResolvedTProps,
 } from '../../utils/translation/prepareT.shared';
+import { JsxChildren } from '@generaltranslation/format/types';
+import { logRuntimeTranslationRenderError } from '../../utils/errors/logRuntimeTranslationError';
 
 // RSC implementation: request conditions are passed explicitly instead of
 // being read from hooks. This module must stay free of hook/context imports
@@ -43,11 +45,19 @@ async function RscTx({
   }
 
   const i18nCache = getReactI18nCache();
-  const targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
-    locale,
-    prepared.sourceJsxChildren,
-    prepared.targetOptions
-  );
+  let targetJsxChildren: JsxChildren | undefined;
+  // In development the cache rethrows lookup failures (for example a 401 from
+  // an invalid dev API key); degrade to source content instead of letting the
+  // rejection crash the server render.
+  try {
+    targetJsxChildren = await i18nCache.lookupTranslationWithFallback(
+      locale,
+      prepared.sourceJsxChildren,
+      prepared.targetOptions
+    );
+  } catch (error) {
+    logRuntimeTranslationRenderError(error);
+  }
 
   return _renderPreparedT({
     ...prepared,

--- a/packages/react-core/src/components/translation/__tests__/T.test.tsx
+++ b/packages/react-core/src/components/translation/__tests__/T.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { initializeI18nConfig } from 'gt-i18n/internal';
 import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
 import { RscT } from '../T.rsc';
@@ -13,14 +13,17 @@ function resetGTGlobals() {
 }
 
 const getLookupTranslation = vi.fn();
+const lookupTranslationWithFallback = vi.fn();
 
-function setup() {
+function setup(configParams: Record<string, unknown> = {}) {
   initializeI18nConfig({
     defaultLocale: 'en',
     locales: ['en', 'fr'],
+    ...configParams,
   });
   setReactI18nCache({
     getLookupTranslation,
+    lookupTranslationWithFallback,
   } as unknown as ReactI18nCache);
 }
 
@@ -63,5 +66,59 @@ describe('RscT', () => {
     ).resolves.toBe('Hello');
 
     expect(getLookupTranslation).not.toHaveBeenCalled();
+  });
+});
+
+// In development the cache rethrows lookup failures (for example a 401 from
+// an invalid dev API key), so the awaited lookups here used to crash the RSC
+// render instead of degrading to source content.
+describe('RscT runtime translation failure handling', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGTGlobals();
+    vi.resetAllMocks();
+    setup();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('renders source and logs once when getLookupTranslation rejects', async () => {
+    getLookupTranslation.mockRejectedValue(
+      new Error('Remote translation request failed: 401 (T lookup)')
+    );
+
+    await expect(
+      RscT({ children: 'Hello', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Hello');
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('401 (T lookup)')
+    );
+  });
+
+  it('renders source when the dev hot reload lookup rejects', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    // The config singleton keeps its first instance, so re-init from scratch
+    // to enable dev hot reload.
+    resetGTGlobals();
+    setup({ devApiKey: 'invalid-dev-key', projectId: 'test-project' });
+    lookupTranslationWithFallback.mockRejectedValue(
+      new Error('Remote translation request failed: 401 (T hot reload)')
+    );
+
+    await expect(
+      RscT({ children: 'Hello', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Hello');
+
+    expect(lookupTranslationWithFallback).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('401 (T hot reload)')
+    );
   });
 });

--- a/packages/react-core/src/components/translation/__tests__/Tx.test.tsx
+++ b/packages/react-core/src/components/translation/__tests__/Tx.test.tsx
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from 'gt-i18n/internal';
+import { setReactI18nCache } from '../../../i18n-cache/singleton-operations';
+import { RscTx } from '../Tx.rsc';
+import type { ReactI18nCache } from '../../../i18n-cache/ReactI18nCache';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+function resetGTGlobals() {
+  Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+}
+
+const lookupTranslationWithFallback = vi.fn();
+
+function setup() {
+  initializeI18nConfig({
+    defaultLocale: 'en',
+    locales: ['en', 'fr'],
+  });
+  setReactI18nCache({
+    lookupTranslationWithFallback,
+  } as unknown as ReactI18nCache);
+}
+
+// In development the cache rethrows lookup failures (for example a 401 from
+// an invalid dev API key), so the awaited runtime lookup here used to crash
+// the RSC render instead of degrading to source content.
+describe('RscTx runtime translation failure handling', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetGTGlobals();
+    vi.clearAllMocks();
+    setup();
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('renders the translation when the runtime lookup resolves', async () => {
+    lookupTranslationWithFallback.mockResolvedValue('Bonjour');
+
+    await expect(
+      RscTx({ children: 'Hello', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Bonjour');
+
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('renders source and logs once when the runtime lookup rejects', async () => {
+    lookupTranslationWithFallback.mockRejectedValue(
+      new Error('Remote translation request failed: 401 (Tx runtime)')
+    );
+
+    await expect(
+      RscTx({ children: 'Hello', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Hello');
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('401 (Tx runtime)')
+    );
+  });
+
+  it('logs an identical failure once across renders', async () => {
+    lookupTranslationWithFallback.mockRejectedValue(
+      new Error('Remote translation request failed: 401 (Tx dedupe)')
+    );
+
+    await expect(
+      RscTx({ children: 'Hello', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Hello');
+    await expect(
+      RscTx({ children: 'Goodbye', _locale: 'fr', _enableI18n: true })
+    ).resolves.toBe('Goodbye');
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-core/src/i18n-store/I18nStore.ts
+++ b/packages/react-core/src/i18n-store/I18nStore.ts
@@ -1,7 +1,3 @@
-import {
-  createDiagnosticMessage,
-  formatDiagnosticErrorDetails,
-} from 'generaltranslation/internal';
 import { getTranslateListenerKey } from 'gt-i18n/internal';
 import type {
   DictionaryEntrySnapshot,
@@ -22,24 +18,9 @@ import {
   lookupDictionaryEntry,
   lookupDictionaryObject,
 } from './utils/dictionaries';
+import { logRuntimeTranslationError } from '../utils/errors/logRuntimeTranslationError';
 
 export type DictionaryStoreListener = (event: DictionaryLookup) => void;
-
-const MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS = 100;
-
-function getRuntimeTranslationErrorDedupeKey(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name}|${error.message}`;
-  }
-  if (error !== null && typeof error === 'object') {
-    try {
-      return `object|${JSON.stringify(error)}`;
-    } catch {
-      return `object|${String(error)}`;
-    }
-  }
-  return `${typeof error}|${String(error)}`;
-}
 
 /**
  * I18nStore gives us the ability to perform client-side updates to translations.
@@ -114,31 +95,10 @@ export class I18nStore {
    * Runtime translation runs fire-and-forget, so a rejected request (for
    * example a 401 from an invalid dev API key) is logged here instead of
    * escaping as an unhandled rejection that kills the dev server during SSR.
-   * Identical failures log once.
+   * Identical failures log once per store instance.
    */
   private logRuntimeTranslationError(error: unknown): void {
-    const details = formatDiagnosticErrorDetails(error);
-    const dedupeKey = getRuntimeTranslationErrorDedupeKey(error);
-    if (this.loggedRuntimeTranslationErrors.has(dedupeKey)) return;
-    this.loggedRuntimeTranslationErrors.add(dedupeKey);
-    if (
-      this.loggedRuntimeTranslationErrors.size >
-      MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS
-    ) {
-      const oldest = this.loggedRuntimeTranslationErrors.values().next().value;
-      if (oldest !== undefined) {
-        this.loggedRuntimeTranslationErrors.delete(oldest);
-      }
-    }
-    console.error(
-      createDiagnosticMessage({
-        source: '@generaltranslation/react-core',
-        severity: 'Error',
-        whatHappened: 'A runtime translation request failed.',
-        wayOut: 'Rendering falls back to untranslated content.',
-        details,
-      })
-    );
+    logRuntimeTranslationError(error, this.loggedRuntimeTranslationErrors);
   }
 
   // ========== UseSyncExternalStore ========== //

--- a/packages/react-core/src/utils/errors/logRuntimeTranslationError.ts
+++ b/packages/react-core/src/utils/errors/logRuntimeTranslationError.ts
@@ -1,0 +1,61 @@
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+
+const MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS = 100;
+
+function getRuntimeTranslationErrorDedupeKey(error: unknown): string {
+  if (error instanceof Error) {
+    return `${error.name}|${error.message}`;
+  }
+  if (error !== null && typeof error === 'object') {
+    try {
+      return `object|${JSON.stringify(error)}`;
+    } catch {
+      return `object|${String(error)}`;
+    }
+  }
+  return `${typeof error}|${String(error)}`;
+}
+
+/**
+ * Log a failed runtime translation request (for example a 401 from an invalid
+ * dev API key) instead of letting the rejection escape and kill rendering.
+ * Identical failures log once per dedupe set; callers own the set so the
+ * I18nStore scopes it per instance while the RSC render path uses one module
+ * set.
+ */
+function logRuntimeTranslationError(
+  error: unknown,
+  loggedErrors: Set<string>
+): void {
+  const details = formatDiagnosticErrorDetails(error);
+  const dedupeKey = getRuntimeTranslationErrorDedupeKey(error);
+  if (loggedErrors.has(dedupeKey)) return;
+  loggedErrors.add(dedupeKey);
+  if (loggedErrors.size > MAX_LOGGED_RUNTIME_TRANSLATION_ERRORS) {
+    const oldest = loggedErrors.values().next().value;
+    if (oldest !== undefined) {
+      loggedErrors.delete(oldest);
+    }
+  }
+  console.error(
+    createDiagnosticMessage({
+      source: '@generaltranslation/react-core',
+      severity: 'Error',
+      whatHappened: 'A runtime translation request failed.',
+      wayOut: 'Rendering falls back to untranslated content.',
+      details,
+    })
+  );
+}
+
+const loggedRscRenderErrors = new Set<string>();
+
+/** Deduped failure logger for RSC render paths, which have no store instance. */
+function logRuntimeTranslationRenderError(error: unknown): void {
+  logRuntimeTranslationError(error, loggedRscRenderErrors);
+}
+
+export { logRuntimeTranslationError, logRuntimeTranslationRenderError };


### PR DESCRIPTION
## Summary

- Fixes the RSC sibling of #1938: a rejected runtime translation request (for example a 401 from an invalid dev API key) escaped the awaited lookups in `RscT` and `RscTx` and crashed the React Server Component render in development; both components now catch the rejection and render source content.
- Logs one structured, deduped console error per distinct failure by moving the logger and its dedupe key out of `I18nStore` into a shared `logRuntimeTranslationError` module, so the store and the RSC render path bind to one implementation; the store keeps its per-instance dedupe set.
- Adds a patch changeset for `@generaltranslation/react-core`; production behavior is unchanged since the cache already logs and falls back outside development.

## Validation

- `npx vitest run` on 62734ffe8: react-core 83 passed (17 files), gt-react 30 passed (7 files); the 4 new failure-path tests fail against the base revision's components.
- `npx tsc --noEmit` in `packages/react-core`, `npx oxlint`, and `npx oxfmt --check` on touched paths: clean.
- Not run: gt-next suite (it re-exports the unchanged react-core surface) and a live RSC app reproduction.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents failed runtime translation requests from crashing React Server Component renders by logging the error and rendering source content instead.
- Adds failure fallback handling to the RSC implementations of `<T>` and `<Tx>`.
- Extracts structured runtime-error logging into a shared helper while preserving per-store deduplication and adding module-scoped RSC deduplication.
- Adds regression tests for successful lookup, failed lookup, source fallback, and duplicate-log suppression.
- Adds a patch changeset for `@generaltranslation/react-core`.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The changed RSC paths use the established undefined-target source fallback, while the extracted logger preserves existing structured logging and bounded deduplication behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react-core/src/components/translation/T.rsc.tsx | Wraps both RSC translation lookup paths in fallback handling that logs failures and passes an undefined target to the established source-rendering path. |
| packages/react-core/src/components/translation/Tx.rsc.tsx | Adds the same logged source-content fallback to the runtime-only RSC translation path. |
| packages/react-core/src/utils/errors/logRuntimeTranslationError.ts | Centralizes the existing structured logger and bounded deduplication behavior, with a module-scoped set for RSC renders. |
| packages/react-core/src/i18n-store/I18nStore.ts | Delegates existing per-instance runtime-error logging to the shared helper without changing store-level deduplication scope. |
| packages/react-core/src/components/translation/__tests__/T.test.tsx | Adds coverage for source fallback and logging when either standard or hot-reload RSC lookup rejects. |
| packages/react-core/src/components/translation/__tests__/Tx.test.tsx | Adds success, failure fallback, and cross-render log-deduplication coverage for RscTx. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  RSC["RscT / RscTx render"] --> Lookup["Runtime translation lookup"]
  Lookup -->|Success| Target["Render translated content"]
  Lookup -->|Rejected| Catch["Catch lookup error"]
  Catch --> Log["Log structured deduplicated error"]
  Log --> Source["Render source content"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react-core): degrade to source conte..."](https://github.com/generaltranslation/gt/commit/62734ffe89742424caecb96440a59e4636ebe183) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55447232)</sub>

**Context used:**

- Knowledge Base — [react-core Package](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/react-core-package.md)

<!-- /greptile_comment -->