### PR TITLE
Add a lightweight snapshot translation runtime

### DIFF
--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -9,50 +9,22 @@ import {
   _selectRelativeTimeUnit,
 } from './formatting/format';
 import { intlCache } from './cache/IntlCache';
-import {
-  _prepareApprovedLocales,
-  type ApprovedLocales,
-} from './locales/approvedLocales';
-import { _requiresTranslationWithScope } from './locales/requiresTranslation';
-import { _determineLocaleWithIndex } from './locales/determineLocale';
-import { _isSameLanguage } from './locales/isSameLanguage';
-import { _getLocaleProperties } from './locales/getLocaleProperties';
-import { _getLocaleEmoji } from './locales/getLocaleEmoji';
-import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
-import { _getLocaleName } from './locales/getLocaleName';
-import { _getLocaleDirection } from './locales/getLocaleDirection';
 import { libraryDefaultLocale } from './settings/settings';
-import { _isSameDialect } from './locales/isSameDialect';
-import { _isSupersetLocale } from './locales/isSupersetLocale';
-import type { CustomMapping, FormatVariables } from './types';
-import { _resolveAliasLocale } from './locales/resolveAliasLocale';
-import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
-import { getCustomLocaleCode } from './locales/customLocaleMapping';
+import type { FormatVariables } from './types';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import type { StringFormat } from './types-dir/jsx/content';
+import {
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from './LocaleResolver';
 
-export type LocaleConfigConstructorParams = {
-  defaultLocale?: string;
-  locales?: string[];
-  customMapping?: CustomMapping;
-};
+export type LocaleConfigConstructorParams = LocaleResolverConstructorParams;
 
 type LocalesOption = {
   locales?: string | string[];
 };
 
 type WithLocales<T = object> = T & LocalesOption;
-
-/**
- * Approved-locales work that requiresTranslation and determineLocale would
- * otherwise redo on every call: canonical codes plus the validated and
- * indexed scope built from them.
- */
-type LocaleResolutionScope = {
-  approvedLocalePairs: { locale: string; canonicalLocale: string }[];
-  canonicalMappingCodes: (string | undefined)[];
-  approved: ApprovedLocales;
-};
 
 /**
  * LocaleConfig contains the locale and formatting primitives exposed through
@@ -62,77 +34,7 @@ type LocaleResolutionScope = {
  * translation credentials. It only stores locale metadata needed to resolve
  * aliases, choose formatting fallbacks, and format values with Intl.
  */
-export class LocaleConfig {
-  readonly defaultLocale: string;
-  readonly locales: string[];
-  readonly customMapping?: CustomMapping;
-  // Built lazily so construction stays cheap for instances that never resolve
-  // locales. The snapshot is refreshed if callers mutate the public locale or
-  // custom-mapping collections retained by this instance.
-  private resolutionScope?: LocaleResolutionScope;
-
-  private getResolutionScope(): LocaleResolutionScope {
-    if (
-      this.resolutionScope &&
-      this.isResolutionScopeCurrent(this.resolutionScope)
-    ) {
-      return this.resolutionScope;
-    }
-    const resolutionScope = this.buildResolutionScope(this.locales);
-    Object.defineProperty(this, 'resolutionScope', {
-      configurable: true,
-      value: resolutionScope,
-      writable: true,
-    });
-    return resolutionScope;
-  }
-
-  private isResolutionScopeCurrent(scope: LocaleResolutionScope): boolean {
-    if (scope.approvedLocalePairs.length !== this.locales.length) return false;
-    for (let index = 0; index < this.locales.length; index++) {
-      const locale = this.locales[index];
-      const pair = scope.approvedLocalePairs[index];
-      if (
-        pair.locale !== locale ||
-        pair.canonicalLocale !== this.resolveCanonicalLocale(locale) ||
-        scope.canonicalMappingCodes[index] !==
-          getCustomLocaleCode(this.customMapping, pair.canonicalLocale)
-      ) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private buildResolutionScope(
-    approvedLocales: string[]
-  ): LocaleResolutionScope {
-    const approvedLocalePairs = approvedLocales.map((locale) => ({
-      locale,
-      canonicalLocale: this.resolveCanonicalLocale(locale),
-    }));
-    return {
-      approvedLocalePairs,
-      canonicalMappingCodes: approvedLocalePairs.map(({ canonicalLocale }) =>
-        getCustomLocaleCode(this.customMapping, canonicalLocale)
-      ),
-      approved: _prepareApprovedLocales(
-        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
-        this.customMapping
-      ),
-    };
-  }
-
-  constructor({
-    defaultLocale = libraryDefaultLocale,
-    locales = [],
-    customMapping,
-  }: LocaleConfigConstructorParams = {}) {
-    this.defaultLocale = defaultLocale;
-    this.locales = locales;
-    this.customMapping = customMapping;
-  }
-
+export class LocaleConfig extends LocaleResolver {
   private getFormattingLocales(
     targetLocale?: string,
     locales?: string | string[]
@@ -280,118 +182,5 @@ export class LocaleConfig {
       locales: this.getFormattingLocales(targetLocale, locales),
       options: intlOptions,
     });
-  }
-
-  getLocaleName(locale: string) {
-    return _getLocaleName(locale, this.defaultLocale, this.customMapping);
-  }
-
-  getLocaleEmoji(locale: string) {
-    return _getLocaleEmoji(locale, this.customMapping);
-  }
-
-  getLocaleProperties(locale: string) {
-    return _getLocaleProperties(locale, this.defaultLocale, this.customMapping);
-  }
-
-  requiresTranslation(
-    targetLocale: string,
-    sourceLocale: string = this.defaultLocale,
-    approvedLocales: string[] | undefined = this.locales.length
-      ? this.locales
-      : undefined
-  ) {
-    // The default scope (this.locales) is prepared once per instance; a
-    // caller-provided list is prepared for that call only. No configured
-    // locales means no approved-locales restriction.
-    const approvedScope = approvedLocales
-      ? approvedLocales === this.locales
-        ? this.getResolutionScope().approved
-        : _prepareApprovedLocales(
-            approvedLocales.map((locale) =>
-              this.resolveCanonicalLocale(locale)
-            ),
-            this.customMapping
-          )
-      : undefined;
-    return _requiresTranslationWithScope(
-      this.resolveCanonicalLocale(sourceLocale),
-      this.resolveCanonicalLocale(targetLocale),
-      approvedScope,
-      this.customMapping
-    );
-  }
-
-  /**
-   * NOTE: consider moving LocaleCandidates type to this package, and
-   * determineLocale could accept that as a parameter.
-   */
-  determineLocale(
-    locales: string | string[],
-    approvedLocales: string[] = this.locales
-  ) {
-    const { approvedLocalePairs, approved } =
-      approvedLocales === this.locales
-        ? this.getResolutionScope()
-        : this.buildResolutionScope(approvedLocales);
-    const resolvedLocale = _determineLocaleWithIndex(
-      Array.isArray(locales)
-        ? locales.map((locale) => this.resolveCanonicalLocale(locale))
-        : this.resolveCanonicalLocale(locales),
-      approved,
-      this.customMapping
-    );
-    if (!resolvedLocale) return undefined;
-    const approvedLocale = approvedLocalePairs.find(
-      ({ canonicalLocale }) => canonicalLocale === resolvedLocale
-    );
-    return approvedLocale?.locale ?? this.resolveAliasLocale(resolvedLocale);
-  }
-
-  getLocaleDirection(locale: string) {
-    return _getLocaleDirection(this.resolveCanonicalLocale(locale));
-  }
-
-  isValidLocale(locale: string) {
-    return _isValidLocale(locale, this.customMapping);
-  }
-
-  resolveCanonicalLocale(locale: string) {
-    return _resolveCanonicalLocale(locale, this.customMapping);
-  }
-
-  resolveAliasLocale(locale: string) {
-    return _resolveAliasLocale(locale, this.customMapping);
-  }
-
-  standardizeLocale(locale: string) {
-    return _standardizeLocale(locale);
-  }
-
-  isSameDialect(...locales: (string | string[])[]) {
-    return _isSameDialect(
-      ...locales.map((locale) =>
-        Array.isArray(locale)
-          ? locale.map((code) => this.resolveCanonicalLocale(code))
-          : this.resolveCanonicalLocale(locale)
-      )
-    );
-  }
-
-  isSameLanguage(...locales: (string | string[])[]) {
-    return _isSameLanguage(
-      ...locales.map((locale) =>
-        Array.isArray(locale)
-          ? locale.map((code) => this.resolveCanonicalLocale(code))
-          : this.resolveCanonicalLocale(locale)
-      )
-    );
-  }
-
-  isSupersetLocale(superLocale: string, subLocale: string) {
-    return _isSupersetLocale(
-      this.resolveCanonicalLocale(superLocale),
-      this.resolveCanonicalLocale(subLocale)
-    );
   }
 }

--- a/packages/format/src/LocaleResolver.ts
+++ b/packages/format/src/LocaleResolver.ts
@@ -1,0 +1,207 @@
+import {
+  _prepareApprovedLocales,
+  type ApprovedLocales,
+} from './locales/approvedLocales';
+import { _requiresTranslationWithScope } from './locales/requiresTranslation';
+import { _determineLocaleWithIndex } from './locales/determineLocale';
+import { _isSameLanguage } from './locales/isSameLanguage';
+import { _getLocaleProperties } from './locales/getLocaleProperties';
+import { _getLocaleEmoji } from './locales/getLocaleEmoji';
+import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
+import { _getLocaleName } from './locales/getLocaleName';
+import { _getLocaleDirection } from './locales/getLocaleDirection';
+import { libraryDefaultLocale } from './settings/settings';
+import { _isSameDialect } from './locales/isSameDialect';
+import { _isSupersetLocale } from './locales/isSupersetLocale';
+import type { CustomMapping } from './types';
+import { _resolveAliasLocale } from './locales/resolveAliasLocale';
+import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
+import { getCustomLocaleCode } from './locales/customLocaleMapping';
+
+export type LocaleResolverConstructorParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+type LocaleResolutionScope = {
+  approvedLocalePairs: { locale: string; canonicalLocale: string }[];
+  canonicalMappingCodes: (string | undefined)[];
+  approved: ApprovedLocales;
+};
+
+/** Locale metadata and resolution without value or message formatting. */
+export class LocaleResolver {
+  readonly defaultLocale: string;
+  readonly locales: string[];
+  readonly customMapping?: CustomMapping;
+  private resolutionScope?: LocaleResolutionScope;
+
+  private getResolutionScope(): LocaleResolutionScope {
+    if (
+      this.resolutionScope &&
+      this.isResolutionScopeCurrent(this.resolutionScope)
+    ) {
+      return this.resolutionScope;
+    }
+    const resolutionScope = this.buildResolutionScope(this.locales);
+    Object.defineProperty(this, 'resolutionScope', {
+      configurable: true,
+      value: resolutionScope,
+      writable: true,
+    });
+    return resolutionScope;
+  }
+
+  private isResolutionScopeCurrent(scope: LocaleResolutionScope): boolean {
+    if (scope.approvedLocalePairs.length !== this.locales.length) return false;
+    for (let index = 0; index < this.locales.length; index++) {
+      const locale = this.locales[index];
+      const pair = scope.approvedLocalePairs[index];
+      if (
+        pair.locale !== locale ||
+        pair.canonicalLocale !== this.resolveCanonicalLocale(locale) ||
+        scope.canonicalMappingCodes[index] !==
+          getCustomLocaleCode(this.customMapping, pair.canonicalLocale)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private buildResolutionScope(
+    approvedLocales: string[]
+  ): LocaleResolutionScope {
+    const approvedLocalePairs = approvedLocales.map((locale) => ({
+      locale,
+      canonicalLocale: this.resolveCanonicalLocale(locale),
+    }));
+    return {
+      approvedLocalePairs,
+      canonicalMappingCodes: approvedLocalePairs.map(({ canonicalLocale }) =>
+        getCustomLocaleCode(this.customMapping, canonicalLocale)
+      ),
+      approved: _prepareApprovedLocales(
+        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+        this.customMapping
+      ),
+    };
+  }
+
+  constructor({
+    defaultLocale = libraryDefaultLocale,
+    locales = [],
+    customMapping,
+  }: LocaleResolverConstructorParams = {}) {
+    this.defaultLocale = defaultLocale;
+    this.locales = locales;
+    this.customMapping = customMapping;
+  }
+
+  getLocaleName(locale: string) {
+    return _getLocaleName(locale, this.defaultLocale, this.customMapping);
+  }
+
+  getLocaleEmoji(locale: string) {
+    return _getLocaleEmoji(locale, this.customMapping);
+  }
+
+  getLocaleProperties(locale: string) {
+    return _getLocaleProperties(locale, this.defaultLocale, this.customMapping);
+  }
+
+  requiresTranslation(
+    targetLocale: string,
+    sourceLocale: string = this.defaultLocale,
+    approvedLocales: string[] | undefined = this.locales.length
+      ? this.locales
+      : undefined
+  ) {
+    const approvedScope = approvedLocales
+      ? approvedLocales === this.locales
+        ? this.getResolutionScope().approved
+        : _prepareApprovedLocales(
+            approvedLocales.map((locale) =>
+              this.resolveCanonicalLocale(locale)
+            ),
+            this.customMapping
+          )
+      : undefined;
+    return _requiresTranslationWithScope(
+      this.resolveCanonicalLocale(sourceLocale),
+      this.resolveCanonicalLocale(targetLocale),
+      approvedScope,
+      this.customMapping
+    );
+  }
+
+  determineLocale(
+    locales: string | string[],
+    approvedLocales: string[] = this.locales
+  ) {
+    const { approvedLocalePairs, approved } =
+      approvedLocales === this.locales
+        ? this.getResolutionScope()
+        : this.buildResolutionScope(approvedLocales);
+    const resolvedLocale = _determineLocaleWithIndex(
+      Array.isArray(locales)
+        ? locales.map((locale) => this.resolveCanonicalLocale(locale))
+        : this.resolveCanonicalLocale(locales),
+      approved,
+      this.customMapping
+    );
+    if (!resolvedLocale) return undefined;
+    const approvedLocale = approvedLocalePairs.find(
+      ({ canonicalLocale }) => canonicalLocale === resolvedLocale
+    );
+    return approvedLocale?.locale ?? this.resolveAliasLocale(resolvedLocale);
+  }
+
+  getLocaleDirection(locale: string) {
+    return _getLocaleDirection(this.resolveCanonicalLocale(locale));
+  }
+
+  isValidLocale(locale: string) {
+    return _isValidLocale(locale, this.customMapping);
+  }
+
+  resolveCanonicalLocale(locale: string) {
+    return _resolveCanonicalLocale(locale, this.customMapping);
+  }
+
+  resolveAliasLocale(locale: string) {
+    return _resolveAliasLocale(locale, this.customMapping);
+  }
+
+  standardizeLocale(locale: string) {
+    return _standardizeLocale(locale);
+  }
+
+  isSameDialect(...locales: (string | string[])[]) {
+    return _isSameDialect(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
+  }
+
+  isSameLanguage(...locales: (string | string[])[]) {
+    return _isSameLanguage(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
+  }
+
+  isSupersetLocale(superLocale: string, subLocale: string) {
+    return _isSupersetLocale(
+      this.resolveCanonicalLocale(superLocale),
+      this.resolveCanonicalLocale(subLocale)
+    );
+  }
+}

--- a/packages/format/src/internal.ts
+++ b/packages/format/src/internal.ts
@@ -1,5 +1,10 @@
 import { intlCache } from './cache/IntlCache';
 
+export {
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from './LocaleResolver';
+
 export function getCachedPluralRules(
   locales?: Intl.LocalesArgument
 ): Intl.PluralRules {

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -73,7 +73,7 @@ export function createGlobalSingleton<T>({
   function set(next: T): void {
     const ns = getNamespace(namespace);
     if (ns[key] !== undefined && ns[key] !== next) {
-      if (shouldLogDebugWarnings()) {
+      if (process.env.NODE_ENV !== 'production' && shouldLogDebugWarnings()) {
         console.warn(
           createDiagnosticMessage({
             source,

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,21 +1,22 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from '../globals/createGlobalSingleton';
-import { I18nCache } from './I18nCache';
+import type { I18nCache } from './I18nCache';
 import { Translation } from './translations-manager/utils/types/translation-data';
 
-const i18nCacheSingleton = createGlobalSingleton<I18nCache>({
-  namespace: 'i18n',
-  key: 'i18nCache',
-  source: 'gt-i18n',
-  notInitialized: () =>
-    createDiagnosticMessage({
-      source: 'gt-i18n',
-      severity: 'Error',
-      whatHappened: 'Cannot read I18nCache before it has been initialized',
-      why: 'the internal I18nCache singleton is unavailable',
-      fix: 'Initialize GT before accessing I18nCache (call initializeGT() from your GT framework package).',
-    }),
-});
+const i18nCacheSingleton =
+  /* @__PURE__ */ createGlobalSingleton<I18nCache>({
+    namespace: 'i18n',
+    key: 'i18nCache',
+    source: 'gt-i18n',
+    notInitialized: () =>
+      createDiagnosticMessage({
+        source: 'gt-i18n',
+        severity: 'Error',
+        whatHappened: 'Cannot read I18nCache before it has been initialized',
+        why: 'the internal I18nCache singleton is unavailable',
+        fix: 'Initialize GT before accessing I18nCache (call initializeGT() from your GT framework package).',
+      }),
+  });
 
 /**
  * Get the singleton instance of I18nCache

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,25 +1,19 @@
 import {
-  LocaleConfig,
-  type LocaleConfigConstructorParams,
-} from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
-import { GTRuntime } from 'generaltranslation/runtime';
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from '@generaltranslation/format/internal';
+import { getRegionProperties as getRegionPropertiesForLocale } from '@generaltranslation/format';
+import type {
+  CustomMapping,
+  CustomRegionMapping,
+} from '@generaltranslation/format/types';
+import type { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { GTConfig } from '../config/types';
 import {
   getLoadTranslationsType,
   LoadTranslationsType,
 } from '../i18n-cache/utils/getLoadTranslationsType';
-import {
-  getTranslationApiType,
-  TranslationApiType,
-} from '../i18n-cache/utils/getTranslationApiType';
-import {
-  getGeneralTranslationLogLevel,
-  isDebugLogLevel,
-  type GeneralTranslationLogLevel,
-} from '../logs/logLevel';
-import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = Pick<
@@ -36,36 +30,22 @@ export type I18nConfigParams = Pick<
   | '_tagIds'
 >;
 
-type RuntimeConfig = Pick<
-  I18nConfigParams,
-  | 'projectId'
-  | 'devApiKey'
-  | 'apiKey'
-  | 'runtimeUrl'
-  | '_disableDevHotReload'
-  | '_tagIds'
->;
-
 export type LocaleCandidates = string | string[] | undefined;
 
-export class I18nConfig extends LocaleConfig {
-  protected runtimeConfig: RuntimeConfig;
+/** Locale and catalog configuration shared by browser and full runtimes. */
+export class I18nConfig extends LocaleResolver {
+  private projectId: string | undefined;
   private gtServicesEnabled: boolean;
-  private logLevel: GeneralTranslationLogLevel;
+  private customRegionMapping?: CustomRegionMapping;
 
-  constructor(params: I18nConfigParams = {}) {
-    const gtServicesEnabled = resolveGTServicesEnabled(params);
+  constructor(
+    params: I18nConfigParams = {},
+    gtServicesEnabled = getLoadTranslationsType(params) ===
+      LoadTranslationsType.GT_REMOTE
+  ) {
     super(getLocaleConfigParams(params, gtServicesEnabled));
-    this.runtimeConfig = {
-      projectId: params.projectId,
-      devApiKey: params.devApiKey,
-      apiKey: params.apiKey,
-      runtimeUrl: params.runtimeUrl,
-      _disableDevHotReload: params._disableDevHotReload,
-      _tagIds: params._tagIds,
-    };
+    this.projectId = params.projectId;
     this.gtServicesEnabled = gtServicesEnabled;
-    this.logLevel = getGeneralTranslationLogLevel();
   }
 
   getDefaultLocale(): string {
@@ -81,18 +61,39 @@ export class I18nConfig extends LocaleConfig {
   }
 
   getProjectId(): string | undefined {
-    return this.runtimeConfig.projectId;
+    return this.projectId;
   }
 
-  /**
-   * Get a GT instance bound to the resolved target locale. When omitted, the
-   * instance is locale agnostic.
-   *
-   * TODO: keep a cache to avoid creating new instances unnecessarily.
-   */
-  getGTClass(locale?: string): GTRuntime {
-    return this.getGTClassClean(
-      locale ? this.resolveLocale(locale) : undefined
+  getRegionProperties(region: string, locale: string = this.defaultLocale) {
+    if (!this.customRegionMapping) {
+      this.customRegionMapping = {};
+      for (const [mappedLocale, value] of Object.entries(
+        this.customMapping ?? {}
+      )) {
+        if (
+          value &&
+          typeof value === 'object' &&
+          value.regionCode &&
+          !this.customRegionMapping[value.regionCode]
+        ) {
+          this.customRegionMapping[value.regionCode] = {
+            locale: mappedLocale,
+            ...(value.regionName && { name: value.regionName }),
+            ...(value.emoji && { emoji: value.emoji }),
+          };
+        }
+      }
+    }
+    return getRegionPropertiesForLocale(
+      region,
+      locale,
+      this.customRegionMapping
+    );
+  }
+
+  getGTClass(_locale?: string): GTRuntime {
+    throw new Error(
+      'GTRuntime is not available in production browser builds. Import formatting helpers from @generaltranslation/format.'
     );
   }
 
@@ -137,18 +138,8 @@ export class I18nConfig extends LocaleConfig {
     return resolvedLocale;
   }
 
-  /**
-   * Returns true when development hot reload runtime translation requests can run.
-   */
   isDevHotReloadEnabled(): boolean {
-    return (
-      !this.runtimeConfig._disableDevHotReload &&
-      !!this.runtimeConfig.devApiKey &&
-      !!this.runtimeConfig.projectId &&
-      this.runtimeConfig.runtimeUrl !== null &&
-      this.runtimeConfig.runtimeUrl !== '' &&
-      getRuntimeEnvironment() === 'development'
-    );
+    return false;
   }
 
   isGTServicesEnabled(): boolean {
@@ -156,41 +147,19 @@ export class I18nConfig extends LocaleConfig {
   }
 
   isDebugLoggingEnabled(): boolean {
-    return isDebugLogLevel(this.logLevel);
+    return false;
   }
 
-  /**
-   * Create a GT instance without resolving the target locale first.
-   */
-  private getGTClassClean(locale?: string) {
-    return new GTRuntime({
-      sourceLocale: this.getDefaultLocale(),
-      targetLocale: locale,
-      // GT validates approved locales before constructing its LocaleConfig, so
-      // pass canonical locales here while preserving alias target locales.
-      locales: Array.from(
-        new Set(
-          this.getLocales().map((locale) => this.resolveCanonicalLocale(locale))
-        )
-      ),
-      customMapping: this.getCustomMapping(),
-      projectId: this.runtimeConfig.projectId,
-      baseUrl: this.runtimeConfig.runtimeUrl || undefined,
-      apiKey: this.runtimeConfig.apiKey,
-      devApiKey: this.runtimeConfig.devApiKey,
-    });
-  }
-
-  private getLocaleConfig(config?: I18nConfigParams): LocaleConfig {
+  private getLocaleConfig(config?: I18nConfigParams): LocaleResolver {
     if (!config || !hasI18nConfigParams(config)) {
       return this;
     }
-    return new LocaleConfig(getLocaleResolverConfigParams(config));
+    return new LocaleResolver(getLocaleResolverConfigParams(config));
   }
 
   private determineSupportedLocaleWithConfig(
     candidates: LocaleCandidates,
-    localeConfig: LocaleConfig
+    localeConfig: LocaleResolver
   ): string | undefined {
     if (
       candidates == null ||
@@ -205,7 +174,7 @@ export class I18nConfig extends LocaleConfig {
 function getLocaleConfigParams(
   params: I18nConfigParams,
   gtServicesEnabled: boolean
-): LocaleConfigConstructorParams {
+): LocaleResolverConstructorParams {
   const {
     defaultLocale = libraryDefaultLocale,
     locales = [],
@@ -233,7 +202,7 @@ function getLocaleResolverConfigParams({
   defaultLocale = libraryDefaultLocale,
   locales = [],
   customMapping,
-}: I18nConfigParams = {}): LocaleConfigConstructorParams {
+}: I18nConfigParams = {}): LocaleResolverConstructorParams {
   return {
     defaultLocale,
     locales: locales?.length ? locales : [defaultLocale],
@@ -246,12 +215,5 @@ function hasI18nConfigParams(config: I18nConfigParams): boolean {
     config.defaultLocale !== undefined ||
     config.locales !== undefined ||
     config.customMapping !== undefined
-  );
-}
-
-function resolveGTServicesEnabled(config: I18nConfigParams): boolean {
-  return (
-    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
-    getTranslationApiType(config) === TranslationApiType.GT
   );
 }

--- a/packages/i18n/src/i18n-config/RuntimeI18nConfig.ts
+++ b/packages/i18n/src/i18n-config/RuntimeI18nConfig.ts
@@ -1,0 +1,77 @@
+import type { GTRuntime as GTRuntimeType } from 'generaltranslation/runtime';
+import { GTRuntime } from 'generaltranslation/runtime';
+import {
+  getTranslationApiType,
+  TranslationApiType,
+} from '../i18n-cache/utils/getTranslationApiType';
+import {
+  getLoadTranslationsType,
+  LoadTranslationsType,
+} from '../i18n-cache/utils/getLoadTranslationsType';
+import {
+  getGeneralTranslationLogLevel,
+  isDebugLogLevel,
+  type GeneralTranslationLogLevel,
+} from '../logs/logLevel';
+import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+type RuntimeConfig = Pick<
+  I18nConfigParams,
+  'devApiKey' | 'apiKey' | 'runtimeUrl' | '_disableDevHotReload'
+>;
+
+export class RuntimeI18nConfig extends I18nConfig {
+  protected runtimeConfig: RuntimeConfig;
+  private logLevel: GeneralTranslationLogLevel;
+
+  constructor(params: I18nConfigParams = {}) {
+    super(params, resolveGTServicesEnabled(params));
+    this.runtimeConfig = {
+      devApiKey: params.devApiKey,
+      apiKey: params.apiKey,
+      runtimeUrl: params.runtimeUrl,
+      _disableDevHotReload: params._disableDevHotReload,
+    };
+    this.logLevel = getGeneralTranslationLogLevel();
+  }
+
+  getGTClass(locale?: string): GTRuntimeType {
+    return new GTRuntime({
+      sourceLocale: this.getDefaultLocale(),
+      targetLocale: locale ? this.resolveLocale(locale) : undefined,
+      locales: Array.from(
+        new Set(
+          this.getLocales().map((locale) => this.resolveCanonicalLocale(locale))
+        )
+      ),
+      customMapping: this.getCustomMapping(),
+      projectId: this.getProjectId(),
+      baseUrl: this.runtimeConfig.runtimeUrl || undefined,
+      apiKey: this.runtimeConfig.apiKey,
+      devApiKey: this.runtimeConfig.devApiKey,
+    });
+  }
+
+  isDevHotReloadEnabled(): boolean {
+    return (
+      !this.runtimeConfig._disableDevHotReload &&
+      !!this.runtimeConfig.devApiKey &&
+      !!this.getProjectId() &&
+      this.runtimeConfig.runtimeUrl !== null &&
+      this.runtimeConfig.runtimeUrl !== '' &&
+      getRuntimeEnvironment() === 'development'
+    );
+  }
+
+  isDebugLoggingEnabled(): boolean {
+    return isDebugLogLevel(this.logLevel);
+  }
+}
+
+function resolveGTServicesEnabled(config: I18nConfigParams): boolean {
+  return (
+    getLoadTranslationsType(config) === LoadTranslationsType.GT_REMOTE ||
+    getTranslationApiType(config) === TranslationApiType.GT
+  );
+}

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { I18nConfig } from '../I18nConfig';
+import { RuntimeI18nConfig as I18nConfig } from '../RuntimeI18nConfig';
 
 describe('I18nConfig', () => {
   beforeEach(() => {
@@ -22,6 +22,25 @@ describe('I18nConfig', () => {
     const config = new I18nConfig({ defaultLocale: 'fr' });
 
     expect(config.getLocales()).toEqual(['fr']);
+  });
+
+  it('derives localized region overrides from the locale mapping', () => {
+    const config = new I18nConfig({
+      customMapping: {
+        customEnglish: {
+          code: 'en-US',
+          regionCode: 'US',
+          regionName: 'Custom United States',
+          emoji: '🗽',
+        },
+      },
+    });
+
+    expect(config.getRegionProperties('US', 'en')).toMatchObject({
+      name: 'Custom United States',
+      emoji: '🗽',
+      locale: 'customEnglish',
+    });
   });
 
   it('skips locale validation when GT services are disabled', () => {

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,6 +1,7 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from '../globals/createGlobalSingleton';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+import { RuntimeI18nConfig } from './RuntimeI18nConfig';
 
 const i18nConfigSingleton = createGlobalSingleton<I18nConfig>({
   namespace: 'i18n',
@@ -23,7 +24,7 @@ export const isI18nConfigInitialized = i18nConfigSingleton.isInitialized;
 export function initializeI18nConfig(
   params: I18nConfigParams = {}
 ): I18nConfig {
-  const nextI18nConfig = new I18nConfig(params);
+  const nextI18nConfig = new RuntimeI18nConfig(params);
   setI18nConfig(nextI18nConfig);
   return nextI18nConfig;
 }

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -47,7 +47,7 @@ export {
   initializeI18nConfig,
   setI18nConfig,
 } from './i18n-config/singleton-operations';
-export { I18nConfig } from './i18n-config/I18nConfig';
+export { RuntimeI18nConfig as I18nConfig } from './i18n-config/RuntimeI18nConfig';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
 export { createGlobalSingleton } from './globals/createGlobalSingleton';

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -12,7 +12,7 @@
 export { LocaleSelector as Client_LocaleSelector } from 'gt-react';
 export { RegionSelector as Client_RegionSelector } from 'gt-react';
 
-import { getCookieValue, getI18nConfig, I18nConfig } from 'gt-i18n/internal';
+import { getCookieValue, getI18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
@@ -25,6 +25,7 @@ import { compilePathRegex, pathnameMatchesRegex } from './pathRegex';
 
 // withGTConfig exposes this build-time value to both middleware and client code.
 const pathRegex = compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX);
+type I18nConfig = ReturnType<typeof getI18nConfig>;
 
 /**
  * Only need to initalize client. We know server was already

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -1,9 +1,20 @@
+import type { ReactNode } from 'react';
 import { useTranslate } from '../../hooks/external-store';
-import { getI18nConfig } from 'gt-i18n/internal';
-import { useRef, type ReactNode } from 'react';
 import { renderPreparedT } from '../../utils/rendering/renderPipeline';
 import type { TProps } from '../../utils/translation/prepareT.shared';
 import { usePrepareT } from '../../utils/translation/usePrepareT';
+import { useComputeTDev } from './useComputeT.dev';
+
+function useComputeTProd(
+  result: ReactNode,
+  _shouldTranslate: boolean,
+  _targetFound: boolean
+): ReactNode {
+  return result;
+}
+
+const finalizeT =
+  process.env.NODE_ENV === 'production' ? useComputeTProd : useComputeTDev;
 
 // ===== Component ===== //
 
@@ -24,9 +35,6 @@ GtInternalTranslateJsx._gtt = 'translate-client-automatic';
 
 export { GtInternalTranslateJsx, T };
 
-/**
- * Render logic
- */
 function useComputeT({
   children: sourceChildren,
   _locale,
@@ -34,7 +42,6 @@ function useComputeT({
   _renderPreparedT = renderPreparedT,
   ...params
 }: TProps): ReactNode {
-  // Prepare our source children for rendering
   const {
     defaultLocale,
     locale,
@@ -49,27 +56,11 @@ function useComputeT({
     _locale,
     _enableI18n,
   });
-
-  // Lookup translation in cache
   const targetJsxChildren = useTranslate({
     locale,
     message: sourceJsxChildren,
     options: targetOptions,
   });
-
-  // Tx hot reload: render previous translation while loading new one
-  // TODO: account for success vs loading vs failed request states
-  const prev = useRef<ReactNode | null>(null);
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled() &&
-    targetJsxChildren == null &&
-    prev.current != null &&
-    shouldTranslate
-  ) {
-    return prev.current;
-  }
-
   const result = _renderPreparedT({
     taggedSourceChildren,
     targetJsxChildren,
@@ -80,8 +71,5 @@ function useComputeT({
     hash: targetOptions.$_hash,
   });
 
-  // record previous result
-  prev.current = result;
-
-  return result;
+  return finalizeT(result, shouldTranslate, targetJsxChildren != null);
 }

--- a/packages/react-core/src/components/translation/useComputeT.dev.ts
+++ b/packages/react-core/src/components/translation/useComputeT.dev.ts
@@ -1,0 +1,22 @@
+import { useRef, type ReactNode } from 'react';
+import { getI18nConfig } from 'gt-i18n/internal';
+
+export function useComputeTDev(
+  result: ReactNode,
+  shouldTranslate: boolean,
+  targetFound: boolean
+): ReactNode {
+  const previousResult = useRef<ReactNode | null>(null);
+
+  if (
+    getI18nConfig().isDevHotReloadEnabled() &&
+    !targetFound &&
+    previousResult.current != null &&
+    shouldTranslate
+  ) {
+    return previousResult.current;
+  }
+
+  previousResult.current = result;
+  return result;
+}

--- a/packages/react-core/src/components/variables/Currency.shared.ts
+++ b/packages/react-core/src/components/variables/Currency.shared.ts
@@ -1,4 +1,4 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import { formatCurrency } from '@generaltranslation/format';
 import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
@@ -33,11 +33,10 @@ function computeCurrency({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatCurrency(parsedNumber, currency, {
+  return formatCurrency(parsedNumber, currency, {
     locales,
     ...options,
   });

--- a/packages/react-core/src/components/variables/DateTime.shared.ts
+++ b/packages/react-core/src/components/variables/DateTime.shared.ts
@@ -1,4 +1,4 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import { formatDateTime } from '@generaltranslation/format';
 import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
@@ -31,12 +31,11 @@ function computeDateTime({
     enableI18n: _enableI18n,
     localesProp,
   });
-  // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
-  return gt
-    .formatDateTime(children, { locales, ...options })
-    .replace(/[\u200F\u202B\u202E]/g, '');
+  return formatDateTime(children, { locales, ...options }).replace(
+    /[\u200F\u202B\u202E]/g,
+    ''
+  );
 }
 
 export { computeDateTime };

--- a/packages/react-core/src/components/variables/Num.shared.ts
+++ b/packages/react-core/src/components/variables/Num.shared.ts
@@ -1,4 +1,4 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import { formatNum } from '@generaltranslation/format';
 import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
@@ -31,11 +31,13 @@ function computeNum({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatNum(parsedNumber, { locales, ...options });
+  return formatNum(parsedNumber, {
+    locales,
+    ...options,
+  });
 }
 
 export { computeNum };

--- a/packages/react-core/src/components/variables/RelativeTime.shared.ts
+++ b/packages/react-core/src/components/variables/RelativeTime.shared.ts
@@ -1,4 +1,7 @@
-import { getI18nConfig } from 'gt-i18n/internal';
+import {
+  formatRelativeTime,
+  formatRelativeTimeFromDate,
+} from '@generaltranslation/format';
 import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
@@ -39,7 +42,6 @@ function computeRelativeTime({
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   const resolvedDate = date ?? children;
 
   if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {
@@ -50,7 +52,7 @@ function computeRelativeTime({
   }
 
   if (value !== undefined && unit) {
-    return gt.formatRelativeTime(value, unit, {
+    return formatRelativeTime(value, unit, {
       locales,
       numeric: options.numeric,
       style: options.style,
@@ -59,7 +61,7 @@ function computeRelativeTime({
   }
 
   if (resolvedDate != null) {
-    return gt.formatRelativeTimeFromDate(resolvedDate, {
+    return formatRelativeTimeFromDate(resolvedDate, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,

--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
-import { I18nStore } from '../i18n-store/I18nStore';
+import { useMemo, type ReactNode } from 'react';
+import type { I18nStore } from '../i18n-store/I18nStore';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import type {
   Locale,
@@ -20,7 +20,7 @@ export type InternalGTProviderProps = {
   dictionaries?: Record<Locale, Dictionary>;
   // Declared upstream dependent on environment
   conditionStore: WritableConditionStoreInterface;
-  i18nStore: I18nStore;
+  i18nStore?: I18nStore;
   // Custom override missing translation behavior for dev hot reload
   onMissingTranslation?: OnMissingTranslation;
   onMissingDictionaryEntry?: OnMissingDictionaryEntry;
@@ -67,12 +67,6 @@ export function InternalGTProvider({
       onMissingDictionaryObj,
     ]
   );
-
-  // Update cache with data from server, do not emit events
-  useEffect(() => {
-    i18nStore.updateTranslations(translations);
-    i18nStore.updateDictionaries(dictionaries ?? {});
-  }, [translations, dictionaries, i18nStore]);
 
   return <GTContext.Provider value={value}>{children}</GTContext.Provider>;
 }

--- a/packages/react-core/src/context/__tests__/clientSnapshots.test.ts
+++ b/packages/react-core/src/context/__tests__/clientSnapshots.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  getClientDictionariesSnapshot,
+  getClientTranslationsSnapshot,
+  setClientSnapshots,
+} from '../clientSnapshots';
+
+describe('clientSnapshots', () => {
+  beforeEach(() => {
+    setClientSnapshots({}, {});
+  });
+
+  it('shares SPA translations and dictionaries', () => {
+    setClientSnapshots(
+      { fr: { greeting: 'Bonjour' } },
+      { en: { greeting: 'Hello' } }
+    );
+
+    expect(getClientTranslationsSnapshot()).toEqual({
+      fr: { greeting: 'Bonjour' },
+    });
+    expect(getClientDictionariesSnapshot()).toEqual({
+      en: { greeting: 'Hello' },
+    });
+  });
+});

--- a/packages/react-core/src/context/clientSnapshots.ts
+++ b/packages/react-core/src/context/clientSnapshots.ts
@@ -1,0 +1,26 @@
+import type { Dictionary, Hash, Locale } from 'gt-i18n/internal/types';
+import type { Translation } from 'gt-i18n/types';
+
+type TranslationsSnapshot = Record<Locale, Record<Hash, Translation>>;
+type DictionariesSnapshot = Record<Locale, Dictionary>;
+
+let translationsSnapshot: TranslationsSnapshot = {};
+let dictionariesSnapshot: DictionariesSnapshot = {};
+
+export function getClientTranslationsSnapshot(): TranslationsSnapshot {
+  return translationsSnapshot;
+}
+
+export function getClientDictionariesSnapshot(): DictionariesSnapshot {
+  return dictionariesSnapshot;
+}
+
+export function setClientSnapshots(
+  translations: TranslationsSnapshot,
+  dictionaries: DictionariesSnapshot = {}
+): void {
+  translationsSnapshot = translations;
+  dictionariesSnapshot = dictionaries;
+}
+
+export type { DictionariesSnapshot, TranslationsSnapshot };

--- a/packages/react-core/src/context/context.ts
+++ b/packages/react-core/src/context/context.ts
@@ -8,7 +8,7 @@ import { Translation } from 'gt-i18n/types';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from 'gt-i18n/internal';
 import { createContext, useContext, type Context } from 'react';
-import { I18nStore } from '../i18n-store/I18nStore';
+import type { I18nStore } from '../i18n-store/I18nStore';
 import { getI18nConfig } from '../setup/i18nConfig';
 import type {
   OnMissingTranslation,
@@ -18,9 +18,8 @@ import type {
 
 export type GTContextType = {
   /**
-   * Source of truth for translations, streamed from server
-   * In SPA mode, these won't be accessible and translations
-   * can be accessed via useSyncExternalStore() directly
+   * Source of truth for translations and dictionaries streamed from the
+   * server. SPA consumers fall back to the shared client snapshots.
    */
   translationsSnapshot: Record<Locale, Record<Hash, Translation>>;
   dictionariesSnapshot: Record<Locale, Dictionary>;
@@ -28,7 +27,7 @@ export type GTContextType = {
    * I18nStore allows us to sync state updates in ConditionStore and I18nCache
    * with renders
    */
-  i18nStore: I18nStore;
+  i18nStore?: I18nStore;
   /**
    * ConditionStore should always remain separate from i18nStore as
    * it manages how we perform lookups

--- a/packages/react-core/src/context/useSnapshots.ts
+++ b/packages/react-core/src/context/useSnapshots.ts
@@ -1,0 +1,22 @@
+import type { Dictionary, Hash, Locale } from 'gt-i18n/internal/types';
+import type { Translation } from 'gt-i18n/types';
+import { useGTContext } from './context';
+import {
+  getClientDictionariesSnapshot,
+  getClientTranslationsSnapshot,
+} from './clientSnapshots';
+
+export function useTranslationsSnapshot(): Record<
+  Locale,
+  Record<Hash, Translation>
+> {
+  return (
+    useGTContext()?.translationsSnapshot ?? getClientTranslationsSnapshot()
+  );
+}
+
+export function useDictionariesSnapshot(): Record<Locale, Dictionary> {
+  return (
+    useGTContext()?.dictionariesSnapshot ?? getClientDictionariesSnapshot()
+  );
+}

--- a/packages/react-core/src/hooks/external-store.dev.ts
+++ b/packages/react-core/src/hooks/external-store.dev.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react';
+import { getI18nConfig } from 'gt-i18n/internal';
+import type { Translation } from 'gt-i18n/types';
+import type {
+  TranslateLookup,
+  TranslateSnapshot,
+} from '../i18n-store/storeTypes';
+import { useTranslationsSnapshot } from '../context/useSnapshots';
+import { useI18nStore } from '../i18n-store/useI18nStore';
+import { useHandleMissingTranslation } from './utils/missing-translation';
+
+export function useTranslateDev<T extends Translation>(
+  lookup: TranslateLookup<T>
+): TranslateSnapshot<T> {
+  const i18nStore = useI18nStore();
+  const translationsSnapshot = useTranslationsSnapshot();
+  const onMissingTranslation = useHandleMissingTranslation();
+  const storeTranslation = useSyncExternalStore(
+    (listener) => i18nStore.subscribeToTranslate(lookup, listener),
+    () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot),
+    () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot)
+  );
+
+  if (storeTranslation == null && getI18nConfig().isDevHotReloadEnabled()) {
+    onMissingTranslation(lookup);
+  }
+
+  return storeTranslation;
+}

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -1,45 +1,18 @@
-import { useSyncExternalStore } from 'react';
+import { useTranslateDev } from './external-store.dev';
 import type { Translation } from 'gt-i18n/types';
 import type {
   TranslateLookup,
   TranslateSnapshot,
 } from '../i18n-store/storeTypes';
-import {
-  useI18nStore,
-  useTranslationsSnapshot,
-} from '../i18n-store/useI18nStore';
-import { getI18nConfig } from 'gt-i18n/internal';
-import { useHandleMissingTranslation } from './utils/missing-translation';
+import { useTranslationsSnapshot } from '../context/useSnapshots';
+import { lookupTranslation } from '../i18n-store/utils/translations';
 
-/**
- * @internal
- */
-export function useTranslate<T extends Translation>(
+function useTranslateProd<T extends Translation>(
   lookup: TranslateLookup<T>
 ): TranslateSnapshot<T> {
-  const i18nStore = useI18nStore();
   const translationsSnapshot = useTranslationsSnapshot();
-  const onMissingTranslation = useHandleMissingTranslation();
-
-  /**
-   * TODO: for snapshot lookup, we can use the translation snapshot
-   * to avoid the adapter.resolveTranslation call.
-   */
-  const storeTranslation = useSyncExternalStore(
-    (listener) => i18nStore.subscribeToTranslate(lookup, listener),
-    () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot),
-    () => i18nStore.getTranslateSnapshot(lookup, translationsSnapshot)
-  );
-
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    storeTranslation == null &&
-    getI18nConfig().isDevHotReloadEnabled()
-  ) {
-    // TODO: (separate PR): add configuration for a use() + suspense strategy
-    // TODO: consider moving this to a useEffect
-    onMissingTranslation(lookup);
-  }
-
-  return storeTranslation;
+  return lookupTranslation(translationsSnapshot, lookup);
 }
+
+export const useTranslate =
+  process.env.NODE_ENV === 'production' ? useTranslateProd : useTranslateDev;

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
@@ -3,10 +3,8 @@ import type {
   DictionaryLookup,
   DictionaryObjectSnapshot,
 } from '../../i18n-store/storeTypes';
-import {
-  useDictionariesSnapshot,
-  useI18nStore,
-} from '../../i18n-store/useI18nStore';
+import { useDictionariesSnapshot } from '../../context/useSnapshots';
+import { useI18nStore } from '../../i18n-store/useI18nStore';
 import { useCallback, useRef } from 'react';
 import { useHandleMissingDictionaryObject } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
@@ -1,8 +1,6 @@
 import { useCallback, useRef } from 'react';
-import {
-  useDictionariesSnapshot,
-  useI18nStore,
-} from '../../i18n-store/useI18nStore';
+import { useDictionariesSnapshot } from '../../context/useSnapshots';
+import { useI18nStore } from '../../i18n-store/useI18nStore';
 import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -11,10 +11,8 @@ import type {
 } from '../../i18n-store/storeTypes';
 import type { TranslationMetadata } from 'gt-i18n/internal/types';
 import type { StringFormat } from '@generaltranslation/format';
-import {
-  useI18nStore,
-  useTranslationsSnapshot,
-} from '../../i18n-store/useI18nStore';
+import { useTranslationsSnapshot } from '../../context/useSnapshots';
+import { useI18nStore } from '../../i18n-store/useI18nStore';
 import { useHandleMissingTranslationWithConditions } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
 

--- a/packages/react-core/src/hooks/resolution/useDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/resolution/useDictionaryResolver.ts
@@ -1,0 +1,37 @@
+import { useTrackedDictionaryResolver } from '../external-store/useTrackedDictionaryResolver';
+import { useTrackedDictionaryObjResolver } from '../external-store/useTrackedDictionaryObjResolver';
+import { useCallback } from 'react';
+import type { DictionaryLookup } from '../../i18n-store/storeTypes';
+import { useDictionariesSnapshot } from '../../context/useSnapshots';
+import {
+  lookupDictionaryEntry,
+  lookupDictionaryObject,
+} from '../../i18n-store/utils/dictionaries';
+
+function useDictionaryEntryResolverProd() {
+  const dictionariesSnapshot = useDictionariesSnapshot();
+  return useCallback(
+    (lookup: DictionaryLookup) =>
+      lookupDictionaryEntry(dictionariesSnapshot, lookup),
+    [dictionariesSnapshot]
+  );
+}
+
+function useDictionaryObjectResolverProd() {
+  const dictionariesSnapshot = useDictionariesSnapshot();
+  return useCallback(
+    (lookup: DictionaryLookup) =>
+      lookupDictionaryObject(dictionariesSnapshot, lookup),
+    [dictionariesSnapshot]
+  );
+}
+
+export const useDictionaryEntryResolver =
+  process.env.NODE_ENV === 'production'
+    ? useDictionaryEntryResolverProd
+    : useTrackedDictionaryResolver;
+
+export const useDictionaryObjectResolver =
+  process.env.NODE_ENV === 'production'
+    ? useDictionaryObjectResolverProd
+    : useTrackedDictionaryObjResolver;

--- a/packages/react-core/src/hooks/resolution/useTranslationResolver.ts
+++ b/packages/react-core/src/hooks/resolution/useTranslationResolver.ts
@@ -1,0 +1,31 @@
+import {
+  useTrackedTranslationResolver,
+  type Message,
+} from '../external-store/useTrackedTranslationResolver';
+import { useCallback } from 'react';
+import type { Translation } from 'gt-i18n/types';
+import type {
+  TranslateLookup,
+  TranslateSnapshot,
+} from '../../i18n-store/storeTypes';
+import { useTranslationsSnapshot } from '../../context/useSnapshots';
+import { lookupTranslation } from '../../i18n-store/utils/translations';
+
+function useTranslationResolverProd(): <T extends Translation>(
+  lookup: TranslateLookup<T>
+) => TranslateSnapshot<T> {
+  const translationsSnapshot = useTranslationsSnapshot();
+
+  return useCallback(
+    <T extends Translation>(lookup: TranslateLookup<T>) =>
+      lookupTranslation(translationsSnapshot, lookup),
+    [translationsSnapshot]
+  );
+}
+
+export const useTranslationResolver: typeof useTrackedTranslationResolver =
+  process.env.NODE_ENV === 'production'
+    ? useTranslationResolverProd
+    : useTrackedTranslationResolver;
+
+export type { Message };

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -6,15 +6,15 @@ import type { StringFormat } from '@generaltranslation/format/types';
 import { useDefaultLocale } from './i18n-config';
 import {
   type Message,
-  useTrackedTranslationResolver,
-} from './external-store/useTrackedTranslationResolver';
+  useTranslationResolver,
+} from './resolution/useTranslationResolver';
 
 // ===== Hook ===== //
 
 export function useGT(_messages?: Message[]): GTFunctionType {
   const { locale, shouldTranslate } = useTranslationConditions();
   const defaultLocale = useDefaultLocale();
-  const resolveTranslation = useTrackedTranslationResolver(
+  const resolveTranslation = useTranslationResolver(
     _messages,
     locale,
     shouldTranslate

--- a/packages/react-core/src/hooks/useInternalRegionSelector.ts
+++ b/packages/react-core/src/hooks/useInternalRegionSelector.ts
@@ -58,7 +58,7 @@ export function useInternalRegionSelector({
     regions, // ordered list of ISO 3166 region codes
     regionData, // map of ISO 3166 region codes to region display data, potentially not ordered
   ] = useMemo<[string[], Map<string, RegionData>]>(() => {
-    const gt = getI18nConfig().getGTClass(locale);
+    const i18nConfig = getI18nConfig();
     const regionToLocaleMap = new Map(
       contextLocales.map((l) => {
         const lp = getLocaleProperties(l, locale, localeCustomMapping); // has to be directly called so sourceLocale can be in the user's current locale
@@ -76,7 +76,7 @@ export function useInternalRegionSelector({
           r,
           {
             locale: regionToLocaleMap?.get(r)?.code || locale,
-            ...gt.getRegionProperties(r),
+            ...i18nConfig.getRegionProperties(r, locale),
             ...(typeof customMapping?.[r] === 'string'
               ? { name: customMapping?.[r] }
               : customMapping?.[r]),

--- a/packages/react-core/src/hooks/useMessages.ts
+++ b/packages/react-core/src/hooks/useMessages.ts
@@ -3,7 +3,7 @@ import { decodeOptions } from 'gt-i18n';
 import { useGT } from './useGT';
 import type { GTTranslationOptions, MFunctionType } from 'gt-i18n/types';
 import { isEncodedTranslationOptions } from 'gt-i18n/internal';
-import { Message } from './external-store/useTrackedTranslationResolver';
+import { Message } from './resolution/useTranslationResolver';
 
 // ===== Hook ===== //
 

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -13,8 +13,10 @@ import type {
 } from 'gt-i18n/types';
 import { useDefaultLocale } from './i18n-config';
 import { useShouldTranslate } from './utils';
-import { useTrackedDictionaryResolver } from './external-store/useTrackedDictionaryResolver';
-import { useTrackedDictionaryObjResolver } from './external-store/useTrackedDictionaryObjResolver';
+import {
+  useDictionaryEntryResolver,
+  useDictionaryObjectResolver,
+} from './resolution/useDictionaryResolver';
 
 // ===== Hook ===== //
 
@@ -23,7 +25,7 @@ export function useTranslations(rootId?: string): UseTranslationsFunction {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const gt = useGT();
-  const resolveDictionaryEntry = useTrackedDictionaryResolver();
+  const resolveDictionaryEntry = useDictionaryEntryResolver();
   const translateObject = useTranslationsObj(rootId);
 
   const translateEntry = useCallback(
@@ -78,7 +80,7 @@ function useTranslationsObj(rootId?: string): UseTranslationsObjFunction {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const gt = useGT();
-  const resolveDictionaryObject = useTrackedDictionaryObjResolver();
+  const resolveDictionaryObject = useDictionaryObjectResolver();
 
   return useCallback(
     (suffix: string) => {

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -47,17 +47,14 @@ export function useTranslationConditions(): {
 }
 
 export function useLocaleProperties(locale: string): LocaleProperties {
-  return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleProperties(locale),
-    [locale]
-  );
+  return useMemo(() => getI18nConfig().getLocaleProperties(locale), [locale]);
 }
 
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
   const currentLocale = useLocale();
   const resolvedLocale = locale ?? currentLocale;
   return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleDirection(resolvedLocale),
+    () => getI18nConfig().getLocaleDirection(resolvedLocale),
     [resolvedLocale]
   );
 }

--- a/packages/react-core/src/i18n-store/useI18nStore.ts
+++ b/packages/react-core/src/i18n-store/useI18nStore.ts
@@ -1,23 +1,8 @@
-import { Dictionary, Hash, Locale } from 'gt-i18n/internal/types';
 import { useGTContext } from '../context/context';
 import { I18nStore } from './I18nStore';
 import { getI18nStore } from './singleton-operations';
-import { Translation } from 'gt-i18n/types';
 
 export function useI18nStore(): I18nStore {
   const context = useGTContext();
   return context?.i18nStore || getI18nStore();
-}
-
-export function useTranslationsSnapshot(): Record<
-  Locale,
-  Record<Hash, Translation>
-> {
-  const context = useGTContext();
-  return context?.translationsSnapshot || {};
-}
-
-export function useDictionariesSnapshot(): Record<Locale, Dictionary> {
-  const context = useGTContext();
-  return context?.dictionariesSnapshot || {};
 }

--- a/packages/react-core/src/setup/i18nConfig.ts
+++ b/packages/react-core/src/setup/i18nConfig.ts
@@ -30,12 +30,14 @@ const defaultRenderStrategy: RenderStrategy = 'server-render';
 const reactI18nConfigBrand = Symbol.for(
   'generaltranslation.react-core.ReactI18nConfig'
 );
+type BaseI18nConfig = ReturnType<typeof getBaseI18nConfig>;
 
 export class ReactI18nConfig extends I18nConfig {
   private renderStrategy: RenderStrategy;
   private localeCookieName: string;
   private regionCookieName: string;
   private enableI18nCookieName: string;
+  private idTaggingEnabled: boolean;
 
   constructor(
     params: ReactI18nConfigParams = {},
@@ -49,6 +51,7 @@ export class ReactI18nConfig extends I18nConfig {
     this.regionCookieName = params.regionCookieName ?? defaultRegionCookieName;
     this.enableI18nCookieName =
       params.enableI18nCookieName ?? defaultEnableI18nCookieName;
+    this.idTaggingEnabled = params._tagIds === true;
   }
 
   getRenderStrategy(): RenderStrategy {
@@ -72,7 +75,7 @@ export class ReactI18nConfig extends I18nConfig {
    * a `data-_gt-hash` attribute for tooling. Requires the literal `true`.
    */
   isIdTaggingEnabled(): boolean {
-    return this.runtimeConfig._tagIds === true;
+    return this.idTaggingEnabled;
   }
 }
 
@@ -121,8 +124,8 @@ function validateRenderStrategy(
 }
 
 function isReactI18nConfig(
-  i18nConfig: I18nConfig
-): i18nConfig is ReactI18nConfig {
+  i18nConfig: BaseI18nConfig
+): i18nConfig is BaseI18nConfig & ReactI18nConfig {
   if (i18nConfig instanceof ReactI18nConfig) return true;
 
   const maybeReactI18nConfig = i18nConfig as I18nConfig &


### PR DESCRIPTION
## TL;DR

Add the lightweight translation foundation without changing package resolution. Production-capable React lookups can read provider-owned translation snapshots directly, while server and development runtimes retain the cache, fallback requests, and fine-grained subscriptions. The stacked follow-up activates this foundation in browser builds.

## Code Changes

- Split locale resolution from formatting so browser configuration does not retain formatter implementations.
- Split shared locale/catalog configuration from the full server/development runtime configuration.
- Store provider translations and dictionaries as lightweight client snapshots.
- Route React translation and dictionary hooks through snapshot resolvers, with cache subscriptions isolated to development modules.
- Keep snapshot hooks in their own lightweight module so production graphs cannot retain I18nStore by association.
- Preserve the existing synchronous t.ts implementation and all server-side cache/runtime behavior.

## Notes / Flags

- Package conditional exports remain unchanged; activation-only APIs and translation loading live in #2198.
- Reduced from the original +1,397/-624 across 48 files to +660/-468 across 36 files: 53% fewer additions and 44% less total churn.
- Validated with affected builds and typechecks plus 728 format, i18n, and react-core tests.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves production translation lookup to snapshots and routes variable formatting through standalone helpers. Two user-visible regressions remain:

- Production SPAs that initialize translations without passing snapshots through a provider can render source text because the snapshot loaded during SPA initialization is not published to the production resolver's client snapshot.
- Configured locale aliases are passed directly to `Intl` by the standalone variable formatters. A mapping such as `brand-french -> fr-FR` produces fallback English currency output instead of French formatting. Number, date-time, and relative-time variables share this locale path.

### T-Rex validation blocked
The production snapshot reproduction could not provide executable proof because the final harness did not exercise the production resolver selection, and the artifact upload mechanism was unavailable for its captured output. The initialization and resolver code still show the missing snapshot handoff.

<details open><summary><h3>Confidence Score: 3/5</h3></summary>

Do not merge until SPA initialization publishes loaded translations to the production snapshot source and formatting locales are canonicalized before standalone formatting.

The locale-alias failure was reproduced through the Currency component's exact formatting path and corrected by a temporary canonicalization change. The production snapshot handoff is directly evident in the initialization and resolver code, but its final production-branch harness did not exercise the intended resolver path.

**Files Needing Attention:** packages/react/src/setup/initializeGTSPA.ts, packages/react-core/src/hooks/resolution/useTranslationResolver.ts, packages/react-core/src/hooks/utils/getFormatLocales.ts, and the shared Currency, Num, DateTime, and RelativeTime variable formatter files.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced proofs for three P1 findings related to currency locale handling and attached a reproduction test source plus pre- and post-canonicalization logs.
- Production-path validation was attempted but blocked by a tool limitation, so the final runtime proof for the production branch could not be completed.
- T-Rex validated the canonical locale mapping fix, showing the canonical locale produced the expected French result and the test passed.

<a href="https://app.greptile.com/trex/runs/20875727/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Standalone variable formatters pass custom locale aliases directly to Intl**

   - **Bug**
     - `computeCurrency` now calls standalone `formatCurrency` with the raw locale array from `getFormatLocales`. A configured custom mapping such as `brand-french -> fr-FR` is not converted to `fr-FR`. The executed Currency repro returns `$1,234.50` rather than `1 234,50 $US`. Num, DateTime, and RelativeTime use the identical raw helper output, so they inherit the behavior.
   - **Cause**
     - PR #2197 replaced `getI18nConfig().getGTClass().formatCurrency(...)`, whose `LocaleConfig.getFormattingLocales()` resolved each entry with `resolveCanonicalLocale`, with standalone formatting. The new standalone formatter delegates raw locale values to Intl and has no access to custom mappings. `getFormatLocales()` continues to return raw configured aliases.
   - **Fix**
     - Canonicalize locales before handing them to standalone formatters, preferably once in `packages/react-core/src/hooks/utils/getFormatLocales.ts` by mapping its selected array through `getI18nConfig().resolveCanonicalLocale()`. Add Currency coverage for a custom alias and parity coverage for Num, DateTime, and RelativeTime.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232197%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2197&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Fresolution%2FuseTranslationResolver.ts%3A24-30%0A**SPA%20initialization%20drops%20snapshots**%0A%0A%60initializeGTSPA%60%20waits%20for%20%60getTranslationsSnapshot%28%29%60%20but%20discards%20the%20loaded%20translations.%20In%20production%2C%20this%20resolver%20reads%20the%20no-provider%20module-global%20client%20snapshot%2C%20which%20starts%20empty%20and%20is%20only%20populated%20through%20%60setClientSnapshots%60%3B%20SPA%20initialization%20never%20calls%20it.%20Consequently%2C%20an%20SPA%20that%20correctly%20awaits%20initialization%20but%20does%20not%20provide%20snapshots%20to%20the%20React%20tree%20cannot%20resolve%20the%20translations%20it%20loaded%20and%20falls%20back%20to%20source%20content.%0A%0A%23%23%23%20Issue%202%0Apackages%2Freact-core%2Fsrc%2Fcomponents%2Fvariables%2FCurrency.shared.ts%3A36-39%0A**Formatters%20bypass%20locale%20aliases**%0A%0A%60computeCurrency%60%20passes%20raw%20selected%20locales%20from%20%60getFormatLocales%28%29%60%20to%20the%20standalone%20formatter%20instead%20of%20resolving%20configured%20aliases%20through%20the%20i18n%20configuration.%20With%20%60brand-french%20-%3E%20fr-FR%60%2C%20the%20executed%20Currency%20path%20returns%20%60%241%2C234.50%60%20rather%20than%20%601%E2%80%AF234%2C50%C2%A0%24US%60.%20%60Num%60%2C%20%60DateTime%60%2C%20and%20%60RelativeTime%60%20share%20this%20helper%2C%20so%20they%20also%20skip%20configured%20locale%20mappings.%20Canonicalize%20the%20selected%20locales%20before%20passing%20them%20to%20the%20standalone%20format%20helpers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Flightweight-snapshot-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Flightweight-snapshot-runtime%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Freact-core%2Fsrc%2Fhooks%2Fresolution%2FuseTranslationResolver.ts%3A24-30%0A**SPA%20initialization%20drops%20snapshots**%0A%0A%60initializeGTSPA%60%20waits%20for%20%60getTranslationsSnapshot%28%29%60%20but%20discards%20the%20loaded%20translations.%20In%20production%2C%20this%20resolver%20reads%20the%20no-provider%20module-global%20client%20snapshot%2C%20which%20starts%20empty%20and%20is%20only%20populated%20through%20%60setClientSnapshots%60%3B%20SPA%20initialization%20never%20calls%20it.%20Consequently%2C%20an%20SPA%20that%20correctly%20awaits%20initialization%20but%20does%20not%20provide%20snapshots%20to%20the%20React%20tree%20cannot%20resolve%20the%20translations%20it%20loaded%20and%20falls%20back%20to%20source%20content.%0A%0A%23%23%23%20Issue%202%0Apackages%2Freact-core%2Fsrc%2Fcomponents%2Fvariables%2FCurrency.shared.ts%3A36-39%0A**Formatters%20bypass%20locale%20aliases**%0A%0A%60computeCurrency%60%20passes%20raw%20selected%20locales%20from%20%60getFormatLocales%28%29%60%20to%20the%20standalone%20formatter%20instead%20of%20resolving%20configured%20aliases%20through%20the%20i18n%20configuration.%20With%20%60brand-french%20-%3E%20fr-FR%60%2C%20the%20executed%20Currency%20path%20returns%20%60%241%2C234.50%60%20rather%20than%20%601%E2%80%AF234%2C50%C2%A0%24US%60.%20%60Num%60%2C%20%60DateTime%60%2C%20and%20%60RelativeTime%60%20share%20this%20helper%2C%20so%20they%20also%20skip%20configured%20locale%20mappings.%20Canonicalize%20the%20selected%20locales%20before%20passing%20them%20to%20the%20standalone%20format%20helpers.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2197&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor: add lightweight translation ru..."](https://github.com/generaltranslation/gt/commit/ca96764ebac908a9c0fe88906371575c7a5705c8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57215831)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->