### PR TITLE
feat(cli): merge downloaded xcstrings translations into the catalog

### DIFF
--- a/.changeset/xcstrings-download-merge.md
+++ b/.changeset/xcstrings-download-merge.md
@@ -1,0 +1,5 @@
+---
+'gt': minor
+---
+
+Merge downloaded Apple `.xcstrings` translations back into the on-disk catalog, folding each locale's slice into the shared file while preserving unknown fields and entry order.

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -191,6 +191,157 @@ describe('collectAndSendUserEditDiffs', () => {
     expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
   });
 
+  describe('xcstrings catalogs', () => {
+    const catalogRelPath = 'Sources/Localizable.xcstrings';
+
+    const buildXcstringsSettings = () =>
+      createMockSettings({
+        configDirectory: tempDir,
+        config: path.join(tempDir, 'gt.config.json'),
+        defaultLocale: 'en',
+        locales: ['es'],
+        _branchId: 'branch1',
+        files: {
+          resolvedPaths: {
+            xcstrings: [path.join(tempDir, catalogRelPath)],
+          },
+          placeholderPaths: {
+            xcstrings: [path.join(tempDir, catalogRelPath)],
+          },
+          transformPaths: {},
+        },
+      });
+
+    const catalogContent = JSON.stringify(
+      {
+        sourceLanguage: 'en',
+        strings: {
+          greeting: {
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Hello' } },
+              es: { stringUnit: { state: 'translated', value: 'Hola' } },
+            },
+          },
+          Save: {
+            localizations: {
+              es: { stringUnit: { state: 'translated', value: 'Guardar' } },
+            },
+          },
+        },
+        version: '1.0',
+      },
+      null,
+      2
+    );
+
+    // The server serializes with its own top-level key order and whitespace.
+    const serverEsSlice = JSON.stringify({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        greeting: {
+          localizations: {
+            es: { stringUnit: { state: 'translated', value: 'Hola' } },
+          },
+        },
+        Save: {
+          localizations: {
+            es: { stringUnit: { state: 'translated', value: 'Guardar' } },
+          },
+        },
+      },
+    });
+
+    const seedCatalogAndLock = (localCatalog: string) => {
+      const catalogPath = path.join(tempDir, catalogRelPath);
+      fs.mkdirSync(path.dirname(catalogPath), { recursive: true });
+      fs.writeFileSync(catalogPath, localCatalog);
+      // No postProcessHash: the locale is always a diff candidate.
+      writeLockFile({
+        version: 1,
+        entries: {
+          branch1: {
+            file1: {
+              version1: {
+                es: { updatedAt: new Date().toISOString() },
+              },
+            },
+          },
+        },
+      });
+    };
+
+    const mockServerResponses = () => {
+      vi.mocked(gt.queryFileData).mockResolvedValue({
+        translatedFiles: [
+          {
+            branchId: 'branch1',
+            fileId: 'file1',
+            versionId: 'version1',
+            locale: 'es',
+            completedAt: new Date().toISOString(),
+          },
+        ],
+      });
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          {
+            branchId: 'branch1',
+            fileId: 'file1',
+            versionId: 'version1',
+            locale: 'es',
+            data: serverEsSlice,
+          },
+        ],
+      });
+    };
+
+    const files: FileReference[] = [
+      {
+        fileName: catalogRelPath,
+        fileFormat: 'XCSTRINGS',
+        branchId: 'branch1',
+        fileId: 'file1',
+        versionId: 'version1',
+      },
+    ];
+
+    it('submits nothing when the catalog locale matches the server slice', async () => {
+      const settings = buildXcstringsSettings();
+      seedCatalogAndLock(catalogContent);
+      mockServerResponses();
+
+      await collectAndSendUserEditDiffs(files, settings);
+
+      // The multi-locale catalog itself never gets diffed against the
+      // single-locale server slice.
+      expect(getGitUnifiedDiff).not.toHaveBeenCalled();
+      expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
+
+    it('submits the extracted locale slice, not the catalog, when edited', async () => {
+      const settings = buildXcstringsSettings();
+      seedCatalogAndLock(catalogContent.replace('Guardar', 'GUARDAR!'));
+      mockServerResponses();
+      vi.mocked(getGitUnifiedDiff).mockResolvedValue('mock-diff');
+
+      await collectAndSendUserEditDiffs(files, settings);
+
+      expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+      const submitted = vi.mocked(gt.submitUserEditDiffs).mock.calls[0][0]
+        .diffs[0];
+      expect(submitted.locale).toBe('es');
+      const localContent = JSON.parse(submitted.localContent);
+      // Single-locale slice with the local edit, no other locales leaked
+      expect(localContent.strings.Save.localizations).toEqual({
+        es: { stringUnit: { state: 'translated', value: 'GUARDAR!' } },
+      });
+      expect(localContent.strings.greeting.localizations).toEqual({
+        es: { stringUnit: { state: 'translated', value: 'Hola' } },
+      });
+    });
+  });
+
   it('uses the latest downloaded version when the uploaded version has changed', async () => {
     const settings = buildSettings();
     const translatedPath = path.join(tempDir, 'docs', 'ja', 'doc.md');

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -319,6 +319,38 @@ describe('collectAndSendUserEditDiffs', () => {
       expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
     });
 
+    it('ignores server slice entries with no target-locale localization', async () => {
+      const settings = buildXcstringsSettings();
+      seedCatalogAndLock(catalogContent);
+      mockServerResponses();
+      // The server keeps shouldTranslate:false entries verbatim in every
+      // locale's slice, so its slice can hold entries — and locales — the
+      // local extract legitimately omits.
+      const serverDoc = JSON.parse(serverEsSlice);
+      serverDoc.strings['brand.name'] = {
+        shouldTranslate: false,
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: 'Cascade Pro' } },
+        },
+      };
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          {
+            branchId: 'branch1',
+            fileId: 'file1',
+            versionId: 'version1',
+            locale: 'es',
+            data: JSON.stringify(serverDoc),
+          },
+        ],
+      });
+
+      await collectAndSendUserEditDiffs(files, settings);
+
+      expect(getGitUnifiedDiff).not.toHaveBeenCalled();
+      expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
+
     it('submits the extracted locale slice, not the catalog, when edited', async () => {
       const settings = buildXcstringsSettings();
       seedCatalogAndLock(catalogContent.replace('Guardar', 'GUARDAR!'));

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -5,6 +5,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import nodePath from 'node:path';
 import { logger } from '../../console/logger.js';
+import { mergeXcstrings } from '../../formats/xcstrings/mergeXcstrings.js';
+import type { XcstringsCatalog } from '../../formats/xcstrings/parseXcstrings.js';
+import {
+  clearDownloaded,
+  getDownloadedMeta,
+} from '../../state/recentDownloads.js';
 import {
   DownloadFileBatchResult as CoreDownloadFileBatchResult,
   FileFormat,
@@ -26,6 +32,10 @@ vi.mock('../../utils/gt.js', () => ({
     resolveCanonicalLocale: vi.fn((locale) => locale),
   },
 }));
+
+// The 'fs' mock below also captures 'node:fs'; fixtures need the real module
+const { readFileSync: readRealFileSync } =
+  await vi.importActual<typeof import('node:fs')>('node:fs');
 
 vi.mock('fs', () => ({
   existsSync: vi.fn(),
@@ -742,5 +752,369 @@ describe('downloadFileBatch', () => {
     );
     expect(esEntry).toBeDefined();
     expect(esEntry!.tabs[0].tab).toBe('Guías');
+  });
+
+  describe('xcstrings catalog downloads', () => {
+    const catalogPath = 'Cascade/Localizable.xcstrings';
+    // Hermetic copies of xcstrings-fixtures 10 (realistic app) and 19
+    // (catalog coexisting with legacy .strings files)
+    const realisticCatalog = readRealFileSync(
+      nodePath.join(
+        __dirname,
+        '../../formats/xcstrings/__mocks__/realistic_app.xcstrings'
+      ),
+      'utf8'
+    );
+    const legacyMixedCatalog = readRealFileSync(
+      nodePath.join(
+        __dirname,
+        '../../formats/xcstrings/__mocks__/legacy_catalog_mixed.xcstrings'
+      ),
+      'utf8'
+    );
+    const legacyMixedDeStrings = readRealFileSync(
+      nodePath.join(
+        __dirname,
+        '../../formats/xcstrings/__mocks__/legacy_catalog_mixed_de.strings'
+      ),
+      'utf8'
+    );
+
+    /** Routes the mocked fs at an in-memory store so merges read prior writes. */
+    const setupInMemoryFs = (store: Map<string, string>, dirs: string[]) => {
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => store.has(String(p)) || dirs.includes(String(p))
+      );
+      vi.mocked(fs.readFileSync).mockImplementation((p) => {
+        const content = store.get(String(p));
+        if (content === undefined) {
+          throw new Error(`ENOENT: no such file ${String(p)}`);
+        }
+        return content;
+      });
+      vi.mocked(fs.promises.writeFile).mockImplementation(async (p, data) => {
+        store.set(String(p), String(data));
+      });
+    };
+
+    /** A single-locale translated slice covering some of a catalog's keys. */
+    const buildSlice = (
+      catalogContent: string,
+      locale: string,
+      marker: string,
+      keyCount = 5
+    ): string => {
+      const catalog = JSON.parse(catalogContent) as XcstringsCatalog;
+      const keys = Object.keys(catalog.strings)
+        .filter((key) => catalog.strings[key].localizations?.[locale])
+        .slice(0, keyCount);
+      expect(keys.length).toBeGreaterThan(0);
+      return JSON.stringify({
+        sourceLanguage: catalog.sourceLanguage,
+        strings: Object.fromEntries(
+          keys.map((key) => [
+            key,
+            {
+              localizations: {
+                [locale]: {
+                  stringUnit: {
+                    state: 'translated',
+                    value: `${marker} ${key}`,
+                  },
+                },
+              },
+            },
+          ])
+        ),
+      });
+    };
+
+    const xcstringsBatchFile = (
+      locale: string,
+      overrides: Partial<BatchedFiles[0]> = {}
+    ): BatchedFiles[0] => ({
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      outputPath: catalogPath,
+      inputPath: catalogPath,
+      locale,
+      ...overrides,
+    });
+
+    const xcstringsResponseFile = (
+      locale: string,
+      data: string,
+      overrides: Record<string, unknown> = {}
+    ) => ({
+      id: `translation-${locale}`,
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      locale,
+      fileFormat: 'XCSTRINGS' as FileFormat,
+      data,
+      fileName: catalogPath,
+      metadata: {},
+      ...overrides,
+    });
+
+    beforeEach(() => {
+      clearDownloaded();
+    });
+
+    it('merges every downloaded locale into the shared catalog sequentially', async () => {
+      const esSlice = buildSlice(realisticCatalog, 'es', 'nuevo');
+      const frSlice = buildSlice(realisticCatalog, 'fr', 'nouveau');
+      const files = [xcstringsBatchFile('es'), xcstringsBatchFile('fr')];
+      const fileTracker = createMockFileTracker(files);
+      const lockEntry: DownloadedVersionEntry = {
+        fileId: 'file-1',
+        versionId: 'version-1',
+        translations: {},
+      };
+      vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          xcstringsResponseFile('es', esSlice),
+          xcstringsResponseFile('fr', frSlice),
+        ],
+        count: 2,
+      });
+      const store = new Map([[catalogPath, realisticCatalog]]);
+      setupInMemoryFs(store, ['Cascade']);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['es', 'fr'] })
+      );
+
+      expect(result.successful).toHaveLength(2);
+      expect(result.skipped).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+
+      // Both merges land in the one on-disk file, byte-exactly: each locale
+      // folds into the previous locale's write
+      const afterEs = mergeXcstrings(realisticCatalog, esSlice, 'es');
+      const afterFr = mergeXcstrings(afterEs, frSlice, 'fr');
+      const writes = vi
+        .mocked(fs.promises.writeFile)
+        .mock.calls.filter((call) => call[0] === catalogPath);
+      expect(writes).toHaveLength(2);
+      expect(writes[0][1]).toBe(afterEs);
+      expect(writes[1][1]).toBe(afterFr);
+      expect(store.get(catalogPath)).toBe(afterFr);
+
+      const merged = JSON.parse(store.get(catalogPath)!) as XcstringsCatalog;
+      const [esKey] = Object.keys(
+        (JSON.parse(esSlice) as XcstringsCatalog).strings
+      );
+      expect(merged.strings[esKey].localizations!.es).toEqual({
+        stringUnit: { state: 'translated', value: `nuevo ${esKey}` },
+      });
+      // Untouched locales survive both merges
+      const original = JSON.parse(realisticCatalog) as XcstringsCatalog;
+      expect(merged.strings[esKey].localizations!.de).toEqual(
+        original.strings[esKey].localizations!.de
+      );
+
+      // The lockfile tracks each locale separately...
+      expect(Object.keys(lockEntry.translations).sort()).toEqual(['es', 'fr']);
+      // ...but recentDownloads meta is keyed by output path, so the shared
+      // catalog keeps only the last locale's meta (last-locale-wins), exactly
+      // like composite JSON files that share one output path
+      expect(getDownloadedMeta().get(catalogPath)?.locale).toBe('fr');
+    });
+
+    it('never takes the already-downloaded skip: an up-to-date lockfile still merges fresh data', async () => {
+      // Mirrors the composite test above: the catalog always exists on disk,
+      // so the lock can't tell whether this locale's content is present. The
+      // in-place exemption must keep the skip unreachable for xcstrings —
+      // otherwise locales silently never merge.
+      const esSlice = buildSlice(realisticCatalog, 'es', 'nuevo');
+      const files = [xcstringsBatchFile('es')];
+      const fileTracker = createMockFileTracker(files);
+
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [xcstringsResponseFile('es', esSlice)],
+        count: 1,
+      });
+      vi.mocked(readLockfile).mockReturnValue({
+        data: { version: 2, branchId: 'branch-1', entries: [] },
+        entryMap: new Map<string, DownloadedVersionEntry>([
+          [
+            'file-1',
+            {
+              fileId: 'file-1',
+              versionId: 'version-1',
+              fileName: catalogPath,
+              translations: {
+                es: {
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                  fileName: catalogPath,
+                },
+              },
+            },
+          ],
+        ]),
+        originalV1: false,
+      });
+      const store = new Map([[catalogPath, realisticCatalog]]);
+      setupInMemoryFs(store, ['Cascade']);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['es'] })
+      );
+
+      expect(result.skipped).toHaveLength(0);
+      expect(result.successful).toHaveLength(1);
+      expect(store.get(catalogPath)).toBe(
+        mergeXcstrings(realisticCatalog, esSlice, 'es')
+      );
+    });
+
+    it('touches only the catalog when it coexists with legacy .strings files', async () => {
+      const fixtureCatalogPath =
+        'Sources/FieldNotesKit/Resources/Localizable.xcstrings';
+      const legacyDePath =
+        'Sources/FieldNotesKit/Resources/de.lproj/Localizable.strings';
+      const legacyEnPath =
+        'Sources/FieldNotesKit/Resources/en.lproj/Localizable.strings';
+      const deSlice = buildSlice(legacyMixedCatalog, 'de', 'frisch');
+      const legacyDePayload = '"legacy.error.generic" = "Frisch übersetzt";\n';
+
+      const files: BatchedFiles = [
+        xcstringsBatchFile('de', {
+          inputPath: fixtureCatalogPath,
+          outputPath: fixtureCatalogPath,
+        }),
+        {
+          branchId: 'branch-1',
+          fileId: 'file-2',
+          versionId: 'version-2',
+          inputPath: legacyEnPath,
+          outputPath: legacyDePath,
+          locale: 'de',
+        },
+      ];
+      const fileTracker = createMockFileTracker(files);
+
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          xcstringsResponseFile('de', deSlice, {
+            fileName: fixtureCatalogPath,
+          }),
+          {
+            id: 'translation-legacy-de',
+            branchId: 'branch-1',
+            fileId: 'file-2',
+            versionId: 'version-2',
+            locale: 'de',
+            fileFormat: 'APPLE_STRINGS' as FileFormat,
+            data: legacyDePayload,
+            fileName: legacyEnPath,
+            metadata: {},
+          },
+        ],
+        count: 2,
+      });
+      const store = new Map([
+        [fixtureCatalogPath, legacyMixedCatalog],
+        [legacyDePath, legacyMixedDeStrings],
+      ]);
+      setupInMemoryFs(store, [
+        'Sources/FieldNotesKit/Resources',
+        'Sources/FieldNotesKit/Resources/de.lproj',
+      ]);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de'] })
+      );
+
+      expect(result.successful).toHaveLength(2);
+      // Catalog merged in place; the legacy file written verbatim, unmerged
+      expect(store.get(fixtureCatalogPath)).toBe(
+        mergeXcstrings(legacyMixedCatalog, deSlice, 'de')
+      );
+      expect(store.get(legacyDePath)).toBe(legacyDePayload);
+      // The catalog merge reads only the catalog — never the legacy files
+      for (const call of vi.mocked(fs.readFileSync).mock.calls) {
+        expect(call[0]).toBe(fixtureCatalogPath);
+      }
+      // One write per output path, nothing else touched
+      const writtenPaths = vi
+        .mocked(fs.promises.writeFile)
+        .mock.calls.map((call) => call[0]);
+      expect(writtenPaths.sort()).toEqual([fixtureCatalogPath, legacyDePath]);
+    });
+
+    it('never routes a merged catalog through the JSON key sorter', async () => {
+      // Entry order is part of the pinned catalog bytes. Even if a path
+      // transform remaps the output to a .json name, the merged catalog must
+      // be written as-is — sortJsonString would reorder keys and drop the
+      // trailing newline.
+      const unsortedCatalog = JSON.stringify({
+        sourceLanguage: 'en',
+        strings: {
+          zebra: {
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Zebra' } },
+            },
+          },
+          alpha: {
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Alpha' } },
+            },
+          },
+        },
+      });
+      const esSlice = JSON.stringify({
+        sourceLanguage: 'en',
+        strings: {
+          zebra: {
+            localizations: {
+              es: { stringUnit: { state: 'translated', value: 'Cebra' } },
+            },
+          },
+        },
+      });
+      const files: BatchedFiles = [
+        xcstringsBatchFile('es', {
+          inputPath: 'App.xcstrings',
+          outputPath: 'locales/App.es.json',
+        }),
+      ];
+      const fileTracker = createMockFileTracker(files);
+
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          xcstringsResponseFile('es', esSlice, { fileName: 'App.xcstrings' }),
+        ],
+        count: 1,
+      });
+      const store = new Map([['App.xcstrings', unsortedCatalog]]);
+      setupInMemoryFs(store, ['locales']);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['es'] })
+      );
+
+      expect(result.successful).toHaveLength(1);
+      const written = store.get('locales/App.es.json')!;
+      expect(written).toBe(mergeXcstrings(unsortedCatalog, esSlice, 'es'));
+      // Catalog entry order and the trailing newline survive
+      expect(
+        Object.keys((JSON.parse(written) as XcstringsCatalog).strings)
+      ).toEqual(['zebra', 'alpha']);
+      expect(written.endsWith('\n')).toBe(true);
+    });
   });
 });

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -977,6 +977,52 @@ describe('downloadFileBatch', () => {
       );
     });
 
