### PR TITLE
Fix custom locale aliases in formatting fallbacks

### DIFF
--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -111,4 +111,29 @@ describe('getFormatLocales', () => {
       })
     ).toEqual(['en']);
   });
+
+  it('resolves custom locale mappings before formatting', () => {
+    setup({
+      locale: 'brand-french',
+      locales: ['en', 'brand-french', 'brand-canadian'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr-FR',
+          name: 'Brand French',
+        },
+        'brand-canadian': {
+          code: 'fr-CA',
+          name: 'Brand Canadian',
+        },
+      },
+    });
+
+    expect(
+      getFormatLocales({
+        locale: 'brand-french',
+        enableI18n: true,
+        localesProp: ['brand-canadian'],
+      })
+    ).toEqual(['fr-CA', 'fr-FR', 'en']);
+  });
 });

--- a/packages/react-core/src/hooks/utils/getFormatLocales.ts
+++ b/packages/react-core/src/hooks/utils/getFormatLocales.ts
@@ -15,10 +15,11 @@ export function getFormatLocales({
   enableI18n: boolean;
   localesProp?: string[];
 }): string[] {
-  const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate =
-    enableI18n && getI18nConfig().requiresTranslation(locale);
-  return shouldTranslate
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const shouldTranslate = enableI18n && i18nConfig.requiresTranslation(locale);
+  const locales = shouldTranslate
     ? [...localesProp, locale, defaultLocale]
     : [defaultLocale];
+  return locales.map((locale) => i18nConfig.resolveCanonicalLocale(locale));
 }


### PR DESCRIPTION
## TL;DR

Resolve custom locale aliases to canonical BCP 47 locale codes before passing fallback locale lists to Intl formatters.

## Code Changes

- Reuse the initialized i18n configuration while building formatting locales.
- Canonicalize explicit, active, and default locale fallbacks.
- Add coverage for multiple custom locale aliases.

## Notes / Flags

- This is independent from the production runtime stack.
- Validated with react-core typecheck, formatting, lint, and all 83 react-core tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change canonicalizes custom locale aliases before React formatting fallback lists are used, while preserving fallback order. The potential failure where aliases in explicit, active, or default fallback positions remained unresolved was exercised and disproved: the returned values were `fr-CA`, `fr-FR`, and `en-US` in order, and the no-translation path returned the canonical default. The existing react-core locale utility suite also passed.

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The locale fallback change is safe to merge based on focused execution of alias resolution across every fallback position and the passing utility regression suite.

No defects remain: the exercised alias-resolution path produced canonical BCP 47 values in preserved fallback order, including when translation is disabled.

**Files Needing Attention:** No files need further attention.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a focused locale alias validation test to compare the pre-PR behavior with the post-PR behavior.
- Observed that the post-PR results include fr-CA, fr-FR, en-US for locale aliases and en-US for non-translation.
- Concluded there is no security impact and no author action is required based on the validation.

<a href="https://app.greptile.com/trex/runs/20875710/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(react): canonicalize formatting loca..."](https://github.com/generaltranslation/gt/commit/4f86c0da52c3212b8c7a0391e497345156a410fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57215799)</sub>

<!-- /greptile_comment -->