### PR TITLE
fix(tanstack-start): keep server functions alive in dev when translation loading fails

### DIFF
--- a/.changeset/tanstack-server-functions-missing-file.md
+++ b/.changeset/tanstack-server-functions-missing-file.md
@@ -1,0 +1,5 @@
+---
+'gt-tanstack-start': patch
+---
+
+Keep server functions alive in development when translation loading fails. Calling `getGT()`, `getMessages()`, or `getTranslations()` on the server for a locale whose translation or dictionary files do not exist yet used to reject and turn the request into an HTTP 500 in development; the request now logs one structured warning and renders untranslated source content instead. A later request retries the loader once translations exist, and production behavior is unchanged.

--- a/packages/tanstack-start/src/functions/__tests__/runtimeLoadFailure.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/runtimeLoadFailure.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tanstack/react-start', () => ({
+  createIsomorphicFn: () => ({
+    server: (serverFn: (...args: never[]) => unknown) => ({
+      client: (clientFn: (...args: never[]) => unknown) =>
+        Object.assign(serverFn, { client: clientFn, server: serverFn }),
+    }),
+  }),
+}));
+
+vi.mock('@tanstack/react-start/server', () => ({
+  setCookie: vi.fn(),
+}));
+
+import {
+  ReactI18nCache,
+  initializeI18nConfig,
+  setReactI18nCache,
+} from '@generaltranslation/react-core/pure';
+import { hashMessage } from 'gt-i18n/internal';
+import { AsyncLocalConditionStore } from '../../condition-store/AsyncLocalConditionStore';
+import {
+  getConditionStore,
+  setConditionStore,
+} from '../../condition-store/singleton';
+import { getGT, getMessages, getTranslations } from '../runtime';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+const config = {
+  defaultLocale: 'en',
+  locales: ['en', 'es'],
+};
+
+const failingLoader = () =>
+  Promise.reject(new Error("Cannot find module './_gt/es.json'"));
+
+function setup(cacheParams: ConstructorParameters<typeof ReactI18nCache>[0]) {
+  initializeI18nConfig(config);
+  setReactI18nCache(new ReactI18nCache(cacheParams));
+  setConditionStore(new AsyncLocalConditionStore(config));
+}
+
+function runRequest<T>(callback: () => Promise<T>): Promise<T> {
+  return getConditionStore().run(
+    new Request('https://example.com', {
+      headers: { cookie: 'generaltranslation.locale=es' },
+    }),
+    callback
+  );
+}
+
+describe.sequential('server functions when translation loading fails', () => {
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it('resolves translated content when the loader succeeds', async () => {
+    setup({
+      loadTranslations: async () => ({
+        [hashMessage('Hello, world!', { $format: 'ICU' })]: 'Hola, mundo!',
+      }),
+    });
+
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hola, mundo!');
+    });
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+
+  it('development: getGT falls back to source content when the loader fails', async () => {
+    // Same failure class as gt#1937: the cache rethrows in dev, which used to
+    // reject the server function and turn the request into an HTTP 500
+    vi.stubEnv('NODE_ENV', 'development');
+    setup({ loadTranslations: failingLoader });
+
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, {name}!', { name: 'Alice' })).toBe('Hello, Alice!');
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('"es"')
+    );
+  });
+
+  it('development: getMessages falls back to source content when the loader fails', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    setup({ loadTranslations: failingLoader });
+
+    await runRequest(async () => {
+      const m = await getMessages();
+      expect(m('Hello, world!')).toBe('Hello, world!');
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('development: getTranslations falls back to the source dictionary when loaders fail', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    setup({
+      dictionary: { greeting: 'Hello {name}!' },
+      loadDictionary: failingLoader,
+      loadTranslations: failingLoader,
+    });
+
+    await runRequest(async () => {
+      const t = await getTranslations();
+      expect(t('greeting', { name: 'Alice' })).toBe('Hello Alice!');
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('development: a later request retries the loader and recovers', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const loadTranslations = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Cannot find module './_gt/es.json'"))
+      .mockResolvedValue({
+        [hashMessage('Hello, world!', { $format: 'ICU' })]: 'Hola, mundo!',
+      });
+    setup({ loadTranslations });
+
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hello, world!');
+    });
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hola, mundo!');
+    });
+    expect(loadTranslations).toHaveBeenCalledTimes(2);
+  });
+
+  it('production: the loader failure stays inside the cache and logs no warning', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    setup({ loadTranslations: failingLoader });
+
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hello, world!');
+    });
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tanstack-start/src/functions/__tests__/runtimeLoadFailure.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/runtimeLoadFailure.test.ts
@@ -35,8 +35,8 @@ const config = {
   locales: ['en', 'es'],
 };
 
-const failingLoader = () =>
-  Promise.reject(new Error("Cannot find module './_gt/es.json'"));
+const failingLoader = (message: string) => () =>
+  Promise.reject(new Error(message));
 
 function setup(cacheParams: ConstructorParameters<typeof ReactI18nCache>[0]) {
   initializeI18nConfig(config);
@@ -88,7 +88,11 @@ describe.sequential('server functions when translation loading fails', () => {
     // Same failure class as gt#1937: the cache rethrows in dev, which used to
     // reject the server function and turn the request into an HTTP 500
     vi.stubEnv('NODE_ENV', 'development');
-    setup({ loadTranslations: failingLoader });
+    setup({
+      loadTranslations: failingLoader(
+        "Cannot find module './_gt/es.json' (getGT)"
+      ),
+    });
 
     await runRequest(async () => {
       const gt = await getGT();
@@ -102,7 +106,11 @@ describe.sequential('server functions when translation loading fails', () => {
 
   it('development: getMessages falls back to source content when the loader fails', async () => {
     vi.stubEnv('NODE_ENV', 'development');
-    setup({ loadTranslations: failingLoader });
+    setup({
+      loadTranslations: failingLoader(
+        "Cannot find module './_gt/es.json' (getMessages)"
+      ),
+    });
 
     await runRequest(async () => {
       const m = await getMessages();
@@ -115,8 +123,8 @@ describe.sequential('server functions when translation loading fails', () => {
     vi.stubEnv('NODE_ENV', 'development');
     setup({
       dictionary: { greeting: 'Hello {name}!' },
-      loadDictionary: failingLoader,
-      loadTranslations: failingLoader,
+      loadDictionary: failingLoader('missing dictionary (getTranslations)'),
+      loadTranslations: failingLoader('missing translations (getTranslations)'),
     });
 
     await runRequest(async () => {
@@ -130,7 +138,9 @@ describe.sequential('server functions when translation loading fails', () => {
     vi.stubEnv('NODE_ENV', 'development');
     const loadTranslations = vi
       .fn()
-      .mockRejectedValueOnce(new Error("Cannot find module './_gt/es.json'"))
+      .mockRejectedValueOnce(
+        new Error("Cannot find module './_gt/es.json' (recovers)")
+      )
       .mockResolvedValue({
         [hashMessage('Hello, world!', { $format: 'ICU' })]: 'Hola, mundo!',
       });
@@ -147,9 +157,26 @@ describe.sequential('server functions when translation loading fails', () => {
     expect(loadTranslations).toHaveBeenCalledTimes(2);
   });
 
+  it('development: an identical repeated failure warns only once', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    setup({ loadTranslations: failingLoader('repeat failure (dedupe)') });
+
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hello, world!');
+    });
+    await runRequest(async () => {
+      const gt = await getGT();
+      expect(gt('Hello, world!')).toBe('Hello, world!');
+    });
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('production: the loader failure stays inside the cache and logs no warning', async () => {
     vi.stubEnv('NODE_ENV', 'production');
-    setup({ loadTranslations: failingLoader });
+    setup({
+      loadTranslations: failingLoader('missing translations (production)'),
+    });
 
     await runRequest(async () => {
       const gt = await getGT();

--- a/packages/tanstack-start/src/functions/runtime.ts
+++ b/packages/tanstack-start/src/functions/runtime.ts
@@ -1,8 +1,13 @@
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getReadonlyConditionStore } from '@generaltranslation/react-core/pure';
 import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import {
   getGTInternal,
   getMessagesInternal,
+  getRuntimeEnvironment,
   getTranslationsInternal,
 } from 'gt-i18n/internal';
 import type {
@@ -12,6 +17,46 @@ import type {
   TFunctionType,
 } from 'gt-i18n/types';
 import { getConditionStore } from '../condition-store/singleton';
+
+type LocaleConditions = {
+  locale: string;
+  enableI18n: boolean;
+};
+
+/**
+ * In development a failed translation load rejects inside the i18n cache,
+ * which would turn the server-function request into an HTTP 500; warn once
+ * and degrade the request to source content instead.
+ */
+async function resolveWithSourceFallback<T>(
+  conditions: LocaleConditions,
+  create: (conditions: LocaleConditions) => Promise<T>
+): Promise<T> {
+  try {
+    return await create(conditions);
+  } catch (error) {
+    if (getRuntimeEnvironment() !== 'development') throw error;
+    console.warn(
+      createDiagnosticMessage({
+        source: 'gt-tanstack-start',
+        severity: 'Warning',
+        whatHappened: `Could not load translations for locale "${conditions.locale}", so this request renders untranslated content`,
+        why: 'the translation loader failed, usually because translations for this locale have not been generated yet',
+        fix: 'Generate translations for this locale, or check your loadTranslations configuration.',
+        details: formatDiagnosticErrorDetails(error),
+      })
+    );
+    return create({ ...conditions, enableI18n: false });
+  }
+}
+
+function getServerConditions(): LocaleConditions {
+  const conditionStore = getConditionStore();
+  return {
+    locale: conditionStore.getLocale(),
+    enableI18n: conditionStore.getEnableI18n(),
+  };
+}
 
 /** Return the locale associated with the current request or browser. */
 export const getLocale: () => string = createIsomorphicFn()
@@ -26,16 +71,11 @@ export const getEnableI18n: () => boolean = createIsomorphicFn()
 /** Return a string translation function for the current runtime. */
 export const getGT: (messages?: Message[]) => Promise<GTFunctionType> =
   createIsomorphicFn()
-    .server((messages?: Message[]) => {
-      const conditionStore = getConditionStore();
-      return getGTInternal(
-        {
-          locale: conditionStore.getLocale(),
-          enableI18n: conditionStore.getEnableI18n(),
-        },
-        messages
-      );
-    })
+    .server((messages?: Message[]) =>
+      resolveWithSourceFallback(getServerConditions(), (conditions) =>
+        getGTInternal(conditions, messages)
+      )
+    )
     .client((messages?: Message[]) => {
       const conditionStore = getReadonlyConditionStore();
       return getGTInternal(
@@ -49,13 +89,11 @@ export const getGT: (messages?: Message[]) => Promise<GTFunctionType> =
 
 /** Return a registered-message translation function for the current runtime. */
 export const getMessages: () => Promise<MFunctionType> = createIsomorphicFn()
-  .server(() => {
-    const conditionStore = getConditionStore();
-    return getMessagesInternal({
-      locale: conditionStore.getLocale(),
-      enableI18n: conditionStore.getEnableI18n(),
-    });
-  })
+  .server(() =>
+    resolveWithSourceFallback(getServerConditions(), (conditions) =>
+      getMessagesInternal(conditions)
+    )
+  )
   .client(() => {
     const conditionStore = getReadonlyConditionStore();
     return getMessagesInternal({
@@ -67,14 +105,11 @@ export const getMessages: () => Promise<MFunctionType> = createIsomorphicFn()
 /** Return a dictionary translation function for the current runtime. */
 export const getTranslations: (rootId?: string) => Promise<TFunctionType> =
   createIsomorphicFn()
-    .server((rootId?: string) => {
-      const conditionStore = getConditionStore();
-      return getTranslationsInternal({
-        locale: conditionStore.getLocale(),
-        enableI18n: conditionStore.getEnableI18n(),
-        rootId,
-      });
-    })
+    .server((rootId?: string) =>
+      resolveWithSourceFallback(getServerConditions(), (conditions) =>
+        getTranslationsInternal({ ...conditions, rootId })
+      )
+    )
     .client((rootId?: string) => {
       const conditionStore = getReadonlyConditionStore();
       return getTranslationsInternal({

--- a/packages/tanstack-start/src/functions/runtime.ts
+++ b/packages/tanstack-start/src/functions/runtime.ts
@@ -28,6 +28,17 @@ type LocaleConditions = {
  * which would turn the server-function request into an HTTP 500; warn once
  * and degrade the request to source content instead.
  */
+const MAX_WARNED_RUNTIME_LOAD_FAILURES = 100;
+const warnedRuntimeLoadFailures = new Set<string>();
+
+function getRuntimeLoadFailureKey(locale: string, error: unknown): string {
+  const errorKey =
+    error instanceof Error
+      ? `${error.name}|${error.message}`
+      : `${typeof error}|${String(error)}`;
+  return `${locale}|${errorKey}`;
+}
+
 async function resolveWithSourceFallback<T>(
   conditions: LocaleConditions,
   create: (conditions: LocaleConditions) => Promise<T>
@@ -36,6 +47,17 @@ async function resolveWithSourceFallback<T>(
     return await create(conditions);
   } catch (error) {
     if (getRuntimeEnvironment() !== 'development') throw error;
+    const failureKey = getRuntimeLoadFailureKey(conditions.locale, error);
+    if (warnedRuntimeLoadFailures.has(failureKey)) {
+      return create({ ...conditions, enableI18n: false });
+    }
+    warnedRuntimeLoadFailures.add(failureKey);
+    if (warnedRuntimeLoadFailures.size > MAX_WARNED_RUNTIME_LOAD_FAILURES) {
+      const oldest = warnedRuntimeLoadFailures.values().next().value;
+      if (oldest !== undefined) {
+        warnedRuntimeLoadFailures.delete(oldest);
+      }
+    }
     console.warn(
       createDiagnosticMessage({
         source: 'gt-tanstack-start',


### PR DESCRIPTION
## Summary

- Fixes the server-function sibling of #1937: in development, a missing translation file for the request locale rejected `getGT()`, `getMessages()`, and `getTranslations()` in gt-tanstack-start and returned HTTP 500; the three server implementations now catch the failure, log one structured console warning naming the locale and the loader error, and retry with internationalization disabled so the request renders source content.
- Leaves production semantics unchanged: outside development the error rethrows exactly as before, and the client implementations and the i18n cache are untouched.
- Adds a patch changeset for `gt-tanstack-start`.

## Validation

- `npx vitest run` in `packages/tanstack-start` on 87c715875: 9 files, 41 tests passed; the 4 new development failure-path tests fail against the base revision's files.
- `npx tsc --noEmit` in `packages/tanstack-start`, `npx oxlint`, and `npx oxfmt --check` on touched paths: clean.
- Not run: a live TanStack Start app reproduction; the behavior is pinned at the server-function seam.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change lets TanStack Start server translation helpers fall back to source content during development when translation loading fails, while leaving production failures unchanged.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

No blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Executed the Vitest test run for src/functions/\_\_tests\_\_/runtimeWarnOnceRepro.test.ts with the configured vitest.config.ts from the tanstack-start package, and observed consecutiveDuplicateWarnings: 1, warningsAfterDistinctFailures: 102, and warningsAfterFirstFailureRevisit: 103.

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(tanstack-start): warn once per local..."](https://github.com/generaltranslation/gt/commit/214a4845fd9bdfb8d8ae147637afa2b3e30a1e45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55447251)</sub>

<!-- /greptile_comment -->