### PR TITLE
fix(react): guard navigator access to avoid ReferenceError during SSR

### DIFF
--- a/.changeset/tidy-otters-sing.md
+++ b/.changeset/tidy-otters-sing.md
@@ -1,0 +1,5 @@
+---
+'gt-react': patch
+---
+
+Avoid a ReferenceError when reading navigator locales outside a browser environment (e.g. during SSR).

--- a/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
@@ -99,15 +99,31 @@ describe('createOrUpdateBrowserConditionStore', () => {
     });
   });
 
-  it('does not throw when navigator is undefined (e.g. during SSR)', () => {
-    vi.stubGlobal('navigator', undefined);
+  it('does not throw when navigator is unbound (e.g. during SSR)', () => {
+    // `vi.stubGlobal('navigator', undefined)` only assigns `undefined` to an
+    // already-declared global — it doesn't reproduce the real failure, where
+    // `navigator` is an unbound identifier and a bare reference throws a
+    // ReferenceError. Delete the property outright instead.
+    const originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'navigator'
+    );
+    delete (globalThis as { navigator?: unknown }).navigator;
 
-    expect(() =>
-      createOrUpdateBrowserConditionStore({
-        locale: 'fr',
-      })
-    ).not.toThrow();
-
-    vi.unstubAllGlobals();
+    try {
+      expect(() =>
+        createOrUpdateBrowserConditionStore({
+          locale: 'fr',
+        })
+      ).not.toThrow();
+    } finally {
+      if (originalNavigatorDescriptor) {
+        Object.defineProperty(
+          globalThis,
+          'navigator',
+          originalNavigatorDescriptor
+        );
+      }
+    }
   });
 });

--- a/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
@@ -98,4 +98,16 @@ describe('createOrUpdateBrowserConditionStore', () => {
       value: 'true',
     });
   });
+
+  it('does not throw when navigator is undefined (e.g. during SSR)', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(() =>
+      createOrUpdateBrowserConditionStore({
+        locale: 'fr',
+      })
+    ).not.toThrow();
+
+    vi.unstubAllGlobals();
+  });
 });

--- a/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
+++ b/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
@@ -38,6 +38,8 @@ describe('readBrowserLocale', () => {
         'navigator',
         originalNavigatorDescriptor
       );
+    } else {
+      deleteGlobalNavigator();
     }
   });
 

