### PR TITLE
Activate the lightweight production browser runtime

### DIFF
--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -77,6 +77,28 @@
       }
     },
     "./internal": {
+      "browser": {
+        "development": {
+          "require": {
+            "types": "./dist/internal.d.cts",
+            "default": "./dist/internal.cjs"
+          },
+          "import": {
+            "types": "./dist/internal.d.mts",
+            "default": "./dist/internal.mjs"
+          },
+          "default": "./dist/internal.mjs"
+        },
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/internal-static.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/internal-static.mjs"
+        },
+        "default": "./dist/internal-static.mjs"
+      },
       "require": {
         "types": "./dist/internal.d.cts",
         "default": "./dist/internal.cjs"

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -18,6 +18,10 @@ const i18nCacheSingleton =
       }),
   });
 
+export function isI18nCacheInitialized(): boolean {
+  return i18nCacheSingleton.isInitialized();
+}
+
 /**
  * Get the singleton instance of I18nCache
  * @returns The singleton instance of I18nCache

--- a/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/loadTranslationsForLocale.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/loadTranslationsForLocale.ts
@@ -1,0 +1,31 @@
+import type { I18nCacheConstructorParams } from '../../types';
+import { getLoadTranslationsType } from '../../utils/getLoadTranslationsType';
+import { resolveCacheLocale } from '../../utils/resolveCacheLocale';
+import type { Translation } from '../utils/types/translation-data';
+import type { Hash } from '../TranslationsCache';
+import { routeCreateTranslationLoader } from './routeCreateTranslationLoader';
+
+export async function loadTranslationsForLocale<
+  TranslationValue extends Translation = Translation,
+>(
+  params: I18nCacheConstructorParams,
+  locale: string
+): Promise<Record<Hash, TranslationValue>> {
+  const translationLocale = resolveCacheLocale(locale);
+  if (!translationLocale) return {};
+
+  const loadTranslations = routeCreateTranslationLoader({
+    loadTranslations: params.loadTranslations,
+    type: getLoadTranslationsType(params),
+    remoteTranslationLoaderParams: {
+      cacheUrl: params.cacheUrl,
+      projectId: params.projectId,
+      _versionId: params._versionId,
+      _branchId: params._branchId,
+    },
+  });
+  return (await loadTranslations(translationLocale)) as Record<
+    Hash,
+    TranslationValue
+  >;
+}

--- a/packages/i18n/src/i18n-cache/utils/resolveCacheLocale.ts
+++ b/packages/i18n/src/i18n-cache/utils/resolveCacheLocale.ts
@@ -1,0 +1,27 @@
+import { getI18nConfig } from '../../i18n-config/singleton-operations';
+
+export function resolveLocale(locale: string): string {
+  const i18nConfig = getI18nConfig();
+  const resolvedLocale = i18nConfig.determineLocale(locale);
+  if (!i18nConfig.isValidLocale(locale) || !resolvedLocale) {
+    throw new Error(
+      `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
+    );
+  }
+  return resolvedLocale;
+}
+
+export function resolveCacheLocale(locale: string): string | undefined {
+  const resolvedLocale = resolveLocale(locale);
+  const i18nConfig = getI18nConfig();
+  if (i18nConfig.requiresTranslation(resolvedLocale)) {
+    return resolvedLocale;
+  }
+
+  const aliasLocale = i18nConfig.resolveAliasLocale(
+    i18nConfig.standardizeLocale(locale)
+  );
+  if (i18nConfig.requiresTranslation(aliasLocale)) {
+    return aliasLocale;
+  }
+}

--- a/packages/i18n/src/i18n-config/browser-singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/browser-singleton-operations.ts
@@ -1,0 +1,16 @@
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+import {
+  getI18nConfig,
+  isI18nConfigInitialized,
+  setI18nConfig,
+} from './singleton-operations';
+
+export { getI18nConfig, isI18nConfigInitialized, setI18nConfig };
+
+export function initializeI18nConfig(
+  params: I18nConfigParams = {}
+): I18nConfig {
+  const nextI18nConfig = new I18nConfig(params);
+  setI18nConfig(nextI18nConfig);
+  return nextI18nConfig;
+}

--- a/packages/i18n/src/internal-static.ts
+++ b/packages/i18n/src/internal-static.ts
@@ -7,16 +7,16 @@ export {
   getTranslations,
   getTranslationsInternal,
 } from './translation-functions/internal/getTranslations';
-export { tx, txInternal } from './translation-functions/internal/tx';
-export {
-  GtInternalRuntimeTranslateString,
-  GtInternalRuntimeTranslateJsx,
-} from './translation-functions/internal/runtime-translate';
 export { createLookupOptions } from './translation-functions/internal/helpers';
 export { renderDictionaryEntry } from './translation-functions/internal/renderDictionaryEntry';
 export { renderDictionaryObject } from './translation-functions/internal/renderDictionaryObject';
-export { I18nCache } from './i18n-cache/I18nCache';
-export type { TranslationsCacheMissEvent } from './i18n-cache/I18nCache';
+class ProductionI18nCache {
+  constructor() {
+    throw new Error('I18nCache is not available in production browser builds.');
+  }
+}
+
+export { ProductionI18nCache as I18nCache };
 export { ReadonlyConditionStore } from './condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from './condition-store/WritableConditionStore';
@@ -35,23 +35,18 @@ export {
   getDictionaryListenerKey,
   getTranslateListenerKey,
 } from './utils/listenerKeys';
-export type {
-  DictionaryListenerLookup,
-  TranslateListenerLookup,
-} from './utils/listenerKeys';
 export {
   getDictionaryEntry,
   isDictionaryValue,
   getDictionaryValue,
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
-
 export {
   getI18nConfig,
   initializeI18nConfig,
   setI18nConfig,
-} from './i18n-config/singleton-operations';
-export { RuntimeI18nConfig as I18nConfig } from './i18n-config/RuntimeI18nConfig';
+} from './i18n-config/browser-singleton-operations';
+export { I18nConfig } from './i18n-config/I18nConfig';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
 export { createGlobalSingleton } from './globals/createGlobalSingleton';

--- a/packages/i18n/tsdown.config.mts
+++ b/packages/i18n/tsdown.config.mts
@@ -1,13 +1,22 @@
 import { defineConfig } from 'tsdown';
 import { createTsdownConfig } from '../../tsdown.preset.mts';
 
-export default defineConfig(
-  createTsdownConfig([
-    'src/index.ts',
-    'src/internal-cookies.ts',
-    'src/internal-string.ts',
-    'src/types.ts',
-    'src/internal.ts',
-    'src/internal-types.ts',
-  ])
+const standard = createTsdownConfig([
+  'src/index.ts',
+  'src/internal-cookies.ts',
+  'src/internal-string.ts',
+  'src/types.ts',
+  'src/internal.ts',
+  'src/internal-types.ts',
+]);
+const production = createTsdownConfig(['src/internal-static.ts']).map(
+  (config) => ({
+    ...config,
+    clean: false,
+    define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+    dts: false,
+    treeshake: { moduleSideEffects: false },
+  })
 );
+
+export default defineConfig([...standard, ...production]);

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -86,7 +86,7 @@ describe('initializeGTClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses the client-safe ReactI18nCache', () => {
+  it('uses the client-safe ReactI18nCache in development', () => {
     initializeGTClient({
       i18nConfigParams: {
         defaultLocale: 'en',

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -1,4 +1,4 @@
-import { internalInitializeGTSRA } from '@generaltranslation/react-core/pure';
+import { initializeGT as initializeReactGT } from 'gt-react';
 import { getParams } from './shared';
 import type { NextSetupI18nConfigParams } from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
@@ -15,7 +15,7 @@ export function initializeGTClient(
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
-  internalInitializeGTSRA({
+  initializeReactGT({
     ...i18nConfigParams,
     ...nextI18nCacheParams,
     /**

--- a/packages/react-core/src/__tests__/react-core-package.test.ts
+++ b/packages/react-core/src/__tests__/react-core-package.test.ts
@@ -63,6 +63,9 @@ describe('@generaltranslation/react-core package exports', () => {
           const componentsRsc = require('@generaltranslation/react-core/components-rsc');
 
           assert.equal(typeof pure.msg, 'function');
+          assert.equal(typeof pure.getSnapshotGT, 'function');
+          assert.equal(typeof pure.getSnapshotMessages, 'function');
+          assert.equal(typeof pure.getSnapshotTranslations, 'function');
           assert.equal(typeof components.T, 'function');
           assert.equal(typeof hooks.useGT, 'function');
           assert.equal(typeof componentsRsc.Branch, 'function');
@@ -76,12 +79,20 @@ describe('@generaltranslation/react-core package exports', () => {
       '-e',
       `
           import assert from 'node:assert/strict';
-          import { msg } from '@generaltranslation/react-core/pure';
+          import {
+            getSnapshotGT,
+            getSnapshotMessages,
+            getSnapshotTranslations,
+            msg,
+          } from '@generaltranslation/react-core/pure';
           import { T } from '@generaltranslation/react-core/components';
           import { useGT } from '@generaltranslation/react-core/hooks';
           import { Branch } from '@generaltranslation/react-core/components-rsc';
 
           assert.equal(typeof msg, 'function');
+          assert.equal(typeof getSnapshotGT, 'function');
+          assert.equal(typeof getSnapshotMessages, 'function');
+          assert.equal(typeof getSnapshotTranslations, 'function');
           assert.equal(typeof T, 'function');
           assert.equal(typeof useGT, 'function');
           assert.equal(typeof Branch, 'function');

--- a/packages/react-core/src/context/clientSnapshots.ts
+++ b/packages/react-core/src/context/clientSnapshots.ts
@@ -1,5 +1,16 @@
 import type { Dictionary, Hash, Locale } from 'gt-i18n/internal/types';
+import type { LookupOptions } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
+import type { StringContent } from 'generaltranslation/types';
+import {
+  lookupDictionaryEntry,
+  lookupDictionaryObject,
+} from '../i18n-store/utils/dictionaries';
+import type {
+  DictionaryEntrySnapshot,
+  DictionaryObjectSnapshot,
+} from '../i18n-store/storeTypes';
+import { lookupTranslation } from '../i18n-store/utils/translations';
 
 type TranslationsSnapshot = Record<Locale, Record<Hash, Translation>>;
 type DictionariesSnapshot = Record<Locale, Dictionary>;
@@ -21,6 +32,32 @@ export function setClientSnapshots(
 ): void {
   translationsSnapshot = translations;
   dictionariesSnapshot = dictionaries;
+}
+
+export function lookupClientTranslation(
+  locale: string,
+  message: StringContent,
+  options: LookupOptions
+): StringContent | undefined {
+  return lookupTranslation(translationsSnapshot, {
+    locale,
+    message,
+    options,
+  });
+}
+
+export function lookupClientDictionaryEntry(
+  locale: string,
+  id: string
+): DictionaryEntrySnapshot {
+  return lookupDictionaryEntry(dictionariesSnapshot, { locale, id });
+}
+
+export function lookupClientDictionaryObject(
+  locale: string,
+  id: string
+): DictionaryObjectSnapshot {
+  return lookupDictionaryObject(dictionariesSnapshot, { locale, id });
 }
 
 export type { DictionariesSnapshot, TranslationsSnapshot };

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -1,10 +1,7 @@
 import { Hash, Locale } from 'gt-i18n/internal/types';
 import { Translation } from 'gt-i18n/types';
-import {
-  createDiagnosticMessage,
-  formatDiagnosticErrorDetails,
-} from 'generaltranslation/internal';
 import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { loadTranslationsSnapshot } from './loadTranslationsSnapshot';
 
 /**
  * Serializable cached translations for provider hydration; a failed load
@@ -15,19 +12,7 @@ export async function getTranslationsSnapshot(
   locale: Locale
 ): Promise<Record<Locale, Record<Hash, Translation>>> {
   const i18nCache = getReactI18nCache();
-  try {
-    return { [locale]: await i18nCache.loadTranslations(locale) };
-  } catch (error) {
-    console.warn(
-      createDiagnosticMessage({
-        source: '@generaltranslation/react-core',
-        severity: 'Warning',
-        whatHappened: `Could not load translations for locale "${locale}", so content for this locale renders untranslated`,
-        why: 'the translation loader failed, usually because translations for this locale have not been generated yet',
-        fix: 'Generate translations for this locale, or check your loadTranslations configuration.',
-        details: formatDiagnosticErrorDetails(error),
-      })
-    );
-    return {};
-  }
+  return loadTranslationsSnapshot(locale, (locale) =>
+    i18nCache.loadTranslations(locale)
+  );
 }

--- a/packages/react-core/src/functions/helpers/loadTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/loadTranslationsSnapshot.ts
@@ -1,0 +1,29 @@
+import type { Hash, Locale } from 'gt-i18n/internal/types';
+import type { Translation } from 'gt-i18n/types';
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+
+type LoadTranslations = (locale: Locale) => Promise<Record<Hash, Translation>>;
+
+export async function loadTranslationsSnapshot(
+  locale: Locale,
+  loadTranslations: LoadTranslations
+): Promise<Record<Locale, Record<Hash, Translation>>> {
+  try {
+    return { [locale]: await loadTranslations(locale) };
+  } catch (error) {
+    console.warn(
+      createDiagnosticMessage({
+        source: '@generaltranslation/react-core',
+        severity: 'Warning',
+        whatHappened: `Could not load translations for locale "${locale}", so content for this locale renders untranslated`,
+        why: 'the translation loader failed, usually because translations for this locale have not been generated yet',
+        fix: 'Generate translations for this locale, or check your loadTranslations configuration.',
+        details: formatDiagnosticErrorDetails(error),
+      })
+    );
+    return {};
+  }
+}

--- a/packages/react-core/src/functions/translation/__tests__/snapshotRuntime.test.ts
+++ b/packages/react-core/src/functions/translation/__tests__/snapshotRuntime.test.ts
@@ -1,0 +1,68 @@
+import {
+  createLookupOptions,
+  hashMessage,
+  ReadonlyConditionStore,
+} from 'gt-i18n/internal';
+import { msg } from 'gt-i18n';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { setReadonlyConditionStore } from '../../../condition-store/singleton-operations';
+import { setClientSnapshots } from '../../../context/clientSnapshots';
+import { isReactI18nCacheInitialized } from '../../../i18n-cache/singleton-operations';
+import { initializeI18nConfig } from '../../../setup/i18nConfig';
+import {
+  getSnapshotGT,
+  getSnapshotMessages,
+  getSnapshotTranslations,
+} from '../snapshotRuntime';
+
+type TestGlobal = typeof globalThis & {
+  __generaltranslation?: unknown;
+};
+
+describe('snapshot translation runtime', () => {
+  beforeEach(() => {
+    Reflect.deleteProperty(globalThis as TestGlobal, '__generaltranslation');
+    initializeI18nConfig({ defaultLocale: 'en', locales: ['en', 'fr'] }, 'SPA');
+    setReadonlyConditionStore(
+      new ReadonlyConditionStore({ locale: 'fr', enableI18n: true })
+    );
+
+    const message = 'Hello {name}!';
+    const lookupOptions = createLookupOptions('fr', {}, 'ICU');
+    setClientSnapshots(
+      {
+        fr: {
+          [hashMessage(message, lookupOptions)]: 'Bonjour {name} !',
+        },
+      },
+      {
+        en: {
+          metadata: {
+            greeting: message,
+            profile: { name: 'Name', title: 'Title' },
+          },
+        },
+        fr: {
+          metadata: {
+            greeting: 'Bonjour {name} !',
+            profile: { name: 'Nom' },
+          },
+        },
+      }
+    );
+  });
+
+  it('resolves strings, messages, and dictionaries without an I18nCache', async () => {
+    expect(isReactI18nCacheInitialized()).toBe(false);
+
+    const gt = await getSnapshotGT();
+    expect(gt('Hello {name}!', { name: 'Ada' })).toBe('Bonjour Ada !');
+
+    const m = await getSnapshotMessages();
+    expect(m(msg('Hello {name}!', { name: 'Ada' }))).toBe('Bonjour Ada !');
+
+    const t = await getSnapshotTranslations('metadata');
+    expect(t('greeting', { name: 'Ada' })).toBe('Bonjour Ada !');
+    expect(t.obj('profile')).toEqual({ name: 'Nom', title: 'Title' });
+  });
+});

--- a/packages/react-core/src/functions/translation/createT.ts
+++ b/packages/react-core/src/functions/translation/createT.ts
@@ -1,0 +1,156 @@
+import {
+  createLookupOptions,
+  getRuntimeEnvironment,
+  interpolateMessage,
+} from 'gt-i18n/internal';
+import type { LookupOptions, LookupOptionsFor } from 'gt-i18n/internal/types';
+import type { GTTranslationOptions } from 'gt-i18n/types';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import type { StringContent, StringFormat } from 'generaltranslation/types';
+import {
+  getReadonlyConditionStore,
+  isReadonlyConditionStoreInitialized,
+} from '../../condition-store/singleton-operations';
+import { getShouldTranslate } from '../../hooks/utils/getShouldTranslate';
+import { getI18nConfig } from '../../setup/i18nConfig';
+
+export type SyncTranslationLookup = (
+  locale: string,
+  message: StringContent,
+  options: LookupOptions
+) => StringContent | undefined;
+
+export function createT(
+  lookupTranslation: SyncTranslationLookup
+): StringOrTemplateSyncResolutionFunction {
+  function resolveStringContent(
+    locale: string,
+    content: StringContent,
+    options: LookupOptionsFor<StringFormat> = {}
+  ): StringContent {
+    const defaultLocale = getI18nConfig().getDefaultLocale();
+    const lookupOptions = createLookupOptions(locale, options, 'ICU');
+    if (!getShouldTranslate()) {
+      return interpolateMessage({
+        options: lookupOptions,
+        source: content,
+        sourceLocale: defaultLocale,
+      });
+    }
+
+    const translation = lookupTranslation(
+      lookupOptions.$locale,
+      content,
+      lookupOptions
+    );
+    return interpolateMessage({
+      source: content,
+      target: translation,
+      options: lookupOptions,
+      sourceLocale: defaultLocale,
+    });
+  }
+
+  return (messageOrStrings, ...values) => {
+    enforceSSRRules(messageOrStrings);
+
+    if (typeof messageOrStrings === 'string') {
+      const options = values.at(0) as GTTranslationOptions | undefined;
+      const locale = options?.$locale ?? getLocale();
+      return resolveStringContent(locale, messageOrStrings, options);
+    }
+
+    const locale = getLocale();
+    const interpolatedTemplate = interpolateTemplateLiteral(
+      messageOrStrings,
+      values
+    );
+    const translatedInterpolatedTemplate = lookupTranslation(
+      locale,
+      interpolatedTemplate,
+      { $format: 'STRING' }
+    );
+    if (translatedInterpolatedTemplate) return translatedInterpolatedTemplate;
+
+    const { message, variables } = extractInterpolatableValues(
+      messageOrStrings,
+      values
+    );
+    return resolveStringContent(locale, message, variables);
+  };
+}
+
+function extractInterpolatableValues(
+  strings: TemplateStringsArray,
+  values: unknown[]
+): {
+  message: string;
+  variables: Record<string, unknown>;
+} {
+  const parts: string[] = [];
+  const variables: Record<string, unknown> = {};
+  let varIndex = 0;
+
+  for (let i = 0; i < strings.length; i++) {
+    parts.push(strings[i]);
+    if (i < values.length) {
+      const key = varIndex.toString();
+      parts.push(`{${key}}`);
+      variables[key] = values[i];
+      varIndex++;
+    }
+  }
+
+  return {
+    message: parts.join(''),
+    variables,
+  };
+}
+
+function interpolateTemplateLiteral(
+  strings: TemplateStringsArray,
+  values: unknown[]
+): string {
+  return strings
+    .map((string, index) => string + (values[index] ?? ''))
+    .join('');
+}
+
+function enforceSSRRules(
+  messageOrStrings: string | TemplateStringsArray
+): void {
+  const ssrEnabled = getI18nConfig().getRenderStrategy() === 'server-render';
+  const moduleLevel = !isReadonlyConditionStoreInitialized();
+  if (!ssrEnabled || !moduleLevel) return;
+
+  const message =
+    typeof messageOrStrings === 'string'
+      ? messageOrStrings
+      : messageOrStrings.join('');
+  const runtimeEnvironment = getRuntimeEnvironment();
+  const errorMessage = createDiagnosticMessage({
+    source: '@generaltranslation/react-core',
+    severity: 'Error',
+    whatHappened:
+      'Using the t() function at the module level is forbidden in server-rendered applications.',
+    fix: 'Either move the t() invocation into a request-time scope or register the string with the msg() function and translate with an m() function. Ensure that you have added the <GTProvider> at the root of your component tree.',
+    wayOut:
+      runtimeEnvironment === 'development'
+        ? undefined
+        : 'Falling back to defaultLocale value.',
+    details: `Message: "${message}"`,
+  });
+  if (runtimeEnvironment === 'development') {
+    throw new Error(errorMessage);
+  }
+  console.error(errorMessage);
+}
+
+function getLocale(): string {
+  return getReadonlyConditionStore().getLocale();
+}
+
+export interface StringOrTemplateSyncResolutionFunction {
+  (strings: TemplateStringsArray, ...values: unknown[]): string;
+  (message: string, options?: GTTranslationOptions): string;
+}

--- a/packages/react-core/src/functions/translation/snapshotRuntime.ts
+++ b/packages/react-core/src/functions/translation/snapshotRuntime.ts
@@ -1,0 +1,128 @@
+import { decodeOptions } from 'gt-i18n';
+import {
+  extractVariables,
+  isEncodedTranslationOptions,
+  renderDictionaryEntry,
+  renderDictionaryObject,
+  resolveDictionaryLookupOptions,
+} from 'gt-i18n/internal';
+import type {
+  DictionaryObjectTranslation,
+  GTFunctionType,
+  GTTranslationOptions,
+  MFunctionType,
+  TFunctionType,
+  TranslationVariables,
+} from 'gt-i18n/types';
+import {
+  lookupClientDictionaryEntry,
+  lookupClientDictionaryObject,
+  lookupClientTranslation,
+} from '../../context/clientSnapshots';
+import { getReadonlyConditionStore } from '../../condition-store/singleton-operations';
+import { getI18nConfig } from '../../setup/i18nConfig';
+import { createT } from './createT';
+
+const snapshotGT: GTFunctionType = createT(lookupClientTranslation);
+
+const snapshotMessages: MFunctionType = <T extends string | null | undefined>(
+  encodedMsg: T,
+  options: GTTranslationOptions = {}
+): T extends string ? string : T => {
+  if (encodedMsg == null) {
+    return encodedMsg as T extends string ? string : T;
+  }
+
+  const decodedOptions = decodeOptions(encodedMsg) ?? {};
+  if (isEncodedTranslationOptions(decodedOptions)) {
+    return snapshotGT(
+      decodedOptions.$_source,
+      decodedOptions
+    ) as T extends string ? string : T;
+  }
+
+  return snapshotGT(encodedMsg, options) as T extends string ? string : T;
+};
+
+export async function getSnapshotGT(): Promise<GTFunctionType> {
+  return snapshotGT;
+}
+
+export async function getSnapshotMessages(): Promise<MFunctionType> {
+  return snapshotMessages;
+}
+
+export async function getSnapshotTranslations(
+  rootId?: string
+): Promise<TFunctionType> {
+  const conditionStore = getReadonlyConditionStore();
+  const i18nConfig = getI18nConfig();
+  const locale = conditionStore.getLocale();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const shouldTranslate =
+    conditionStore.getEnableI18n() && i18nConfig.requiresTranslation(locale);
+
+  const translate = ((suffix: string, options: TranslationVariables = {}) => {
+    const id = getId(rootId, suffix);
+    const sourceEntry = lookupClientDictionaryEntry(defaultLocale, id);
+    if (sourceEntry === undefined) {
+      throw new Error(`Dictionary entry ${id} cannot be found`);
+    }
+
+    const dictionaryOptions = resolveDictionaryLookupOptions(
+      sourceEntry.options
+    );
+    if (!shouldTranslate) {
+      return snapshotGT(sourceEntry.entry, {
+        ...dictionaryOptions,
+        ...extractVariables(options),
+        $locale: defaultLocale,
+      });
+    }
+
+    const targetEntry = lookupClientDictionaryEntry(locale, id);
+    if (targetEntry?.entry != null) {
+      return renderDictionaryEntry({
+        sourceLocale: defaultLocale,
+        targetLocale: locale,
+        sourceEntry,
+        target: targetEntry.entry,
+        dictionaryOptions,
+        options,
+      });
+    }
+
+    return snapshotGT(sourceEntry.entry, {
+      ...dictionaryOptions,
+      ...extractVariables(options),
+      $locale: locale,
+    });
+  }) as TFunctionType;
+
+  translate.obj = (suffix: string): DictionaryObjectTranslation => {
+    const id = getId(rootId, suffix);
+    const sourceObject = lookupClientDictionaryObject(defaultLocale, id);
+    if (sourceObject === undefined) {
+      throw new Error(`Dictionary entry ${id} cannot be found`);
+    }
+
+    const targetObject = shouldTranslate
+      ? lookupClientDictionaryObject(locale, id)
+      : undefined;
+    return renderDictionaryObject({
+      sourceObject,
+      targetObject,
+      translate: (sourceEntry, dictionaryOptions) =>
+        snapshotGT(sourceEntry.entry, {
+          ...dictionaryOptions,
+          $locale: shouldTranslate ? locale : defaultLocale,
+        }),
+    });
+  };
+
+  return translate;
+}
+
+function getId(prefix: string | undefined, suffix: string): string {
+  return prefix ? `${prefix}.${suffix}` : suffix;
+}

--- a/packages/react-core/src/i18n-cache/singleton-operations.ts
+++ b/packages/react-core/src/i18n-cache/singleton-operations.ts
@@ -1,4 +1,8 @@
-import { getI18nCache, setI18nCache } from 'gt-i18n/internal';
+import {
+  getI18nCache,
+  isI18nCacheInitialized,
+  setI18nCache,
+} from 'gt-i18n/internal';
 import type { I18nCache } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
 import type { ReactI18nCache } from './ReactI18nCache';
@@ -8,6 +12,8 @@ import type { ReactI18nCache } from './ReactI18nCache';
 export function getReactI18nCache(): ReactI18nCache {
   return getI18nCache() as ReactI18nCache;
 }
+
+export { isI18nCacheInitialized as isReactI18nCacheInitialized };
 
 export function setReactI18nCache(i18nCache: ReactI18nCache): void {
   setI18nCache(i18nCache as I18nCache<Translation>);

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -15,12 +15,30 @@ export {
 
 export { getFormatLocales } from './hooks/utils/getFormatLocales';
 export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';
+export { loadTranslationsSnapshot } from './functions/helpers/loadTranslationsSnapshot';
+export {
+  getClientDictionariesSnapshot,
+  getClientTranslationsSnapshot,
+  lookupClientTranslation,
+  setClientSnapshots,
+} from './context/clientSnapshots';
+export {
+  getSnapshotGT,
+  getSnapshotMessages,
+  getSnapshotTranslations,
+} from './functions/translation/snapshotRuntime';
 export { t } from './functions/translation/t';
+export { createT } from './functions/translation/createT';
+export type {
+  StringOrTemplateSyncResolutionFunction,
+  SyncTranslationLookup,
+} from './functions/translation/createT';
 export { createRenderPipeline } from './utils/rendering/createRenderPipeline';
 export type { RenderPipeline } from './utils/rendering/createRenderPipeline';
 export type { RenderPreparedT } from './utils/translation/prepareT.shared';
 export {
   getReactI18nCache,
+  isReactI18nCacheInitialized,
   setReactI18nCache,
 } from './i18n-cache/singleton-operations';
 export {
@@ -44,6 +62,7 @@ export type {
 
 export {
   internalInitializeGTSRA,
+  internalInitializeGTSRAClient,
   type ReactInitializeGTParams,
 } from './setup/initializeGTSRA';
 

--- a/packages/react-core/src/setup/initializeGTSRA.ts
+++ b/packages/react-core/src/setup/initializeGTSRA.ts
@@ -12,6 +12,18 @@ export type ReactInitializeGTParams = ReactI18nConfigParams &
 export function internalInitializeGTSRA(config: ReactInitializeGTParams): void {
   initializeI18nConfig(config, 'server-render');
 
+  initializeCache(config);
+}
+
+export function internalInitializeGTSRAClient(
+  config: ReactInitializeGTParams
+): void {
+  initializeI18nConfig(config, 'server-render');
+
+  if (process.env.NODE_ENV !== 'production') initializeCache(config);
+}
+
+function initializeCache(config: ReactInitializeGTParams): void {
   const i18nCache = new ReactI18nCache(config);
   setReactI18nCache(i18nCache);
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,7 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
+    "@generaltranslation/format": "workspace:*",
     "generaltranslation": "workspace:*",
     "@generaltranslation/react-core": "workspace:*",
     "gt-i18n": "workspace:*"
@@ -88,15 +89,26 @@
         "default": "./dist/index.server.mjs"
       },
       "browser": {
+        "development": {
+          "require": {
+            "types": "./dist/index.types.d.cts",
+            "default": "./dist/index.client.cjs"
+          },
+          "import": {
+            "types": "./dist/index.types.d.mts",
+            "default": "./dist/index.client.mjs"
+          },
+          "default": "./dist/index.client.mjs"
+        },
         "require": {
           "types": "./dist/index.types.d.cts",
-          "default": "./dist/index.client.cjs"
+          "default": "./dist/prod/index.client.prod.cjs"
         },
         "import": {
           "types": "./dist/index.types.d.mts",
-          "default": "./dist/index.client.mjs"
+          "default": "./dist/prod/index.client.prod.mjs"
         },
-        "default": "./dist/index.client.mjs"
+        "default": "./dist/prod/index.client.prod.mjs"
       },
       "require": {
         "types": "./dist/index.types.d.cts",
@@ -117,12 +129,48 @@
         "types": "./dist/macros.d.mts",
         "default": "./dist/macros.mjs"
       }
+    },
+    "./internal": {
+      "browser": {
+        "development": {
+          "require": {
+            "types": "./dist/internal.d.cts",
+            "default": "./dist/internal.cjs"
+          },
+          "import": {
+            "types": "./dist/internal.d.mts",
+            "default": "./dist/internal.mjs"
+          },
+          "default": "./dist/internal.mjs"
+        },
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/prod/internal.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/prod/internal.mjs"
+        },
+        "default": "./dist/prod/internal.mjs"
+      },
+      "require": {
+        "types": "./dist/internal.d.cts",
+        "default": "./dist/internal.cjs"
+      },
+      "import": {
+        "types": "./dist/internal.d.mts",
+        "default": "./dist/internal.mjs"
+      },
+      "default": "./dist/internal.mjs"
     }
   },
   "typesVersions": {
     "*": {
       "macros": [
         "./dist/macros.d.cts"
+      ],
+      "internal": [
+        "./dist/internal.d.cts"
       ]
     }
   },

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -7,6 +7,8 @@ import { beforeAll, describe, expect, it } from 'vitest';
 
 const packageRoot = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
 const runtimeArtifactNames = [
+  'internal.cjs',
+  'internal.mjs',
   'index.rsc.cjs',
   'index.rsc.mjs',
   'index.client.cjs',
@@ -16,9 +18,13 @@ const runtimeArtifactNames = [
   'macros.cjs',
   'macros.mjs',
 ].sort();
-const builtArtifacts = runtimeArtifactNames.map((artifact) =>
-  join(packageRoot, 'dist', artifact)
-);
+const builtArtifacts = [
+  ...runtimeArtifactNames,
+  'prod/internal.cjs',
+  'prod/internal.mjs',
+  'prod/index.client.prod.cjs',
+  'prod/index.client.prod.mjs',
+].map((artifact) => join(packageRoot, 'dist', artifact));
 
 function hasBuiltArtifacts(): boolean {
   return builtArtifacts.every((artifact) => existsSync(artifact));
@@ -46,6 +52,9 @@ function isAllowedExternalizedSubpath(
   file: string,
   specifier: string
 ): boolean {
+  if (file.startsWith('internal.')) {
+    return specifier === '@generaltranslation/react-core/pure';
+  }
   return (
     file.startsWith('index.') &&
     (specifier.startsWith('@generaltranslation/react-core/') ||
@@ -65,12 +74,15 @@ describe('gt-react package exports', () => {
       `
           const assert = require('node:assert/strict');
           const react = require('gt-react');
+          const internal = require('gt-react/internal');
 
           assert.equal(typeof react.GTProvider, 'function');
           assert.equal(typeof react.T, 'function');
           assert.equal(typeof react.parseLocale, 'function');
           assert.equal(typeof react.GtInternalVar, 'function');
           assert.equal(typeof react.GtInternalRuntimeTranslateString, 'function');
+          assert.equal(react.getSnapshotGT, undefined);
+          assert.equal(typeof internal.snapshotRuntime.getGT, 'function');
         `,
     ]);
   });
@@ -123,6 +135,175 @@ describe('gt-react package exports', () => {
           import { createOrUpdateBrowserConditionStore } from 'gt-react';
 
           assert.equal(typeof createOrUpdateBrowserConditionStore, 'function');
+        `,
+    ]);
+  });
+
+  it('selects production and development browser artifacts', () => {
+    node([
+      '--conditions=browser',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/prod/index.client.prod.mjs'),
+            true
+          );
+          assert.equal(
+            import.meta.resolve('gt-react/internal').endsWith('/dist/prod/internal.mjs'),
+            true
+          );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal-static.mjs'),
+            true
+          );
+        `,
+    ]);
+    node([
+      '--conditions=browser',
+      '--conditions=development',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/index.client.mjs'),
+            true
+          );
+          assert.equal(
+            import.meta.resolve('gt-react/internal').endsWith('/dist/internal.mjs'),
+            true
+          );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal.mjs'),
+            true
+          );
+        `,
+    ]);
+  });
+
+  it('uses locale-only configuration in production browser builds', () => {
+    node([
+      '--conditions=browser',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import { I18nConfig } from 'gt-i18n/internal';
+
+          const config = new I18nConfig({
+            defaultLocale: 'en',
+            locales: ['en', 'fr'],
+            projectId: 'test-project',
+          });
+
+          assert.equal(config.resolveSupportedLocale('fr-FR'), 'fr');
+          assert.equal(config.isDevHotReloadEnabled(), false);
+          assert.throws(() => config.getGTClass(), /not available in production browser builds/);
+        `,
+    ]);
+    node([
+      '--conditions=browser',
+      '--conditions=development',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import { I18nConfig } from 'gt-i18n/internal';
+
+          const config = new I18nConfig({ defaultLocale: 'en' });
+          assert.equal(typeof config.getGTClass().translateMany, 'function');
+        `,
+    ]);
+  });
+
+  it('translates from the production SPA snapshot without initializing a cache', () => {
+    node([
+      '--conditions=browser',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import { getReactI18nCache, initializeGTSPA, t } from 'gt-react';
+          import { createLookupOptions, hashMessage } from 'gt-i18n/internal';
+
+          Object.defineProperty(globalThis, 'navigator', {
+            configurable: true,
+            value: { languages: [] },
+          });
+          const message = 'Hello';
+          const lookupOptions = createLookupOptions('fr', {}, 'ICU');
+          const hash = hashMessage(message, lookupOptions);
+
+          await initializeGTSPA({
+            defaultLocale: 'en',
+            locales: ['fr'],
+            locale: 'fr',
+            _getLocale: () => 'fr',
+            loadTranslations: async (locale) => {
+              assert.equal(locale, 'fr');
+              return { [hash]: 'Bonjour' };
+            },
+          });
+
+          assert.equal(t(message), 'Bonjour');
+          assert.throws(
+            () => getReactI18nCache(),
+            /not available in production browser builds/
+          );
+        `,
+    ]);
+  });
+
+  it('translates from a production provider snapshot without initializing a cache', () => {
+    node([
+      '--conditions=browser',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import { createElement } from 'react';
+          import { renderToStaticMarkup } from 'react-dom/server';
+          import { GTProvider, initializeGT, t, useGT } from 'gt-react';
+          import { snapshotRuntime } from 'gt-react/internal';
+          import { createLookupOptions, hashMessage } from 'gt-i18n/internal';
+
+          Object.defineProperty(globalThis, 'navigator', {
+            configurable: true,
+            value: { languages: [] },
+          });
+          const message = 'Hello';
+          const lookupOptions = createLookupOptions('fr', {}, 'ICU');
+          const hash = hashMessage(message, lookupOptions);
+
+          initializeGT({
+            defaultLocale: 'en',
+            locales: ['en', 'fr'],
+          });
+
+          function Child() {
+            const gt = useGT();
+            return createElement('span', null, gt(message), ' / ', t(message));
+          }
+
+          const html = renderToStaticMarkup(
+            createElement(
+              GTProvider,
+              {
+                locale: 'fr',
+                _getLocale: () => 'fr',
+                translations: { fr: { [hash]: 'Bonjour' } },
+              },
+              createElement(Child)
+            )
+          );
+          const snapshotGT = await snapshotRuntime.getGT();
+
+          assert.equal(html, '<span>Bonjour / Bonjour</span>');
+          assert.equal(snapshotGT(message), 'Bonjour');
         `,
     ]);
   });
@@ -253,6 +434,20 @@ describe('gt-react package exports', () => {
         'gt:tx:'
       );
     }
+  });
+
+  it('keeps development runtime machinery out of the production client graph', () => {
+    const productionCode = readdirSync(join(packageRoot, 'dist', 'prod'), {
+      recursive: true,
+    })
+      .map((file) => String(file))
+      .filter((file) => /\.(cjs|mjs)$/.test(file))
+      .map((file) => readFileSync(join(packageRoot, 'dist', 'prod', file)))
+      .join('\n');
+
+    expect(productionCode).not.toMatch(
+      /I18nStore|useSyncExternalStore|subscribeToTranslate|lookupTranslationWithFallback|LocalStorageTranslationCache|BatchedMissingTranslationResolver|RuntimeTranslationsCache|VITE_GT_DEV_API_KEY/
+    );
   });
 
   it('bundles workspace subpath imports in runtime artifacts', () => {

--- a/packages/react/src/functions/t.client.ts
+++ b/packages/react/src/functions/t.client.ts
@@ -1,0 +1,6 @@
+import {
+  createT,
+  lookupClientTranslation,
+} from '@generaltranslation/react-core/pure';
+
+export const t = createT(lookupClientTranslation);

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -2,6 +2,27 @@
 
 import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
+import {
+  GtInternalRuntimeTranslateJsx,
+  GtInternalRuntimeTranslateString,
+} from './setup/runtimeTranslation';
+import { t as clientT } from './functions/t.client';
+import { t as runtimeT } from '@generaltranslation/react-core/pure';
+import {
+  getClientTranslationsSnapshot,
+  getTranslationsSnapshot as getRuntimeTranslationsSnapshot,
+  getReactI18nCache as getRuntimeReactI18nCache,
+  ReactI18nCache as RuntimeReactI18nCache,
+  setReactI18nCache as setRuntimeReactI18nCache,
+} from '@generaltranslation/react-core/pure';
+import type { Hash, Locale } from 'gt-i18n/internal/types';
+import type { Translation } from 'gt-i18n/types';
+
+class ProductionBrowserI18nCache {
+  constructor() {
+    unavailableInProductionBrowser();
+  }
+}
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { initializeGTSRAClient as initializeGT } from './setup/initializeGTSRAClient';
@@ -13,7 +34,7 @@ export { useRegionSelector } from './components/useRegionSelector';
 // ===== Components ===== //
 export { LocaleSelector } from './components/LocaleSelector';
 export { RegionSelector } from './components/RegionSelector';
-export { BrowserGTProvider as GTProvider } from './provider/BrowserGTProvider';
+export { BrowserGTProvider as GTProvider } from './provider/BrowserGTProvider.runtime';
 
 // ===== Components ===== //
 export {
@@ -68,13 +89,40 @@ export {
   getLocaleProperties,
   getLocales,
   resolveCanonicalLocale,
-  getReactI18nCache,
-  getTranslationsSnapshot,
   getVersionId,
   createRenderPipeline,
-  setReactI18nCache,
-  t,
 } from '@generaltranslation/react-core/pure';
+
+export const t = process.env.NODE_ENV === 'production' ? clientT : runtimeT;
+export const getTranslationsSnapshot =
+  process.env.NODE_ENV === 'production'
+    ? getClientTranslationsSnapshotForLocale
+    : getRuntimeTranslationsSnapshot;
+export const getReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? unavailableInProductionBrowser
+    : getRuntimeReactI18nCache;
+export const setReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? unavailableInProductionBrowser
+    : setRuntimeReactI18nCache;
+export const ReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? ProductionBrowserI18nCache
+    : RuntimeReactI18nCache;
+
+async function getClientTranslationsSnapshotForLocale(
+  locale: Locale
+): Promise<Record<Locale, Record<Hash, Translation>>> {
+  const translations = getClientTranslationsSnapshot()[locale];
+  return translations ? { [locale]: translations } : {};
+}
+
+function unavailableInProductionBrowser(): never {
+  throw new Error(
+    'I18nCache is not available in production browser builds. Use the translations provided to GTProvider instead.'
+  );
+}
 
 export type {
   RenderPipeline,
@@ -82,10 +130,7 @@ export type {
 } from '@generaltranslation/react-core/pure';
 
 export type { SharedGTProviderProps } from './provider/GTProviderProps';
-export {
-  GtInternalRuntimeTranslateJsx,
-  GtInternalRuntimeTranslateString,
-} from 'gt-i18n/internal';
+export { GtInternalRuntimeTranslateJsx, GtInternalRuntimeTranslateString };
 export type {
   GTTranslationOptions,
   RuntimeTranslationOptions,
@@ -95,8 +140,4 @@ export type {
   SyncResolutionFunctionWithFallback,
 } from 'gt-i18n/types';
 
-// ===== Singletons ===== //
-export {
-  ReactI18nCache,
-  type ReactI18nCacheParams,
-} from '@generaltranslation/react-core/pure';
+export type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/internal.ts
+++ b/packages/react/src/internal.ts
@@ -1,0 +1,11 @@
+import {
+  getSnapshotGT,
+  getSnapshotMessages,
+  getSnapshotTranslations,
+} from '@generaltranslation/react-core/pure';
+
+export const snapshotRuntime = {
+  getGT: getSnapshotGT,
+  getMessages: getSnapshotMessages,
+  getTranslations: getSnapshotTranslations,
+};

--- a/packages/react/src/provider/BrowserGTProvider.prod.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.prod.tsx
@@ -1,0 +1,16 @@
+import { InternalGTProvider } from '@generaltranslation/react-core/components';
+import { setClientSnapshots } from '@generaltranslation/react-core/pure';
+import { useMemo } from 'react';
+import { createOrUpdateBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
+import type { SharedGTProviderProps } from './GTProviderProps';
+
+export function BrowserGTProviderProd(props: SharedGTProviderProps) {
+  setClientSnapshots(props.translations, props.dictionaries ?? {});
+
+  const conditionStore = useMemo(
+    () => createOrUpdateBrowserConditionStore(props),
+    [props.locale, props.region, props.enableI18n, props._reload]
+  );
+
+  return <InternalGTProvider {...props} conditionStore={conditionStore} />;
+}

--- a/packages/react/src/provider/BrowserGTProvider.runtime.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.runtime.tsx
@@ -1,0 +1,7 @@
+import { BrowserGTProvider as BrowserGTProviderDev } from './BrowserGTProvider';
+import { BrowserGTProviderProd } from './BrowserGTProvider.prod';
+
+export const BrowserGTProvider =
+  process.env.NODE_ENV === 'production'
+    ? BrowserGTProviderProd
+    : BrowserGTProviderDev;

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -5,12 +5,15 @@ import {
 import { useMemo, useRef } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
 import { createOrUpdateBrowserConditionStore } from '../condition-store/createBrowserConditionStore';
+import { syncI18nCache } from './syncI18nCache';
 
 /**
  * Consumes snapshot from server
  * Implementation for client-side only
  */
 export function BrowserGTProvider(props: SharedGTProviderProps) {
+  syncI18nCache(props);
+
   const conditionStore = useMemo(() => {
     return createOrUpdateBrowserConditionStore(props);
   }, [props.locale, props.region, props.enableI18n, props._reload]);

--- a/packages/react/src/provider/ServerGTProvider.dev.tsx
+++ b/packages/react/src/provider/ServerGTProvider.dev.tsx
@@ -1,0 +1,36 @@
+import {
+  I18nStore,
+  InternalGTProvider,
+} from '@generaltranslation/react-core/components';
+import { ReadonlyConditionStore } from '@generaltranslation/react-core/pure';
+import { useMemo, useRef } from 'react';
+import type { SharedGTProviderProps } from './GTProviderProps';
+import { useHandleMissingTranslations } from '../hooks/useHandleMissingTranslations';
+import { syncI18nCache } from './syncI18nCache';
+
+export function ServerGTProviderDev({
+  locale,
+  region,
+  enableI18n,
+  ...props
+}: SharedGTProviderProps) {
+  syncI18nCache(props);
+
+  const conditionStore = useMemo(
+    () => new ReadonlyConditionStore({ locale, region, enableI18n }),
+    [locale, region, enableI18n]
+  );
+  const i18nStoreRef = useRef<I18nStore | null>(null);
+  if (i18nStoreRef.current == null) i18nStoreRef.current = new I18nStore();
+
+  const missingHandlers = useHandleMissingTranslations(i18nStoreRef.current);
+
+  return (
+    <InternalGTProvider
+      {...props}
+      {...missingHandlers}
+      conditionStore={conditionStore}
+      i18nStore={i18nStoreRef.current}
+    />
+  );
+}

--- a/packages/react/src/provider/ServerGTProvider.tsx
+++ b/packages/react/src/provider/ServerGTProvider.tsx
@@ -1,45 +1,27 @@
-import {
-  I18nStore,
-  InternalGTProvider,
-} from '@generaltranslation/react-core/components';
+import { ServerGTProviderDev } from './ServerGTProvider.dev';
+import { InternalGTProvider } from '@generaltranslation/react-core/components';
 import { ReadonlyConditionStore } from '@generaltranslation/react-core/pure';
-import { useMemo, useRef } from 'react';
+import { useMemo } from 'react';
 import type { SharedGTProviderProps } from './GTProviderProps';
-import { useHandleMissingTranslations } from '../hooks/useHandleMissingTranslations';
+import { syncI18nCache } from './syncI18nCache';
 
-/**
- * Consumes snapshot from server
- * Implementation for server-side only
- */
-export function ServerGTProvider({
+function ServerGTProviderProd({
   locale,
   region,
   enableI18n,
   ...props
 }: SharedGTProviderProps) {
-  const conditionStore = useMemo(() => {
-    return new ReadonlyConditionStore({ locale, region, enableI18n });
-  }, [locale, region, enableI18n]);
+  syncI18nCache(props);
 
-  const i18nStoreRef = useRef<I18nStore | null>(null);
-  if (i18nStoreRef.current == null) {
-    i18nStoreRef.current = new I18nStore();
-  }
-
-  const {
-    onMissingTranslation,
-    onMissingDictionaryEntry,
-    onMissingDictionaryObj,
-  } = useHandleMissingTranslations(i18nStoreRef.current);
-
-  return (
-    <InternalGTProvider
-      {...props}
-      conditionStore={conditionStore}
-      i18nStore={i18nStoreRef.current}
-      onMissingTranslation={onMissingTranslation}
-      onMissingDictionaryEntry={onMissingDictionaryEntry}
-      onMissingDictionaryObj={onMissingDictionaryObj}
-    />
+  const conditionStore = useMemo(
+    () => new ReadonlyConditionStore({ locale, region, enableI18n }),
+    [locale, region, enableI18n]
   );
+
+  return <InternalGTProvider {...props} conditionStore={conditionStore} />;
 }
+
+export const ServerGTProvider =
+  process.env.NODE_ENV === 'production'
+    ? ServerGTProviderProd
+    : ServerGTProviderDev;

--- a/packages/react/src/provider/syncI18nCache.ts
+++ b/packages/react/src/provider/syncI18nCache.ts
@@ -1,0 +1,16 @@
+import {
+  getReactI18nCache,
+  isReactI18nCacheInitialized,
+} from '@generaltranslation/react-core/pure';
+import type { SharedGTProviderProps } from './GTProviderProps';
+
+export function syncI18nCache({
+  translations,
+  dictionaries,
+}: Pick<SharedGTProviderProps, 'translations' | 'dictionaries'>): void {
+  if (!isReactI18nCacheInitialized()) return;
+
+  const i18nCache = getReactI18nCache();
+  i18nCache.updateTranslations(translations);
+  i18nCache.updateDictionaries(dictionaries ?? {});
+}

--- a/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
+++ b/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
@@ -41,9 +41,8 @@ describe('runtime credentials', () => {
     vi.stubEnv('VITE_GT_PROJECT_ID', 'vite-project-id');
     vi.stubEnv('VITE_GT_DEV_API_KEY', 'vite-dev-api-key');
 
-    expect(addRuntimeCredentials({})).toMatchObject({
+    expect(addRuntimeCredentials({})).toEqual({
       projectId: 'vite-project-id',
-      devApiKey: undefined,
     });
   });
 });

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -1,11 +1,15 @@
 import {
   getTranslationsSnapshot,
-  I18nStore,
-  setI18nStore,
+  getI18nConfig,
+  loadTranslationsSnapshot,
+  setClientSnapshots,
   setReactI18nCache,
   getReadonlyConditionStore,
   initializeI18nConfig,
+  I18nStore,
+  setI18nStore,
 } from '@generaltranslation/react-core/pure';
+import { loadTranslationsForLocale } from 'gt-i18n/internal';
 import type { I18nConfigParams } from '@generaltranslation/react-core/pure';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
 import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
@@ -21,9 +25,9 @@ export type InitializeGTSPAParams = I18nConfigParams &
 
 /**
  * Initialize GT for an SPA
- * - i18nCache
- * - conditionStore
- * - i18nStore
+ * - condition store in every environment
+ * - shared translations snapshot in every environment
+ * - cache and external store in development only
  *
  * This is SPA for browser runtime
  */
@@ -31,14 +35,22 @@ export async function initializeGTSPA(config: InitializeGTSPAParams) {
   const runtimeConfig = addRuntimeCredentials(config);
   initializeI18nConfig(runtimeConfig, 'SPA');
 
-  const i18nCache = new BrowserI18nCache(runtimeConfig);
-  setReactI18nCache(i18nCache);
-
   createOrUpdateBrowserConditionStore(runtimeConfig);
 
-  const i18nStore = new I18nStore();
-  setI18nStore(i18nStore);
+  if (process.env.NODE_ENV !== 'production') {
+    const i18nCache = new BrowserI18nCache(runtimeConfig);
+    setReactI18nCache(i18nCache);
+    setI18nStore(new I18nStore());
+  }
 
-  // Block until translations are loaded
-  await getTranslationsSnapshot(getReadonlyConditionStore().getLocale());
+  const locale = getReadonlyConditionStore().getLocale();
+  const translations =
+    process.env.NODE_ENV === 'production'
+      ? await loadTranslationsSnapshot(locale, (locale) =>
+          loadTranslationsForLocale(runtimeConfig, locale)
+        )
+      : await getTranslationsSnapshot(locale);
+  setClientSnapshots(translations, {
+    [getI18nConfig().getDefaultLocale()]: runtimeConfig.dictionary ?? {},
+  });
 }

--- a/packages/react/src/setup/initializeGTSRAClient.ts
+++ b/packages/react/src/setup/initializeGTSRAClient.ts
@@ -1,5 +1,5 @@
 import {
-  internalInitializeGTSRA,
+  internalInitializeGTSRAClient,
   type ReactInitializeGTParams,
 } from '@generaltranslation/react-core/pure';
 import { addRuntimeCredentials } from './runtimeCredentials';
@@ -10,7 +10,7 @@ export type InitializeGTClientParams = ReactInitializeGTParams;
  * Initialize GT for client-side rendering.
  */
 export function initializeGTSRAClient(config: InitializeGTClientParams): void {
-  internalInitializeGTSRA(
+  internalInitializeGTSRAClient(
     addRuntimeCredentials({
       cacheExpiryTime: null,
       ...config,

--- a/packages/react/src/setup/runtimeCredentials.ts
+++ b/packages/react/src/setup/runtimeCredentials.ts
@@ -1,4 +1,3 @@
-import { getRuntimeEnvironment } from 'gt-i18n/internal';
 import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 type RuntimeCredentials = Pick<I18nConfigParams, 'projectId' | 'devApiKey'>;
@@ -15,7 +14,9 @@ export function addRuntimeCredentials<T extends RuntimeCredentials>(
   return {
     ...config,
     projectId: config.projectId || credentials.projectId,
-    devApiKey: config.devApiKey || credentials.devApiKey,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devApiKey: config.devApiKey || credentials.devApiKey,
+    }),
   };
 }
 
@@ -30,15 +31,15 @@ function getRuntimeCredentials(): RuntimeCredentials {
             }
           ).env?.VITE_GT_PROJECT_ID
       ) || readProcessEnvViteProjectId(),
-    devApiKey:
-      getRuntimeEnvironment() === 'development'
-        ? readImportMetaVite(() =>
-            (import.meta as ImportMeta & { env?: RuntimeEnv }).env?.DEV
-              ? (import.meta as ImportMeta & { env?: RuntimeEnv }).env
-                  ?.VITE_GT_DEV_API_KEY
-              : undefined
-          ) || readProcessEnvViteDevApiKey()
-        : undefined,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devApiKey:
+        readImportMetaVite(() =>
+          (import.meta as ImportMeta & { env?: RuntimeEnv }).env?.DEV
+            ? (import.meta as ImportMeta & { env?: RuntimeEnv }).env
+                ?.VITE_GT_DEV_API_KEY
+            : undefined
+        ) || readProcessEnvViteDevApiKey(),
+    }),
   };
 }
 

--- a/packages/react/src/setup/runtimeTranslation.dev.ts
+++ b/packages/react/src/setup/runtimeTranslation.dev.ts
@@ -1,0 +1,4 @@
+export {
+  GtInternalRuntimeTranslateJsx,
+  GtInternalRuntimeTranslateString,
+} from 'gt-i18n/internal';

--- a/packages/react/src/setup/runtimeTranslation.ts
+++ b/packages/react/src/setup/runtimeTranslation.ts
@@ -1,0 +1,15 @@
+import {
+  GtInternalRuntimeTranslateJsx as runtimeTranslateJsx,
+  GtInternalRuntimeTranslateString as runtimeTranslateString,
+} from './runtimeTranslation.dev';
+
+const noopRuntimeTranslate = () => {};
+
+export const GtInternalRuntimeTranslateJsx =
+  process.env.NODE_ENV === 'production'
+    ? noopRuntimeTranslate
+    : runtimeTranslateJsx;
+export const GtInternalRuntimeTranslateString =
+  process.env.NODE_ENV === 'production'
+    ? noopRuntimeTranslate
+    : runtimeTranslateString;

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -25,11 +25,23 @@ const contextDeps = {
   alwaysBundle: [/^@generaltranslation\/format\//, /^generaltranslation\//],
 };
 
+const productionClientDeps = {
+  neverBundle: [
+    ...deps.neverBundle,
+    /^@generaltranslation\/format(?:$|\/)/,
+    /^generaltranslation(?:$|\/)/,
+    /^gt-i18n$/,
+    /^gt-i18n\//,
+  ],
+  alwaysBundle: [/^@generaltranslation\/react-core\//],
+};
+
 const entries = [
   'src/index.rsc.ts',
   'src/index.client.ts',
   'src/index.server.ts',
   'src/index.types.ts',
+  'src/internal.ts',
   'src/macros.ts',
 ];
 
@@ -38,9 +50,12 @@ const entries = [
 // so they are deleted after each build.
 const typesOnlyEntry = 'src/index.types.ts';
 
-export default defineConfig(
-  entries.flatMap((entry, index) => {
-    const entryDeps = entry.startsWith('src/index.') ? contextDeps : deps;
+export default defineConfig([
+  ...entries.flatMap((entry, index) => {
+    const entryDeps =
+      entry.startsWith('src/index.') || entry === 'src/internal.ts'
+        ? contextDeps
+        : deps;
     const [cjsConfig, esmConfig] = createTsdownConfig([entry], entryDeps);
 
     return [
@@ -85,5 +100,50 @@ export default defineConfig(
         }),
       },
     ];
-  })
-);
+  }),
+  ...createProductionClientConfigs(),
+]);
+
+function createProductionClientConfigs() {
+  const [cjsConfig, esmConfig] = createTsdownConfig(
+    ['src/index.client.ts', 'src/internal.ts'],
+    productionClientDeps
+  );
+  const entry = {
+    'index.client.prod': 'src/index.client.ts',
+    internal: 'src/internal.ts',
+  };
+  const define = {
+    'import.meta.env': '{}',
+    'process.env.NODE_ENV': JSON.stringify('production'),
+  };
+  const treeshake = { moduleSideEffects: false };
+  const outputOptions = {
+    preserveModules: true,
+    preserveModulesRoot: 'src',
+  };
+
+  return [
+    {
+      ...cjsConfig,
+      entry,
+      clean: false,
+      dts: false,
+      define,
+      outDir: 'dist/prod',
+      outputOptions,
+      treeshake,
+    },
+    {
+      ...esmConfig,
+      entry,
+      clean: false,
+      dts: false,
+      deps: { onlyBundle: false, ...productionClientDeps },
+      define,
+      outDir: 'dist/prod',
+      outputOptions,
+      treeshake,
+    },
+  ];
+}

--- a/packages/tanstack-start/src/functions/__tests__/runtime.test.ts
+++ b/packages/tanstack-start/src/functions/__tests__/runtime.test.ts
@@ -4,6 +4,9 @@ const {
   mockClientConditionStore,
   mockGetGTInternal,
   mockGetMessagesInternal,
+  mockGetSnapshotGT,
+  mockGetSnapshotMessages,
+  mockGetSnapshotTranslations,
   mockGetTranslationsInternal,
 } = vi.hoisted(() => ({
   mockClientConditionStore: {
@@ -12,6 +15,9 @@ const {
   },
   mockGetGTInternal: vi.fn(async () => 'gt'),
   mockGetMessagesInternal: vi.fn(async () => 'messages'),
+  mockGetSnapshotGT: vi.fn(async () => 'snapshot-gt'),
+  mockGetSnapshotMessages: vi.fn(async () => 'snapshot-messages'),
+  mockGetSnapshotTranslations: vi.fn(async () => 'snapshot-translations'),
   mockGetTranslationsInternal: vi.fn(async () => 'translations'),
 }));
 
@@ -29,6 +35,14 @@ vi.mock('@generaltranslation/react-core/pure', async (importOriginal) => ({
     typeof import('@generaltranslation/react-core/pure')
   >()),
   getReadonlyConditionStore: () => mockClientConditionStore,
+}));
+
+vi.mock('gt-react/internal', () => ({
+  snapshotRuntime: {
+    getGT: mockGetSnapshotGT,
+    getMessages: mockGetSnapshotMessages,
+    getTranslations: mockGetSnapshotTranslations,
+  },
 }));
 
 vi.mock('gt-i18n/internal', async (importOriginal) => ({
@@ -83,6 +97,7 @@ function resetSingletons() {
 
 describe.sequential('isomorphic translation functions', () => {
   beforeEach(() => {
+    vi.unstubAllEnvs();
     resetSingletons();
     initializeI18nConfig(config);
     setConditionStore(new AsyncLocalConditionStore(config));
@@ -90,6 +105,9 @@ describe.sequential('isomorphic translation functions', () => {
     mockClientConditionStore.getEnableI18n.mockClear();
     mockGetGTInternal.mockClear();
     mockGetMessagesInternal.mockClear();
+    mockGetSnapshotGT.mockClear();
+    mockGetSnapshotMessages.mockClear();
+    mockGetSnapshotTranslations.mockClear();
     mockGetTranslationsInternal.mockClear();
   });
 
@@ -131,24 +149,11 @@ describe.sequential('isomorphic translation functions', () => {
     });
   });
 
-  it('passes browser conditions to the internal translation functions', async () => {
-    const clientGetLocale = (
-      getLocale as unknown as { client: typeof getLocale }
-    ).client;
-    const clientGetEnableI18n = (
-      getEnableI18n as unknown as { client: typeof getEnableI18n }
-    ).client;
-    const clientGetGT = (getGT as unknown as { client: typeof getGT }).client;
-    const clientGetMessages = (
-      getMessages as unknown as { client: typeof getMessages }
-    ).client;
-    const clientGetTranslations = (
-      getTranslations as unknown as { client: typeof getTranslations }
-    ).client;
+  it('uses the cache-backed translation runtime in development browsers', async () => {
+    const { clientGetGT, clientGetMessages, clientGetTranslations } =
+      getClientTranslationFunctions();
     const messages = [{ message: 'Hello' }];
 
-    expect(clientGetLocale()).toBe('es');
-    expect(clientGetEnableI18n()).toBe(true);
     await expect(clientGetGT(messages)).resolves.toBe('gt');
     await expect(clientGetMessages()).resolves.toBe('messages');
     await expect(clientGetTranslations('metadata')).resolves.toBe(
@@ -168,5 +173,49 @@ describe.sequential('isomorphic translation functions', () => {
       enableI18n: true,
       rootId: 'metadata',
     });
+    expect(mockGetSnapshotGT).not.toHaveBeenCalled();
+    expect(mockGetSnapshotMessages).not.toHaveBeenCalled();
+    expect(mockGetSnapshotTranslations).not.toHaveBeenCalled();
+  });
+
+  it('uses the cache-free translation runtime in production browsers', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const clientGetLocale = (
+      getLocale as unknown as { client: typeof getLocale }
+    ).client;
+    const clientGetEnableI18n = (
+      getEnableI18n as unknown as { client: typeof getEnableI18n }
+    ).client;
+    const { clientGetGT, clientGetMessages, clientGetTranslations } =
+      getClientTranslationFunctions();
+    const messages = [{ message: 'Hello' }];
+
+    expect(clientGetLocale()).toBe('es');
+    expect(clientGetEnableI18n()).toBe(true);
+    await expect(clientGetGT(messages)).resolves.toBe('snapshot-gt');
+    await expect(clientGetMessages()).resolves.toBe('snapshot-messages');
+    await expect(clientGetTranslations('metadata')).resolves.toBe(
+      'snapshot-translations'
+    );
+
+    expect(mockGetSnapshotGT).toHaveBeenCalledOnce();
+    expect(mockGetSnapshotGT).toHaveBeenCalledWith();
+    expect(mockGetSnapshotMessages).toHaveBeenCalledOnce();
+    expect(mockGetSnapshotTranslations).toHaveBeenCalledWith('metadata');
+    expect(mockGetGTInternal).not.toHaveBeenCalled();
+    expect(mockGetMessagesInternal).not.toHaveBeenCalled();
+    expect(mockGetTranslationsInternal).not.toHaveBeenCalled();
   });
 });
+
+function getClientTranslationFunctions() {
+  return {
+    clientGetGT: (getGT as unknown as { client: typeof getGT }).client,
+    clientGetMessages: (
+      getMessages as unknown as { client: typeof getMessages }
+    ).client,
+    clientGetTranslations: (
+      getTranslations as unknown as { client: typeof getTranslations }
+    ).client,
+  };
+}

--- a/packages/tanstack-start/src/functions/runtime.ts
+++ b/packages/tanstack-start/src/functions/runtime.ts
@@ -1,5 +1,6 @@
 import { createIsomorphicFn } from '@tanstack/react-start';
 import { getReadonlyConditionStore } from '@generaltranslation/react-core/pure';
+import { snapshotRuntime } from 'gt-react/internal';
 import {
   getGTInternal,
   getMessagesInternal,
@@ -37,14 +38,8 @@ export const getGT: (messages?: Message[]) => Promise<GTFunctionType> =
       );
     })
     .client((messages?: Message[]) => {
-      const conditionStore = getReadonlyConditionStore();
-      return getGTInternal(
-        {
-          locale: conditionStore.getLocale(),
-          enableI18n: conditionStore.getEnableI18n(),
-        },
-        messages
-      );
+      if (process.env.NODE_ENV === 'production') return snapshotRuntime.getGT();
+      return getGTInternal(getClientConditions(), messages);
     });
 
 /** Return a registered-message translation function for the current runtime. */
@@ -57,11 +52,10 @@ export const getMessages: () => Promise<MFunctionType> = createIsomorphicFn()
     });
   })
   .client(() => {
-    const conditionStore = getReadonlyConditionStore();
-    return getMessagesInternal({
-      locale: conditionStore.getLocale(),
-      enableI18n: conditionStore.getEnableI18n(),
-    });
+    if (process.env.NODE_ENV === 'production') {
+      return snapshotRuntime.getMessages();
+    }
+    return getMessagesInternal(getClientConditions());
   });
 
 /** Return a dictionary translation function for the current runtime. */
@@ -76,10 +70,16 @@ export const getTranslations: (rootId?: string) => Promise<TFunctionType> =
       });
     })
     .client((rootId?: string) => {
-      const conditionStore = getReadonlyConditionStore();
-      return getTranslationsInternal({
-        locale: conditionStore.getLocale(),
-        enableI18n: conditionStore.getEnableI18n(),
-        rootId,
-      });
+      if (process.env.NODE_ENV === 'production') {
+        return snapshotRuntime.getTranslations(rootId);
+      }
+      return getTranslationsInternal({ ...getClientConditions(), rootId });
     });
