### PR TITLE
refactor: add production client runtime

### DIFF
--- a/.changeset/lightweight-production-runtime.md
+++ b/.changeset/lightweight-production-runtime.md
@@ -1,0 +1,8 @@
+---
+'gt-i18n': patch
+'@generaltranslation/react-core': patch
+'gt-react': patch
+'gt-next': patch
+---
+
+Use a lightweight snapshot runtime for production React clients while retaining the full translation cache in development.

--- a/packages/i18n/src/globals/createGlobalSingleton.ts
+++ b/packages/i18n/src/globals/createGlobalSingleton.ts
@@ -73,7 +73,7 @@ export function createGlobalSingleton<T>({
   function set(next: T): void {
     const ns = getNamespace(namespace);
     if (ns[key] !== undefined && ns[key] !== next) {
-      if (shouldLogDebugWarnings()) {
+      if (process.env.NODE_ENV !== 'production' && shouldLogDebugWarnings()) {
         console.warn(
           createDiagnosticMessage({
             source,

--- a/packages/i18n/src/helpers/versionId.ts
+++ b/packages/i18n/src/helpers/versionId.ts
@@ -1,4 +1,4 @@
-import { getI18nCache } from '../i18n-cache/singleton-operations';
+import { getI18nRuntime } from '../i18n-cache/runtime-operations';
 
 /**
  * Get the version ID for the current source
@@ -9,6 +9,5 @@ import { getI18nCache } from '../i18n-cache/singleton-operations';
  * console.log(versionId); // 'abc123'
  */
 export function getVersionId() {
-  const i18nCache = getI18nCache();
-  return i18nCache.getVersionId();
+  return getI18nRuntime().getVersionId();
 }

--- a/packages/i18n/src/i18n-cache/ClientI18nRuntime.ts
+++ b/packages/i18n/src/i18n-cache/ClientI18nRuntime.ts
@@ -1,0 +1,261 @@
+import {
+  createDiagnosticMessage,
+  formatDiagnosticErrorDetails,
+} from 'generaltranslation/internal';
+import { getI18nConfig } from '../i18n-config/singleton-operations';
+import { hashMessage } from '../utils/hashMessage';
+import type { LookupOptions } from '../translation-functions/types/options';
+import { ResourceCache } from './translations-manager/ResourceCache';
+import { createTranslationLoader } from './translations-manager/translations-loaders/routeCreateTranslationLoader';
+import type { SafeTranslationsLoader } from './translations-manager/translations-loaders/types';
+import {
+  cloneDictionaryValue,
+  getDictionaryEntry,
+  getDictionaryValueAtPath,
+} from './translations-manager/utils/dictionary-helpers';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import type {
+  Dictionary,
+  I18nCacheConstructorParams,
+  I18nRuntime,
+  TranslationResolver,
+} from './types';
+import type {
+  DictionaryEntry,
+  DictionaryObject,
+} from './translations-manager/DictionaryCache';
+import type { Hash, Locale } from './translations-manager/TranslationsCache';
+import { validateDictionaryConfig } from './validateDictionaryConfig';
+
+const invalidLocale = Symbol('invalidLocale');
+
+/**
+ * Production browser runtime. It implements the shared lookup contract without
+ * pulling in runtime translation, batching, subscriptions, or React state.
+ */
+class ClientI18nRuntime implements I18nRuntime {
+  private versionId: string | undefined;
+  private translations: ResourceCache<Locale, Record<Hash, Translation>>;
+  private dictionaries: ResourceCache<Locale, Dictionary>;
+
+  constructor(config: I18nCacheConstructorParams) {
+    validateDictionaryConfig(config);
+    this.versionId = config._versionId;
+    const loadTranslations = createTranslationLoader(
+      config
+    ) as SafeTranslationsLoader<Translation>;
+    const loadDictionary = config.loadDictionary ?? (async () => ({}));
+
+    this.translations = new ResourceCache({
+      ttl: config.cacheExpiryTime,
+      load: async (locale) => structuredClone(await loadTranslations(locale)),
+    });
+    this.dictionaries = new ResourceCache({
+      ttl: config.cacheExpiryTime,
+      load: async (locale) => structuredClone(await loadDictionary(locale)),
+    });
+    this.dictionaries.set(
+      getI18nConfig().getDefaultLocale(),
+      structuredClone(config.dictionary ?? {}),
+      { expiresAt: -1 }
+    );
+  }
+
+  getVersionId(): string | undefined {
+    return this.versionId;
+  }
+
+  async loadTranslations(locale: string): Promise<Record<Hash, Translation>> {
+    const cacheLocale = this.resolveTranslationLocale(locale);
+    if (!cacheLocale || cacheLocale === invalidLocale) return {};
+    return structuredClone(
+      (await this.load(this.translations, cacheLocale, 'translations')) ?? {}
+    );
+  }
+
+  async loadDictionary(locale: string): Promise<Dictionary> {
+    const cacheLocale = this.resolveDictionaryLocale(locale);
+    if (!cacheLocale) return {};
+    return cloneDictionaryValue(
+      (await this.load(this.dictionaries, cacheLocale, 'dictionary')) ?? {}
+    );
+  }
+
+  lookupTranslation<T extends Translation>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): T | undefined {
+    const cacheLocale = this.resolveTranslationLocale(locale);
+    if (cacheLocale === invalidLocale) return;
+    if (!cacheLocale) return message;
+    return this.lookupTranslationIn(
+      this.translations.get(cacheLocale),
+      message,
+      options,
+      cacheLocale
+    );
+  }
+
+  lookupDictionary(locale: string, id: string): DictionaryEntry | undefined {
+    const value = this.lookupDictionaryObj(locale, id);
+    return value === undefined ? undefined : getDictionaryEntry(value);
+  }
+
+  lookupDictionaryObj(
+    locale: string,
+    id: string
+  ): DictionaryObject | undefined {
+    const cacheLocale = this.resolveDictionaryLocale(locale);
+    if (!cacheLocale) return;
+    const dictionary = this.dictionaries.get(cacheLocale);
+    if (!dictionary) return;
+    return this.lookupDictionaryValue(dictionary, id);
+  }
+
+  async getLookupTranslation(locale: string): Promise<TranslationResolver> {
+    const cacheLocale = this.resolveTranslationLocale(locale);
+    if (!cacheLocale || cacheLocale === invalidLocale) {
+      return (message) => message;
+    }
+    const translations = await this.load(
+      this.translations,
+      cacheLocale,
+      'translations'
+    );
+    if (!translations) return (message) => message;
+
+    return (message, options = {} as LookupOptions) => {
+      const lookupLocale = options.$locale ?? locale;
+      const lookupCacheLocale = this.resolveTranslationLocale(lookupLocale);
+      if (lookupCacheLocale === invalidLocale) return;
+      if (!lookupCacheLocale) return message;
+      return this.lookupTranslationIn(
+        lookupCacheLocale === cacheLocale
+          ? translations
+          : this.translations.get(lookupCacheLocale),
+        message,
+        options,
+        lookupCacheLocale
+      );
+    };
+  }
+
+  async getLookupDictionary(locale: string) {
+    const cacheLocale = this.resolveDictionaryLocale(locale);
+    const dictionary = cacheLocale
+      ? await this.load(this.dictionaries, cacheLocale, 'dictionary')
+      : undefined;
+    return {
+      lookupDictionary: (id: string) => {
+        const value = dictionary
+          ? this.lookupDictionaryValue(dictionary, id)
+          : undefined;
+        return value === undefined ? undefined : getDictionaryEntry(value);
+      },
+      lookupDictionaryObj: (id: string) =>
+        dictionary ? this.lookupDictionaryValue(dictionary, id) : undefined,
+    };
+  }
+
+  private lookupTranslationIn<T extends Translation>(
+    translations: Record<Hash, Translation> | undefined,
+    message: T,
+    options: LookupOptions,
+    locale: Locale
+  ): T | undefined {
+    const resolvedOptions = options.$locale
+      ? { ...options, $locale: locale }
+      : options;
+    return this.guard(
+      () =>
+        translations?.[
+          options.$_hash ?? hashMessage(message, resolvedOptions)
+        ] as T | undefined
+    );
+  }
+
+  private lookupDictionaryValue(
+    dictionary: Dictionary,
+    id: string
+  ): DictionaryObject | undefined {
+    return this.guard(() =>
+      cloneDictionaryValue(getDictionaryValueAtPath(dictionary, id))
+    );
+  }
+
+  private resolveTranslationLocale(
+    locale: string
+  ): Locale | undefined | typeof invalidLocale {
+    try {
+      return getI18nConfig().resolveTranslationLocale(locale);
+    } catch (error) {
+      this.reportLocaleError(locale, error);
+      return invalidLocale;
+    }
+  }
+
+  private resolveDictionaryLocale(locale: string): Locale | undefined {
+    const translationLocale = this.resolveTranslationLocale(locale);
+    if (translationLocale === invalidLocale) return;
+    return translationLocale ?? getI18nConfig().getDefaultLocale();
+  }
+
+  private async load<Value>(
+    cache: ResourceCache<Locale, Value>,
+    locale: Locale,
+    resource: 'translations' | 'dictionary'
+  ): Promise<Value | undefined> {
+    try {
+      return await cache.getOrLoad(locale);
+    } catch (error) {
+      console.warn(
+        createDiagnosticMessage({
+          source: 'gt-i18n',
+          severity: 'Warning',
+          whatHappened: `Could not load ${resource} for locale "${locale}", so source content is used`,
+          why: `the ${resource} loader failed`,
+          fix: `Check your ${
+            resource === 'translations' ? 'loadTranslations' : 'loadDictionary'
+          } configuration and generated files.`,
+          details: formatDiagnosticErrorDetails(error),
+        })
+      );
+    }
+  }
+
+  private reportLocaleError(locale: string, error: unknown): void {
+    console.error(
+      createDiagnosticMessage({
+        source: 'gt-i18n',
+        severity: 'Error',
+        whatHappened: `Could not resolve locale "${locale}", so source content is used`,
+        why: 'locale resolution failed',
+        fix: 'Check the configured locales and custom locale mappings.',
+        details: formatDiagnosticErrorDetails(error),
+      })
+    );
+  }
+
+  private guard<Value>(lookup: () => Value): Value | undefined {
+    try {
+      return lookup();
+    } catch (error) {
+      console.error(
+        createDiagnosticMessage({
+          source: 'gt-i18n',
+          severity: 'Error',
+          whatHappened:
+            'A client i18n lookup failed, so source content is used',
+          details: formatDiagnosticErrorDetails(error),
+        })
+      );
+    }
+  }
+}
+
+export function createClientI18nRuntime(
+  config: I18nCacheConstructorParams
+): I18nRuntime {
+  return new ClientI18nRuntime(config);
+}

--- a/packages/i18n/src/i18n-cache/I18nCache.ts
+++ b/packages/i18n/src/i18n-cache/I18nCache.ts
@@ -1,5 +1,13 @@
 import logger from '../logs/logger';
-import { I18nCacheConfig, I18nCacheConstructorParams } from './types';
+import {
+  type I18nCacheConfig,
+  type I18nCacheConstructorParams,
+  type I18nRuntime,
+  type DictionaryResolvers,
+  type PrefetchEntry,
+  type PrefetchEntries,
+  type TranslationResolver,
+} from './types';
 import {
   createDiagnosticMessage,
   defaultRuntimeApiUrl,
@@ -11,8 +19,7 @@ import {
   createTranslateManyFactory,
   type CreateTranslateMany,
 } from './translations-manager/utils/createTranslateMany';
-import { routeCreateTranslationLoader } from './translations-manager/translations-loaders/routeCreateTranslationLoader';
-import { getLoadTranslationsType } from './utils/getLoadTranslationsType';
+import { createTranslationLoader } from './translations-manager/translations-loaders/routeCreateTranslationLoader';
 import { ResourceCache } from './translations-manager/ResourceCache';
 import { TranslationsCache } from './translations-manager/TranslationsCache';
 import type { Hash, Locale } from './translations-manager/TranslationsCache';
@@ -26,53 +33,12 @@ import { resolveDictionaryLookupOptions } from './translations-manager/utils/dic
 import { DictionarySourceNotFoundError } from './translations-manager/utils/DictionarySourceNotFoundError';
 import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { getI18nConfig } from '../i18n-config/singleton-operations';
+import { validateDictionaryConfig } from './validateDictionaryConfig';
 
 /**
  * Default translation timeout in milliseconds for a runtime translation request
  */
 const DEFAULT_TRANSLATION_TIMEOUT = 12_000; // 12 seconds
-
-/**
- * A translation resolver is a function that synchronously resolves a translation
- * @template U - The type of the translation (default: Translation)
- * @param {U} message - The message to get the translation for
- * @param {LookupOptions} [options] - The options for the translation
- * @returns {U | undefined} The translation for the given message and options or undefined if the translation is not found
- */
-type TranslationResolver<U extends Translation = Translation> = <
-  T extends U = U,
->(
-  message: T,
-  options?: LookupOptions
-) => T | undefined;
-
-type DictionaryResolver = (id: string) => DictionaryEntry | undefined;
-
-type DictionaryObjResolver = (id: string) => DictionaryObject | undefined;
-
-type DictionaryResolvers = {
-  lookupDictionary: DictionaryResolver;
-  lookupDictionaryObj: DictionaryObjResolver;
-};
-
-/**
- * A prefetch entry is an entry that we want to prefetch during the async period
- * @template TranslationType - The type of the translation
- * @param {TranslationType} message - The message to prefetch
- * @param {LookupOptions} options - The options for the prefetch
- * @returns {PrefetchEntry<TranslationType>} The prefetch entry
- */
-type PrefetchEntry<TranslationType extends Translation> = {
-  message: TranslationType;
-  options: LookupOptions;
-};
-
-/**
- * Callback function to prefetch entries during the async period
- */
-type PrefetchEntriesType<TranslationType extends Translation> = (
-  prefetchEntries: PrefetchEntry<TranslationType>[]
-) => Promise<void>;
 
 /**
  * Event fired when a runtime translation resolves a cache miss
@@ -89,7 +55,9 @@ export type TranslationsCacheMissEvent<
  * Class for managing translation functionality
  * @template TranslationValue - The type of the translation that will be cached
  */
-class I18nCache<TranslationValue extends Translation = Translation> {
+class I18nCache<
+  TranslationValue extends Translation = Translation,
+> implements I18nRuntime<TranslationValue> {
   protected config: I18nCacheConfig;
 
   /**
@@ -138,16 +106,9 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     };
 
     // Create cache miss handlers
-    const loadTranslations = routeCreateTranslationLoader({
-      loadTranslations: params.loadTranslations,
-      type: getLoadTranslationsType(params),
-      remoteTranslationLoaderParams: {
-        cacheUrl: params.cacheUrl,
-        projectId: params.projectId,
-        _versionId: params._versionId,
-        _branchId: params._branchId,
-      },
-    }) as SafeTranslationsLoader<TranslationValue>;
+    const loadTranslations = createTranslationLoader(
+      params
+    ) as SafeTranslationsLoader<TranslationValue>;
     const loadDictionary = params.loadDictionary ?? (() => Promise.resolve({}));
     this.createTranslateMany = createTranslateManyFactory(
       getI18nConfig().getGTClass(),
@@ -500,7 +461,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
    */
   async getLookupTranslation(locale: string): Promise<
     TranslationResolver<TranslationValue> & {
-      prefetchEntries?: PrefetchEntriesType<TranslationValue>;
+      prefetchEntries?: PrefetchEntries<TranslationValue>;
     }
   > {
     return this.guardAsync<TranslationResolver<TranslationValue>>(
@@ -535,7 +496,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
               asyncBoundaryLocale,
               (entryLocale) =>
                 this._resolveCacheLocale(entryLocale) ??
-                this._resolveLocale(entryLocale)
+                getI18nConfig().resolveLocale(entryLocale)
             );
             if (resolvedPrefetchEntries.length !== prefetchEntries.length) {
               logger.warn(
@@ -624,36 +585,12 @@ class I18nCache<TranslationValue extends Translation = Translation> {
     }
   }
 
-  private _resolveLocale(locale: string) {
-    const i18nConfig = getI18nConfig();
-    const resolvedLocale = i18nConfig.determineLocale(locale);
-    if (!i18nConfig.isValidLocale(locale) || !resolvedLocale) {
-      throw new Error(
-        `Locale "${locale}" is not valid. Use a valid BCP 47 locale code or add a custom mapping.`
-      );
-    }
-    return resolvedLocale;
-  }
-
   /**
    * Resolve the locale key used to load/read locale caches.
    * Returns undefined when the requested locale can use source content.
    */
   private _resolveCacheLocale(locale: string) {
-    const resolvedLocale = this._resolveLocale(locale);
-    const i18nConfig = getI18nConfig();
-    if (i18nConfig.requiresTranslation(resolvedLocale)) {
-      return resolvedLocale;
-    }
-
-    const aliasLocale = i18nConfig.resolveAliasLocale(
-      i18nConfig.standardizeLocale(locale)
-    );
-    if (i18nConfig.requiresTranslation(aliasLocale)) {
-      return aliasLocale;
-    }
-
-    return undefined;
+    return getI18nConfig().resolveTranslationLocale(locale);
   }
 
   private resolveLookupParams(locale: string, options: LookupOptions) {
@@ -678,7 +615,7 @@ class I18nCache<TranslationValue extends Translation = Translation> {
       $locale:
         translationLocale ??
         this._resolveCacheLocale(options.$locale) ??
-        this._resolveLocale(options.$locale),
+        getI18nConfig().resolveLocale(options.$locale),
     };
   }
 
@@ -706,12 +643,7 @@ export { I18nCache };
 
 // ===== Helper Functions ===== //
 
-/**
- * Validate constructor params: log warnings for suspicious configs and throw
- * on hard misconfigurations.
- */
 function validateCacheParams(params: I18nCacheConstructorParams): void {
-  // Runtime translation against a custom API URL still needs GT credentials
   if (params.runtimeUrl && params.runtimeUrl !== defaultRuntimeApiUrl) {
     if (!params.projectId) {
       logger.warn(
@@ -733,18 +665,7 @@ function validateCacheParams(params: I18nCacheConstructorParams): void {
     }
   }
 
-  // loadDictionary requires dictionary so the default locale always has a
-  // source dictionary
-  if (params.loadDictionary && !params.dictionary) {
-    logger.error(
-      'I18nCache: ' +
-        createDiagnosticMessage({
-          whatHappened: 'loadDictionary needs a source dictionary',
-          fix: 'Provide dictionary so the default locale has source content',
-        })
-    );
-    throw new Error('Validation errors occurred');
-  }
+  validateDictionaryConfig(params);
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/__tests__/I18nRuntime.contract.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/I18nRuntime.contract.test.ts
@@ -1,0 +1,408 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { initializeI18nConfig } from '../../i18n-config/singleton-operations';
+import { hashMessage } from '../../utils/hashMessage';
+import { createClientI18nRuntime } from '../ClientI18nRuntime';
+import { I18nCache } from '../I18nCache';
+import { isDictionaryValue } from '../translations-manager/utils/dictionary-helpers';
+import type {
+  Dictionary,
+  I18nCacheConstructorParams,
+  I18nRuntime,
+} from '../types';
+import type { Hash, Locale } from '../translations-manager/TranslationsCache';
+import type { Translation } from '../translations-manager/utils/types/translation-data';
+
+type TranslationsSnapshot = Record<Locale, Record<Hash, Translation>>;
+type RuntimeHarness = {
+  runtime: I18nRuntime;
+  getTranslationsSnapshot: (locale: Locale) => Promise<TranslationsSnapshot>;
+};
+
+type RuntimeAdapter = {
+  name: string;
+  create: (config: I18nCacheConstructorParams) => RuntimeHarness;
+};
+
+const adapters: RuntimeAdapter[] = [
+  {
+    name: 'full I18nCache',
+    create(config) {
+      const cache = new I18nCache(config);
+      return {
+        runtime: cache,
+        async getTranslationsSnapshot(locale) {
+          return { [locale]: await cache.loadTranslations(locale) };
+        },
+      };
+    },
+  },
+  {
+    name: 'client I18n runtime',
+    create(config) {
+      const runtime = createClientI18nRuntime(config);
+      return {
+        runtime,
+        async getTranslationsSnapshot(locale) {
+          return { [locale]: await runtime.loadTranslations(locale) };
+        },
+      };
+    },
+  },
+];
+
+type GlobalWithRegistry = {
+  __generaltranslation?: Record<string, unknown>;
+};
+
+const lookupOptions = { $format: 'ICU' } as const;
+const greetingHash = hashMessage('Hello', lookupOptions);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  const registry = (globalThis as GlobalWithRegistry).__generaltranslation;
+  if (!registry) return;
+  Reflect.deleteProperty(registry, 'i18n');
+  Reflect.deleteProperty(registry, 'reactCore');
+});
+
+describe.each(adapters)('$name runtime contract', ({ create }) => {
+  function setup(config: I18nCacheConstructorParams = {}): RuntimeHarness {
+    const resolvedConfig = {
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+      ...config,
+    };
+    initializeI18nConfig(resolvedConfig);
+    return create(resolvedConfig);
+  }
+
+  it('does not load translations for the source locale', async () => {
+    const loadTranslations = vi.fn(async () => ({
+      [greetingHash]: 'Unexpected',
+    }));
+    const harness = setup({ loadTranslations });
+
+    await expect(harness.getTranslationsSnapshot('en')).resolves.toEqual({
+      en: {},
+    });
+    const lookup = await harness.runtime.getLookupTranslation('en');
+
+    expect(lookup('Hello', lookupOptions)).toBe('Hello');
+    expect(loadTranslations).not.toHaveBeenCalled();
+  });
+
+  it('exposes the configured version ID', () => {
+    const { runtime } = setup({ _versionId: 'version-1' });
+
+    expect(runtime.getVersionId()).toBe('version-1');
+  });
+
+  it('deduplicates target-locale loads', async () => {
+    const loadTranslations = vi.fn(async () => ({
+      [greetingHash]: 'Bonjour',
+    }));
+    const { runtime } = setup({ loadTranslations });
+
+    const [first, second] = await Promise.all([
+      runtime.getLookupTranslation('fr'),
+      runtime.getLookupTranslation('fr'),
+    ]);
+
+    expect(first('Hello', lookupOptions)).toBe('Bonjour');
+    expect(second('Hello', lookupOptions)).toBe('Bonjour');
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadTranslations).toHaveBeenCalledWith('fr');
+  });
+
+  it('exposes loaded resources through synchronous lookups', async () => {
+    const { runtime } = setup({
+      dictionary: { greeting: 'Hello' },
+      loadTranslations: async () => ({ [greetingHash]: 'Bonjour' }),
+      loadDictionary: async () => ({ greeting: 'Bonjour' }),
+    });
+
+    await Promise.all([
+      runtime.loadTranslations('fr'),
+      runtime.loadDictionary('fr'),
+    ]);
+
+    expect(runtime.lookupTranslation('fr', 'Hello', lookupOptions)).toBe(
+      'Bonjour'
+    );
+    expect(runtime.lookupDictionary('fr', 'greeting')?.entry).toBe('Bonjour');
+    expect(runtime.lookupDictionaryObj('fr', 'greeting')).toBe('Bonjour');
+  });
+
+  it('returns isolated translation snapshots', async () => {
+    const harness = setup({
+      loadTranslations: async () => ({ [greetingHash]: 'Bonjour' }),
+    });
+
+    const snapshot = await harness.getTranslationsSnapshot('fr');
+    snapshot.fr[greetingHash] = 'Mutated';
+
+    await expect(harness.getTranslationsSnapshot('fr')).resolves.toEqual({
+      fr: { [greetingHash]: 'Bonjour' },
+    });
+  });
+
+  it('shares canonical and configured alias loads', async () => {
+    const loadTranslations = vi.fn(async () => ({
+      [greetingHash]: 'Bonjour',
+    }));
+    const { runtime } = setup({
+      locales: ['en', 'brand-french'],
+      customMapping: {
+        'brand-french': { code: 'fr', name: 'Brand French' },
+      },
+      loadTranslations,
+    });
+
+    const [aliasLookup, canonicalLookup] = await Promise.all([
+      runtime.getLookupTranslation('brand-french'),
+      runtime.getLookupTranslation('fr'),
+    ]);
+
+    expect(aliasLookup('Hello', lookupOptions)).toBe('Bonjour');
+    expect(canonicalLookup('Hello', lookupOptions)).toBe('Bonjour');
+    expect(loadTranslations).toHaveBeenCalledTimes(1);
+    expect(loadTranslations).toHaveBeenCalledWith('brand-french');
+  });
+
+  it('expires loaded catalogs without changing existing resolvers', async () => {
+    let loadCount = 0;
+    const { runtime } = setup({
+      cacheExpiryTime: 0,
+      loadTranslations: async () => ({
+        [greetingHash]: `Bonjour ${++loadCount}`,
+      }),
+    });
+
+    const first = await runtime.getLookupTranslation('fr');
+    const second = await runtime.getLookupTranslation('fr');
+
+    expect(first('Hello', lookupOptions)).toBe('Bonjour 1');
+    expect(second('Hello', lookupOptions)).toBe('Bonjour 2');
+    expect(first('Hello', lookupOptions)).toBe('Bonjour 1');
+    expect(loadCount).toBe(2);
+  });
+
+  it('retries failed translation loads', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let loadCount = 0;
+    const { runtime } = setup({
+      loadTranslations: async () => {
+        if (++loadCount === 1) throw new Error('temporary failure');
+        return { [greetingHash]: 'Bonjour' };
+      },
+    });
+
+    const first = await runtime.getLookupTranslation('fr');
+    const second = await runtime.getLookupTranslation('fr');
+
+    expect(first('Hello', lookupOptions)).toBe('Hello');
+    expect(second('Hello', lookupOptions)).toBe('Bonjour');
+    expect(loadCount).toBe(2);
+  });
+
+  it('retains loader state across expired loads', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { runtime } = setup({ cacheExpiryTime: 0 });
+
+    await runtime.getLookupTranslation('fr');
+    await runtime.getLookupTranslation('fr');
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns isolated dictionary objects', async () => {
+    const harness = setup({
+      dictionary: { navigation: { about: 'About' } },
+    });
+    const dictionaryLookup = await harness.runtime.getLookupDictionary('en');
+    const navigation = dictionaryLookup.lookupDictionaryObj('navigation');
+    if (!isDictionaryValue(navigation)) {
+      throw new Error('Expected a navigation dictionary object');
+    }
+    navigation.about = 'Mutated';
+
+    expect(dictionaryLookup.lookupDictionaryObj('navigation')).toEqual({
+      about: 'About',
+    });
+  });
+
+  it('rejects unsafe dictionary paths without throwing', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { runtime } = setup({ dictionary: { greeting: 'Hello' } });
+    await runtime.loadDictionary('en');
+
+    expect(runtime.lookupDictionaryObj('en', '__proto__.polluted')).toBe(
+      undefined
+    );
+  });
+
+  it('isolates the configured source dictionary', async () => {
+    const dictionary: Dictionary = {
+      navigation: { about: 'About' },
+    };
+    const harness = setup({ dictionary });
+    const dictionaryLookup = await harness.runtime.getLookupDictionary('en');
+    const navigation = dictionary.navigation;
+    if (!isDictionaryValue(navigation)) {
+      throw new Error('Expected a navigation dictionary object');
+    }
+    navigation.about = 'Mutated';
+
+    expect(dictionaryLookup.lookupDictionaryObj('navigation')).toEqual({
+      about: 'About',
+    });
+  });
+
+  it('deduplicates target-locale dictionary loads', async () => {
+    const loadDictionary = vi.fn(async () => ({ greeting: 'Bonjour' }));
+    const { runtime } = setup({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    const [first, second] = await Promise.all([
+      runtime.getLookupDictionary('fr'),
+      runtime.getLookupDictionary('fr'),
+    ]);
+
+    expect(first.lookupDictionary('greeting')?.entry).toBe('Bonjour');
+    expect(second.lookupDictionary('greeting')?.entry).toBe('Bonjour');
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledWith('fr');
+  });
+
+  it('does not load the source dictionary', async () => {
+    const loadDictionary = vi.fn(async () => ({ greeting: 'Unexpected' }));
+    const { runtime } = setup({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    const lookup = await runtime.getLookupDictionary('en');
+
+    expect(lookup.lookupDictionary('greeting')?.entry).toBe('Hello');
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('uses the source dictionary for source-language dialects', async () => {
+    const loadDictionary = vi.fn(async () => ({ greeting: 'Unexpected' }));
+    const { runtime } = setup({
+      locales: ['en', 'en-US', 'fr'],
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    await expect(runtime.loadDictionary('en-US')).resolves.toEqual({
+      greeting: 'Hello',
+    });
+    expect(runtime.lookupDictionary('en-US', 'greeting')?.entry).toBe('Hello');
+    const lookup = await runtime.getLookupDictionary('en-US');
+    expect(lookup.lookupDictionary('greeting')?.entry).toBe('Hello');
+    expect(loadDictionary).not.toHaveBeenCalled();
+  });
+
+  it('shares canonical and configured alias dictionary loads', async () => {
+    const loadDictionary = vi.fn(async () => ({ greeting: 'Bonjour' }));
+    const { runtime } = setup({
+      locales: ['en', 'brand-french'],
+      customMapping: {
+        'brand-french': { code: 'fr', name: 'Brand French' },
+      },
+      dictionary: { greeting: 'Hello' },
+      loadDictionary,
+    });
+
+    const [aliasLookup, canonicalLookup] = await Promise.all([
+      runtime.getLookupDictionary('brand-french'),
+      runtime.getLookupDictionary('fr'),
+    ]);
+
+    expect(aliasLookup.lookupDictionary('greeting')?.entry).toBe('Bonjour');
+    expect(canonicalLookup.lookupDictionary('greeting')?.entry).toBe('Bonjour');
+    expect(loadDictionary).toHaveBeenCalledTimes(1);
+    expect(loadDictionary).toHaveBeenCalledWith('brand-french');
+  });
+
+  it('expires loaded dictionaries without changing existing resolvers', async () => {
+    let loadCount = 0;
+    const { runtime } = setup({
+      cacheExpiryTime: 0,
+      dictionary: { greeting: 'Hello' },
+      loadDictionary: async () => ({
+        greeting: `Bonjour ${++loadCount}`,
+      }),
+    });
+
+    const first = await runtime.getLookupDictionary('fr');
+    const second = await runtime.getLookupDictionary('fr');
+
+    expect(first.lookupDictionary('greeting')?.entry).toBe('Bonjour 1');
+    expect(second.lookupDictionary('greeting')?.entry).toBe('Bonjour 2');
+    expect(first.lookupDictionary('greeting')?.entry).toBe('Bonjour 1');
+    expect(loadCount).toBe(2);
+  });
+
+  it('retries failed dictionary loads', async () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    let loadCount = 0;
+    const { runtime } = setup({
+      dictionary: { greeting: 'Hello' },
+      loadDictionary: async () => {
+        if (++loadCount === 1) throw new Error('temporary failure');
+        return { greeting: 'Bonjour' };
+      },
+    });
+
+    const first = await runtime.getLookupDictionary('fr');
+    const second = await runtime.getLookupDictionary('fr');
+
+    expect(first.lookupDictionary('greeting')).toBeUndefined();
+    expect(second.lookupDictionary('greeting')?.entry).toBe('Bonjour');
+    expect(loadCount).toBe(2);
+  });
+
+  it('uses loaded alternate locales in bound translation resolvers', async () => {
+    const { runtime } = setup({
+      locales: ['en', 'fr', 'de'],
+      loadTranslations: async (locale) => ({
+        [greetingHash]: locale === 'fr' ? 'Bonjour' : 'Hallo',
+      }),
+    });
+    await runtime.loadTranslations('de');
+
+    const lookup = await runtime.getLookupTranslation('fr');
+
+    expect(lookup('Hello', { ...lookupOptions, $locale: 'de' })).toBe('Hallo');
+  });
+
+  it('validates dictionary loaders at initialization', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => setup({ loadDictionary: async () => ({}) })).toThrow(
+      'Validation errors occurred'
+    );
+  });
+
+  it('falls back without loading for invalid locales', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const loadTranslations = vi.fn(async () => ({
+      [greetingHash]: 'Unexpected',
+    }));
+    const { runtime } = setup({ loadTranslations });
+
+    const lookup = await runtime.getLookupTranslation('not-configured');
+
+    expect(lookup('Hello', lookupOptions)).toBe('Hello');
+    expect(
+      runtime.lookupTranslation('not-configured', 'Hello', lookupOptions)
+    ).toBeUndefined();
+    expect(loadTranslations).not.toHaveBeenCalled();
+  });
+});

--- a/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
+++ b/packages/i18n/src/i18n-cache/__tests__/singleton-operations.test.ts
@@ -16,6 +16,7 @@ function resetI18nCacheGlobal() {
   const globalObj = globalThis as TestGlobal;
   if (globalObj.__generaltranslation?.i18n) {
     Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nCache');
+    Reflect.deleteProperty(globalObj.__generaltranslation.i18n, 'i18nRuntime');
   }
 }
 
@@ -41,6 +42,7 @@ describe('i18n cache singleton operations', () => {
 
   it('shares the cache across module reloads', async () => {
     const { setI18nCache } = await import('../singleton-operations');
+    const { getI18nRuntime } = await import('../runtime-operations');
     const cache = createCacheStub();
 
     setI18nCache(cache);
@@ -49,6 +51,7 @@ describe('i18n cache singleton operations', () => {
     const { getI18nCache } = await import('../singleton-operations');
 
     expect(getI18nCache()).toBe(cache);
+    expect(getI18nRuntime()).toBe(cache);
   });
 
   it('preserves an existing global cache', async () => {

--- a/packages/i18n/src/i18n-cache/runtime-operations.ts
+++ b/packages/i18n/src/i18n-cache/runtime-operations.ts
@@ -1,0 +1,16 @@
+import { createGlobalSingleton } from '../globals/createGlobalSingleton';
+import type { I18nRuntime } from './types';
+
+const i18nRuntimeSingleton =
+  /* @__PURE__ */ createGlobalSingleton<I18nRuntime>({
+    namespace: 'i18n',
+    key: 'i18nRuntime',
+    source: 'gt-i18n',
+    notInitialized: () => 'I18n runtime is not initialized.',
+  });
+
+export function getI18nRuntime(): I18nRuntime {
+  return i18nRuntimeSingleton.get();
+}
+
+export const setI18nRuntime = i18nRuntimeSingleton.set;

--- a/packages/i18n/src/i18n-cache/singleton-operations.ts
+++ b/packages/i18n/src/i18n-cache/singleton-operations.ts
@@ -1,21 +1,28 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from '../globals/createGlobalSingleton';
-import { I18nCache } from './I18nCache';
+import type { I18nCache } from './I18nCache';
 import { Translation } from './translations-manager/utils/types/translation-data';
+import { setI18nRuntime } from './runtime-operations';
+import type { I18nRuntime } from './types';
 
-const i18nCacheSingleton = createGlobalSingleton<I18nCache>({
-  namespace: 'i18n',
-  key: 'i18nCache',
-  source: 'gt-i18n',
-  notInitialized: () =>
-    createDiagnosticMessage({
-      source: 'gt-i18n',
-      severity: 'Error',
-      whatHappened: 'Cannot read I18nCache before it has been initialized',
-      why: 'the internal I18nCache singleton is unavailable',
-      fix: 'Initialize GT before accessing I18nCache (call initializeGT() from your GT framework package).',
-    }),
-});
+const i18nCacheSingleton =
+  /* @__PURE__ */ createGlobalSingleton<I18nCache>({
+    namespace: 'i18n',
+    key: 'i18nCache',
+    source: 'gt-i18n',
+    notInitialized: () =>
+      createDiagnosticMessage({
+        source: 'gt-i18n',
+        severity: 'Error',
+        whatHappened: 'Cannot read I18nCache before it has been initialized',
+        why: 'the internal I18nCache singleton is unavailable',
+        fix: 'Initialize GT before accessing I18nCache (call initializeGT() from your GT framework package).',
+      }),
+  });
+
+export function isI18nCacheInitialized(): boolean {
+  return i18nCacheSingleton.isInitialized();
+}
 
 /**
  * Get the singleton instance of I18nCache
@@ -42,4 +49,5 @@ export function setI18nCache<TranslationValue extends Translation>(
   i18nCacheInstance: I18nCache<TranslationValue>
 ): void {
   i18nCacheSingleton.set(i18nCacheInstance as unknown as I18nCache);
+  setI18nRuntime(i18nCacheInstance as unknown as I18nRuntime);
 }

--- a/packages/i18n/src/i18n-cache/translations-manager/DictionaryCache.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/DictionaryCache.ts
@@ -3,7 +3,7 @@ import {
   getDictionaryEntry,
   getDictionaryValue,
   getDictionaryValueAtPath,
-  isDictionaryValue,
+  mergeDictionary,
   setDictionaryValueAtPath,
 } from './utils/dictionary-helpers';
 import { materializeDictionaryValue } from './utils/materialize-dictionary';
@@ -12,7 +12,6 @@ import type {
   Dictionary,
   DictionaryEntry,
   DictionaryKey,
-  DictionaryPath,
   DictionaryValue,
 } from './utils/types/dictionary';
 export type {
@@ -131,16 +130,5 @@ export class DictionaryCache {
         })
       )
     );
-  }
-}
-
-function mergeDictionary(target: Dictionary, source: Dictionary): void {
-  for (const [key, value] of Object.entries(source)) {
-    const targetValue = target[key];
-    if (isDictionaryValue(targetValue) && isDictionaryValue(value)) {
-      mergeDictionary(targetValue, value);
-    } else {
-      target[key] = cloneDictionaryValue(value);
-    }
   }
 }

--- a/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader.ts
@@ -1,5 +1,9 @@
 import { TranslationsLoader } from './types';
-import { LoadTranslationsType } from '../../utils/getLoadTranslationsType';
+import {
+  getLoadTranslationsType,
+  LoadTranslationsType,
+} from '../../utils/getLoadTranslationsType';
+import type { I18nCacheConstructorParams } from '../../types';
 import logger from '../../../logs/logger';
 import { createRemoteTranslationLoader } from './createRemoteTranslationLoader';
 import { getI18nConfig } from '../../../i18n-config/singleton-operations';
@@ -68,6 +72,21 @@ export function routeCreateTranslationLoader({
         })
       );
   }
+}
+
+export function createTranslationLoader(
+  params: I18nCacheConstructorParams
+): TranslationsLoader {
+  return routeCreateTranslationLoader({
+    loadTranslations: params.loadTranslations,
+    type: getLoadTranslationsType(params),
+    remoteTranslationLoaderParams: {
+      cacheUrl: params.cacheUrl,
+      projectId: params.projectId,
+      _versionId: params._versionId,
+      _branchId: params._branchId,
+    },
+  });
 }
 
 /**

--- a/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
+++ b/packages/i18n/src/i18n-cache/translations-manager/utils/dictionary-helpers.ts
@@ -44,6 +44,17 @@ export function cloneDictionaryValue<Value extends DictionaryValue | undefined>(
   return structuredClone(value) as Value;
 }
 
+export function mergeDictionary(target: Dictionary, source: Dictionary): void {
+  for (const [key, value] of Object.entries(source)) {
+    const targetValue = target[key];
+    if (isDictionaryValue(targetValue) && isDictionaryValue(value)) {
+      mergeDictionary(targetValue, value);
+    } else {
+      target[key] = cloneDictionaryValue(value);
+    }
+  }
+}
+
 export function getDictionaryValueAtPath(
   dictionary: Dictionary,
   path: DictionaryPath

--- a/packages/i18n/src/i18n-cache/types.ts
+++ b/packages/i18n/src/i18n-cache/types.ts
@@ -2,11 +2,60 @@ import type { RuntimeTranslateManyOptions } from 'generaltranslation/internal';
 import type { CustomMapping } from '@generaltranslation/format/types';
 import type { GTConfig } from '../config/types';
 import type { TranslationsLoader } from './translations-manager/translations-loaders/types';
-import type { TranslationBatchConfig } from './translations-manager/TranslationsCache';
+import type {
+  Hash,
+  TranslationBatchConfig,
+} from './translations-manager/TranslationsCache';
 import type {
   Dictionary,
+  DictionaryEntry,
   DictionaryLoader,
+  DictionaryObject,
 } from './translations-manager/DictionaryCache';
+import type { Translation } from './translations-manager/utils/types/translation-data';
+import type { LookupOptions } from '../translation-functions/types/options';
+
+export type TranslationResolver<U extends Translation = Translation> = <
+  T extends U = U,
+>(
+  message: T,
+  options?: LookupOptions
+) => T | undefined;
+
+export type DictionaryResolvers = {
+  lookupDictionary: (id: string) => DictionaryEntry | undefined;
+  lookupDictionaryObj: (id: string) => DictionaryObject | undefined;
+};
+
+export type PrefetchEntry<TranslationValue extends Translation> = {
+  message: TranslationValue;
+  options: LookupOptions;
+};
+
+export type PrefetchEntries<TranslationValue extends Translation> = (
+  entries: PrefetchEntry<TranslationValue>[]
+) => Promise<void>;
+
+export interface I18nRuntime<
+  TranslationValue extends Translation = Translation,
+> {
+  getVersionId(): string | undefined;
+  loadTranslations(locale: string): Promise<Record<Hash, TranslationValue>>;
+  loadDictionary(locale: string): Promise<Dictionary>;
+  lookupTranslation<T extends TranslationValue = TranslationValue>(
+    locale: string,
+    message: T,
+    options: LookupOptions
+  ): T | undefined;
+  lookupDictionary(locale: string, id: string): DictionaryEntry | undefined;
+  lookupDictionaryObj(locale: string, id: string): DictionaryObject | undefined;
+  getLookupTranslation(locale: string): Promise<
+    TranslationResolver<TranslationValue> & {
+      prefetchEntries?: PrefetchEntries<TranslationValue>;
+    }
+  >;
+  getLookupDictionary(locale: string): Promise<DictionaryResolvers>;
+}
 
 export type DictionaryConfig = {
   dictionary?: Dictionary;

--- a/packages/i18n/src/i18n-cache/validateDictionaryConfig.ts
+++ b/packages/i18n/src/i18n-cache/validateDictionaryConfig.ts
@@ -1,0 +1,16 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import logger from '../logs/logger';
+import type { DictionaryConfig } from './types';
+
+export function validateDictionaryConfig(params: DictionaryConfig): void {
+  if (!params.loadDictionary || params.dictionary) return;
+
+  logger.error(
+    'I18nCache: ' +
+      createDiagnosticMessage({
+        whatHappened: 'loadDictionary needs a source dictionary',
+        fix: 'Provide dictionary so the default locale has source content',
+      })
+  );
+  throw new Error('Validation errors occurred');
+}

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -137,6 +137,14 @@ export class I18nConfig extends LocaleConfig {
     return resolvedLocale;
   }
 
+  resolveTranslationLocale(locale: string): string | undefined {
+    const resolvedLocale = this.resolveLocale(locale);
+    if (this.requiresTranslation(resolvedLocale)) return resolvedLocale;
+
+    const aliasLocale = this.resolveAliasLocale(this.standardizeLocale(locale));
+    return this.requiresTranslation(aliasLocale) ? aliasLocale : undefined;
+  }
+
   /**
    * Returns true when development hot reload runtime translation requests can run.
    */

--- a/packages/i18n/src/internal-types.ts
+++ b/packages/i18n/src/internal-types.ts
@@ -11,6 +11,7 @@ export type {
   Dictionary,
   DictionaryLoader,
   DictionaryConfig,
+  I18nRuntime,
 } from './i18n-cache/types';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export type { LocaleCandidates } from './i18n-config/I18nConfig';

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -16,13 +16,23 @@ export { createLookupOptions } from './translation-functions/internal/helpers';
 export { renderDictionaryEntry } from './translation-functions/internal/renderDictionaryEntry';
 export { renderDictionaryObject } from './translation-functions/internal/renderDictionaryObject';
 export { I18nCache } from './i18n-cache/I18nCache';
+export { createClientI18nRuntime } from './i18n-cache/ClientI18nRuntime';
 export type { TranslationsCacheMissEvent } from './i18n-cache/I18nCache';
 export { ReadonlyConditionStore } from './condition-store/ReadonlyConditionStore';
 export type { ReadonlyConditionStoreParams } from './condition-store/ReadonlyConditionStore';
 export { WritableConditionStore } from './condition-store/WritableConditionStore';
 export type { WritableConditionStoreParams } from './condition-store/WritableConditionStore';
 export type { LocaleCandidates } from './i18n-config/I18nConfig';
-export { getI18nCache, setI18nCache } from './i18n-cache/singleton-operations';
+export {
+  getI18nCache,
+  isI18nCacheInitialized,
+  setI18nCache,
+} from './i18n-cache/singleton-operations';
+export {
+  getI18nRuntime,
+  setI18nRuntime,
+} from './i18n-cache/runtime-operations';
+export { validateDictionaryConfig } from './i18n-cache/validateDictionaryConfig';
 export { getVersionId } from './helpers/versionId';
 export { interpolateMessage } from './translation-functions/utils/interpolation/interpolateMessage';
 export { isEncodedTranslationOptions } from './translation-functions/utils/isEncodedTranslationOptions';
@@ -39,6 +49,7 @@ export {
   getDictionaryEntry,
   isDictionaryValue,
   getDictionaryValue,
+  mergeDictionary,
   resolveDictionaryLookupOptions,
 } from './i18n-cache/translations-manager/utils/dictionary-helpers';
 
@@ -55,3 +66,6 @@ export type { GlobalSingleton } from './globals/createGlobalSingleton';
 export { getRuntimeEnvironment } from './utils/getRuntimeEnvironment';
 export { hashMessage } from './utils/hashMessage';
 export { getCookieValue, parseAcceptLanguage } from './utils/request';
+export { createTranslationLoader } from './i18n-cache/translations-manager/translations-loaders/routeCreateTranslationLoader';
+export { DEFAULT_CACHE_EXPIRY_TIME } from './i18n-cache/translations-manager/utils/constants';
+export { dedupePending } from './i18n-cache/translations-manager/utils/dedupePending';

--- a/packages/i18n/src/translation-functions/internal/getGT.ts
+++ b/packages/i18n/src/translation-functions/internal/getGT.ts
@@ -1,4 +1,5 @@
 import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nRuntime } from '../../i18n-cache/runtime-operations';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { GTTranslationOptions, TranslationMetadata } from '../types/options';
 import { GTFunctionType } from '../types/functions';
@@ -40,14 +41,14 @@ export async function getGTInternal(
   _messages?: Message[]
 ): Promise<GTFunctionType> {
   // Get the translation resolver
-  const i18nCache = getI18nCache();
+  const i18nRuntime = getI18nRuntime();
   const sourceLocale = getI18nConfig().getDefaultLocale();
   // Statically gated so bundlers can drop dev hot-reload work from
   // production builds.
   const devHotReloadEnabled =
     process.env.NODE_ENV !== 'production' &&
     getI18nConfig().isDevHotReloadEnabled();
-  const lookupTranslation = await i18nCache.getLookupTranslation(
+  const lookupTranslation = await i18nRuntime.getLookupTranslation(
     enableI18n ? locale : sourceLocale
   );
 
@@ -86,19 +87,19 @@ export async function getGTInternal(
   ) => {
     const targetLocale = enableI18n
       ? (options.$locale ?? locale)
-      : getI18nConfig().getDefaultLocale();
+      : sourceLocale;
     const lookupOptions = createLookupOptions<StringFormat>(
       targetLocale,
       options,
       'ICU'
     );
 
-    // Lookup translation
-    const translation = lookupTranslation(message, lookupOptions);
+    const translation = lookupTranslation(message, lookupOptions) as
+      | string
+      | undefined;
 
-    // Dev hot reload (fire and forget, will be available in a later lookup)
     if (devHotReloadEnabled && translation == null) {
-      void i18nCache
+      void getI18nCache()
         .lookupTranslationWithFallback(
           lookupOptions.$locale,
           message,

--- a/packages/i18n/src/translation-functions/internal/getMessages.ts
+++ b/packages/i18n/src/translation-functions/internal/getMessages.ts
@@ -34,9 +34,7 @@ export async function getMessagesInternal({
   locale: string;
   enableI18n: boolean;
 }): Promise<MFunctionType> {
-  // Get the gt function
   const gt = await getGTInternal({ locale, enableI18n });
-
   /**
    * Resolves a registered message to its translation.
    * @param {string | null | undefined} encodedMsg - The encoded message to decode and interpolate.

--- a/packages/i18n/src/translation-functions/internal/getTranslations.ts
+++ b/packages/i18n/src/translation-functions/internal/getTranslations.ts
@@ -1,4 +1,4 @@
-import { getI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nRuntime } from '../../i18n-cache/runtime-operations';
 import { getI18nConfig } from '../../i18n-config/singleton-operations';
 import { TranslationVariables } from '../types/options';
 import { TFunctionType } from '../types/functions';
@@ -36,14 +36,14 @@ export async function getTranslationsInternal({
   enableI18n: boolean;
   rootId?: string;
 }): Promise<TFunctionType> {
-  const i18nCache = getI18nCache();
+  const i18nRuntime = getI18nRuntime();
   const sourceLocale = getI18nConfig().getDefaultLocale();
   const targetLocale = enableI18n ? locale : sourceLocale;
   const [sourceDictionary, targetDictionary, lookupTranslation] =
     await Promise.all([
-      i18nCache.getLookupDictionary(sourceLocale),
-      i18nCache.getLookupDictionary(targetLocale),
-      i18nCache.getLookupTranslation(targetLocale),
+      i18nRuntime.getLookupDictionary(sourceLocale),
+      i18nRuntime.getLookupDictionary(targetLocale),
+      i18nRuntime.getLookupTranslation(targetLocale),
     ]);
   const {
     lookupDictionary: lookupSourceDictionary,
@@ -53,7 +53,6 @@ export async function getTranslationsInternal({
     lookupDictionary: lookupTargetDictionary,
     lookupDictionaryObj: lookupTargetDictionaryObj,
   } = targetDictionary;
-
   /**
    * Dictionary resolution
    * @param {string} id - The id of the translation to translate.

--- a/packages/next/src/setup/__tests__/initGT.test.ts
+++ b/packages/next/src/setup/__tests__/initGT.test.ts
@@ -86,7 +86,7 @@ describe('initializeGTClient', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses the client-safe ReactI18nCache', () => {
+  it('uses the client-safe ReactI18nCache in development', () => {
     initializeGTClient({
       i18nConfigParams: {
         defaultLocale: 'en',

--- a/packages/next/src/setup/initGT.client.ts
+++ b/packages/next/src/setup/initGT.client.ts
@@ -1,4 +1,4 @@
-import { internalInitializeGTSRA } from '@generaltranslation/react-core/pure';
+import { initializeGT as initializeReactGT } from 'gt-react';
 import { getParams } from './shared';
 import type { NextSetupI18nConfigParams } from './shared';
 import type { NextI18nCacheParams } from '../i18n-cache/NextI18nCache';
@@ -15,7 +15,7 @@ export function initializeGTClient(
     nextI18nCacheParams: NextI18nCacheParams;
   } = getParams()
 ): void {
-  internalInitializeGTSRA({
+  initializeReactGT({
     ...i18nConfigParams,
     ...nextI18nCacheParams,
     /**

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -12,7 +12,7 @@
 export { LocaleSelector as Client_LocaleSelector } from 'gt-react';
 export { RegionSelector as Client_RegionSelector } from 'gt-react';
 
-import { getCookieValue, getI18nConfig, I18nConfig } from 'gt-i18n/internal';
+import { getCookieValue, getI18nConfig } from 'gt-i18n/internal';
 import { GTProvider, type SharedGTProviderProps } from 'gt-react';
 import { usePathname, useRouter } from 'next/navigation';
 import { useCallback, useEffect } from 'react';
@@ -25,6 +25,7 @@ import { compilePathRegex, pathnameMatchesRegex } from './pathRegex';
 
 // withGTConfig exposes this build-time value to both middleware and client code.
 const pathRegex = compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX);
+type I18nConfig = ReturnType<typeof getI18nConfig>;
 
 /**
  * Only need to initalize client. We know server was already

--- a/packages/react-core/src/components/translation/T.tsx
+++ b/packages/react-core/src/components/translation/T.tsx
@@ -5,6 +5,31 @@ import { renderPreparedT } from '../../utils/rendering/renderPipeline';
 import type { TProps } from '../../utils/translation/prepareT.shared';
 import { usePrepareT } from '../../utils/translation/usePrepareT';
 
+function useComputeTDev(
+  result: ReactNode,
+  shouldTranslate: boolean,
+  targetFound: boolean
+): ReactNode {
+  // Tx hot reload: render previous translation while loading new one
+  // TODO: account for success vs loading vs failed request states
+  const prev = useRef<ReactNode | null>(null);
+  if (
+    getI18nConfig().isDevHotReloadEnabled() &&
+    !targetFound &&
+    prev.current != null &&
+    shouldTranslate
+  ) {
+    return prev.current;
+  }
+
+  // record previous result
+  prev.current = result;
+  return result;
+}
+
+const finalizeT: typeof useComputeTDev =
+  process.env.NODE_ENV === 'production' ? (result) => result : useComputeTDev;
+
 // ===== Component ===== //
 
 /**
@@ -56,20 +81,6 @@ function useComputeT({
     message: sourceJsxChildren,
     options: targetOptions,
   });
-
-  // Tx hot reload: render previous translation while loading new one
-  // TODO: account for success vs loading vs failed request states
-  const prev = useRef<ReactNode | null>(null);
-  if (
-    process.env.NODE_ENV !== 'production' &&
-    getI18nConfig().isDevHotReloadEnabled() &&
-    targetJsxChildren == null &&
-    prev.current != null &&
-    shouldTranslate
-  ) {
-    return prev.current;
-  }
-
   const result = _renderPreparedT({
     taggedSourceChildren,
     targetJsxChildren,
@@ -80,8 +91,5 @@ function useComputeT({
     hash: targetOptions.$_hash,
   });
 
-  // record previous result
-  prev.current = result;
-
-  return result;
+  return finalizeT(result, shouldTranslate, targetJsxChildren != null);
 }

--- a/packages/react-core/src/context/InternalGTProvider.tsx
+++ b/packages/react-core/src/context/InternalGTProvider.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, type ReactNode } from 'react';
-import { I18nStore } from '../i18n-store/I18nStore';
+import { useMemo, type ReactNode } from 'react';
+import type { I18nStore } from '../i18n-store/I18nStore';
 import type { Dictionary, Translation } from 'gt-i18n/types';
 import type {
   Locale,
@@ -20,7 +20,7 @@ export type InternalGTProviderProps = {
   dictionaries?: Record<Locale, Dictionary>;
   // Declared upstream dependent on environment
   conditionStore: WritableConditionStoreInterface;
-  i18nStore: I18nStore;
+  i18nStore?: I18nStore;
   // Custom override missing translation behavior for dev hot reload
   onMissingTranslation?: OnMissingTranslation;
   onMissingDictionaryEntry?: OnMissingDictionaryEntry;
@@ -67,12 +67,6 @@ export function InternalGTProvider({
       onMissingDictionaryObj,
     ]
   );
-
-  // Update cache with data from server, do not emit events
-  useEffect(() => {
-    i18nStore.updateTranslations(translations);
-    i18nStore.updateDictionaries(dictionaries ?? {});
-  }, [translations, dictionaries, i18nStore]);
 
   return <GTContext.Provider value={value}>{children}</GTContext.Provider>;
 }

--- a/packages/react-core/src/context/context.ts
+++ b/packages/react-core/src/context/context.ts
@@ -8,7 +8,7 @@ import { Translation } from 'gt-i18n/types';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from 'gt-i18n/internal';
 import { createContext, useContext, type Context } from 'react';
-import { I18nStore } from '../i18n-store/I18nStore';
+import type { I18nStore } from '../i18n-store/I18nStore';
 import { getI18nConfig } from '../setup/i18nConfig';
 import type {
   OnMissingTranslation,
@@ -18,9 +18,8 @@ import type {
 
 export type GTContextType = {
   /**
-   * Source of truth for translations, streamed from server
-   * In SPA mode, these won't be accessible and translations
-   * can be accessed via useSyncExternalStore() directly
+   * Immutable translations and dictionaries for this provider render.
+   * Provider-free SPA consumers read from the initialized i18n runtime.
    */
   translationsSnapshot: Record<Locale, Record<Hash, Translation>>;
   dictionariesSnapshot: Record<Locale, Dictionary>;
@@ -28,7 +27,7 @@ export type GTContextType = {
    * I18nStore allows us to sync state updates in ConditionStore and I18nCache
    * with renders
    */
-  i18nStore: I18nStore;
+  i18nStore?: I18nStore;
   /**
    * ConditionStore should always remain separate from i18nStore as
    * it manages how we perform lookups

--- a/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
+++ b/packages/react-core/src/functions/helpers/getTranslationsSnapshot.ts
@@ -1,22 +1,32 @@
-import { Hash, Locale } from 'gt-i18n/internal/types';
-import { Translation } from 'gt-i18n/types';
+import type { Hash, Locale } from 'gt-i18n/internal/types';
+import type { Translation } from 'gt-i18n/types';
 import {
   createDiagnosticMessage,
   formatDiagnosticErrorDetails,
 } from 'generaltranslation/internal';
-import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
+import { getI18nRuntime } from 'gt-i18n/internal';
+
+type TranslationsSnapshot = Record<Locale, Record<Hash, Translation>>;
+type LoadTranslations = (locale: Locale) => Promise<Record<Hash, Translation>>;
 
 /**
- * Serializable cached translations for provider hydration; a failed load
- * yields a snapshot with no entry for the locale, so hydration caches nothing
- * and a later lookup retries. TODO: perhaps move to /i18n for type generics
+ * Serializable translations for a provider; a failed load yields a snapshot
+ * with no entry for the locale, so a later lookup retries.
  */
 export async function getTranslationsSnapshot(
   locale: Locale
-): Promise<Record<Locale, Record<Hash, Translation>>> {
-  const i18nCache = getReactI18nCache();
+): Promise<TranslationsSnapshot> {
+  return loadTranslationsSnapshot(locale, (locale) =>
+    getI18nRuntime().loadTranslations(locale)
+  );
+}
+
+export async function loadTranslationsSnapshot(
+  locale: Locale,
+  loadTranslations: LoadTranslations
+): Promise<TranslationsSnapshot> {
   try {
-    return { [locale]: await i18nCache.loadTranslations(locale) };
+    return { [locale]: await loadTranslations(locale) };
   } catch (error) {
     console.warn(
       createDiagnosticMessage({

--- a/packages/react-core/src/functions/translation/t.ts
+++ b/packages/react-core/src/functions/translation/t.ts
@@ -1,19 +1,25 @@
 import {
   createLookupOptions,
+  getI18nRuntime,
   getRuntimeEnvironment,
   interpolateMessage,
 } from 'gt-i18n/internal';
+import type { LookupOptions, LookupOptionsFor } from 'gt-i18n/internal/types';
 import type { GTTranslationOptions } from 'gt-i18n/types';
-import type { LookupOptionsFor } from 'gt-i18n/internal/types';
-import { getI18nConfig } from '../../setup/i18nConfig';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import type { StringContent, StringFormat } from 'generaltranslation/types';
 import {
   getReadonlyConditionStore,
   isReadonlyConditionStoreInitialized,
 } from '../../condition-store/singleton-operations';
-import { StringContent, StringFormat } from 'generaltranslation/types';
-import { getReactI18nCache } from '../../i18n-cache/singleton-operations';
 import { getShouldTranslate } from '../../hooks/utils/getShouldTranslate';
-import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { getI18nConfig } from '../../setup/i18nConfig';
+
+type SyncTranslationLookup = (
+  locale: string,
+  message: StringContent,
+  options: LookupOptions
+) => StringContent | undefined;
 
 /**
  * Translate a message
@@ -31,95 +37,77 @@ import { createDiagnosticMessage } from 'generaltranslation/internal';
  * t`Hello, ${name}` // Translate via tagged template literal
  *
  */
-export const t: StringOrTemplateSyncResolutionFunction = (
+let runtimeT: StringOrTemplateSyncResolutionFunction | undefined;
+
+export function t(strings: TemplateStringsArray, ...values: unknown[]): string;
+export function t(message: string, options?: GTTranslationOptions): string;
+export function t(
   messageOrStrings: string | TemplateStringsArray,
   ...values: unknown[]
-) => {
-  // Warnings and errors
-  enforceSSRRules(messageOrStrings);
+): string {
+  runtimeT ??= createT((locale, message, options) =>
+    getI18nRuntime().lookupTranslation(locale, message, options)
+  );
+  return typeof messageOrStrings === 'string'
+    ? runtimeT(
+        messageOrStrings,
+        values.at(0) as GTTranslationOptions | undefined
+      )
+    : runtimeT(messageOrStrings, ...values);
+}
 
-  //  t("Hello, {name}!", { name: "John" })
-  if (typeof messageOrStrings === 'string') {
-    const options = values.at(0) as GTTranslationOptions | undefined;
-    const locale = options?.$locale ?? getLocale();
-    return resolveStringContent(
-      locale,
-      messageOrStrings,
-      createLookupOptions(locale, options ?? {}, 'ICU')
-    );
-  }
+export function createT(
+  lookupTranslation: SyncTranslationLookup
+): StringOrTemplateSyncResolutionFunction {
+  function resolveStringContent(
+    locale: string,
+    content: StringContent,
+    options: LookupOptionsFor<StringFormat> = {}
+  ): StringContent {
+    const defaultLocale = getI18nConfig().getDefaultLocale();
+    const lookupOptions = createLookupOptions(locale, options, 'ICU');
+    if (!getShouldTranslate()) {
+      return interpolateMessage({
+        options: lookupOptions,
+        source: content,
+        sourceLocale: defaultLocale,
+      });
+    }
 
-  // t`Hello, ${name}`
-  return handleTaggedTemplateLiteralTranslation(messageOrStrings, values);
-};
-
-// ----- Helper Functions ----- //
-
-export function resolveStringContent(
-  locale: string,
-  content: StringContent,
-  options: LookupOptionsFor<StringFormat> = {}
-): StringContent {
-  const i18nCache = getReactI18nCache();
-  const defaultLocale = getI18nConfig().getDefaultLocale();
-  if (!getShouldTranslate()) {
     return interpolateMessage({
-      options,
       source: content,
+      target: lookupTranslation(lookupOptions.$locale, content, lookupOptions),
+      options: lookupOptions,
       sourceLocale: defaultLocale,
     });
   }
 
-  const lookupOptions = createLookupOptions(locale, options, 'ICU');
-  const translation = i18nCache.lookupTranslation(
-    lookupOptions.$locale,
-    content,
-    lookupOptions
-  );
-  return interpolateMessage({
-    source: content,
-    target: translation,
-    options: lookupOptions,
-    sourceLocale: defaultLocale,
-  });
-}
+  return (messageOrStrings, ...values) => {
+    enforceSSRRules(messageOrStrings);
 
-/**
- * Handle tagged template literal translation
- * @param messageOrStrings - The message or strings to translate.
- * @param values - The values to interpolate.
- * @returns The translated message.
- *
- * This is triggered when there has been no compiler transformation
- *
- * Try looking up interpolated template first
- * If not found, resolve uninterpolated message
- */
-function handleTaggedTemplateLiteralTranslation(
-  messageOrStrings: TemplateStringsArray,
-  values: unknown[]
-): string {
-  const locale = getLocale();
-  // for tagged template literals, there has been no compiler transformation
-  // (1) lookup interpolated template (aka derived message)
-  const interpolatedTemplate = interpolateTemplateLiteral(
-    messageOrStrings,
-    values
-  );
-  const i18nCache = getReactI18nCache();
-  const translatedInterpolatedTemplate = i18nCache.lookupTranslation(
-    locale,
-    interpolatedTemplate,
-    { $format: 'STRING' }
-  );
-  if (translatedInterpolatedTemplate) return translatedInterpolatedTemplate;
+    if (typeof messageOrStrings === 'string') {
+      const options = values.at(0) as GTTranslationOptions | undefined;
+      return resolveStringContent(
+        options?.$locale ?? getLocale(),
+        messageOrStrings,
+        options
+      );
+    }
 
-  // (2) resolve uninterpolated message
-  const { message, variables } = extractInterpolatableValues(
-    messageOrStrings,
-    values
-  );
-  return resolveStringContent(locale, message, variables);
+    const locale = getLocale();
+    const translatedTemplate = lookupTranslation(
+      locale,
+      interpolateTemplateLiteral(messageOrStrings, values),
+      { $format: 'STRING' }
+    );
+    if (translatedTemplate) return translatedTemplate;
+
+    const { message, variables } = extractInterpolatableValues(
+      messageOrStrings,
+      values
+    );
+    return resolveStringContent(locale, message, variables);
+  };
 }
 
 /**
@@ -222,18 +210,7 @@ function getLocale(): string {
  * {@link TemplateSyncResolutionFunction}
  * {@link SyncResolutionFunction}
  */
-interface StringOrTemplateSyncResolutionFunction {
+export interface StringOrTemplateSyncResolutionFunction {
   (strings: TemplateStringsArray, ...values: unknown[]): string;
   (message: string, options?: GTTranslationOptions): string;
 }
-
-/**
- * Type for the `t` function when used as a tagged template literal.
- * @param strings - The template strings.
- * @param values - The values to interpolate.
- * @returns The translated message.
- */
-type TemplateSyncResolutionFunction = (
-  strings: TemplateStringsArray,
-  ...values: unknown[]
-) => string;

--- a/packages/react-core/src/hooks/__tests__/useGT.test.ts
+++ b/packages/react-core/src/hooks/__tests__/useGT.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { useTrackedTranslationResolver } from '../external-store/useTrackedTranslationResolver';
+import { useTranslationResolver } from '../external-store/useTrackedTranslationResolver';
 import { useDefaultLocale } from '../i18n-config';
 import { useTranslationConditions } from '../utils';
 import { useGT } from '../useGT';
@@ -10,7 +10,7 @@ vi.mock('react', () => ({
 }));
 
 vi.mock('../external-store/useTrackedTranslationResolver', () => ({
-  useTrackedTranslationResolver: vi.fn(),
+  useTranslationResolver: vi.fn(),
 }));
 
 vi.mock('../i18n-config', () => ({
@@ -28,7 +28,7 @@ describe('useGT', () => {
       locale: 'en',
       shouldTranslate: false,
     });
-    vi.mocked(useTrackedTranslationResolver).mockReturnValue(vi.fn());
+    vi.mocked(useTranslationResolver).mockReturnValue(vi.fn());
   });
 
   it('interpolates source strings when translation is not required', () => {
@@ -46,10 +46,6 @@ describe('useGT', () => {
 
     useGT(messages);
 
-    expect(useTrackedTranslationResolver).toHaveBeenCalledWith(
-      messages,
-      'fr',
-      true
-    );
+    expect(useTranslationResolver).toHaveBeenCalledWith(messages, 'fr', true);
   });
 });

--- a/packages/react-core/src/hooks/external-store.ts
+++ b/packages/react-core/src/hooks/external-store.ts
@@ -8,13 +8,15 @@ import {
   useI18nStore,
   useTranslationsSnapshot,
 } from '../i18n-store/useI18nStore';
-import { getI18nConfig } from 'gt-i18n/internal';
+import { lookupTranslation } from '../i18n-store/utils/translations';
+import { getI18nConfig, getI18nRuntime } from 'gt-i18n/internal';
 import { useHandleMissingTranslation } from './utils/missing-translation';
+import { useGTContext } from '../context/context';
 
 /**
  * @internal
  */
-export function useTranslate<T extends Translation>(
+function useTranslateDev<T extends Translation>(
   lookup: TranslateLookup<T>
 ): TranslateSnapshot<T> {
   const i18nStore = useI18nStore();
@@ -43,3 +45,19 @@ export function useTranslate<T extends Translation>(
 
   return storeTranslation;
 }
+
+function useTranslateProd<T extends Translation>(
+  lookup: TranslateLookup<T>
+): TranslateSnapshot<T> {
+  const context = useGTContext();
+  return context
+    ? lookupTranslation(context.translationsSnapshot, lookup)
+    : getI18nRuntime().lookupTranslation(
+        lookup.locale,
+        lookup.message,
+        lookup.options
+      );
+}
+
+export const useTranslate =
+  process.env.NODE_ENV === 'production' ? useTranslateProd : useTranslateDev;

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryObjResolver.ts
@@ -1,4 +1,8 @@
-import { getDictionaryListenerKey, getI18nConfig } from 'gt-i18n/internal';
+import {
+  getDictionaryListenerKey,
+  getI18nConfig,
+  getI18nRuntime,
+} from 'gt-i18n/internal';
 import type {
   DictionaryLookup,
   DictionaryObjectSnapshot,
@@ -10,6 +14,8 @@ import {
 import { useCallback, useRef } from 'react';
 import { useHandleMissingDictionaryObject } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
+import { lookupDictionaryObject } from '../../i18n-store/utils/dictionaries';
+import { useGTContext } from '../../context/context';
 
 export type TrackedDictionaryObjResolver = (
   lookup: DictionaryLookup
@@ -66,3 +72,19 @@ export function useTrackedDictionaryObjResolver(): TrackedDictionaryObjResolver 
     ]
   );
 }
+
+function useSnapshotDictionaryResolver(): TrackedDictionaryObjResolver {
+  const context = useGTContext();
+  return useCallback(
+    (lookup) =>
+      context
+        ? lookupDictionaryObject(context.dictionariesSnapshot, lookup)
+        : getI18nRuntime().lookupDictionaryObj(lookup.locale, lookup.id),
+    [context]
+  );
+}
+
+export const useDictionaryObjectResolver =
+  process.env.NODE_ENV === 'production'
+    ? useSnapshotDictionaryResolver
+    : useTrackedDictionaryObjResolver;

--- a/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedDictionaryResolver.ts
@@ -7,9 +7,15 @@ import type {
   DictionaryEntrySnapshot,
   DictionaryLookup,
 } from '../../i18n-store/storeTypes';
-import { getDictionaryListenerKey, getI18nConfig } from 'gt-i18n/internal';
+import {
+  getDictionaryListenerKey,
+  getI18nConfig,
+  getI18nRuntime,
+} from 'gt-i18n/internal';
 import { useHandleMissingDictionaryEntry } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
+import { lookupDictionaryEntry } from '../../i18n-store/utils/dictionaries';
+import { useGTContext } from '../../context/context';
 
 export type TrackedDictionaryEntryResolver = (
   lookup: DictionaryLookup
@@ -66,3 +72,19 @@ export function useTrackedDictionaryResolver(): TrackedDictionaryEntryResolver {
     ]
   );
 }
+
+function useSnapshotDictionaryResolver(): TrackedDictionaryEntryResolver {
+  const context = useGTContext();
+  return useCallback(
+    (lookup) =>
+      context
+        ? lookupDictionaryEntry(context.dictionariesSnapshot, lookup)
+        : getI18nRuntime().lookupDictionary(lookup.locale, lookup.id),
+    [context]
+  );
+}
+
+export const useDictionaryEntryResolver =
+  process.env.NODE_ENV === 'production'
+    ? useSnapshotDictionaryResolver
+    : useTrackedDictionaryResolver;

--- a/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
+++ b/packages/react-core/src/hooks/external-store/useTrackedTranslationResolver.ts
@@ -2,6 +2,7 @@ import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   createLookupOptions,
   getI18nConfig,
+  getI18nRuntime,
   getTranslateListenerKey,
 } from 'gt-i18n/internal';
 import type { Translation } from 'gt-i18n/types';
@@ -17,6 +18,8 @@ import {
 } from '../../i18n-store/useI18nStore';
 import { useHandleMissingTranslationWithConditions } from '../utils/missing-translation';
 import { useSubscribeToTrackedLookups } from './useSubscribeToTrackedLookups';
+import { lookupTranslation } from '../../i18n-store/utils/translations';
+import { useGTContext } from '../../context/context';
 
 /**
  * Returns the translation, but also triggers a translation if it is not found
@@ -103,6 +106,26 @@ export function useTrackedTranslationResolver(
     [i18nStore, translationsSnapshot, onMissingTranslation, devHotReloadEnabled]
   );
 }
+
+function useSnapshotTranslationResolver(): TrackedTranslationResolver {
+  const context = useGTContext();
+  return useCallback(
+    (lookup) =>
+      context
+        ? lookupTranslation(context.translationsSnapshot, lookup)
+        : getI18nRuntime().lookupTranslation(
+            lookup.locale,
+            lookup.message,
+            lookup.options
+          ),
+    [context]
+  );
+}
+
+export const useTranslationResolver: typeof useTrackedTranslationResolver =
+  process.env.NODE_ENV === 'production'
+    ? useSnapshotTranslationResolver
+    : useTrackedTranslationResolver;
 
 /**
  * Pre-subscribe to compiler-injected lookups

--- a/packages/react-core/src/hooks/useGT.ts
+++ b/packages/react-core/src/hooks/useGT.ts
@@ -6,7 +6,7 @@ import type { StringFormat } from '@generaltranslation/format/types';
 import { useDefaultLocale } from './i18n-config';
 import {
   type Message,
-  useTrackedTranslationResolver,
+  useTranslationResolver,
 } from './external-store/useTrackedTranslationResolver';
 
 // ===== Hook ===== //
@@ -14,7 +14,7 @@ import {
 export function useGT(_messages?: Message[]): GTFunctionType {
   const { locale, shouldTranslate } = useTranslationConditions();
   const defaultLocale = useDefaultLocale();
-  const resolveTranslation = useTrackedTranslationResolver(
+  const resolveTranslation = useTranslationResolver(
     _messages,
     locale,
     shouldTranslate

--- a/packages/react-core/src/hooks/useTranslations.ts
+++ b/packages/react-core/src/hooks/useTranslations.ts
@@ -13,8 +13,8 @@ import type {
 } from 'gt-i18n/types';
 import { useDefaultLocale } from './i18n-config';
 import { useShouldTranslate } from './utils';
-import { useTrackedDictionaryResolver } from './external-store/useTrackedDictionaryResolver';
-import { useTrackedDictionaryObjResolver } from './external-store/useTrackedDictionaryObjResolver';
+import { useDictionaryEntryResolver } from './external-store/useTrackedDictionaryResolver';
+import { useDictionaryObjectResolver } from './external-store/useTrackedDictionaryObjResolver';
 
 // ===== Hook ===== //
 
@@ -23,7 +23,7 @@ export function useTranslations(rootId?: string): UseTranslationsFunction {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const gt = useGT();
-  const resolveDictionaryEntry = useTrackedDictionaryResolver();
+  const resolveDictionaryEntry = useDictionaryEntryResolver();
   const translateObject = useTranslationsObj(rootId);
 
   const translateEntry = useCallback(
@@ -78,7 +78,7 @@ function useTranslationsObj(rootId?: string): UseTranslationsObjFunction {
   const defaultLocale = useDefaultLocale();
   const shouldTranslate = useShouldTranslate();
   const gt = useGT();
-  const resolveDictionaryObject = useTrackedDictionaryObjResolver();
+  const resolveDictionaryObject = useDictionaryObjectResolver();
 
   return useCallback(
     (suffix: string) => {

--- a/packages/react-core/src/i18n-store/useI18nStore.ts
+++ b/packages/react-core/src/i18n-store/useI18nStore.ts
@@ -14,10 +14,10 @@ export function useTranslationsSnapshot(): Record<
   Record<Hash, Translation>
 > {
   const context = useGTContext();
-  return context?.translationsSnapshot || {};
+  return context?.translationsSnapshot ?? {};
 }
 
 export function useDictionariesSnapshot(): Record<Locale, Dictionary> {
   const context = useGTContext();
-  return context?.dictionariesSnapshot || {};
+  return context?.dictionariesSnapshot ?? {};
 }

--- a/packages/react-core/src/i18n-store/utils/translations.ts
+++ b/packages/react-core/src/i18n-store/utils/translations.ts
@@ -1,4 +1,4 @@
-import { hashMessage } from 'gt-i18n/internal';
+import { getI18nConfig, hashMessage } from 'gt-i18n/internal';
 import type { Hash, Locale } from 'gt-i18n/internal/types';
 import type { Translation } from 'gt-i18n/types';
 import type { TranslateLookup, TranslateSnapshot } from '../storeTypes';
@@ -7,7 +7,23 @@ export function lookupTranslation<T extends Translation>(
   translationsSnapshot: Record<Locale, Record<Hash, Translation>> | undefined,
   lookup: TranslateLookup<T>
 ): TranslateSnapshot<T> {
+  const translationLocale = resolveTranslationLocale(lookup.locale);
+  if (!translationLocale) return lookup.message;
+
   const hash =
     lookup.options.$_hash ?? hashMessage(lookup.message, lookup.options);
-  return translationsSnapshot?.[lookup.locale]?.[hash] as TranslateSnapshot<T>;
+  const translation = translationsSnapshot?.[translationLocale]?.[hash];
+  return (
+    translation !== undefined || translationLocale === lookup.locale
+      ? translation
+      : translationsSnapshot?.[lookup.locale]?.[hash]
+  ) as TranslateSnapshot<T>;
+}
+
+function resolveTranslationLocale(locale: string): string | undefined {
+  try {
+    return getI18nConfig().resolveTranslationLocale(locale);
+  } catch {
+    return locale;
+  }
 }

--- a/packages/react-core/src/pure.ts
+++ b/packages/react-core/src/pure.ts
@@ -16,6 +16,7 @@ export {
 export { getFormatLocales } from './hooks/utils/getFormatLocales';
 export { getTranslationsSnapshot } from './functions/helpers/getTranslationsSnapshot';
 export { t } from './functions/translation/t';
+export type { StringOrTemplateSyncResolutionFunction } from './functions/translation/t';
 export { createRenderPipeline } from './utils/rendering/createRenderPipeline';
 export type { RenderPipeline } from './utils/rendering/createRenderPipeline';
 export type { RenderPreparedT } from './utils/translation/prepareT.shared';
@@ -44,6 +45,7 @@ export type {
 
 export {
   internalInitializeGTSRA,
+  internalInitializeGTSRAClient,
   type ReactInitializeGTParams,
 } from './setup/initializeGTSRA';
 

--- a/packages/react-core/src/setup/initializeGTSRA.ts
+++ b/packages/react-core/src/setup/initializeGTSRA.ts
@@ -2,6 +2,7 @@ import type { ReactI18nCacheParams } from '../i18n-cache/ReactI18nCache';
 import { setReactI18nCache } from '../i18n-cache/singleton-operations';
 import { ReactI18nCache } from '../i18n-cache/ReactI18nCache';
 import { initializeI18nConfig, type ReactI18nConfigParams } from './i18nConfig';
+import { createClientI18nRuntime, setI18nRuntime } from 'gt-i18n/internal';
 
 export type ReactInitializeGTParams = ReactI18nConfigParams &
   ReactI18nCacheParams;
@@ -12,6 +13,21 @@ export type ReactInitializeGTParams = ReactI18nConfigParams &
 export function internalInitializeGTSRA(config: ReactInitializeGTParams): void {
   initializeI18nConfig(config, 'server-render');
 
-  const i18nCache = new ReactI18nCache(config);
-  setReactI18nCache(i18nCache);
+  initializeCache(config);
+}
+
+export function internalInitializeGTSRAClient(
+  config: ReactInitializeGTParams
+): void {
+  initializeI18nConfig(config, 'server-render');
+
+  if (process.env.NODE_ENV === 'production') {
+    setI18nRuntime(createClientI18nRuntime(config));
+  } else {
+    initializeCache(config);
+  }
+}
+
+function initializeCache(config: ReactInitializeGTParams): void {
+  setReactI18nCache(new ReactI18nCache(config));
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -17,6 +17,7 @@
     "react-dom": ">=18.0.0"
   },
   "dependencies": {
+    "@generaltranslation/format": "workspace:*",
     "generaltranslation": "workspace:*",
     "@generaltranslation/react-core": "workspace:*",
     "gt-i18n": "workspace:*"
@@ -88,6 +89,28 @@
         "default": "./dist/index.server.mjs"
       },
       "browser": {
+        "development": {
+          "require": {
+            "types": "./dist/index.types.d.cts",
+            "default": "./dist/index.client.cjs"
+          },
+          "import": {
+            "types": "./dist/index.types.d.mts",
+            "default": "./dist/index.client.mjs"
+          },
+          "default": "./dist/index.client.mjs"
+        },
+        "production": {
+          "require": {
+            "types": "./dist/index.types.d.cts",
+            "default": "./dist/index.client.prod.cjs"
+          },
+          "import": {
+            "types": "./dist/index.types.d.mts",
+            "default": "./dist/index.client.prod.mjs"
+          },
+          "default": "./dist/index.client.prod.mjs"
+        },
         "require": {
           "types": "./dist/index.types.d.cts",
           "default": "./dist/index.client.cjs"

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -16,9 +16,11 @@ const runtimeArtifactNames = [
   'macros.cjs',
   'macros.mjs',
 ].sort();
-const builtArtifacts = runtimeArtifactNames.map((artifact) =>
-  join(packageRoot, 'dist', artifact)
-);
+const builtArtifacts = [
+  ...runtimeArtifactNames,
+  'index.client.prod.cjs',
+  'index.client.prod.mjs',
+].map((artifact) => join(packageRoot, 'dist', artifact));
 
 function hasBuiltArtifacts(): boolean {
   return builtArtifacts.every((artifact) => existsSync(artifact));
@@ -49,7 +51,10 @@ function isAllowedExternalizedSubpath(
   return (
     file.startsWith('index.') &&
     (specifier.startsWith('@generaltranslation/react-core/') ||
-      specifier.startsWith('gt-i18n/'))
+      specifier.startsWith('gt-i18n/') ||
+      (file.startsWith('index.client.prod.') &&
+        (specifier.startsWith('@generaltranslation/format/') ||
+          specifier.startsWith('generaltranslation/'))))
   );
 }
 
@@ -127,6 +132,133 @@ describe('gt-react package exports', () => {
     ]);
   });
 
+  it('requires an explicit production condition for the production browser artifact', () => {
+    node([
+      '--conditions=browser',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/index.client.mjs'),
+            true
+          );
+        `,
+    ]);
+    node([
+      '--conditions=browser',
+      '--conditions=development',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/index.client.mjs'),
+            true
+          );
+        `,
+    ]);
+    node([
+      '--conditions=browser',
+      '--conditions=production',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+
+          assert.equal(
+            import.meta.resolve('gt-react').endsWith('/dist/index.client.prod.mjs'),
+            true
+          );
+        `,
+    ]);
+  });
+
+  it('shares production snapshots without initializing a cache', () => {
+    node([
+      '--conditions=browser',
+      '--conditions=production',
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import React from 'react';
+          import { renderToStaticMarkup } from 'react-dom/server';
+          import { GTProvider, GtInternalRuntimeTranslateJsx, GtInternalRuntimeTranslateString, Num, getReactI18nCache, getTranslationsSnapshot, initializeGTSPA, t, useGT } from 'gt-react';
+          import { createLookupOptions, hashMessage } from 'gt-i18n/internal';
+
+          await Promise.all([
+            GtInternalRuntimeTranslateJsx('Hello'),
+            GtInternalRuntimeTranslateString('Hello'),
+          ]);
+
+          Object.defineProperty(globalThis, 'navigator', {
+            configurable: true,
+            value: { languages: [] },
+          });
+          const message = 'Hello';
+          const locale = 'customFrench';
+          const lookupOptions = createLookupOptions(locale, {}, 'ICU');
+          const hash = hashMessage(message, lookupOptions);
+          let loadCount = 0;
+          const config = {
+            defaultLocale: 'en',
+            locales: [locale],
+            locale,
+            _getLocale: () => locale,
+            customMapping: {
+              [locale]: { code: 'fr', name: 'Custom French' },
+            },
+            loadTranslations: async (loadedLocale) => {
+              loadCount++;
+              assert.equal(loadedLocale, locale);
+              return { [hash]: 'Bonjour' };
+            },
+          };
+          await initializeGTSPA(config);
+
+          assert.deepEqual(await getTranslationsSnapshot('en'), { en: {} });
+          assert.equal(loadCount, 1);
+          assert.equal(t(message), 'Bonjour');
+          function SpaChild() {
+            const gt = useGT();
+            return React.createElement('span', null, gt(message));
+          }
+          assert.equal(
+            renderToStaticMarkup(React.createElement(SpaChild)),
+            '<span>Bonjour</span>'
+          );
+          assert.equal(t(message, { $locale: 'not-configured' }), message);
+
+          function ProviderChild() {
+            const gt = useGT();
+            return React.createElement('span', null, gt(message));
+          }
+
+          const html = renderToStaticMarkup(
+            React.createElement(
+              GTProvider,
+              { ...config, translations: { [locale]: { [hash]: 'Injected' } } },
+              React.createElement(
+                React.Fragment,
+                null,
+                React.createElement(ProviderChild),
+                React.createElement(Num, null, 1234)
+              )
+            )
+          );
+          assert.equal(html, '<span>Injected</span>1 234');
+          assert.equal(t(message), 'Bonjour');
+          assert.throws(
+            () => getReactI18nCache(),
+            /not available in production browser builds/
+          );
+        `,
+    ]);
+  });
+
   it.each(['workerd', 'worker'])(
     'resolves server entrypoints when %s and browser conditions are active',
     (workerCondition) => {
@@ -159,6 +291,40 @@ describe('gt-react package exports', () => {
       ]);
     }
   );
+
+  it('does not mutate the global cache while rendering the server provider', () => {
+    node([
+      '--input-type=module',
+      '-e',
+      `
+          import assert from 'node:assert/strict';
+          import React from 'react';
+          import { renderToStaticMarkup } from 'react-dom/server';
+          import { GTProvider, initializeGT } from 'gt-react';
+          import { getGTInternal, hashMessage } from 'gt-i18n/internal';
+
+          process.env.NODE_ENV = 'production';
+          const hash = hashMessage('Hello', { $format: 'ICU' });
+          initializeGT({
+            defaultLocale: 'en',
+            locales: ['en', 'fr'],
+            cacheExpiryTime: null,
+            loadTranslations: async () => ({ [hash]: 'Original' }),
+          });
+          const gt = await getGTInternal({ locale: 'fr', enableI18n: true });
+          assert.equal(gt('Hello'), 'Original');
+
+          renderToStaticMarkup(
+            React.createElement(GTProvider, {
+              locale: 'fr',
+              enableI18n: true,
+              translations: { fr: { [hash]: 'Injected' } },
+            })
+          );
+          assert.equal(gt('Hello'), 'Original');
+        `,
+    ]);
+  });
 
   it('throws when the condition-store factory is called from the server entrypoint', () => {
     node([
@@ -208,6 +374,7 @@ describe('gt-react package exports', () => {
       '-e',
       `
           const assert = require('node:assert/strict');
+
           assert.equal(
             require.resolve('gt-react').endsWith('/dist/index.rsc.cjs'),
             true
@@ -253,6 +420,16 @@ describe('gt-react package exports', () => {
         'gt:tx:'
       );
     }
+  });
+
+  it('keeps development runtime machinery out of the production client graph', () => {
+    const productionCode = ['index.client.prod.cjs', 'index.client.prod.mjs']
+      .map((file) => readFileSync(join(packageRoot, 'dist', file)))
+      .join('\n');
+
+    expect(productionCode).not.toMatch(
+      /new I18nStore|useSyncExternalStore|subscribeToTranslate|lookupTranslationWithFallback|LocalStorageTranslationCache|BatchedMissingTranslationResolver|RuntimeTranslationsCache|VITE_GT_DEV_API_KEY|getI18nCache/
+    );
   });
 
   it('bundles workspace subpath imports in runtime artifacts', () => {

--- a/packages/react/src/index.client.ts
+++ b/packages/react/src/index.client.ts
@@ -2,6 +2,15 @@
 
 import type { ReactNode } from 'react';
 import type { TxProps } from './utils/TxProps';
+import {
+  getReactI18nCache as getRuntimeReactI18nCache,
+  ReactI18nCache as RuntimeReactI18nCache,
+  setReactI18nCache as setRuntimeReactI18nCache,
+} from '@generaltranslation/react-core/pure';
+import {
+  GtInternalRuntimeTranslateJsx as runtimeTranslateJsx,
+  GtInternalRuntimeTranslateString as runtimeTranslateString,
+} from 'gt-i18n/internal';
 
 export { initializeGTSPA } from './setup/initializeGTSPA';
 export { initializeGTSRAClient as initializeGT } from './setup/initializeGTSRAClient';
@@ -68,13 +77,32 @@ export {
   getLocaleProperties,
   getLocales,
   resolveCanonicalLocale,
-  getReactI18nCache,
-  getTranslationsSnapshot,
   getVersionId,
   createRenderPipeline,
-  setReactI18nCache,
+  getTranslationsSnapshot,
   t,
 } from '@generaltranslation/react-core/pure';
+
+// TODO: Move ReactI18nCache and its get/set helpers to a gt-react internal
+// subpath, then remove their root exports from every runtime entrypoint.
+export const getReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? unavailableInProductionBrowser
+    : getRuntimeReactI18nCache;
+export const setReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? unavailableInProductionBrowser
+    : setRuntimeReactI18nCache;
+export const ReactI18nCache =
+  process.env.NODE_ENV === 'production'
+    ? unavailableInProductionBrowser
+    : RuntimeReactI18nCache;
+
+function unavailableInProductionBrowser(): never {
+  throw new Error(
+    'I18nCache is not available in production browser builds. Use the translations provided to GTProvider instead.'
+  );
+}
 
 export type {
   RenderPipeline,
@@ -82,10 +110,15 @@ export type {
 } from '@generaltranslation/react-core/pure';
 
 export type { SharedGTProviderProps } from './provider/GTProviderProps';
-export {
-  GtInternalRuntimeTranslateJsx,
-  GtInternalRuntimeTranslateString,
-} from 'gt-i18n/internal';
+const skipRuntimeTranslation = () => {};
+export const GtInternalRuntimeTranslateJsx =
+  process.env.NODE_ENV === 'production'
+    ? skipRuntimeTranslation
+    : runtimeTranslateJsx;
+export const GtInternalRuntimeTranslateString =
+  process.env.NODE_ENV === 'production'
+    ? skipRuntimeTranslation
+    : runtimeTranslateString;
 export type {
   GTTranslationOptions,
   RuntimeTranslationOptions,
@@ -95,8 +128,4 @@ export type {
   SyncResolutionFunctionWithFallback,
 } from 'gt-i18n/types';
 
-// ===== Singletons ===== //
-export {
-  ReactI18nCache,
-  type ReactI18nCacheParams,
-} from '@generaltranslation/react-core/pure';
+export type { ReactI18nCacheParams } from '@generaltranslation/react-core/pure';

--- a/packages/react/src/index.rsc.ts
+++ b/packages/react/src/index.rsc.ts
@@ -97,6 +97,8 @@ export {
   t,
 } from '@generaltranslation/react-core/components-rsc';
 
+// TODO: Move ReactI18nCache and its get/set helpers to a gt-react internal
+// subpath, then remove their root exports from every runtime entrypoint.
 // ===== Internal ===== //
 export {
   getReactI18nCache,

--- a/packages/react/src/index.server.ts
+++ b/packages/react/src/index.server.ts
@@ -87,6 +87,8 @@ export {
   useSetEnableI18n,
 } from '@generaltranslation/react-core/hooks';
 
+// TODO: Move ReactI18nCache and its get/set helpers to a gt-react internal
+// subpath, then remove their root exports from every runtime entrypoint.
 // ===== Functions ===== //
 export {
   msg,

--- a/packages/react/src/index.types.ts
+++ b/packages/react/src/index.types.ts
@@ -53,6 +53,8 @@ export {
   useSetEnableI18n,
 } from '@generaltranslation/react-core/hooks';
 
+// TODO: Move ReactI18nCache and its get/set helpers to a gt-react internal
+// subpath, then remove their root exports from every runtime entrypoint.
 // ===== Functions ===== //
 export {
   msg,

--- a/packages/react/src/provider/BrowserGTProvider.tsx
+++ b/packages/react/src/provider/BrowserGTProvider.tsx
@@ -16,7 +16,7 @@ export function BrowserGTProvider(props: SharedGTProviderProps) {
   }, [props.locale, props.region, props.enableI18n, props._reload]);
 
   const i18nStoreRef = useRef<I18nStore | null>(null);
-  if (i18nStoreRef.current == null) {
+  if (process.env.NODE_ENV !== 'production' && i18nStoreRef.current == null) {
     i18nStoreRef.current = new I18nStore();
   }
 
@@ -24,7 +24,7 @@ export function BrowserGTProvider(props: SharedGTProviderProps) {
     <InternalGTProvider
       {...props}
       conditionStore={conditionStore}
-      i18nStore={i18nStoreRef.current}
+      i18nStore={i18nStoreRef.current ?? undefined}
     />
   );
 }

--- a/packages/react/src/provider/ServerGTProvider.tsx
+++ b/packages/react/src/provider/ServerGTProvider.tsx
@@ -11,16 +11,23 @@ import { useHandleMissingTranslations } from '../hooks/useHandleMissingTranslati
  * Consumes snapshot from server
  * Implementation for server-side only
  */
-export function ServerGTProvider({
-  locale,
-  region,
-  enableI18n,
-  ...props
-}: SharedGTProviderProps) {
+export function ServerGTProvider(props: SharedGTProviderProps) {
+  const { locale, region, enableI18n } = props;
   const conditionStore = useMemo(() => {
     return new ReadonlyConditionStore({ locale, region, enableI18n });
   }, [locale, region, enableI18n]);
 
+  return process.env.NODE_ENV === 'production' ? (
+    <InternalGTProvider {...props} conditionStore={conditionStore} />
+  ) : (
+    <ServerGTProviderDev {...props} conditionStore={conditionStore} />
+  );
+}
+
+function ServerGTProviderDev({
+  conditionStore,
+  ...props
+}: SharedGTProviderProps & { conditionStore: ReadonlyConditionStore }) {
   const i18nStoreRef = useRef<I18nStore | null>(null);
   if (i18nStoreRef.current == null) {
     i18nStoreRef.current = new I18nStore();

--- a/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
+++ b/packages/react/src/setup/__tests__/runtimeCredentials.test.ts
@@ -41,9 +41,8 @@ describe('runtime credentials', () => {
     vi.stubEnv('VITE_GT_PROJECT_ID', 'vite-project-id');
     vi.stubEnv('VITE_GT_DEV_API_KEY', 'vite-dev-api-key');
 
-    expect(addRuntimeCredentials({})).toMatchObject({
+    expect(addRuntimeCredentials({})).toEqual({
       projectId: 'vite-project-id',
-      devApiKey: undefined,
     });
   });
 });

--- a/packages/react/src/setup/initializeGTSPA.ts
+++ b/packages/react/src/setup/initializeGTSPA.ts
@@ -1,11 +1,12 @@
 import {
   getTranslationsSnapshot,
-  I18nStore,
-  setI18nStore,
   setReactI18nCache,
   getReadonlyConditionStore,
   initializeI18nConfig,
+  I18nStore,
+  setI18nStore,
 } from '@generaltranslation/react-core/pure';
+import { createClientI18nRuntime, setI18nRuntime } from 'gt-i18n/internal';
 import type { I18nConfigParams } from '@generaltranslation/react-core/pure';
 import { BrowserI18nCache } from '../i18n-cache/BrowserI18nCache';
 import type { BrowserI18nCacheParams } from '../i18n-cache/BrowserI18nCache';
@@ -21,9 +22,9 @@ export type InitializeGTSPAParams = I18nConfigParams &
 
 /**
  * Initialize GT for an SPA
- * - i18nCache
- * - conditionStore
- * - i18nStore
+ * - condition store in every environment
+ * - shared i18n runtime in every environment
+ * - cache and external store in development only
  *
  * This is SPA for browser runtime
  */
@@ -31,14 +32,15 @@ export async function initializeGTSPA(config: InitializeGTSPAParams) {
   const runtimeConfig = addRuntimeCredentials(config);
   initializeI18nConfig(runtimeConfig, 'SPA');
 
-  const i18nCache = new BrowserI18nCache(runtimeConfig);
-  setReactI18nCache(i18nCache);
-
   createOrUpdateBrowserConditionStore(runtimeConfig);
+  const locale = getReadonlyConditionStore().getLocale();
 
-  const i18nStore = new I18nStore();
-  setI18nStore(i18nStore);
-
-  // Block until translations are loaded
-  await getTranslationsSnapshot(getReadonlyConditionStore().getLocale());
+  if (process.env.NODE_ENV === 'production') {
+    setI18nRuntime(createClientI18nRuntime(runtimeConfig));
+  } else {
+    const i18nCache = new BrowserI18nCache(runtimeConfig);
+    setReactI18nCache(i18nCache);
+    setI18nStore(new I18nStore());
+  }
+  await getTranslationsSnapshot(locale);
 }

--- a/packages/react/src/setup/initializeGTSRAClient.ts
+++ b/packages/react/src/setup/initializeGTSRAClient.ts
@@ -1,5 +1,5 @@
 import {
-  internalInitializeGTSRA,
+  internalInitializeGTSRAClient,
   type ReactInitializeGTParams,
 } from '@generaltranslation/react-core/pure';
 import { addRuntimeCredentials } from './runtimeCredentials';
@@ -10,7 +10,7 @@ export type InitializeGTClientParams = ReactInitializeGTParams;
  * Initialize GT for client-side rendering.
  */
 export function initializeGTSRAClient(config: InitializeGTClientParams): void {
-  internalInitializeGTSRA(
+  internalInitializeGTSRAClient(
     addRuntimeCredentials({
       cacheExpiryTime: null,
       ...config,

--- a/packages/react/src/setup/runtimeCredentials.ts
+++ b/packages/react/src/setup/runtimeCredentials.ts
@@ -1,4 +1,3 @@
-import { getRuntimeEnvironment } from 'gt-i18n/internal';
 import type { I18nConfigParams } from 'gt-i18n/internal/types';
 
 type RuntimeCredentials = Pick<I18nConfigParams, 'projectId' | 'devApiKey'>;
@@ -15,7 +14,9 @@ export function addRuntimeCredentials<T extends RuntimeCredentials>(
   return {
     ...config,
     projectId: config.projectId || credentials.projectId,
-    devApiKey: config.devApiKey || credentials.devApiKey,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devApiKey: config.devApiKey || credentials.devApiKey,
+    }),
   };
 }
 
@@ -30,15 +31,15 @@ function getRuntimeCredentials(): RuntimeCredentials {
             }
           ).env?.VITE_GT_PROJECT_ID
       ) || readProcessEnvViteProjectId(),
-    devApiKey:
-      getRuntimeEnvironment() === 'development'
-        ? readImportMetaVite(() =>
-            (import.meta as ImportMeta & { env?: RuntimeEnv }).env?.DEV
-              ? (import.meta as ImportMeta & { env?: RuntimeEnv }).env
-                  ?.VITE_GT_DEV_API_KEY
-              : undefined
-          ) || readProcessEnvViteDevApiKey()
-        : undefined,
+    ...(process.env.NODE_ENV !== 'production' && {
+      devApiKey:
+        readImportMetaVite(() =>
+          (import.meta as ImportMeta & { env?: RuntimeEnv }).env?.DEV
+            ? (import.meta as ImportMeta & { env?: RuntimeEnv }).env
+                ?.VITE_GT_DEV_API_KEY
+            : undefined
+        ) || readProcessEnvViteDevApiKey(),
+    }),
   };
 }
 

--- a/packages/react/tsdown.config.mts
+++ b/packages/react/tsdown.config.mts
@@ -25,6 +25,16 @@ const contextDeps = {
   alwaysBundle: [/^@generaltranslation\/format\//, /^generaltranslation\//],
 };
 
+const productionClientDeps = {
+  neverBundle: [
+    ...deps.neverBundle,
+    /^@generaltranslation\/format(?:$|\/)/,
+    /^generaltranslation(?:$|\/)/,
+    /^gt-i18n(?:$|\/)/,
+  ],
+  alwaysBundle: [/^@generaltranslation\/react-core\//],
+};
+
 const entries = [
   'src/index.rsc.ts',
   'src/index.client.ts',
@@ -38,8 +48,28 @@ const entries = [
 // so they are deleted after each build.
 const typesOnlyEntry = 'src/index.types.ts';
 
-export default defineConfig(
-  entries.flatMap((entry, index) => {
+const productionConfigs = createTsdownConfig(
+  ['src/index.client.ts'],
+  productionClientDeps
+).map((config, index) => ({
+  ...config,
+  entry: { 'index.client.prod': 'src/index.client.ts' },
+  clean: false,
+  deps: { onlyBundle: false, ...productionClientDeps },
+  define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+  dts: false,
+  treeshake: { moduleSideEffects: false },
+  plugins: [
+    createUseClientBoundaryPlugin({
+      emittedSourceFiles: entries,
+      name: 'gt-react:use-client-boundaries',
+      outputExtension: index === 0 ? '.cjs' : '.mjs',
+    }),
+  ],
+}));
+
+export default defineConfig([
+  ...entries.flatMap((entry, index) => {
     const entryDeps = entry.startsWith('src/index.') ? contextDeps : deps;
     const [cjsConfig, esmConfig] = createTsdownConfig([entry], entryDeps);
 
@@ -85,5 +115,6 @@ export default defineConfig(
         }),
       },
     ];
-  })
-);
+  }),
+  ...productionConfigs,
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1304,6 +1304,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@generaltranslation/format':
+        specifier: workspace:*
+        version: link:../format
       '@generaltranslation/react-core':
         specifier: workspace:*
         version: link:../react-core


### PR DESCRIPTION
## TL;DR

Adds a lightweight production client runtime backed by provider snapshots while retaining the full mutable cache in development.

## Code Changes

- Introduces a shared I18nRuntime contract implemented by the full cache and lightweight production adapter.
- Keeps provider snapshots request-local and uses the runtime only for provider-free SPA lookups.
- Makes compiler-injected runtime translation preload hooks safe production no-ops.
- Adds shared adapter contract tests, package-level regressions, and coordinated release metadata.

## Notes / Flags

- This PR is standalone and based on main.
- Production ReactI18nCache compatibility APIs intentionally throw; TODOs track moving them to an internal subpath.
- Source LOC: +761 / -267, net +494, excluding tests, comments, manifests, generated files, and non-source files.
- Next production GT chunk: 156,840 B raw / 48,585 B gzip to 137,101 B raw / 43,237 B gzip, saving 19,739 B raw / 5,348 B gzip.
- TanStack production client JS: 441,491 B raw / 142,778 B gzip to 429,912 B raw / 137,889 B gzip, saving 11,579 B raw / 4,889 B gzip.
- Affected package builds, tests, typechecks, lint, formatting, Changesets status, and Next/TanStack production builds pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR introduces a lightweight, snapshot-backed production client runtime while retaining the mutable cache and hot-reload machinery in development.
- Adds a shared runtime contract and production adapter for translation and dictionary lookups.
- Routes production React provider lookups through immutable snapshots and provider-free SPA lookups through the runtime.
- Adds production-specific React client artifacts, package export conditions, contract tests, and release metadata.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR appears safe to merge, with a non-blocking packaging issue that can prevent some browser builds from receiving the optimized production artifact.

The runtime and snapshot paths preserve the reviewed lookup contracts, but the browser export fallback still selects the development client artifact when the consumer does not provide a production export condition.

**Files Needing Attention:** packages/react/package.json
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/i18n/src/i18n-cache/ClientI18nRuntime.ts | Adds the lightweight production runtime with locale-aware catalog loading, isolated snapshots, dictionary lookup, and source fallbacks. |
| packages/react-core/src/hooks/external-store.ts | Splits translation resolution between the mutable development store and immutable production provider snapshots/runtime. |
| packages/react-core/src/functions/translation/t.ts | Refactors synchronous translation into an injectable runtime-backed implementation while preserving interpolation and SSR safeguards. |
| packages/react/src/setup/initializeGTSPA.ts | Initializes the lightweight runtime in production and retains the browser cache and external store only in development. |
| packages/react/package.json | Adds environment-specific browser exports, but its unconditional fallback can route production consumers without a production condition to the development artifact. |
| packages/react/tsdown.config.mts | Builds dedicated production client artifacts with development machinery removed. |
| packages/next/src/setup/initGT.client.ts | Routes Next.js client initialization through the React package’s environment-specific initializer. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Setup[React client initialization] --> Mode{Build mode}
  Mode -->|Development| Cache[Mutable ReactI18nCache and I18nStore]
  Mode -->|Production| Runtime[Lightweight ClientI18nRuntime]
  Provider[GTProvider snapshots] --> Hooks[React hooks and T component]
  Runtime --> SPA[Provider-free SPA lookups]
  Cache --> Dev[Hot reload and mutable updates]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/react/package.json`, line 114-122 ([link](https://github.com/generaltranslation/gt/blob/ad7c200fdc69be67bc1d4c9b29543b61408e0b5f/packages/react/package.json#L114-L122)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Development artifact browser fallback**

   When a production browser resolver supplies `browser` and `import` but not the `production` export condition, this fallback selects `index.client.mjs`, retaining the development client graph and preventing the advertised production bundle-size reduction.

   **Knowledge Base Used:**
   - [React integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/react-integration.md)
   - [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: packages/react/package.json
   Line: 114-122
   
   Comment:
   **Development artifact browser fallback**
   
   When a production browser resolver supplies `browser` and `import` but not the `production` export condition, this fallback selects `index.client.mjs`, retaining the development client graph and preventing the advertised production bundle-size reduction.
   
   **Knowledge Base Used:**
   - [React integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/react-integration.md)
   - [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fpackage.json%0ALine%3A%20114-122%0A%0AComment%3A%0A**Development%20artifact%20browser%20fallback**%0A%0AWhen%20a%20production%20browser%20resolver%20supplies%20%60browser%60%20and%20%60import%60%20but%20not%20the%20%60production%60%20export%20condition%2C%20this%20fallback%20selects%20%60index.client.mjs%60%2C%20retaining%20the%20development%20client%20graph%20and%20preventing%20the%20advertised%20production%20bundle-size%20reduction.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BReact%20integration%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Freact-integration.md%29%0A-%20%5BNext.js%20integration%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fnextjs-integration.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fproduction-snapshot-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fproduction-snapshot-runtime%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Freact%2Fpackage.json%0ALine%3A%20114-122%0A%0AComment%3A%0A**Development%20artifact%20browser%20fallback**%0A%0AWhen%20a%20production%20browser%20resolver%20supplies%20%60browser%60%20and%20%60import%60%20but%20not%20the%20%60production%60%20export%20condition%2C%20this%20fallback%20selects%20%60index.client.mjs%60%2C%20retaining%20the%20development%20client%20graph%20and%20preventing%20the%20advertised%20production%20bundle-size%20reduction.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BReact%20integration%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Freact-integration.md%29%0A-%20%5BNext.js%20integration%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fnextjs-integration.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232213%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2213&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Freact%2Fpackage.json%3A114-122%0A**Development%20artifact%20browser%20fallback**%0A%0AWhen%20a%20production%20browser%20resolver%20supplies%20%60browser%60%20and%20%60import%60%20but%20not%20the%20%60production%60%20export%20condition%2C%20this%20fallback%20selects%20%60index.client.mjs%60%2C%20retaining%20the%20development%20client%20graph%20and%20preventing%20the%20advertised%20production%20bundle-size%20reduction.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22bg%2Fproduction-snapshot-runtime%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22bg%2Fproduction-snapshot-runtime%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Freact%2Fpackage.json%3A114-122%0A**Development%20artifact%20browser%20fallback**%0A%0AWhen%20a%20production%20browser%20resolver%20supplies%20%60browser%60%20and%20%60import%60%20but%20not%20the%20%60production%60%20export%20condition%2C%20this%20fallback%20selects%20%60index.client.mjs%60%2C%20retaining%20the%20development%20client%20graph%20and%20preventing%20the%20advertised%20production%20bundle-size%20reduction.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2213&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/react/package.json:114-122
**Development artifact browser fallback**

When a production browser resolver supplies `browser` and `import` but not the `production` export condition, this fallback selects `index.client.mjs`, retaining the development client graph and preventing the advertised production bundle-size reduction.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: add production client runtime"](https://github.com/generaltranslation/gt/commit/ad7c200fdc69be67bc1d4c9b29543b61408e0b5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58119261)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Localization runtime and shared domain](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/localization-runtime.md)
- Knowledge Base — [Translation runtime](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-runtime.md)
- Knowledge Base — [Application framework integrations](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/application-framework-integrations.md)
- Knowledge Base — [React integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/react-integration.md)
- Knowledge Base — [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)
</details>


<!-- /greptile_comment -->