+    it('accumulates every locale when a path transform shares one non-source output', async () => {
+      // Without [locale] in the transform, all locales merge into one output
+      // file that is not the source catalog. The source never sees those
+      // merges, so later locales must build on the output written earlier in
+      // this run rather than rereading the source and discarding them.
+      const transformedPath = 'Cascade/Localizable.translated.xcstrings';
+      const esSlice = buildSlice(realisticCatalog, 'es', 'nuevo');
+      const frSlice = buildSlice(realisticCatalog, 'fr', 'nouveau');
+      const files = [
+        xcstringsBatchFile('es', { outputPath: transformedPath }),
+        xcstringsBatchFile('fr', { outputPath: transformedPath }),
+      ];
+      const fileTracker = createMockFileTracker(files);
+      const lockEntry: DownloadedVersionEntry = {
+        fileId: 'file-1',
+        versionId: 'version-1',
+        translations: {},
+      };
+      vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+
+      vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+        files: [
+          xcstringsResponseFile('es', esSlice),
+          xcstringsResponseFile('fr', frSlice),
+        ],
+        count: 2,
+      });
+      const store = new Map([[catalogPath, realisticCatalog]]);
+      setupInMemoryFs(store, ['Cascade']);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['es', 'fr'] })
+      );
+
+      expect(result.successful).toHaveLength(2);
+      expect(result.failed).toHaveLength(0);
+
+      // The source catalog is untouched; the shared output holds both merges
+      expect(store.get(catalogPath)).toBe(realisticCatalog);
+      const afterEs = mergeXcstrings(realisticCatalog, esSlice, 'es');
+      const afterFr = mergeXcstrings(afterEs, frSlice, 'fr');
+      expect(store.get(transformedPath)).toBe(afterFr);
+    });
+
     it('touches only the catalog when it coexists with legacy .strings files', async () => {
       const fixtureCatalogPath =
         'Sources/FieldNotesKit/Resources/Localizable.xcstrings';

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -42,6 +42,22 @@ const findLatestDownloadedVersion = (
 };
 
 /**
+ * Canonicalizes one locale's editable content in an xcstrings slice: a
+ * stable-stringified map of entry key -> that locale's localization. Entries
+ * without the locale are irrelevant to edit detection, as is every other
+ * field and any serialization ordering.
+ */
+function projectXcstringsLocale(sliceContent: string, locale: string): string {
+  const catalog = parseXcstringsCatalog(sliceContent);
+  const projection: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(catalog.strings)) {
+    const localization = entry.localizations?.[locale];
+    if (localization !== undefined) projection[key] = localization;
+  }
+  return stringify(projection);
+}
+
+/**
  * Collects local user edits by diffing the latest downloaded server translation version
  * against the current local translation file, and submits the diffs upstream.
  *
@@ -194,11 +210,13 @@ export async function collectAndSendUserEditDiffs(
           } catch {
             continue;
           }
-          // Key order is serialization-dependent (the server orders top-level
-          // fields its own way); only content differences are user edits.
+          // Only this locale's localizations are user-editable here. Compare
+          // that projection: key order is serialization-dependent, and the
+          // server slice legitimately carries entries with no target-locale
+          // localization (e.g. shouldTranslate:false entries kept verbatim).
           if (
-            stringify(JSON.parse(serverSlice)) ===
-            stringify(JSON.parse(localSlice))
+            projectXcstringsLocale(serverSlice, c.locale) ===
+            projectXcstringsLocale(localSlice, c.locale)
           ) {
             continue;
           }

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -15,6 +15,12 @@ import { randomUUID } from 'node:crypto';
 import { hashStringSync } from '../utils/hash.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
+import { extractXcstrings } from '../formats/xcstrings/extractXcstrings.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstrings,
+} from '../formats/xcstrings/parseXcstrings.js';
+import stringify from 'fast-json-stable-stringify';
 
 type LatestDownloadedVersion = {
   versionId: string;
@@ -163,6 +169,65 @@ export async function collectAndSendUserEditDiffs(
         )
           .toString('base64')
           .replace(/=+$/g, '');
+
+        // Xcstrings catalogs hold every locale in one on-disk file, so the
+        // local comparand is the extracted target-locale slice, never the
+        // whole catalog — diffing the catalog against the server's
+        // single-locale slice would read as an edit on every run and submit
+        // the full catalog (other locales included) as this locale's content.
+        if (c.fileName.endsWith('.xcstrings')) {
+          const rawLocalContent = await fs.promises.readFile(
+            c.outputPath,
+            'utf8'
+          );
+          const localSlice = extractXcstrings(
+            rawLocalContent,
+            c.fileName,
+            c.locale
+          );
+          if (!localSlice) continue;
+          let serverSlice: string;
+          try {
+            serverSlice = serializeXcstrings(
+              parseXcstringsCatalog(serverContent)
+            );
+          } catch {
+            continue;
+          }
+          // Key order is serialization-dependent (the server orders top-level
+          // fields its own way); only content differences are user edits.
+          if (
+            stringify(JSON.parse(serverSlice)) ===
+            stringify(JSON.parse(localSlice))
+          ) {
+            continue;
+          }
+          const tempServerFile = path.join(tempDir, `${safeName}.server`);
+          const tempLocalFile = path.join(tempDir, `${safeName}.local`);
+          await fs.promises.writeFile(tempServerFile, serverSlice, 'utf8');
+          await fs.promises.writeFile(tempLocalFile, localSlice, 'utf8');
+          const diff = await getGitUnifiedDiff(tempServerFile, tempLocalFile);
+          for (const tempFile of [tempServerFile, tempLocalFile]) {
+            try {
+              await fs.promises.unlink(tempFile);
+            } catch {
+              // Ignore cleanup errors for temporary comparison files.
+            }
+          }
+          if (diff && diff.trim().length > 0) {
+            collectedDiffs.push({
+              fileName: c.fileName,
+              locale: c.locale,
+              diff,
+              branchId: c.branchId,
+              versionId: c.versionId,
+              fileId: c.fileId,
+              localContent: localSlice,
+            } satisfies SubmitUserEditDiff);
+          }
+          continue;
+        }
+
         const tempServerFile = path.join(tempDir, `${safeName}.server`);
         await fs.promises.writeFile(tempServerFile, serverContent, 'utf8');
 

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -20,7 +20,11 @@ import {
   writeLockfile,
   findOrCreateEntry,
 } from '../fs/config/downloadedVersions.js';
-import { recordDownloaded, recordRemerged } from '../state/recentDownloads.js';
+import {
+  getDownloaded,
+  recordDownloaded,
+  recordRemerged,
+} from '../state/recentDownloads.js';
 import { recordWarning } from '../state/translateWarnings.js';
 import stringify from 'fast-json-stable-stringify';
 import type { FileStatusTracker } from '../workflows/steps/PollJobsStep.js';
@@ -93,17 +97,19 @@ function mergeWithSource(
   translatedContent: string,
   locale: string,
   inputPath: string,
-  options: Settings
+  options: Settings,
+  xcstringsMergeBasePath: string = inputPath
 ): string {
   if (shouldSkipSourceFormatMerge(inputPath, options)) {
     return translatedContent;
   }
   // Xcstrings: fold the downloaded locale slice into the current on-disk
   // catalog. Read fresh each merge — the download loop is sequential, so
-  // each locale sees the previous locale's write.
+  // each locale sees the previous locale's write (via the merge base when a
+  // path transform sends every locale to one shared non-source output).
   if (inputPath.endsWith('.xcstrings')) {
     return mergeXcstrings(
-      fs.readFileSync(inputPath, 'utf8'),
+      fs.readFileSync(xcstringsMergeBasePath, 'utf8'),
       translatedContent,
       locale
     );
@@ -435,7 +441,23 @@ export async function downloadFileBatch(
           result.skipped.push(requestedFile);
           continue;
         }
-        let data = mergeWithSource(file.data, locale, inputPath, options);
+        // When a path transform maps every locale's merge to one shared
+        // output that is not the source catalog, the source never sees those
+        // merges; later locales must fold into the output written earlier in
+        // this run or each write discards the locales merged before it.
+        const xcstringsMergeBasePath =
+          isXcstringsCatalogMerge &&
+          outputPath !== inputPath &&
+          getDownloaded().has(outputPath)
+            ? outputPath
+            : inputPath;
+        let data = mergeWithSource(
+          file.data,
+          locale,
+          inputPath,
+          options,
+          xcstringsMergeBasePath
+        );
 
         // Stable sort JSON keys for deterministic output. Merged xcstrings
         // catalogs are byte-pinned by serializeXcstrings and must never pass

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -8,6 +8,7 @@ import { validateJsonSchema } from '../formats/json/utils.js';
 import { validateYamlSchema } from '../formats/yaml/utils.js';
 import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
+import { mergeXcstrings } from '../formats/xcstrings/mergeXcstrings.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import {
@@ -96,6 +97,16 @@ function mergeWithSource(
 ): string {
   if (shouldSkipSourceFormatMerge(inputPath, options)) {
     return translatedContent;
+  }
+  // Xcstrings: fold the downloaded locale slice into the current on-disk
+  // catalog. Read fresh each merge — the download loop is sequential, so
+  // each locale sees the previous locale's write.
+  if (inputPath.endsWith('.xcstrings')) {
+    return mergeXcstrings(
+      fs.readFileSync(inputPath, 'utf8'),
+      translatedContent,
+      locale
+    );
   }
   if (!options.options) return translatedContent;
 
@@ -330,20 +341,30 @@ export async function downloadFileBatch(
           continue;
         }
 
-        // Composite schema files merge translations into the source file itself,
-        // so outputPath always exists and the lock can't tell whether derived
-        // split outputs (e.g. {locale}/docs.json) are still on disk. Always
-        // merge fresh API data so derived files are regenerated every run;
-        // local edits to translated output are preserved via `gt save-local`.
-        const isInPlaceComposite = options.options?.jsonSchema
-          ? !!validateJsonSchema(options.options, inputPath)?.composite
-          : false;
+        // Xcstrings catalogs merge each downloaded locale slice into the
+        // source catalog itself, unless a format transform redirects output
+        // to a derived file instead.
+        const isXcstringsCatalogMerge =
+          inputPath.endsWith('.xcstrings') &&
+          !shouldSkipSourceFormatMerge(inputPath, options);
+
+        // In-place translation files (composite schema JSON, xcstrings
+        // catalogs) merge translations into the source file itself, so
+        // outputPath always exists and the lock can't tell whether this
+        // locale's content (or derived split outputs, e.g. {locale}/docs.json)
+        // is still on disk. Always merge fresh API data; local edits to
+        // translated output are preserved via `gt save-local`.
+        const isInPlaceTranslationFile =
+          isXcstringsCatalogMerge ||
+          (options.options?.jsonSchema
+            ? !!validateJsonSchema(options.options, inputPath)?.composite
+            : false);
 
         if (
           !forceDownload &&
           fileExists &&
           downloadedTranslation &&
-          !isInPlaceComposite
+          !isInPlaceTranslationFile
         ) {
           // For schema-based files, re-merge with current source in case
           // non-translatable fields changed (skip the API download, not the merge)
@@ -416,8 +437,14 @@ export async function downloadFileBatch(
         }
         let data = mergeWithSource(file.data, locale, inputPath, options);
 
-        // Stable sort JSON keys for deterministic output
-        if (file.fileFormat === 'GTJSON' || outputPath.endsWith('.json')) {
+        // Stable sort JSON keys for deterministic output. Merged xcstrings
+        // catalogs are byte-pinned by serializeXcstrings and must never pass
+        // through the JSON sorter, even if a transform maps the output to a
+        // .json path.
+        if (
+          !isXcstringsCatalogMerge &&
+          (file.fileFormat === 'GTJSON' || outputPath.endsWith('.json'))
+        ) {
           try {
             data = sortJsonString(data);
           } catch (error) {

--- a/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
+++ b/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
@@ -37,6 +37,28 @@ describe('createFileMapping', () => {
     );
   });
 
+  it('maps every locale of an xcstrings catalog to the same shared file', () => {
+    // Catalog include patterns carry no [locale], so the placeholder path
+    // equals the source path and download merges target the one on-disk file
+    const catalogPath = path.resolve('Cascade/Localizable.xcstrings');
+
+    const mapping = createFileMapping(
+      { xcstrings: [catalogPath] },
+      { xcstrings: [catalogPath] },
+      {},
+      {},
+      ['es', 'fr'],
+      'en'
+    );
+
+    expect(mapping.es['Cascade/Localizable.xcstrings']).toBe(
+      'Cascade/Localizable.xcstrings'
+    );
+    expect(mapping.fr['Cascade/Localizable.xcstrings']).toBe(
+      'Cascade/Localizable.xcstrings'
+    );
+  });
+
   describe('non-canonical locale tags', () => {
     // A locale written as "fr-ca" canonicalizes to "fr-CA". Everything that
     // names a path must use the tag as configured, because [locale]

--- a/packages/cli/src/formats/xcstrings/__mocks__/legacy_catalog_mixed.xcstrings
+++ b/packages/cli/src/formats/xcstrings/__mocks__/legacy_catalog_mixed.xcstrings
@@ -1,0 +1,342 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "action.cancel" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        }
+      }
+    },
+    "action.delete" : {
+      "comment" : "Destructive action in the note context menu.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Delete"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "削除"
+          }
+        }
+      }
+    },
+    "action.save" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Guardar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "保存"
+          }
+        }
+      }
+    },
+    "home.empty" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No notes yet. Tap + to create one."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aún no hay notas. Toca + para crear una."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "まだメモがありません。＋をタップして作成してください。"
+          }
+        }
+      }
+    },
+    "home.subtitle" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All your field notes in one place"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Todas tus notas de campo en un solo lugar"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "すべてのフィールドノートを一か所に"
+          }
+        }
+      }
+    },
+    "home.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inicio"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ホーム"
+          }
+        }
+      }
+    },
+    "profile.edit" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Edit Profile"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Editar perfil"
+          }
+        }
+      }
+    },
+    "profile.title" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profile"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perfil"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プロフィール"
+          }
+        }
+      }
+    },
+    "search.placeholder" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search notes…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Buscar notas…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "メモを検索…"
+          }
+        }
+      }
+    },
+    "search.results_for" : {
+      "comment" : "Shown above search results. %@ is the query the user typed.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Results for “%@”"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Resultados para “%@”"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "「%@」の検索結果"
+          }
+        }
+      }
+    },
+    "settings.appearance" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Appearance"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Apariencia"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "外観"
+          }
+        }
+      }
+    },
+    "settings.notifications" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificaciones"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "通知"
+          }
+        }
+      }
+    },
+    "settings.title" : {
+      "comment" : "Also still present in de.lproj/Localizable.strings with a different value.",
+      "extractionState" : "migrated",
+      "localizations" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Einstellungen"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ajustes"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        }
+      }
+    },
+    "sync.last_synced" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Last synced %@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Última sincronización: %@"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最終同期: %@"
+          }
+        }
+      }
+    },
+    "sync.status.syncing" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Syncing…"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizando…"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "同期中…"
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/packages/cli/src/formats/xcstrings/__mocks__/legacy_catalog_mixed_de.strings
+++ b/packages/cli/src/formats/xcstrings/__mocks__/legacy_catalog_mixed_de.strings
@@ -1,0 +1,22 @@
+/* FieldNotes — German strings that were never migrated to Localizable.xcstrings.
+   Everything below except settings.title exists ONLY here. */
+
+"legacy.error.generic" = "Ein unbekannter Fehler ist aufgetreten.";
+"legacy.error.network" = "Keine Internetverbindung. Bitte versuche es später erneut.";
+
+/* Account */
+"legacy.logout.button" = "Abmelden";
+"legacy.logout.confirm" = "Möchtest du dich wirklich abmelden?";
+
+/* First-run flow */
+"legacy.onboarding.next" = "Weiter";
+"legacy.onboarding.skip" = "Überspringen";
+
+"legacy.rating.prompt" = "Gefällt dir FieldNotes? Bewerte uns im App Store!";
+"legacy.share.subject" = "Notiz aus FieldNotes";
+"legacy.support.email_subject" = "FieldNotes Support-Anfrage";
+"legacy.whatsnew.title" = "Neu in dieser Version";
+
+/* Migrated to Localizable.xcstrings but never deleted here.
+   The catalog's de value is intentionally different. */
+"settings.title" = "App-Einstellungen (Legacy)";

--- a/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { mergeXcstrings } from '../mergeXcstrings.js';
+import { extractXcstrings } from '../extractXcstrings.js';
+import type { XcstringsCatalog } from '../parseXcstrings.js';
+import { logger } from '../../../console/logger.js';
+
+vi.mock('../../../console/logger.js');
+
+const realisticAppContent = readFileSync(
+  path.join(__dirname, '../__mocks__', 'realistic_app.xcstrings'),
+  'utf8'
+);
+
+const parseCatalog = (content: string): XcstringsCatalog =>
+  JSON.parse(content) as XcstringsCatalog;
+
+/** Appends a marker to every "value" string, keeping structure intact. */
+function rewriteValues(node: unknown, suffix: string): unknown {
+  if (Array.isArray(node)) {
+    return node.map((item) => rewriteValues(item, suffix));
+  }
+  if (node !== null && typeof node === 'object') {
+    return Object.fromEntries(
+      Object.entries(node).map(([key, value]) => [
+        key,
+        key === 'value' && typeof value === 'string'
+          ? `${value} ${suffix}`
+          : rewriteValues(value, suffix),
+      ])
+    );
+  }
+  return node;
+}
+
+/**
+ * Builds a downloaded translation slice for a locale: the upload-time slice
+ * with every value rewritten, serialized WITHOUT the pinned serializer so
+ * the merge cannot depend on slice formatting.
+ */
+function buildTranslatedSlice(
+  content: string,
+  locale: string,
+  suffix: string
+): string {
+  const slice = parseCatalog(extractXcstrings(content, 'fixture', locale)!);
+  return JSON.stringify(rewriteValues(slice, suffix));
+}
+
+describe('mergeXcstrings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('replaces one locale in the realistic catalog and leaves everything else byte-stable', () => {
+    const input = parseCatalog(realisticAppContent);
+    const esSlice = buildTranslatedSlice(realisticAppContent, 'es', '(rev)');
+    const sliceStrings = parseCatalog(esSlice).strings;
+
+    const merged = mergeXcstrings(realisticAppContent, esSlice, 'es');
+    const catalog = parseCatalog(merged);
+
+    // Document shape and entry order are the on-disk catalog's
+    expect(catalog.sourceLanguage).toBe(input.sourceLanguage);
+    expect(catalog.version).toBe(input.version);
+    expect(Object.keys(catalog.strings)).toEqual(Object.keys(input.strings));
+
+    for (const [key, inputEntry] of Object.entries(input.strings)) {
+      const mergedEntry = catalog.strings[key];
+      // Entry-level fields other than localizations are untouched
+      expect({ ...mergedEntry, localizations: undefined }).toEqual({
+        ...inputEntry,
+        localizations: undefined,
+      });
+      if (inputEntry.localizations === undefined) {
+        expect(mergedEntry.localizations).toBeUndefined();
+        continue;
+      }
+      // Locale key order is untouched (es already exists in the fixture)
+      expect(Object.keys(mergedEntry.localizations!)).toEqual(
+        Object.keys(inputEntry.localizations)
+      );
+      for (const [locale, localization] of Object.entries(
+        inputEntry.localizations
+      )) {
+        if (locale === 'es' && sliceStrings[key] !== undefined) {
+          // Target locale replaced wholesale from the slice
+          expect(mergedEntry.localizations![locale]).toEqual(
+            sliceStrings[key].localizations!.es
+          );
+          continue;
+        }
+        // Other locales byte-stable: deep-equal AND identical serialization
+        expect(mergedEntry.localizations![locale]).toEqual(localization);
+        expect(JSON.stringify(mergedEntry.localizations![locale])).toBe(
+          JSON.stringify(localization)
+        );
+      }
+    }
+
+    // A second merge of the same slice is byte-idempotent
+    expect(mergeXcstrings(merged, esSlice, 'es')).toBe(merged);
+  });
+
+  it('produces identical bytes regardless of locale merge order', () => {
+    const catalogContent = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: {
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+            fr: { stringUnit: { state: 'translated', value: 'Salut' } },
+          },
+        },
+      },
+    });
+    const makeSlice = (locale: string, value: string) =>
+      JSON.stringify({
+        sourceLanguage: 'en',
+        strings: {
+          greeting: {
+            localizations: {
+              [locale]: { stringUnit: { state: 'translated', value } },
+            },
+          },
+        },
+      });
+    // One new locale sorts before the existing fr, the other after it
+    const deSlice = makeSlice('de', 'Hallo');
+    const itSlice = makeSlice('it', 'Ciao');
+
+    const deThenIt = mergeXcstrings(
+      mergeXcstrings(catalogContent, deSlice, 'de'),
+      itSlice,
+      'it'
+    );
+    const itThenDe = mergeXcstrings(
+      mergeXcstrings(catalogContent, itSlice, 'it'),
+      deSlice,
+      'de'
+    );
+
+    expect(deThenIt).toBe(itThenDe);
+    // Existing locales never move; new ones land at their sorted position
+    expect(
+      Object.keys(parseCatalog(deThenIt).strings.greeting.localizations!)
+    ).toEqual(['de', 'en', 'fr', 'it']);
+  });
+
+  it('skips slice entries with no matching catalog entry and warns', () => {
+    const catalogContent = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: {
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+          },
+        },
+      },
+    });
+    const sliceContent = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: {
+          localizations: {
+            es: { stringUnit: { state: 'translated', value: 'Hola' } },
+          },
+        },
+        'deleted.key': {
+          localizations: {
+            es: { stringUnit: { state: 'translated', value: 'Huérfano' } },
+          },
+        },
+      },
+    });
+
+    const catalog = parseCatalog(
+      mergeXcstrings(catalogContent, sliceContent, 'es')
+    );
+
+    // The on-disk catalog is truth for entry existence
+    expect(Object.keys(catalog.strings)).toEqual(['greeting']);
+    expect(catalog.strings.greeting.localizations!.es).toEqual({
+      stringUnit: { state: 'translated', value: 'Hola' },
+    });
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('"deleted.key"')
+    );
+  });
+
+  it('preserves unknown fields everywhere and replaces the target locale wholesale', () => {
+    const catalogContent = JSON.stringify({
+      sourceLanguage: 'en',
+      unknownRoot: { keep: ['me'] },
+      strings: {
+        'task.count': {
+          comment: 'Badge',
+          unknownEntryField: 7,
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Tasks' } },
+            // Stale machine translation with source-shaped categories and an
+            // unknown unit field — replaced wholesale by the download
+            es: {
+              variations: {
+                plural: {
+                  one: { stringUnit: { state: 'new', value: 'Tarea' } },
+                  other: { stringUnit: { state: 'new', value: 'Tareas' } },
+                },
+              },
+            },
+            fr: {
+              stringUnit: {
+                state: 'translated',
+                value: 'Tâches',
+                unknownUnitField: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    // Target-language plural categories legitimately differ from the source's
+    const sliceContent = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        'task.count': {
+          localizations: {
+            es: {
+              variations: {
+                plural: {
+                  one: { stringUnit: { state: 'translated', value: 'Tarea' } },
+                  many: {
+                    stringUnit: { state: 'translated', value: 'Tareas' },
+                  },
+                  other: {
+                    stringUnit: { state: 'translated', value: 'Tareas' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const catalog = parseCatalog(
+      mergeXcstrings(catalogContent, sliceContent, 'es')
+    );
+
+    expect(catalog.unknownRoot).toEqual({ keep: ['me'] });
+    const entry = catalog.strings['task.count'];
+    expect(entry.comment).toBe('Badge');
+    expect(entry.unknownEntryField).toBe(7);
+    expect(entry.localizations!.fr).toEqual({
+      stringUnit: {
+        state: 'translated',
+        value: 'Tâches',
+        unknownUnitField: true,
+      },
+    });
+    expect(entry.localizations!.es).toEqual({
+      variations: {
+        plural: {
+          one: { stringUnit: { state: 'translated', value: 'Tarea' } },
+          many: { stringUnit: { state: 'translated', value: 'Tareas' } },
+          other: { stringUnit: { state: 'translated', value: 'Tareas' } },
+        },
+      },
+    });
+  });
+
+  it('throws on invalid catalog or slice content', () => {
+    const valid = JSON.stringify({ sourceLanguage: 'en', strings: {} });
+    expect(() => mergeXcstrings('not json', valid, 'es')).toThrow(
+      'Invalid .xcstrings content'
+    );
+    expect(() => mergeXcstrings(valid, '{"strings":{}}', 'es')).toThrow(
+      'Invalid .xcstrings content'
+    );
+  });
+});

--- a/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { mergeXcstrings } from '../mergeXcstrings.js';
 import { extractXcstrings } from '../extractXcstrings.js';
-import type { XcstringsCatalog } from '../parseXcstrings.js';
+import { parseXcstrings, type XcstringsCatalog } from '../parseXcstrings.js';
 import { logger } from '../../../console/logger.js';
 
 vi.mock('../../../console/logger.js');
@@ -146,6 +146,60 @@ describe('mergeXcstrings', () => {
     expect(
       Object.keys(parseCatalog(deThenIt).strings.greeting.localizations!)
     ).toEqual(['de', 'en', 'fr', 'it']);
+  });
+
+  it('leaves the source slice (and so versionId) byte-stable across merges', () => {
+    // Implicit entries gain a localizations object holding only target
+    // locales when translations merge in. Re-slicing the merged catalog must
+    // reproduce the original source slice, or every translate run re-versions
+    // the file and re-triggers translation.
+    const catalogContent = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        Save: {},
+        Cancel: { comment: 'toolbar' },
+        greeting: {
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+          },
+        },
+      },
+    });
+    const makeSlice = (locale: string, values: Record<string, string>) =>
+      JSON.stringify({
+        sourceLanguage: 'en',
+        strings: Object.fromEntries(
+          Object.entries(values).map(([key, value]) => [
+            key,
+            {
+              localizations: {
+                [locale]: { stringUnit: { state: 'translated', value } },
+              },
+            },
+          ])
+        ),
+      });
+
+    let merged = mergeXcstrings(
+      catalogContent,
+      makeSlice('es', {
+        Save: 'Guardar',
+        Cancel: 'Cancelar',
+        greeting: 'Hola',
+      }),
+      'es'
+    );
+    merged = mergeXcstrings(
+      merged,
+      makeSlice('fr', {
+        Save: 'Enregistrer',
+        Cancel: 'Annuler',
+        greeting: 'Salut',
+      }),
+      'fr'
+    );
+
+    expect(parseXcstrings(merged)).toBe(parseXcstrings(catalogContent));
   });
 
   it('skips slice entries with no matching catalog entry and warns', () => {

--- a/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
@@ -53,11 +53,12 @@ describe('parseXcstrings - source slice', () => {
         expect(slicedEntry).toEqual(inputEntry);
         continue;
       }
-      // Only the source language remains; its content is untouched
+      // Only the source language remains; its content is untouched. Entries
+      // with no source-language unit slice as implicit (no localizations key).
       expect(slicedEntry.localizations).toEqual(
         'en' in inputEntry.localizations
           ? { en: inputEntry.localizations.en }
-          : {}
+          : undefined
       );
       // Entry-level fields other than localizations are untouched
       expect({ ...slicedEntry, localizations: undefined }).toEqual({
@@ -83,6 +84,28 @@ describe('parseXcstrings - source slice', () => {
       comment: 'toolbar',
       extractionState: 'manual',
     });
+  });
+
+  it('slices entries with no source-language localization as implicit entries', () => {
+    // After a download merge, formerly-implicit entries carry only target
+    // locales. Their slice must match the pre-merge implicit form byte-for-
+    // byte, or versionId changes on every run and re-triggers translation.
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        Save: {
+          comment: 'toolbar',
+          localizations: {
+            es: { stringUnit: { state: 'translated', value: 'Guardar' } },
+          },
+        },
+      },
+    });
+
+    const slice = parseCatalog(parseXcstrings(content));
+
+    expect(slice.strings.Save).toEqual({ comment: 'toolbar' });
+    expect('localizations' in slice.strings.Save).toBe(false);
   });
 
   it('keeps shouldTranslate:false entries verbatim, including non-source locales', () => {

--- a/packages/cli/src/formats/xcstrings/extractXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/extractXcstrings.ts
@@ -2,7 +2,7 @@ import { logger } from '../../console/logger.js';
 import {
   filterLocalizations,
   parseXcstringsCatalog,
-  serializeXcstringsSlice,
+  serializeXcstrings,
   type XcstringsEntry,
 } from './parseXcstrings.js';
 
@@ -39,7 +39,7 @@ export function extractXcstrings(
   }
   if (slicedEntries.length === 0) return null;
 
-  return serializeXcstringsSlice({
+  return serializeXcstrings({
     ...catalog,
     strings: Object.fromEntries(slicedEntries),
   });

--- a/packages/cli/src/formats/xcstrings/mergeXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/mergeXcstrings.ts
@@ -1,0 +1,89 @@
+import { logger } from '../../console/logger.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstrings,
+  type XcstringsEntry,
+} from './parseXcstrings.js';
+
+/**
+ * Merges one locale's translated slice back into the full on-disk catalog.
+ *
+ * The catalog is truth for entry existence and every field except the target
+ * locale's localization, which is replaced wholesale from the slice (target
+ * plural/device categories legitimately differ from the source's). Entries
+ * and locales the slice does not mention are preserved verbatim; slice
+ * entries with no matching catalog entry are skipped with a warning. Throws
+ * on invalid content.
+ */
+export function mergeXcstrings(
+  currentCatalogContent: string,
+  translatedSliceContent: string,
+  targetLocale: string
+): string {
+  const catalog = parseXcstringsCatalog(currentCatalogContent);
+  const slice = parseXcstringsCatalog(translatedSliceContent);
+
+  const mergedEntries: [string, XcstringsEntry][] = [];
+  for (const [key, entry] of Object.entries(catalog.strings)) {
+    const sliceEntry = Object.hasOwn(slice.strings, key)
+      ? slice.strings[key]
+      : undefined;
+    const localization =
+      sliceEntry?.localizations !== undefined &&
+      Object.hasOwn(sliceEntry.localizations, targetLocale)
+        ? sliceEntry.localizations[targetLocale]
+        : undefined;
+    if (localization === undefined) {
+      mergedEntries.push([key, entry]);
+      continue;
+    }
+    mergedEntries.push([
+      key,
+      {
+        ...entry,
+        localizations: setLocalization(
+          entry.localizations ?? {},
+          targetLocale,
+          localization
+        ),
+      },
+    ]);
+  }
+
+  const unmatchedKeys = Object.keys(slice.strings).filter(
+    (key) => !Object.hasOwn(catalog.strings, key)
+  );
+  if (unmatchedKeys.length > 0) {
+    logger.warn(
+      `Skipped ${unmatchedKeys.length} downloaded ${targetLocale} translation(s) with no matching entry in the local catalog: ${unmatchedKeys
+        .map((key) => JSON.stringify(key))
+        .join(', ')}`
+    );
+  }
+
+  return serializeXcstrings({
+    ...catalog,
+    strings: Object.fromEntries(mergedEntries),
+  });
+}
+
+/**
+ * Clones localizations with the target locale set. An existing locale keeps
+ * its position; a new one is inserted at its sorted position among existing
+ * keys, so the merged bytes are independent of locale download order while
+ * untouched locales never move.
+ */
+function setLocalization(
+  localizations: Record<string, unknown>,
+  targetLocale: string,
+  localization: unknown
+): Record<string, unknown> {
+  if (Object.hasOwn(localizations, targetLocale)) {
+    return { ...localizations, [targetLocale]: localization };
+  }
+  const entries = Object.entries(localizations);
+  const firstLater = entries.findIndex(([locale]) => targetLocale < locale);
+  const insertAt = firstLater === -1 ? entries.length : firstLater;
+  entries.splice(insertAt, 0, [targetLocale, localization]);
+  return Object.fromEntries(entries);
+}

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -73,10 +73,12 @@ export function parseXcstringsCatalog(content: string): XcstringsCatalog {
  *
  * versionId is a hash of this exact byte output (hashVersionId over the
  * slice in aggregateFiles), so any change here re-versions every customer
- * xcstrings file and re-triggers translation fleet-wide. The byte-exact
- * tests on this format are the contract.
+ * xcstrings file and re-triggers translation fleet-wide. Download merges
+ * (mergeXcstrings) also write catalogs through it, so repeated merges must
+ * round-trip byte-identically. The byte-exact tests on this format are the
+ * contract.
  */
-export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
+export function serializeXcstrings(catalog: XcstringsCatalog): string {
   return JSON.stringify(catalog, null, 2) + '\n';
 }
 
@@ -116,7 +118,7 @@ export function parseXcstrings(content: string): string {
       },
     ]);
   }
-  return serializeXcstringsSlice({
+  return serializeXcstrings({
     ...catalog,
     strings: Object.fromEntries(slicedEntries),
   });

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -96,8 +96,11 @@ export function filterLocalizations(
  * Produces the source-language slice of a catalog: a valid single-locale
  * catalog containing, per entry, only the source-language localization.
  * Entries with no localizations (the key is the source) and
- * shouldTranslate:false entries are kept verbatim. Entry order and unknown
- * fields are preserved. Throws on invalid content.
+ * shouldTranslate:false entries are kept verbatim. An entry holding only
+ * non-source locales slices to the same implicit form (no localizations
+ * key), so the slice — and the versionId hashed from it — is invariant to
+ * target-locale translations merged into the catalog. Entry order and
+ * unknown fields are preserved. Throws on invalid content.
  */
 export function parseXcstrings(content: string): string {
   const catalog = parseXcstringsCatalog(content);
@@ -107,16 +110,16 @@ export function parseXcstrings(content: string): string {
       slicedEntries.push([key, entry]);
       continue;
     }
-    slicedEntries.push([
-      key,
-      {
-        ...entry,
-        localizations: filterLocalizations(
-          entry.localizations,
-          catalog.sourceLanguage
-        ),
-      },
-    ]);
+    const localizations = filterLocalizations(
+      entry.localizations,
+      catalog.sourceLanguage
+    );
+    if (Object.keys(localizations).length === 0) {
+      const { localizations: _dropped, ...implicitEntry } = entry;
+      slicedEntries.push([key, implicitEntry]);
+      continue;
+    }
+    slicedEntries.push([key, { ...entry, localizations }]);
   }
   return serializeXcstrings({
     ...catalog,


### PR DESCRIPTION
## Summary

- Merge-on-download for `.xcstrings`: each downloaded per-locale translation folds back into the single on-disk catalog, read-modify-write, preserving every other locale and all unknown Xcode fields. With #2216 + #2218 this completes the CLI's xcstrings loop.
- Stacked on #2218 (slicing).

## Design

- `mergeXcstrings` is clone-and-set only: the target locale's localization is replaced wholesale per entry (target plural categories legitimately differ from source's); slice entries missing on disk warn and skip — the on-disk file is truth for entry existence. `Object.hasOwn` lookups keep hostile keys (`toString`, `__proto__`) from aliasing prototype members.
- **Order independence**: a new locale key inserts at its sorted position among existing keys, existing locales never move — merging es-then-fr and fr-then-es produce byte-identical files.
- The already-downloaded skip is exempted for catalogs (`isInPlaceComposite` generalized to `isInPlaceTranslationFile`): the shared file always exists, so without the exemption locales silently never merge — the exact trap the composite-JSON precedent solved, and a mutation test pins it.
- The `.json` key-sorter is explicitly guarded off the catalog write path.
- Last-locale-wins download metadata for the shared path follows the composite precedent; per-locale lockfile entries are locale-keyed and unaffected — both asserted in the two-locale test.

## Verification

gt 2297 tests green, core 516; typecheck/oxlint/oxfmt clean. Five mutations killed: rebuild-instead-of-clone, dropped skip exemption, serializer byte change, removed sort guard, append-instead-of-sorted-insert. Fixture-19 (catalog coexisting with legacy `.lproj` files) merge touches only the catalog.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds read-modify-write merging of downloaded locale slices into xcstrings catalogs while preserving unrelated catalog fields and locales.
- Adds xcstrings parsing, serialization, and locale-merge behavior.
- Integrates catalog merging with download skipping, deterministic output, lockfile tracking, and transformed paths.
- Adds focused unit and batch-level coverage for normal shared-catalog downloads.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until multi-locale xcstrings downloads to a shared transformed output preserve every preceding locale.

The normal in-place catalog path is sequential and well tested, but a supported path transform can direct multiple locales to one derived output while every merge rereads the original source, causing later writes to discard earlier locale updates.

**Files Needing Attention:** packages/cli/src/api/downloadFileBatch.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/api/downloadFileBatch.ts | Integrates xcstrings merging into downloads, but transformed shared outputs rebuild each locale from the source and lose preceding locale merges. |
| packages/cli/src/formats/xcstrings/mergeXcstrings.ts | Adds a structured clone-and-set merge that preserves catalog entries, unrelated locales, and unknown fields. |
| packages/cli/src/formats/xcstrings/parseXcstrings.ts | Generalizes the deterministic xcstrings serializer for both extraction and merged catalog output. |
| packages/cli/src/formats/xcstrings/extractXcstrings.ts | Updates extraction to use the renamed shared serializer without changing its serialized contract. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Downloaded locale slice] --> B{XCSTRINGS source?}
  B -->|No| C[Existing format merge]
  B -->|Yes| D[Read source catalog]
  D --> E[Replace target locale entries]
  E --> F[Serialize catalog]
  F --> G[Write mapped output path]
  G --> H[Next locale]
  H --> D
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232220%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2220&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fapi%2FdownloadFileBatch.ts%3A104-108%0A**Transformed%20catalog%20loses%20locales**%0A%0AWhen%20an%20xcstrings%20path%20transform%20without%20%60%5Blocale%5D%60%20maps%20multiple%20locales%20to%20one%20output%20path%20that%20differs%20from%20the%20source%2C%20every%20merge%20rereads%20%60inputPath%60%20instead%20of%20the%20preceding%20transformed%20output.%20Each%20later%20write%20therefore%20discards%20the%20locales%20merged%20earlier%20in%20the%20batch%2C%20leaving%20the%20shared%20output%20with%20only%20the%20last%20locale's%20update.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fxcstrings-merge%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fxcstrings-merge%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fapi%2FdownloadFileBatch.ts%3A104-108%0A**Transformed%20catalog%20loses%20locales**%0A%0AWhen%20an%20xcstrings%20path%20transform%20without%20%60%5Blocale%5D%60%20maps%20multiple%20locales%20to%20one%20output%20path%20that%20differs%20from%20the%20source%2C%20every%20merge%20rereads%20%60inputPath%60%20instead%20of%20the%20preceding%20transformed%20output.%20Each%20later%20write%20therefore%20discards%20the%20locales%20merged%20earlier%20in%20the%20batch%2C%20leaving%20the%20shared%20output%20with%20only%20the%20last%20locale's%20update.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2220&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/api/downloadFileBatch.ts:104-108
**Transformed catalog loses locales**

When an xcstrings path transform without `[locale]` maps multiple locales to one output path that differs from the source, every merge rereads `inputPath` instead of the preceding transformed output. Each later write therefore discards the locales merged earlier in the batch, leaving the shared output with only the last locale's update.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): merge downloaded xcstrings tr..."](https://github.com/generaltranslation/gt/commit/48536134e7a882100db2580013ee3946ee6edca2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58857343)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)

<!-- /greptile_comment -->