+
+function getClientConditions(): { locale: string; enableI18n: boolean } {
+  const conditionStore = getReadonlyConditionStore();
+  return {
+    locale: conditionStore.getLocale(),
+    enableI18n: conditionStore.getEnableI18n(),
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,6 +1277,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@generaltranslation/format':
+        specifier: workspace:*
+        version: link:../format
       '@generaltranslation/react-core':
         specifier: workspace:*
         version: link:../react-core


### PR DESCRIPTION
## TL;DR

Activate the snapshot foundation from #2197 for production browser bundles. Production clients use provider-owned translation objects instead of shipping the cache, missing-translation queue, and fine-grained development subscriptions; development and server builds keep the full runtime.

## Code Changes

- Add production browser conditions for gt-i18n/internal and gt-react.
- Keep activation-only cache probing, standalone translation loading, snapshot imperative APIs, and the isolated createT factory in this PR.
- Route React providers, SPA initialization, and synchronous t() through client snapshots in production.
- Update Next client initialization to select the React runtime entry.
- Add the private gt-react/internal snapshot capability used by TanStack Start.
- Preserve TanStack production-browser imperative getGT, getMessages, and getTranslations behavior without restoring the heavy cache.

## Notes / Flags

- Stacked on #2197; this PR is +1,281/-155 across 41 files relative to that base.
- The public gt-react root does not expose the internal snapshot capability.
- Measured total emitted client JS gzip reductions versus main: Next 236,716 → 225,599 bytes (-4.7%), TanStack Start 141,773 → 133,746 (-5.7%), and Vite SPA 98,363 → 88,963 (-9.6%).
- Validated with lint/format, affected package builds and typechecks, all affected test suites, and production builds of all three fixture apps.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds lightweight production browser translation snapshots for the React runtime. A concurrent React reproduction shows that a provider which suspends and is discarded can still publish its translations globally; after a different provider commits, imperative translation lookups can return text from the discarded tree. This must be corrected before merge so imperative translations remain consistent with the rendered application.

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Not safe to merge until global client snapshots are published from commit-consistent state.

The issue was reproduced against the built production provider with an interrupted concurrent render and a subsequent replacement commit.

**Files Needing Attention:** packages/react/src/provider/BrowserGTProvider.prod.tsx needs attention, along with any shared client-snapshot publication mechanism used by imperative translation consumers.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding.
- T-Rex produced an additional proof for a posted P1 finding.
- T-Rex executed the contract-validation script to verify the observed failure and captured runtime output showing the abandoned translation and the committed replacement.

<a href="https://app.greptile.com/trex/runs/20875740/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232198%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2198&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.prod.tsx%3A8%0A**Render%20publishes%20uncommitted%20snapshots**%0A%0A%60setClientSnapshots%60%20mutates%20the%20module-global%20snapshot%20during%20render.%20In%20concurrent%20React%2C%20a%20provider%20render%20can%20suspend%20and%20be%20discarded%2C%20yet%20its%20translations%20remain%20available%20to%20imperative%20%60t%28%29%60%20and%20snapshot%20consumers%20after%20a%20different%20tree%20commits.%20Publish%20the%20shared%20snapshot%20only%20after%20the%20provider%20commits%2C%20or%20make%20imperative%20reads%20derive%20from%20commit-consistent%20state%2C%20so%20imperative%20translations%20match%20the%20visible%20React%20tree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Factivate-production-browser-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Factivate-production-browser-runtime%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Freact%2Fsrc%2Fprovider%2FBrowserGTProvider.prod.tsx%3A8%0A**Render%20publishes%20uncommitted%20snapshots**%0A%0A%60setClientSnapshots%60%20mutates%20the%20module-global%20snapshot%20during%20render.%20In%20concurrent%20React%2C%20a%20provider%20render%20can%20suspend%20and%20be%20discarded%2C%20yet%20its%20translations%20remain%20available%20to%20imperative%20%60t%28%29%60%20and%20snapshot%20consumers%20after%20a%20different%20tree%20commits.%20Publish%20the%20shared%20snapshot%20only%20after%20the%20provider%20commits%2C%20or%20make%20imperative%20reads%20derive%20from%20commit-consistent%20state%2C%20so%20imperative%20translations%20match%20the%20visible%20React%20tree.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2198&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["refactor: activate lightweight browser r..."](https://github.com/generaltranslation/gt/commit/243403fa0f3953a3bd4d5c1cf79f26ef635dad05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57215862)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->