--- a/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
+++ b/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
@@ -11,30 +11,54 @@ vi.mock('../cookies', () => ({
 
 import { readBrowserLocale } from '../readBrowserLocale';
 
+// `vi.stubGlobal('navigator', undefined)` only assigns `undefined` to an
+// already-declared global — it does not reproduce the real-world failure,
+// where `navigator` is an unbound identifier (no property at all) and a
+// bare reference throws a ReferenceError. We delete the property outright
+// and restore its original descriptor afterward to simulate that.
+let originalNavigatorDescriptor: PropertyDescriptor | undefined;
+
+function deleteGlobalNavigator() {
+  delete (globalThis as { navigator?: unknown }).navigator;
+}
+
 describe('readBrowserLocale', () => {
   beforeEach(() => {
     mockCookieValues.clear();
+    originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis,
+      'navigator'
+    );
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'navigator',
+        originalNavigatorDescriptor
+      );
+    }
   });
 
-  it('does not throw when navigator is undefined (e.g. during SSR)', () => {
-    vi.stubGlobal('navigator', undefined);
+  it('does not throw when navigator is unbound (e.g. during SSR)', () => {
+    deleteGlobalNavigator();
 
     expect(() => readBrowserLocale('generaltranslation.locale')).not.toThrow();
   });
 
-  it('falls back to the cookie locale alone when navigator is undefined', () => {
-    vi.stubGlobal('navigator', undefined);
+  it('falls back to the cookie locale alone when navigator is unbound', () => {
+    deleteGlobalNavigator();
     mockCookieValues.set('generaltranslation.locale', 'de');
 
     expect(readBrowserLocale('generaltranslation.locale')).toEqual(['de']);
   });
 
   it('appends navigator languages after the cookie locale when available', () => {
-    vi.stubGlobal('navigator', { languages: ['fr-FR', 'en-US'] });
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { languages: ['fr-FR', 'en-US'] },
+      configurable: true,
+    });
     mockCookieValues.set('generaltranslation.locale', 'de');
 
     expect(readBrowserLocale('generaltranslation.locale')).toEqual([
@@ -45,7 +69,7 @@ describe('readBrowserLocale', () => {
   });
 
   it('returns an empty array when neither a cookie nor navigator locales are available', () => {
-    vi.stubGlobal('navigator', undefined);
+    deleteGlobalNavigator();
 
     expect(readBrowserLocale('generaltranslation.locale')).toEqual([]);
   });

--- a/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
+++ b/packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCookieValues = vi.hoisted(
+  () => new Map<string, string | undefined>()
+);
+
+vi.mock('../cookies', () => ({
+  getCookieValue: ({ cookieName }: { cookieName: string }) =>
+    mockCookieValues.get(cookieName),
+}));
+
+import { readBrowserLocale } from '../readBrowserLocale';
+
+describe('readBrowserLocale', () => {
+  beforeEach(() => {
+    mockCookieValues.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not throw when navigator is undefined (e.g. during SSR)', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(() => readBrowserLocale('generaltranslation.locale')).not.toThrow();
+  });
+
+  it('falls back to the cookie locale alone when navigator is undefined', () => {
+    vi.stubGlobal('navigator', undefined);
+    mockCookieValues.set('generaltranslation.locale', 'de');
+
+    expect(readBrowserLocale('generaltranslation.locale')).toEqual(['de']);
+  });
+
+  it('appends navigator languages after the cookie locale when available', () => {
+    vi.stubGlobal('navigator', { languages: ['fr-FR', 'en-US'] });
+    mockCookieValues.set('generaltranslation.locale', 'de');
+
+    expect(readBrowserLocale('generaltranslation.locale')).toEqual([
+      'de',
+      'fr-FR',
+      'en-US',
+    ]);
+  });
+
+  it('returns an empty array when neither a cookie nor navigator locales are available', () => {
+    vi.stubGlobal('navigator', undefined);
+
+    expect(readBrowserLocale('generaltranslation.locale')).toEqual([]);
+  });
+});

--- a/packages/react/src/condition-store/readBrowserLocale.ts
+++ b/packages/react/src/condition-store/readBrowserLocale.ts
@@ -10,7 +10,8 @@ export function readBrowserLocale(localeCookieName: string): string[] {
   if (cookieLocale) candidates.push(cookieLocale);
 
   // (2) Check navigator locales
-  const navigatorLocales = navigator?.languages || [];
+  const navigatorLocales =
+    typeof navigator !== 'undefined' ? navigator.languages : [];
   candidates.push(...navigatorLocales);
 
   return candidates;

--- a/packages/react/src/condition-store/readBrowserLocale.ts
+++ b/packages/react/src/condition-store/readBrowserLocale.ts
@@ -11,7 +11,7 @@ export function readBrowserLocale(localeCookieName: string): string[] {
 
   // (2) Check navigator locales
   const navigatorLocales =
-    typeof navigator !== 'undefined' ? navigator.languages : [];
+    typeof navigator !== 'undefined' ? (navigator.languages ?? []) : [];
   candidates.push(...navigatorLocales);
 
   return candidates;


### PR DESCRIPTION
## Summary

- `navigator?.languages` only guards against `navigator` being a `null`/`undefined` *value* — it does nothing when `navigator` is an unbound identifier, which is the case in non-browser SSR/edge runtimes (older Node versions, some SSR/edge sandboxes). Referencing it throws `ReferenceError: navigator is not defined` before optional chaining ever runs.
- Guard it behind `typeof navigator !== 'undefined'` instead, the one JS construct that's safe against undeclared identifiers.
- This matches two existing patterns already in the codebase: `document` is guarded the same way in the sibling file `packages/react/src/condition-store/cookies.ts`, and `navigator` itself is guarded this way in `packages/react-native/src/utils/getNativeLocales.ts`.

Closes #460.

## Why CI didn't catch this originally

All CI workflows pin Node 24, and Node 21+ ships a built-in `navigator` global, so the buggy line never actually threw in this repo's own test/CI environment. The regression tests delete the `navigator` property outright (see Validation below) rather than relying on the host Node version, so they exercise the guard regardless of which Node version runs them.

## Validation

- Ran the new/changed tests against this fix, then temporarily reverted `readBrowserLocale.ts` to the pre-fix line and reran them against that revision, to confirm they actually discriminate between the two:
  - Against the fix: `readBrowserLocale.test.ts` (4/4) and `createBrowserConditionStore.test.ts` (5/5) pass.
  - Against the pre-fix revision: the 4 navigator-dependent tests fail with the exact reported `ReferenceError: navigator is not defined`; the 5 unrelated tests (pre-existing cookie/enableI18n cases, plus the "navigator languages present" happy path) pass unchanged on both revisions.
  - Note: an earlier version of these tests used `vi.stubGlobal('navigator', undefined)`, which only assigns `undefined` to an already-declared global and does not reproduce the ReferenceError — that version passed on both revisions (a vacuous test). The tests now delete the global property (`delete globalThis.navigator`, restoring the original descriptor in `afterEach`/`finally`) to reproduce the actual unbound-identifier failure.
- `pnpm --filter gt-react test` — 8/8 files, 35/35 tests pass
- `pnpm --filter gt-react typecheck` — passed
- `oxlint` / `oxfmt --check` on changed files — passed
- Downstream smoke checks (both depend on `gt-react`'s condition store, no source changed in either): `pnpm --filter gt-tanstack-start test` (8/8, 35/35) and `gt-next` typecheck + vitest suite (26/26, 287/287)

## Notes

- Scope is a single production line in `packages/react/src/condition-store/readBrowserLocale.ts`. `packages/sanity/src/components/page/DebugInfoDialog.tsx`'s unrelated `navigator.clipboard` usage was intentionally left untouched — it's a Sanity Studio panel that only ever mounts client-side, a different risk class from this SSR bug.
- No `gt-react-native` change needed for parity — this is SSR-specific to `gt-react`'s browser condition store; RN has no server-rendering concept and its own locale detection is already correctly guarded.
- Changeset added: patch bump for `gt-react`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR safely guards browser-locale detection when `navigator` is unavailable during SSR and completes the fixes requested in the previous review.
- Uses `typeof navigator !== 'undefined'` before accessing browser locales and defaults missing `navigator.languages` to an empty array.
- Adds coverage for absent `navigator`, absent locale data, cookie fallback, and browser-language ordering.
- Restores or removes the mocked global according to its original state.
- Adds a patch changeset for `gt-react`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/react/src/condition-store/readBrowserLocale.ts | Safely handles both an undeclared navigator global and a navigator without languages, resolving the previously reported fallback failure. |
| packages/react/src/condition-store/__tests__/readBrowserLocale.test.ts | Covers SSR and browser locale behavior while correctly restoring or deleting the navigator global after each test. |
| packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts | Adds integration coverage confirming condition-store creation does not throw when navigator is unavailable. |
| .changeset/tidy-otters-sing.md | Records the SSR navigator fix as a patch release for gt-react. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(react): guard undefined navigator.la..."](https://github.com/generaltranslation/gt/commit/f2995869bdfce58dba7db3a7e702dba652c15234) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57153073)</sub>

<!-- /greptile_comment -->