### PR TITLE
refactor: add lightweight browser config

### DIFF
--- a/.changeset/lightweight-browser-config.md
+++ b/.changeset/lightweight-browser-config.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/format': patch
+'gt-i18n': patch
+'@generaltranslation/react-core': patch
+---
+
+Reduce production React bundles by separating locale resolution from runtime-only configuration and using a lightweight browser artifact.

--- a/packages/format/src/LocaleConfig.ts
+++ b/packages/format/src/LocaleConfig.ts
@@ -9,50 +9,22 @@ import {
   _selectRelativeTimeUnit,
 } from './formatting/format';
 import { intlCache } from './cache/IntlCache';
-import {
-  _prepareApprovedLocales,
-  type ApprovedLocales,
-} from './locales/approvedLocales';
-import { _requiresTranslationWithScope } from './locales/requiresTranslation';
-import { _determineLocaleWithIndex } from './locales/determineLocale';
-import { _isSameLanguage } from './locales/isSameLanguage';
-import { _getLocaleProperties } from './locales/getLocaleProperties';
-import { _getLocaleEmoji } from './locales/getLocaleEmoji';
-import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
-import { _getLocaleName } from './locales/getLocaleName';
-import { _getLocaleDirection } from './locales/getLocaleDirection';
 import { libraryDefaultLocale } from './settings/settings';
-import { _isSameDialect } from './locales/isSameDialect';
-import { _isSupersetLocale } from './locales/isSupersetLocale';
-import type { CustomMapping, FormatVariables } from './types';
-import { _resolveAliasLocale } from './locales/resolveAliasLocale';
-import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
-import { getCustomLocaleCode } from './locales/customLocaleMapping';
+import type { FormatVariables } from './types';
 import type { CutoffFormatOptions } from './formatting/custom-formats/CutoffFormat/types';
 import type { StringFormat } from './types-dir/jsx/content';
+import {
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from './LocaleResolver';
 
-export type LocaleConfigConstructorParams = {
-  defaultLocale?: string;
-  locales?: string[];
-  customMapping?: CustomMapping;
-};
+export type LocaleConfigConstructorParams = LocaleResolverConstructorParams;
 
 type LocalesOption = {
   locales?: string | string[];
 };
 
 type WithLocales<T = object> = T & LocalesOption;
-
-/**
- * Approved-locales work that requiresTranslation and determineLocale would
- * otherwise redo on every call: canonical codes plus the validated and
- * indexed scope built from them.
- */
-type LocaleResolutionScope = {
-  approvedLocalePairs: { locale: string; canonicalLocale: string }[];
-  canonicalMappingCodes: (string | undefined)[];
-  approved: ApprovedLocales;
-};
 
 /**
  * LocaleConfig contains the locale and formatting primitives exposed through
@@ -62,77 +34,7 @@ type LocaleResolutionScope = {
  * translation credentials. It only stores locale metadata needed to resolve
  * aliases, choose formatting fallbacks, and format values with Intl.
  */
-export class LocaleConfig {
-  readonly defaultLocale: string;
-  readonly locales: string[];
-  readonly customMapping?: CustomMapping;
-  // Built lazily so construction stays cheap for instances that never resolve
-  // locales. The snapshot is refreshed if callers mutate the public locale or
-  // custom-mapping collections retained by this instance.
-  private resolutionScope?: LocaleResolutionScope;
-
-  private getResolutionScope(): LocaleResolutionScope {
-    if (
-      this.resolutionScope &&
-      this.isResolutionScopeCurrent(this.resolutionScope)
-    ) {
-      return this.resolutionScope;
-    }
-    const resolutionScope = this.buildResolutionScope(this.locales);
-    Object.defineProperty(this, 'resolutionScope', {
-      configurable: true,
-      value: resolutionScope,
-      writable: true,
-    });
-    return resolutionScope;
-  }
-
-  private isResolutionScopeCurrent(scope: LocaleResolutionScope): boolean {
-    if (scope.approvedLocalePairs.length !== this.locales.length) return false;
-    for (let index = 0; index < this.locales.length; index++) {
-      const locale = this.locales[index];
-      const pair = scope.approvedLocalePairs[index];
-      if (
-        pair.locale !== locale ||
-        pair.canonicalLocale !== this.resolveCanonicalLocale(locale) ||
-        scope.canonicalMappingCodes[index] !==
-          getCustomLocaleCode(this.customMapping, pair.canonicalLocale)
-      ) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  private buildResolutionScope(
-    approvedLocales: string[]
-  ): LocaleResolutionScope {
-    const approvedLocalePairs = approvedLocales.map((locale) => ({
-      locale,
-      canonicalLocale: this.resolveCanonicalLocale(locale),
-    }));
-    return {
-      approvedLocalePairs,
-      canonicalMappingCodes: approvedLocalePairs.map(({ canonicalLocale }) =>
-        getCustomLocaleCode(this.customMapping, canonicalLocale)
-      ),
-      approved: _prepareApprovedLocales(
-        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
-        this.customMapping
-      ),
-    };
-  }
-
-  constructor({
-    defaultLocale = libraryDefaultLocale,
-    locales = [],
-    customMapping,
-  }: LocaleConfigConstructorParams = {}) {
-    this.defaultLocale = defaultLocale;
-    this.locales = locales;
-    this.customMapping = customMapping;
-  }
-
+export class LocaleConfig extends LocaleResolver {
   private getFormattingLocales(
     targetLocale?: string,
     locales?: string | string[]
@@ -280,118 +182,5 @@ export class LocaleConfig {
       locales: this.getFormattingLocales(targetLocale, locales),
       options: intlOptions,
     });
-  }
-
-  getLocaleName(locale: string) {
-    return _getLocaleName(locale, this.defaultLocale, this.customMapping);
-  }
-
-  getLocaleEmoji(locale: string) {
-    return _getLocaleEmoji(locale, this.customMapping);
-  }
-
-  getLocaleProperties(locale: string) {
-    return _getLocaleProperties(locale, this.defaultLocale, this.customMapping);
-  }
-
-  requiresTranslation(
-    targetLocale: string,
-    sourceLocale: string = this.defaultLocale,
-    approvedLocales: string[] | undefined = this.locales.length
-      ? this.locales
-      : undefined
-  ) {
-    // The default scope (this.locales) is prepared once per instance; a
-    // caller-provided list is prepared for that call only. No configured
-    // locales means no approved-locales restriction.
-    const approvedScope = approvedLocales
-      ? approvedLocales === this.locales
-        ? this.getResolutionScope().approved
-        : _prepareApprovedLocales(
-            approvedLocales.map((locale) =>
-              this.resolveCanonicalLocale(locale)
-            ),
-            this.customMapping
-          )
-      : undefined;
-    return _requiresTranslationWithScope(
-      this.resolveCanonicalLocale(sourceLocale),
-      this.resolveCanonicalLocale(targetLocale),
-      approvedScope,
-      this.customMapping
-    );
-  }
-
-  /**
-   * NOTE: consider moving LocaleCandidates type to this package, and
-   * determineLocale could accept that as a parameter.
-   */
-  determineLocale(
-    locales: string | string[],
-    approvedLocales: string[] = this.locales
-  ) {
-    const { approvedLocalePairs, approved } =
-      approvedLocales === this.locales
-        ? this.getResolutionScope()
-        : this.buildResolutionScope(approvedLocales);
-    const resolvedLocale = _determineLocaleWithIndex(
-      Array.isArray(locales)
-        ? locales.map((locale) => this.resolveCanonicalLocale(locale))
-        : this.resolveCanonicalLocale(locales),
-      approved,
-      this.customMapping
-    );
-    if (!resolvedLocale) return undefined;
-    const approvedLocale = approvedLocalePairs.find(
-      ({ canonicalLocale }) => canonicalLocale === resolvedLocale
-    );
-    return approvedLocale?.locale ?? this.resolveAliasLocale(resolvedLocale);
-  }
-
-  getLocaleDirection(locale: string) {
-    return _getLocaleDirection(this.resolveCanonicalLocale(locale));
-  }
-
-  isValidLocale(locale: string) {
-    return _isValidLocale(locale, this.customMapping);
-  }
-
-  resolveCanonicalLocale(locale: string) {
-    return _resolveCanonicalLocale(locale, this.customMapping);
-  }
-
-  resolveAliasLocale(locale: string) {
-    return _resolveAliasLocale(locale, this.customMapping);
-  }
-
-  standardizeLocale(locale: string) {
-    return _standardizeLocale(locale);
-  }
-
-  isSameDialect(...locales: (string | string[])[]) {
-    return _isSameDialect(
-      ...locales.map((locale) =>
-        Array.isArray(locale)
-          ? locale.map((code) => this.resolveCanonicalLocale(code))
-          : this.resolveCanonicalLocale(locale)
-      )
-    );
-  }
-
-  isSameLanguage(...locales: (string | string[])[]) {
-    return _isSameLanguage(
-      ...locales.map((locale) =>
-        Array.isArray(locale)
-          ? locale.map((code) => this.resolveCanonicalLocale(code))
-          : this.resolveCanonicalLocale(locale)
-      )
-    );
-  }
-
-  isSupersetLocale(superLocale: string, subLocale: string) {
-    return _isSupersetLocale(
-      this.resolveCanonicalLocale(superLocale),
-      this.resolveCanonicalLocale(subLocale)
-    );
   }
 }

--- a/packages/format/src/LocaleResolver.ts
+++ b/packages/format/src/LocaleResolver.ts
@@ -1,0 +1,217 @@
+import {
+  _prepareApprovedLocales,
+  type ApprovedLocales,
+} from './locales/approvedLocales';
+import { _requiresTranslationWithScope } from './locales/requiresTranslation';
+import { _determineLocaleWithIndex } from './locales/determineLocale';
+import { _isSameLanguage } from './locales/isSameLanguage';
+import { _getLocaleProperties } from './locales/getLocaleProperties';
+import { _getLocaleEmoji } from './locales/getLocaleEmoji';
+import { _isValidLocale, _standardizeLocale } from './locales/isValidLocale';
+import { _getLocaleName } from './locales/getLocaleName';
+import { _getLocaleDirection } from './locales/getLocaleDirection';
+import { libraryDefaultLocale } from './settings/settings';
+import { _isSameDialect } from './locales/isSameDialect';
+import { _isSupersetLocale } from './locales/isSupersetLocale';
+import type { CustomMapping } from './types';
+import { _resolveAliasLocale } from './locales/resolveAliasLocale';
+import { _resolveCanonicalLocale } from './locales/resolveCanonicalLocale';
+import { getCustomLocaleCode } from './locales/customLocaleMapping';
+
+export type LocaleResolverConstructorParams = {
+  defaultLocale?: string;
+  locales?: string[];
+  customMapping?: CustomMapping;
+};
+
+type LocaleResolutionScope = {
+  approvedLocalePairs: { locale: string; canonicalLocale: string }[];
+  canonicalMappingCodes: (string | undefined)[];
+  approved: ApprovedLocales;
+};
+
+/** Locale metadata and resolution without value or message formatting. */
+export class LocaleResolver {
+  readonly defaultLocale: string;
+  readonly locales: string[];
+  readonly customMapping?: CustomMapping;
+  // Built lazily so construction stays cheap for instances that never resolve
+  // locales. The snapshot is refreshed if callers mutate the public locale or
+  // custom-mapping collections retained by this instance.
+  private resolutionScope?: LocaleResolutionScope;
+
+  private getResolutionScope(): LocaleResolutionScope {
+    if (
+      this.resolutionScope &&
+      this.isResolutionScopeCurrent(this.resolutionScope)
+    ) {
+      return this.resolutionScope;
+    }
+    const resolutionScope = this.buildResolutionScope(this.locales);
+    Object.defineProperty(this, 'resolutionScope', {
+      configurable: true,
+      value: resolutionScope,
+      writable: true,
+    });
+    return resolutionScope;
+  }
+
+  private isResolutionScopeCurrent(scope: LocaleResolutionScope): boolean {
+    if (scope.approvedLocalePairs.length !== this.locales.length) return false;
+    for (let index = 0; index < this.locales.length; index++) {
+      const locale = this.locales[index];
+      const pair = scope.approvedLocalePairs[index];
+      if (
+        pair.locale !== locale ||
+        pair.canonicalLocale !== this.resolveCanonicalLocale(locale) ||
+        scope.canonicalMappingCodes[index] !==
+          getCustomLocaleCode(this.customMapping, pair.canonicalLocale)
+      ) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private buildResolutionScope(
+    approvedLocales: string[]
+  ): LocaleResolutionScope {
+    const approvedLocalePairs = approvedLocales.map((locale) => ({
+      locale,
+      canonicalLocale: this.resolveCanonicalLocale(locale),
+    }));
+    return {
+      approvedLocalePairs,
+      canonicalMappingCodes: approvedLocalePairs.map(({ canonicalLocale }) =>
+        getCustomLocaleCode(this.customMapping, canonicalLocale)
+      ),
+      approved: _prepareApprovedLocales(
+        approvedLocalePairs.map(({ canonicalLocale }) => canonicalLocale),
+        this.customMapping
+      ),
+    };
+  }
+
+  constructor({
+    defaultLocale = libraryDefaultLocale,
+    locales = [],
+    customMapping,
+  }: LocaleResolverConstructorParams = {}) {
+    this.defaultLocale = defaultLocale;
+    this.locales = locales;
+    this.customMapping = customMapping;
+  }
+
+  getLocaleName(locale: string) {
+    return _getLocaleName(locale, this.defaultLocale, this.customMapping);
+  }
+
+  getLocaleEmoji(locale: string) {
+    return _getLocaleEmoji(locale, this.customMapping);
+  }
+
+  getLocaleProperties(locale: string) {
+    return _getLocaleProperties(locale, this.defaultLocale, this.customMapping);
+  }
+
+  requiresTranslation(
+    targetLocale: string,
+    sourceLocale: string = this.defaultLocale,
+    approvedLocales: string[] | undefined = this.locales.length
+      ? this.locales
+      : undefined
+  ) {
+    // The default scope (this.locales) is prepared once per instance; a
+    // caller-provided list is prepared for that call only. No configured
+    // locales means no approved-locales restriction.
+    const approvedScope = approvedLocales
+      ? approvedLocales === this.locales
+        ? this.getResolutionScope().approved
+        : _prepareApprovedLocales(
+            approvedLocales.map((locale) =>
+              this.resolveCanonicalLocale(locale)
+            ),
+            this.customMapping
+          )
+      : undefined;
+    return _requiresTranslationWithScope(
+      this.resolveCanonicalLocale(sourceLocale),
+      this.resolveCanonicalLocale(targetLocale),
+      approvedScope,
+      this.customMapping
+    );
+  }
+
+  /**
+   * NOTE: consider moving LocaleCandidates type to this package, and
+   * determineLocale could accept that as a parameter.
+   */
+  determineLocale(
+    locales: string | string[],
+    approvedLocales: string[] = this.locales
+  ) {
+    const { approvedLocalePairs, approved } =
+      approvedLocales === this.locales
+        ? this.getResolutionScope()
+        : this.buildResolutionScope(approvedLocales);
+    const resolvedLocale = _determineLocaleWithIndex(
+      Array.isArray(locales)
+        ? locales.map((locale) => this.resolveCanonicalLocale(locale))
+        : this.resolveCanonicalLocale(locales),
+      approved,
+      this.customMapping
+    );
+    if (!resolvedLocale) return undefined;
+    const approvedLocale = approvedLocalePairs.find(
+      ({ canonicalLocale }) => canonicalLocale === resolvedLocale
+    );
+    return approvedLocale?.locale ?? this.resolveAliasLocale(resolvedLocale);
+  }
+
+  getLocaleDirection(locale: string) {
+    return _getLocaleDirection(this.resolveCanonicalLocale(locale));
+  }
+
+  isValidLocale(locale: string) {
+    return _isValidLocale(locale, this.customMapping);
+  }
+
+  resolveCanonicalLocale(locale: string) {
+    return _resolveCanonicalLocale(locale, this.customMapping);
+  }
+
+  resolveAliasLocale(locale: string) {
+    return _resolveAliasLocale(locale, this.customMapping);
+  }
+
+  standardizeLocale(locale: string) {
+    return _standardizeLocale(locale);
+  }
+
+  isSameDialect(...locales: (string | string[])[]) {
+    return _isSameDialect(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
+  }
+
+  isSameLanguage(...locales: (string | string[])[]) {
+    return _isSameLanguage(
+      ...locales.map((locale) =>
+        Array.isArray(locale)
+          ? locale.map((code) => this.resolveCanonicalLocale(code))
+          : this.resolveCanonicalLocale(locale)
+      )
+    );
+  }
+
+  isSupersetLocale(superLocale: string, subLocale: string) {
+    return _isSupersetLocale(
+      this.resolveCanonicalLocale(superLocale),
+      this.resolveCanonicalLocale(subLocale)
+    );
+  }
+}

--- a/packages/format/src/internal.ts
+++ b/packages/format/src/internal.ts
@@ -1,5 +1,10 @@
 import { intlCache } from './cache/IntlCache';
 
+export {
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from './LocaleResolver';
+
 export function getCachedPluralRules(
   locales?: Intl.LocalesArgument
 ): Intl.PluralRules {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -77,6 +77,72 @@
       }
     },
     "./internal": {
+      "react-server": {
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/internal.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/internal.mjs"
+        },
+        "default": "./dist/internal.mjs"
+      },
+      "workerd": {
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/internal.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/internal.mjs"
+        },
+        "default": "./dist/internal.mjs"
+      },
+      "worker": {
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/internal.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/internal.mjs"
+        },
+        "default": "./dist/internal.mjs"
+      },
+      "browser": {
+        "development": {
+          "require": {
+            "types": "./dist/internal.d.cts",
+            "default": "./dist/internal.cjs"
+          },
+          "import": {
+            "types": "./dist/internal.d.mts",
+            "default": "./dist/internal.mjs"
+          },
+          "default": "./dist/internal.mjs"
+        },
+        "production": {
+          "require": {
+            "types": "./dist/internal.d.cts",
+            "default": "./dist/internal-static.cjs"
+          },
+          "import": {
+            "types": "./dist/internal.d.mts",
+            "default": "./dist/internal-static.mjs"
+          },
+          "default": "./dist/internal-static.mjs"
+        },
+        "require": {
+          "types": "./dist/internal.d.cts",
+          "default": "./dist/internal.cjs"
+        },
+        "import": {
+          "types": "./dist/internal.d.mts",
+          "default": "./dist/internal.mjs"
+        },
+        "default": "./dist/internal.mjs"
+      },
       "require": {
         "types": "./dist/internal.d.cts",
         "default": "./dist/internal.cjs"

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -8,7 +8,10 @@ import type {
   CustomRegionMapping,
 } from '@generaltranslation/format/types';
 import type { GTRuntime } from 'generaltranslation/runtime';
-import { libraryDefaultLocale } from 'generaltranslation/internal';
+import {
+  createDiagnosticMessage,
+  libraryDefaultLocale,
+} from 'generaltranslation/internal';
 import type { GTConfig } from '../config/types';
 import {
   getLoadTranslationsType,
@@ -35,6 +38,14 @@ export type I18nConfigParams = Pick<
 >;
 
 export type LocaleCandidates = string | string[] | undefined;
+
+const gtRuntimeUnavailableError = createDiagnosticMessage({
+  source: 'gt-i18n',
+  severity: 'Error',
+  whatHappened: 'GTRuntime is not available in production browser builds',
+  why: 'production browser builds use the lightweight locale configuration',
+  fix: 'Import formatting helpers from @generaltranslation/format, or run GTRuntime on the server.',
+});
 
 /** Locale and catalog configuration shared by browser and full runtimes. */
 export class I18nConfig extends LocaleResolver {
@@ -86,9 +97,7 @@ export class I18nConfig extends LocaleResolver {
   }
 
   getGTClass(_locale?: string): GTRuntime {
-    throw new Error(
-      'GTRuntime is not available in production browser builds. Import formatting helpers from @generaltranslation/format.'
-    );
+    throw new Error(gtRuntimeUnavailableError);
   }
 
   determineLocale(

--- a/packages/i18n/src/i18n-config/I18nConfig.ts
+++ b/packages/i18n/src/i18n-config/I18nConfig.ts
@@ -1,9 +1,13 @@
 import {
-  LocaleConfig,
-  type LocaleConfigConstructorParams,
-} from '@generaltranslation/format';
-import type { CustomMapping } from '@generaltranslation/format/types';
-import { GTRuntime } from 'generaltranslation/runtime';
+  LocaleResolver,
+  type LocaleResolverConstructorParams,
+} from '@generaltranslation/format/internal';
+import { getRegionProperties as getRegionPropertiesForLocale } from '@generaltranslation/format';
+import type {
+  CustomMapping,
+  CustomRegionMapping,
+} from '@generaltranslation/format/types';
+import type { GTRuntime } from 'generaltranslation/runtime';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
 import type { GTConfig } from '../config/types';
 import {
@@ -14,12 +18,6 @@ import {
   getTranslationApiType,
   TranslationApiType,
 } from '../i18n-cache/utils/getTranslationApiType';
-import {
-  getGeneralTranslationLogLevel,
-  isDebugLogLevel,
-  type GeneralTranslationLogLevel,
-} from '../logs/logLevel';
-import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
 import { validateI18nConfigParams } from './validation';
 
 export type I18nConfigParams = Pick<
@@ -36,36 +34,18 @@ export type I18nConfigParams = Pick<
   | '_tagIds'
 >;
 
-type RuntimeConfig = Pick<
-  I18nConfigParams,
-  | 'projectId'
-  | 'devApiKey'
-  | 'apiKey'
-  | 'runtimeUrl'
-  | '_disableDevHotReload'
-  | '_tagIds'
->;
-
 export type LocaleCandidates = string | string[] | undefined;
 
-export class I18nConfig extends LocaleConfig {
-  protected runtimeConfig: RuntimeConfig;
-  private gtServicesEnabled: boolean;
-  private logLevel: GeneralTranslationLogLevel;
+/** Locale and catalog configuration shared by browser and full runtimes. */
+export class I18nConfig extends LocaleResolver {
+  private projectId: string | undefined;
 
-  constructor(params: I18nConfigParams = {}) {
-    const gtServicesEnabled = resolveGTServicesEnabled(params);
+  constructor(
+    params: I18nConfigParams = {},
+    private gtServicesEnabled = resolveGTServicesEnabled(params)
+  ) {
     super(getLocaleConfigParams(params, gtServicesEnabled));
-    this.runtimeConfig = {
-      projectId: params.projectId,
-      devApiKey: params.devApiKey,
-      apiKey: params.apiKey,
-      runtimeUrl: params.runtimeUrl,
-      _disableDevHotReload: params._disableDevHotReload,
-      _tagIds: params._tagIds,
-    };
-    this.gtServicesEnabled = gtServicesEnabled;
-    this.logLevel = getGeneralTranslationLogLevel();
+    this.projectId = params.projectId;
   }
 
   getDefaultLocale(): string {
@@ -81,18 +61,33 @@ export class I18nConfig extends LocaleConfig {
   }
 
   getProjectId(): string | undefined {
-    return this.runtimeConfig.projectId;
+    return this.projectId;
   }
 
-  /**
-   * Get a GT instance bound to the resolved target locale. When omitted, the
-   * instance is locale agnostic.
-   *
-   * TODO: keep a cache to avoid creating new instances unnecessarily.
-   */
-  getGTClass(locale?: string): GTRuntime {
-    return this.getGTClassClean(
-      locale ? this.resolveLocale(locale) : undefined
+  getRegionProperties(region: string, locale: string = this.defaultLocale) {
+    const customRegionMapping: CustomRegionMapping = {};
+    for (const [mappedLocale, value] of Object.entries(
+      this.customMapping ?? {}
+    )) {
+      if (
+        value &&
+        typeof value === 'object' &&
+        value.regionCode &&
+        !customRegionMapping[value.regionCode]
+      ) {
+        customRegionMapping[value.regionCode] = {
+          locale: mappedLocale,
+          ...(value.regionName && { name: value.regionName }),
+          ...(value.emoji && { emoji: value.emoji }),
+        };
+      }
+    }
+    return getRegionPropertiesForLocale(region, locale, customRegionMapping);
+  }
+
+  getGTClass(_locale?: string): GTRuntime {
+    throw new Error(
+      'GTRuntime is not available in production browser builds. Import formatting helpers from @generaltranslation/format.'
     );
   }
 
@@ -145,18 +140,8 @@ export class I18nConfig extends LocaleConfig {
     return this.requiresTranslation(aliasLocale) ? aliasLocale : undefined;
   }
 
-  /**
-   * Returns true when development hot reload runtime translation requests can run.
-   */
   isDevHotReloadEnabled(): boolean {
-    return (
-      !this.runtimeConfig._disableDevHotReload &&
-      !!this.runtimeConfig.devApiKey &&
-      !!this.runtimeConfig.projectId &&
-      this.runtimeConfig.runtimeUrl !== null &&
-      this.runtimeConfig.runtimeUrl !== '' &&
-      getRuntimeEnvironment() === 'development'
-    );
+    return false;
   }
 
   isGTServicesEnabled(): boolean {
@@ -164,41 +149,19 @@ export class I18nConfig extends LocaleConfig {
   }
 
   isDebugLoggingEnabled(): boolean {
-    return isDebugLogLevel(this.logLevel);
+    return false;
   }
 
-  /**
-   * Create a GT instance without resolving the target locale first.
-   */
-  private getGTClassClean(locale?: string) {
-    return new GTRuntime({
-      sourceLocale: this.getDefaultLocale(),
-      targetLocale: locale,
-      // GT validates approved locales before constructing its LocaleConfig, so
-      // pass canonical locales here while preserving alias target locales.
-      locales: Array.from(
-        new Set(
-          this.getLocales().map((locale) => this.resolveCanonicalLocale(locale))
-        )
-      ),
-      customMapping: this.getCustomMapping(),
-      projectId: this.runtimeConfig.projectId,
-      baseUrl: this.runtimeConfig.runtimeUrl || undefined,
-      apiKey: this.runtimeConfig.apiKey,
-      devApiKey: this.runtimeConfig.devApiKey,
-    });
-  }
-
-  private getLocaleConfig(config?: I18nConfigParams): LocaleConfig {
+  private getLocaleConfig(config?: I18nConfigParams): LocaleResolver {
     if (!config || !hasI18nConfigParams(config)) {
       return this;
     }
-    return new LocaleConfig(getLocaleResolverConfigParams(config));
+    return new LocaleResolver(getLocaleResolverConfigParams(config));
   }
 
   private determineSupportedLocaleWithConfig(
     candidates: LocaleCandidates,
-    localeConfig: LocaleConfig
+    localeConfig: LocaleResolver
   ): string | undefined {
     if (
       candidates == null ||
@@ -213,7 +176,7 @@ export class I18nConfig extends LocaleConfig {
 function getLocaleConfigParams(
   params: I18nConfigParams,
   gtServicesEnabled: boolean
-): LocaleConfigConstructorParams {
+): LocaleResolverConstructorParams {
   const {
     defaultLocale = libraryDefaultLocale,
     locales = [],
@@ -241,7 +204,7 @@ function getLocaleResolverConfigParams({
   defaultLocale = libraryDefaultLocale,
   locales = [],
   customMapping,
-}: I18nConfigParams = {}): LocaleConfigConstructorParams {
+}: I18nConfigParams = {}): Required<LocaleResolverConstructorParams> {
   return {
     defaultLocale,
     locales: locales?.length ? locales : [defaultLocale],

--- a/packages/i18n/src/i18n-config/RuntimeI18nConfig.ts
+++ b/packages/i18n/src/i18n-config/RuntimeI18nConfig.ts
@@ -1,0 +1,59 @@
+import { GTRuntime } from 'generaltranslation/runtime';
+import {
+  getGeneralTranslationLogLevel,
+  isDebugLogLevel,
+} from '../logs/logLevel';
+import { getRuntimeEnvironment } from '../utils/getRuntimeEnvironment';
+import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+
+type RuntimeConfig = Pick<
+  I18nConfigParams,
+  'apiKey' | 'devApiKey' | 'runtimeUrl' | '_disableDevHotReload'
+>;
+
+export class RuntimeI18nConfig extends I18nConfig {
+  private logLevel = getGeneralTranslationLogLevel();
+  private runtimeConfig: RuntimeConfig;
+
+  constructor(params: I18nConfigParams = {}) {
+    super(params);
+    this.runtimeConfig = {
+      apiKey: params.apiKey,
+      devApiKey: params.devApiKey,
+      runtimeUrl: params.runtimeUrl,
+      _disableDevHotReload: params._disableDevHotReload,
+    };
+  }
+
+  getGTClass(locale?: string): GTRuntime {
+    return new GTRuntime({
+      sourceLocale: this.getDefaultLocale(),
+      targetLocale: locale ? this.resolveLocale(locale) : undefined,
+      locales: Array.from(
+        new Set(
+          this.getLocales().map((locale) => this.resolveCanonicalLocale(locale))
+        )
+      ),
+      customMapping: this.getCustomMapping(),
+      projectId: this.getProjectId(),
+      baseUrl: this.runtimeConfig.runtimeUrl || undefined,
+      apiKey: this.runtimeConfig.apiKey,
+      devApiKey: this.runtimeConfig.devApiKey,
+    });
+  }
+
+  isDevHotReloadEnabled(): boolean {
+    return (
+      !this.runtimeConfig._disableDevHotReload &&
+      !!this.runtimeConfig.devApiKey &&
+      !!this.getProjectId() &&
+      this.runtimeConfig.runtimeUrl !== null &&
+      this.runtimeConfig.runtimeUrl !== '' &&
+      getRuntimeEnvironment() === 'development'
+    );
+  }
+
+  isDebugLoggingEnabled(): boolean {
+    return isDebugLogLevel(this.logLevel);
+  }
+}

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { libraryDefaultLocale } from 'generaltranslation/internal';
-import { I18nConfig } from '../I18nConfig';
+import {
+  I18nConfig as BrowserI18nConfig,
+  type I18nConfigParams,
+} from '../I18nConfig';
+import { RuntimeI18nConfig as I18nConfig } from '../RuntimeI18nConfig';
 
 describe('I18nConfig', () => {
   beforeEach(() => {
@@ -22,6 +26,29 @@ describe('I18nConfig', () => {
     const config = new I18nConfig({ defaultLocale: 'fr' });
 
     expect(config.getLocales()).toEqual(['fr']);
+  });
+
+  it('derives localized region overrides from the locale mapping', () => {
+    const customMapping = {
+      customEnglish: {
+        code: 'en-US',
+        regionCode: 'US',
+        regionName: 'Custom United States',
+        emoji: '🗽',
+      },
+    };
+    const config = new I18nConfig({ customMapping });
+
+    expect(config.getRegionProperties('US', 'en')).toMatchObject({
+      name: 'Custom United States',
+      emoji: '🗽',
+      locale: 'customEnglish',
+    });
+
+    customMapping.customEnglish.regionName = 'Updated United States';
+    expect(config.getRegionProperties('US', 'en').name).toBe(
+      'Updated United States'
+    );
   });
 
   it('skips locale validation when GT services are disabled', () => {
@@ -49,6 +76,20 @@ describe('I18nConfig', () => {
     );
 
     errorSpy.mockRestore();
+  });
+
+  it('validates runtime-only GT configuration in browser builds', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(
+      () =>
+        new BrowserI18nConfig({
+          defaultLocale: 'invalid-locale',
+          projectId: 'test-project',
+          apiKey: 'test-api-key',
+          cacheUrl: null,
+        })
+    ).toThrow('Invalid I18nConfig locale configuration');
   });
 
   it('validates custom mapping locales when GT services are enabled', () => {
@@ -116,6 +157,21 @@ describe('I18nConfig', () => {
     });
 
     expect(config.isDevHotReloadEnabled()).toBe(true);
+  });
+
+  it('copies runtime configuration at initialization', () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    const params: I18nConfigParams = {
+      devApiKey: 'dev-key',
+      projectId: 'project-id',
+    };
+    const config = new I18nConfig(params);
+
+    params.devApiKey = undefined;
+    params.projectId = undefined;
+
+    expect(config.isDevHotReloadEnabled()).toBe(true);
+    expect(config.getProjectId()).toBe('project-id');
   });
 
   it('disables dev hot reload when the config switch is set', () => {

--- a/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
+++ b/packages/i18n/src/i18n-config/__tests__/I18nConfig.test.ts
@@ -92,6 +92,14 @@ describe('I18nConfig', () => {
     ).toThrow('Invalid I18nConfig locale configuration');
   });
 
+  it('reports unavailable browser runtime APIs with a diagnostic', () => {
+    const config = new BrowserI18nConfig();
+
+    expect(() => config.getGTClass()).toThrow(
+      'gt-i18n Error: GTRuntime is not available in production browser builds'
+    );
+  });
+
   it('validates custom mapping locales when GT services are enabled', () => {
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 

--- a/packages/i18n/src/i18n-config/singleton-operations.ts
+++ b/packages/i18n/src/i18n-config/singleton-operations.ts
@@ -1,6 +1,7 @@
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { createGlobalSingleton } from '../globals/createGlobalSingleton';
 import { I18nConfig, type I18nConfigParams } from './I18nConfig';
+import { RuntimeI18nConfig } from './RuntimeI18nConfig';
 
 const i18nConfigSingleton = createGlobalSingleton<I18nConfig>({
   namespace: 'i18n',
@@ -23,7 +24,7 @@ export const isI18nConfigInitialized = i18nConfigSingleton.isInitialized;
 export function initializeI18nConfig(
   params: I18nConfigParams = {}
 ): I18nConfig {
-  const nextI18nConfig = new I18nConfig(params);
+  const nextI18nConfig = new RuntimeI18nConfig(params);
   setI18nConfig(nextI18nConfig);
   return nextI18nConfig;
 }

--- a/packages/i18n/src/internal-static.ts
+++ b/packages/i18n/src/internal-static.ts
@@ -1,0 +1,62 @@
+export {
+  getGT,
+  getGTInternal,
+  getMessages,
+  getMessagesInternal,
+  getTranslations,
+  getTranslationsInternal,
+  createLookupOptions,
+  createClientI18nRuntime,
+  renderDictionaryEntry,
+  renderDictionaryObject,
+  ReadonlyConditionStore,
+  WritableConditionStore,
+  getI18nCache,
+  getI18nRuntime,
+  isI18nCacheInitialized,
+  setI18nCache,
+  setI18nRuntime,
+  validateDictionaryConfig,
+  getVersionId,
+  interpolateMessage,
+  isEncodedTranslationOptions,
+  extractVariables,
+  getDictionaryListenerKey,
+  getTranslateListenerKey,
+  getDictionaryEntry,
+  isDictionaryValue,
+  getDictionaryValue,
+  mergeDictionary,
+  resolveDictionaryLookupOptions,
+  createConditionStoreSingleton,
+  createGlobalSingleton,
+  getRuntimeEnvironment,
+  hashMessage,
+  getCookieValue,
+  parseAcceptLanguage,
+  createTranslationLoader,
+  DEFAULT_CACHE_EXPIRY_TIME,
+  dedupePending,
+} from './internal';
+function ProductionI18nCache(): never {
+  throw new Error('I18nCache is not available in production browser builds.');
+}
+
+export { ProductionI18nCache as I18nCache };
+export { getI18nConfig, I18nConfig, setI18nConfig };
+
+export const GtInternalRuntimeTranslateJsx = () => {};
+export const GtInternalRuntimeTranslateString = () => {};
+
+export function initializeI18nConfig(
+  params: I18nConfigParams = {}
+): I18nConfig {
+  const config = new I18nConfig(params);
+  setI18nConfig(config);
+  return config;
+}
+import { I18nConfig, type I18nConfigParams } from './i18n-config/I18nConfig';
+import {
+  getI18nConfig,
+  setI18nConfig,
+} from './i18n-config/singleton-operations';

--- a/packages/i18n/src/internal-static.ts
+++ b/packages/i18n/src/internal-static.ts
@@ -1,3 +1,27 @@
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { I18nConfig, type I18nConfigParams } from './i18n-config/I18nConfig';
+import {
+  getI18nConfig,
+  setI18nConfig,
+} from './i18n-config/singleton-operations';
+
+const i18nCacheUnavailableError = createDiagnosticMessage({
+  source: 'gt-i18n',
+  severity: 'Error',
+  whatHappened: 'I18nCache is not available in production browser builds',
+  why: 'production browser builds use the lightweight client runtime',
+  fix: 'Use translations supplied by your framework provider instead.',
+});
+
+const runtimeTranslationUnavailableError = createDiagnosticMessage({
+  source: 'gt-i18n',
+  severity: 'Error',
+  whatHappened:
+    'Runtime translation is not available in production browser builds',
+  why: 'it requires the full i18n cache and service runtime',
+  fix: 'Use preloaded translations or perform runtime translation on the server.',
+});
+
 export {
   getGT,
   getGTInternal,
@@ -39,11 +63,20 @@ export {
   dedupePending,
 } from './internal';
 function ProductionI18nCache(): never {
-  throw new Error('I18nCache is not available in production browser builds.');
+  throw new Error(i18nCacheUnavailableError);
 }
 
 export { ProductionI18nCache as I18nCache };
 export { getI18nConfig, I18nConfig, setI18nConfig };
+
+async function unavailableRuntimeTranslation(): Promise<never> {
+  throw new Error(runtimeTranslationUnavailableError);
+}
+
+export const tx: typeof import('./translation-functions/internal/tx').tx =
+  unavailableRuntimeTranslation;
+export const txInternal: typeof import('./translation-functions/internal/tx').txInternal =
+  unavailableRuntimeTranslation;
 
 export const GtInternalRuntimeTranslateJsx = () => {};
 export const GtInternalRuntimeTranslateString = () => {};
@@ -55,8 +88,3 @@ export function initializeI18nConfig(
   setI18nConfig(config);
   return config;
 }
-import { I18nConfig, type I18nConfigParams } from './i18n-config/I18nConfig';
-import {
-  getI18nConfig,
-  setI18nConfig,
-} from './i18n-config/singleton-operations';

--- a/packages/i18n/src/internal.ts
+++ b/packages/i18n/src/internal.ts
@@ -58,7 +58,7 @@ export {
   initializeI18nConfig,
   setI18nConfig,
 } from './i18n-config/singleton-operations';
-export { I18nConfig } from './i18n-config/I18nConfig';
+export { RuntimeI18nConfig as I18nConfig } from './i18n-config/RuntimeI18nConfig';
 export type { I18nConfigParams } from './i18n-config/I18nConfig';
 export { createConditionStoreSingleton } from './condition-store/createConditionStoreSingleton';
 export { createGlobalSingleton } from './globals/createGlobalSingleton';

--- a/packages/i18n/tsdown.config.mts
+++ b/packages/i18n/tsdown.config.mts
@@ -1,13 +1,22 @@
 import { defineConfig } from 'tsdown';
 import { createTsdownConfig } from '../../tsdown.preset.mts';
 
-export default defineConfig(
-  createTsdownConfig([
-    'src/index.ts',
-    'src/internal-cookies.ts',
-    'src/internal-string.ts',
-    'src/types.ts',
-    'src/internal.ts',
-    'src/internal-types.ts',
-  ])
+const standard = createTsdownConfig([
+  'src/index.ts',
+  'src/internal-cookies.ts',
+  'src/internal-string.ts',
+  'src/types.ts',
+  'src/internal.ts',
+  'src/internal-types.ts',
+]);
+const production = createTsdownConfig(['src/internal-static.ts']).map(
+  (config) => ({
+    ...config,
+    clean: false,
+    define: { 'process.env.NODE_ENV': JSON.stringify('production') },
+    dts: false,
+    treeshake: { moduleSideEffects: false },
+  })
 );
+
+export default defineConfig([...standard, ...production]);

--- a/packages/react-core/src/components/variables/Currency.shared.ts
+++ b/packages/react-core/src/components/variables/Currency.shared.ts
@@ -1,5 +1,5 @@
-import { getI18nConfig } from 'gt-i18n/internal';
-import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
+import { formatCurrency } from '@generaltranslation/format';
+import { getCanonicalFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
 // module must stay free of hook/context imports so it can be reached from the
@@ -28,16 +28,15 @@ function computeCurrency({
   options = {},
   locales: localesProp = [],
 }: ResolvedCurrencyProps): string | null {
-  const locales = getFormatLocales({
+  const locales = getCanonicalFormatLocales({
     locale: _locale,
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatCurrency(parsedNumber, currency, {
+  return formatCurrency(parsedNumber, currency, {
     locales,
     ...options,
   });

--- a/packages/react-core/src/components/variables/DateTime.shared.ts
+++ b/packages/react-core/src/components/variables/DateTime.shared.ts
@@ -1,5 +1,5 @@
-import { getI18nConfig } from 'gt-i18n/internal';
-import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
+import { formatDateTime } from '@generaltranslation/format';
+import { getCanonicalFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
 // module must stay free of hook/context imports so it can be reached from the
@@ -26,17 +26,16 @@ function computeDateTime({
   options = {},
   locales: localesProp = [],
 }: ResolvedDateTimeProps): string | null {
-  const locales = getFormatLocales({
+  const locales = getCanonicalFormatLocales({
     locale: _locale,
     enableI18n: _enableI18n,
     localesProp,
   });
-  // TODO: theres a world in which we don't need the i18n cache, if user passes their own params
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
-  return gt
-    .formatDateTime(children, { locales, ...options })
-    .replace(/[\u200F\u202B\u202E]/g, '');
+  return formatDateTime(children, { locales, ...options }).replace(
+    /[\u200F\u202B\u202E]/g,
+    ''
+  );
 }
 
 export { computeDateTime };

--- a/packages/react-core/src/components/variables/Num.shared.ts
+++ b/packages/react-core/src/components/variables/Num.shared.ts
@@ -1,5 +1,5 @@
-import { getI18nConfig } from 'gt-i18n/internal';
-import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
+import { formatNum } from '@generaltranslation/format';
+import { getCanonicalFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
 // module must stay free of hook/context imports so it can be reached from the
@@ -26,16 +26,18 @@ function computeNum({
   options = {},
   locales: localesProp = [],
 }: ResolvedNumProps): string | null {
-  const locales = getFormatLocales({
+  const locales = getCanonicalFormatLocales({
     locale: _locale,
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   if (children == null) return null;
   const parsedNumber =
     typeof children === 'string' ? parseFloat(children) : children;
-  return gt.formatNum(parsedNumber, { locales, ...options });
+  return formatNum(parsedNumber, {
+    locales,
+    ...options,
+  });
 }
 
 export { computeNum };

--- a/packages/react-core/src/components/variables/RelativeTime.shared.ts
+++ b/packages/react-core/src/components/variables/RelativeTime.shared.ts
@@ -1,5 +1,8 @@
-import { getI18nConfig } from 'gt-i18n/internal';
-import { getFormatLocales } from '../../hooks/utils/getFormatLocales';
+import {
+  formatRelativeTime,
+  formatRelativeTimeFromDate,
+} from '@generaltranslation/format';
+import { getCanonicalFormatLocales } from '../../hooks/utils/getFormatLocales';
 
 // Pure compute logic shared by the hook-based and RSC implementations. This
 // module must stay free of hook/context imports so it can be reached from the
@@ -34,12 +37,11 @@ function computeRelativeTime({
   locales: localesProp = [],
   options = {},
 }: ResolvedRelativeTimeProps): string | null {
-  const locales = getFormatLocales({
+  const locales = getCanonicalFormatLocales({
     locale: _locale,
     enableI18n: _enableI18n,
     localesProp,
   });
-  const gt = getI18nConfig().getGTClass();
   const resolvedDate = date ?? children;
 
   if (process.env.NODE_ENV === 'development' && value !== undefined && !unit) {
@@ -50,7 +52,7 @@ function computeRelativeTime({
   }
 
   if (value !== undefined && unit) {
-    return gt.formatRelativeTime(value, unit, {
+    return formatRelativeTime(value, unit, {
       locales,
       numeric: options.numeric,
       style: options.style,
@@ -59,7 +61,7 @@ function computeRelativeTime({
   }
 
   if (resolvedDate != null) {
-    return gt.formatRelativeTimeFromDate(resolvedDate, {
+    return formatRelativeTimeFromDate(resolvedDate, {
       locales,
       baseDate: baseDate ?? new Date(),
       numeric: options.numeric,

--- a/packages/react-core/src/hooks/__tests__/utils.test.ts
+++ b/packages/react-core/src/hooks/__tests__/utils.test.ts
@@ -111,4 +111,24 @@ describe('getFormatLocales', () => {
       })
     ).toEqual(['en']);
   });
+
+  it('preserves custom aliases for public consumers', () => {
+    setup({
+      locale: 'brand-french',
+      locales: ['en', 'brand-french'],
+      customMapping: {
+        'brand-french': {
+          code: 'fr',
+          name: 'Brand French',
+        },
+      },
+    });
+
+    expect(
+      getFormatLocales({
+        locale: 'brand-french',
+        enableI18n: true,
+      })
+    ).toEqual(['brand-french', 'en']);
+  });
 });

--- a/packages/react-core/src/hooks/useInternalRegionSelector.ts
+++ b/packages/react-core/src/hooks/useInternalRegionSelector.ts
@@ -58,7 +58,7 @@ export function useInternalRegionSelector({
     regions, // ordered list of ISO 3166 region codes
     regionData, // map of ISO 3166 region codes to region display data, potentially not ordered
   ] = useMemo<[string[], Map<string, RegionData>]>(() => {
-    const gt = getI18nConfig().getGTClass(locale);
+    const i18nConfig = getI18nConfig();
     const regionToLocaleMap = new Map(
       contextLocales.map((l) => {
         const lp = getLocaleProperties(l, locale, localeCustomMapping); // has to be directly called so sourceLocale can be in the user's current locale
@@ -76,7 +76,7 @@ export function useInternalRegionSelector({
           r,
           {
             locale: regionToLocaleMap?.get(r)?.code || locale,
-            ...gt.getRegionProperties(r),
+            ...i18nConfig.getRegionProperties(r, locale),
             ...(typeof customMapping?.[r] === 'string'
               ? { name: customMapping?.[r] }
               : customMapping?.[r]),

--- a/packages/react-core/src/hooks/utils.ts
+++ b/packages/react-core/src/hooks/utils.ts
@@ -47,17 +47,14 @@ export function useTranslationConditions(): {
 }
 
 export function useLocaleProperties(locale: string): LocaleProperties {
-  return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleProperties(locale),
-    [locale]
-  );
+  return useMemo(() => getI18nConfig().getLocaleProperties(locale), [locale]);
 }
 
 export function useLocaleDirection(locale?: string): 'ltr' | 'rtl' {
   const currentLocale = useLocale();
   const resolvedLocale = locale ?? currentLocale;
   return useMemo(
-    () => getI18nConfig().getGTClass().getLocaleDirection(resolvedLocale),
+    () => getI18nConfig().getLocaleDirection(resolvedLocale),
     [resolvedLocale]
   );
 }

--- a/packages/react-core/src/hooks/utils/getFormatLocales.ts
+++ b/packages/react-core/src/hooks/utils/getFormatLocales.ts
@@ -6,19 +6,29 @@ import { getI18nConfig } from 'gt-i18n/internal';
 
 const EMPTY_LOCALES_PROP: string[] = [];
 
+type GetFormatLocalesParams = {
+  locale: string;
+  enableI18n: boolean;
+  localesProp?: string[];
+};
+
 export function getFormatLocales({
   locale,
   enableI18n,
   localesProp = EMPTY_LOCALES_PROP,
-}: {
-  locale: string;
-  enableI18n: boolean;
-  localesProp?: string[];
-}): string[] {
-  const defaultLocale = getI18nConfig().getDefaultLocale();
-  const shouldTranslate =
-    enableI18n && getI18nConfig().requiresTranslation(locale);
+}: GetFormatLocalesParams): string[] {
+  const i18nConfig = getI18nConfig();
+  const defaultLocale = i18nConfig.getDefaultLocale();
+  const shouldTranslate = enableI18n && i18nConfig.requiresTranslation(locale);
   return shouldTranslate
     ? [...localesProp, locale, defaultLocale]
     : [defaultLocale];
+}
+
+export function getCanonicalFormatLocales(
+  params: GetFormatLocalesParams
+): string[] {
+  const i18nConfig = getI18nConfig();
+  const locales = getFormatLocales(params);
+  return locales.map((locale) => i18nConfig.resolveCanonicalLocale(locale));
 }

--- a/packages/react-core/src/setup/i18nConfig.ts
+++ b/packages/react-core/src/setup/i18nConfig.ts
@@ -30,12 +30,14 @@ const defaultRenderStrategy: RenderStrategy = 'server-render';
 const reactI18nConfigBrand = Symbol.for(
   'generaltranslation.react-core.ReactI18nConfig'
 );
+type BaseI18nConfig = ReturnType<typeof getBaseI18nConfig>;
 
 export class ReactI18nConfig extends I18nConfig {
   private renderStrategy: RenderStrategy;
   private localeCookieName: string;
   private regionCookieName: string;
   private enableI18nCookieName: string;
+  private idTaggingEnabled: boolean;
 
   constructor(
     params: ReactI18nConfigParams = {},
@@ -49,6 +51,7 @@ export class ReactI18nConfig extends I18nConfig {
     this.regionCookieName = params.regionCookieName ?? defaultRegionCookieName;
     this.enableI18nCookieName =
       params.enableI18nCookieName ?? defaultEnableI18nCookieName;
+    this.idTaggingEnabled = params._tagIds === true;
   }
 
   getRenderStrategy(): RenderStrategy {
@@ -72,7 +75,7 @@ export class ReactI18nConfig extends I18nConfig {
    * a `data-_gt-hash` attribute for tooling. Requires the literal `true`.
    */
   isIdTaggingEnabled(): boolean {
-    return this.runtimeConfig._tagIds === true;
+    return this.idTaggingEnabled;
   }
 }
 
@@ -121,8 +124,8 @@ function validateRenderStrategy(
 }
 
 function isReactI18nConfig(
-  i18nConfig: I18nConfig
-): i18nConfig is ReactI18nConfig {
+  i18nConfig: BaseI18nConfig
+): i18nConfig is BaseI18nConfig & ReactI18nConfig {
   if (i18nConfig instanceof ReactI18nConfig) return true;
 
   const maybeReactI18nConfig = i18nConfig as I18nConfig &

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -186,6 +186,22 @@ describe('gt-react package exports', () => {
           );
         `,
     ]);
+    node([
+      '--conditions=browser',
+      '--conditions=production',
+      '-e',
+      `
+          const assert = require('node:assert/strict');
+          const i18n = require('gt-i18n/internal');
+
+          assert.equal(
+            require.resolve('gt-i18n/internal').endsWith('/dist/internal-static.cjs'),
+            true
+          );
+          assert.equal(typeof i18n.tx, 'function');
+          assert.equal(typeof i18n.txInternal, 'function');
+        `,
+    ]);
   });
 
   it('shares production snapshots without initializing a cache', () => {
@@ -199,12 +215,29 @@ describe('gt-react package exports', () => {
           import React from 'react';
           import { renderToStaticMarkup } from 'react-dom/server';
           import { GTProvider, GtInternalRuntimeTranslateJsx, GtInternalRuntimeTranslateString, Num, getReactI18nCache, getTranslationsSnapshot, getVersionId, initializeGTSPA, t, useGT } from 'gt-react';
-          import { createLookupOptions, hashMessage } from 'gt-i18n/internal';
+          import { createLookupOptions, getI18nConfig, hashMessage, I18nCache, tx, txInternal } from 'gt-i18n/internal';
 
           await Promise.all([
             GtInternalRuntimeTranslateJsx('Hello'),
             GtInternalRuntimeTranslateString('Hello'),
           ]);
+          await assert.rejects(
+            tx('Hello'),
+            /gt-i18n Error: Runtime translation is not available in production browser builds/
+          );
+          await assert.rejects(
+            txInternal({
+              locale: 'en',
+              enableI18n: true,
+              content: 'Hello',
+              options: {},
+            }),
+            /gt-i18n Error: Runtime translation is not available in production browser builds/
+          );
+          assert.throws(
+            () => new I18nCache(),
+            /gt-i18n Error: I18nCache is not available in production browser builds/
+          );
 
           Object.defineProperty(globalThis, 'navigator', {
             configurable: true,
@@ -233,6 +266,10 @@ describe('gt-react package exports', () => {
           await initializeGTSPA(config);
 
           assert.deepEqual(await getTranslationsSnapshot('en'), { en: {} });
+          assert.throws(
+            () => getI18nConfig().getGTClass(),
+            /gt-i18n Error: GTRuntime is not available in production browser builds/
+          );
           assert.equal(getVersionId(), 'version-1');
           assert.equal(loadCount, 1);
           assert.equal(t(message), 'Bonjour');

--- a/packages/react/src/__tests__/react-package.test.ts
+++ b/packages/react/src/__tests__/react-package.test.ts
@@ -144,6 +144,10 @@ describe('gt-react package exports', () => {
             import.meta.resolve('gt-react').endsWith('/dist/index.client.mjs'),
             true
           );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal.mjs'),
+            true
+          );
         `,
     ]);
     node([
@@ -156,6 +160,10 @@ describe('gt-react package exports', () => {
 
           assert.equal(
             import.meta.resolve('gt-react').endsWith('/dist/index.client.mjs'),
+            true
+          );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal.mjs'),
             true
           );
         `,
@@ -172,6 +180,10 @@ describe('gt-react package exports', () => {
             import.meta.resolve('gt-react').endsWith('/dist/index.client.prod.mjs'),
             true
           );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal-static.mjs'),
+            true
+          );
         `,
     ]);
   });
@@ -186,7 +198,7 @@ describe('gt-react package exports', () => {
           import assert from 'node:assert/strict';
           import React from 'react';
           import { renderToStaticMarkup } from 'react-dom/server';
-          import { GTProvider, GtInternalRuntimeTranslateJsx, GtInternalRuntimeTranslateString, Num, getReactI18nCache, getTranslationsSnapshot, initializeGTSPA, t, useGT } from 'gt-react';
+          import { GTProvider, GtInternalRuntimeTranslateJsx, GtInternalRuntimeTranslateString, Num, getReactI18nCache, getTranslationsSnapshot, getVersionId, initializeGTSPA, t, useGT } from 'gt-react';
           import { createLookupOptions, hashMessage } from 'gt-i18n/internal';
 
           await Promise.all([
@@ -207,6 +219,7 @@ describe('gt-react package exports', () => {
             defaultLocale: 'en',
             locales: [locale],
             locale,
+            _versionId: 'version-1',
             _getLocale: () => locale,
             customMapping: {
               [locale]: { code: 'fr', name: 'Custom French' },
@@ -220,6 +233,7 @@ describe('gt-react package exports', () => {
           await initializeGTSPA(config);
 
           assert.deepEqual(await getTranslationsSnapshot('en'), { en: {} });
+          assert.equal(getVersionId(), 'version-1');
           assert.equal(loadCount, 1);
           assert.equal(t(message), 'Bonjour');
           function SpaChild() {
@@ -268,11 +282,17 @@ describe('gt-react package exports', () => {
         '-e',
         `
           const assert = require('node:assert/strict');
+          const { initializeGT } = require('gt-react');
 
           assert.equal(
             require.resolve('gt-react').endsWith('/dist/index.server.cjs'),
             true
           );
+          assert.equal(
+            require.resolve('gt-i18n/internal').endsWith('/dist/internal.cjs'),
+            true
+          );
+          assert.doesNotThrow(() => initializeGT({ defaultLocale: 'en' }));
         `,
       ]);
       node([
@@ -282,11 +302,17 @@ describe('gt-react package exports', () => {
         '-e',
         `
           import assert from 'node:assert/strict';
+          import { initializeGT } from 'gt-react';
 
           assert.equal(
             import.meta.resolve('gt-react').endsWith('/dist/index.server.mjs'),
             true
           );
+          assert.equal(
+            import.meta.resolve('gt-i18n/internal').endsWith('/dist/internal.mjs'),
+            true
+          );
+          assert.doesNotThrow(() => initializeGT({ defaultLocale: 'en' }));
         `,
       ]);
     }
@@ -374,11 +400,17 @@ describe('gt-react package exports', () => {
       '-e',
       `
           const assert = require('node:assert/strict');
+          const { initializeGT } = require('gt-react');
 
           assert.equal(
             require.resolve('gt-react').endsWith('/dist/index.rsc.cjs'),
             true
           );
+          assert.equal(
+            require.resolve('gt-i18n/internal').endsWith('/dist/internal.cjs'),
+            true
+          );
+          assert.doesNotThrow(() => initializeGT({ defaultLocale: 'en' }));
         `,
     ]);
   });


### PR DESCRIPTION
## TL;DR

Builds on #2213 to remove runtime-only configuration and formatting code from production browser bundles.

## Code Changes

- Separates locale resolution from the full formatting and runtime configuration.
- Adds an explicit production gt-i18n internal browser artifact with development-safe fallback resolution.
- Uses direct formatting helpers in production-compatible React components.
- Adds package-resolution and production-behavior regression coverage plus separate release metadata.

## Notes / Flags

- This PR is stacked on #2213; merge #2213 first.
- Source LOC for this layer: +428 / -306, net +122, excluding tests, comments, manifests, generated files, and non-source files.
- Next production GT chunk: 137,101 B raw / 43,237 B gzip to 126,434 B raw / 40,273 B gzip, saving 10,667 B raw / 2,964 B gzip in this layer.
- TanStack production client JS: 429,912 B raw / 137,889 B gzip to 416,140 B raw / 134,291 B gzip, saving 13,772 B raw / 3,598 B gzip in this layer.
- Across both PRs, Next saves 30,406 B raw / 8,312 B gzip and TanStack saves 25,351 B raw / 8,487 B gzip.
- Affected package builds, tests, typechecks, lint, formatting, Changesets status, and Next/TanStack production builds pass.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR separates lightweight locale resolution from formatting and runtime-only configuration, then selects a reduced `gt-i18n` artifact for production browser builds.

- Introduces `LocaleResolver` and moves full runtime behavior into `RuntimeI18nConfig`.
- Replaces React value-component runtime formatting calls with direct format helpers.
- Adds conditional package exports, production build configuration, and regression coverage for artifact resolution and production behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete correctness, security, or compatibility failures identified.

The runtime/static configuration split preserves full runtime behavior on server and development paths, while production browser callers use locale-resolution and direct-formatting APIs supported by the lightweight artifact.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/format/src/LocaleResolver.ts | Extracts locale metadata, alias resolution, validation, and supported-locale matching from `LocaleConfig` without an identified behavioral regression. |
| packages/i18n/src/i18n-config/I18nConfig.ts | Defines browser-compatible locale configuration while preserving locale and region behavior and intentionally guarding runtime-only APIs. |
| packages/i18n/src/i18n-config/RuntimeI18nConfig.ts | Retains runtime construction, development hot reload, credentials, URLs, and debug-level behavior for full-runtime environments. |
| packages/i18n/src/internal-static.ts | Provides the production-browser internal surface with lightweight configuration and explicit guards for unavailable runtime facilities. |
| packages/i18n/package.json | Routes production browser consumers to the static artifact while preserving full artifacts for server, worker, development, CJS, and ESM consumers. |
| packages/react-core/src/hooks/utils/getFormatLocales.ts | Adds canonical locale conversion for direct format helpers while retaining the existing component-level locale-selection policy. |
| packages/react-core/src/components/variables/RelativeTime.shared.ts | Replaces runtime-mediated relative-time formatting with direct helpers using the same resolved locale and supported options. |
| packages/react-core/src/hooks/useInternalRegionSelector.ts | Uses lightweight configuration for localized region metadata while preserving active-locale and custom-region behavior. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Consumer[React consumer] --> Conditions{Package conditions}
  Conditions -->|server / worker / development browser| Runtime[gt-i18n internal runtime artifact]
  Conditions -->|production browser| Static[gt-i18n lightweight static artifact]
  Runtime --> RuntimeConfig[RuntimeI18nConfig]
  Static --> BrowserConfig[I18nConfig / LocaleResolver]
  Consumer --> Format[Direct formatting helpers]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["refactor: add lightweight browser config"](https://github.com/generaltranslation/gt/commit/424f8251010e6d2f7edf140ad4e94dbb39903a78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58119283)</sub>

<!-- /greptile_comment -->