### PR TITLE
fix(cli): preserve custom heading IDs in translated MD/MDX

### DIFF
--- a/.changeset/olive-pears-shake.md
+++ b/.changeset/olive-pears-shake.md
@@ -1,0 +1,37 @@
+---
+'gt': patch
+---
+
+Fix custom heading IDs (`## Heading {#id}`) being dropped or misapplied in translated MD/MDX.
+
+`{#id}` is not valid MDX — remark-mdx hands it to acorn as an expression — so files
+using Mintlify's custom heading ID syntax failed validation and were skipped
+entirely. Parsing now tolerates the syntax, so `skipFileValidation` is no longer
+needed to translate those files.
+
+Anchor IDs are also applied far more reliably:
+
+- Headings are located by parser line positions instead of by matching heading
+  text, so indentation (headings nested in `<Tabs>`, `<Steps>`, `<Accordion>`),
+  inline JSX, escaped characters and repeated heading text no longer cause a
+  heading to be skipped or an ID to land on the wrong heading.
+- Repeated headings now get unique IDs (`slug`, `slug-2`, `slug-3`) matching how
+  Mintlify disambiguates them, instead of emitting the same ID several times.
+- Source and translated files are now read with the same extractor. Previously a
+  source using `{#id}` fell back to line scanning while its translation used the
+  AST, so the two heading lists could disagree and shift every ID after the first
+  nested heading.
+- In `experimentalAddHeaderAnchorIds: 'mintlify'` mode, an author-written `{#id}`
+  is carried into the translation in Mintlify's native inline syntax rather than
+  being replaced by a `<div id>` wrapper. Wrappers are still used for IDs the CLI
+  derives from heading text.
+- Applying an anchor no longer re-stringifies the whole document, so it no longer
+  HTML-escapes unrelated heading text or reformats the file.
+- An existing wrapper is recognized from the parsed tree rather than by matching
+  the tag's text, so extra attributes, single quotes, a multi-line tag or a
+  non-`div` element no longer cause a second wrapper to be nested inside the first.
+- An inline anchor is inserted before a heading's closing `##` sequence instead of
+  after it, which previously turned the closing hashes into visible heading text.
+
+Anchor processing now runs after the other MD/MDX post-processing passes, which
+re-indent headings nested in JSX when they stringify.

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -121,19 +121,23 @@ export async function postProcessTranslations(
     }
   }
 
+  // Localize static imports (import Snippet from /snippets/file.mdx -> import Snippet from /snippets/[locale]/file.mdx)
+  if (settings.options?.experimentalLocalizeStaticImports) {
+    await localizeStaticImports(settings, postProcessIncludes);
+  }
+
   const shouldProcessAnchorIds =
     settings.options?.experimentalLocalizeStaticUrls ||
     settings.options?.experimentalAddHeaderAnchorIds;
 
-  // Add explicit anchor IDs to translated MDX/MD files to preserve navigation
-  // Uses inline {#id} format by default, or div wrapping if experimentalAddHeaderAnchorIds is 'mintlify'
+  // Add explicit anchor IDs to translated MDX/MD files to preserve navigation.
+  // Uses inline {#id} format by default, or div wrapping if experimentalAddHeaderAnchorIds is 'mintlify'.
+  //
+  // Runs last of the md/mdx passes: the others re-stringify the document, which
+  // re-indents headings nested in JSX and would otherwise move them out from
+  // under the anchors placed here.
   if (shouldProcessAnchorIds) {
     await processAnchorIds(settings, postProcessIncludes);
-  }
-
-  // Localize static imports (import Snippet from /snippets/file.mdx -> import Snippet from /snippets/[locale]/file.mdx)
-  if (settings.options?.experimentalLocalizeStaticImports) {
-    await localizeStaticImports(settings, postProcessIncludes);
   }
 
   // Flatten json files into a single file

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -631,8 +631,10 @@ This is just an example
       expect(result.hasChanges).toBe(true);
       expect(result.addedIds).toHaveLength(4);
 
+      // Heading text is left exactly as the translation wrote it: applying an
+      // anchor must not HTML-escape unrelated characters.
       expect(result.content).toContain(
-        '## Code &amp; Design Workflow! \\{#code-design-workflow\\}'
+        '## Code & Design Workflow! \\{#code-design-workflow\\}'
       );
       expect(result.content).toContain(
         '## API Reference (v2.0) \\{#api-reference-v20\\}'
@@ -640,7 +642,7 @@ This is just an example
       expect(result.content).toContain(
         '## Getting Started: Step 1 \\{#getting-started-step-1\\}'
       );
-      expect(result.content).toContain('## What&#39;s New? \\{#whats-new\\}');
+      expect(result.content).toContain("## What's New? \\{#whats-new\\}");
     });
 
     it('should handle special characters in Mintlify mode', () => {
@@ -819,5 +821,272 @@ Más contenido.`;
     // because logErrorAndExit calls process.exit(). The validation logic is there and will
     // work in production - it catches cases where source file was edited after translation,
     // causing different header counts between source and translated files.
+  });
+  describe('Custom heading IDs (Mintlify {#id} syntax)', () => {
+    const mintlify = {
+      options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
+    };
+
+    it('extracts headings from a source file that uses custom heading IDs', () => {
+      const source = `## CSS variables reference {#css-variables}
+
+### Completion and the \`callback\` function {#callback}
+`;
+      const headings = extractHeadingInfo(source);
+
+      expect(headings).toHaveLength(2);
+      expect(headings[0]).toMatchObject({
+        text: 'CSS variables reference',
+        slug: 'css-variables',
+        explicit: true,
+        startLine: 1,
+      });
+      expect(headings[1]).toMatchObject({
+        text: 'Completion and the callback function',
+        slug: 'callback',
+        explicit: true,
+        startLine: 3,
+      });
+    });
+
+    it('restores an author-written ID in native syntax rather than a wrapper', () => {
+      const source = '## CSS variables reference {#css-variables}\n';
+      const translated = '## Référence des variables CSS\n';
+
+      const result = addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      );
+
+      expect(result.content).toBe(
+        '## Référence des variables CSS {#css-variables}\n'
+      );
+      // The author chose this ID; it needs no wrapper element, and the escaped
+      // form would render as literal text in Mintlify.
+      expect(result.content).not.toContain('<div id=');
+      expect(result.content).not.toContain('\\{#');
+    });
+
+    it('still wraps headings whose ID had to be derived', () => {
+      const source = '## Setup {#custom}\n\n## Other heading\n';
+      const translated = '## Configuration\n\n## Autre titre\n';
+
+      const result = addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      );
+
+      expect(result.content).toContain('## Configuration {#custom}');
+      expect(result.content).toContain(
+        '<div id="other-heading">\n  ## Autre titre\n</div>'
+      );
+    });
+
+    it('does not double-apply an ID the translation already carried over', () => {
+      const source = '## Setup {#custom}\n';
+      const translated = '## Configuration {#custom}\n';
+
+      const result = addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      );
+
+      expect(result.content).toBe('## Configuration {#custom}\n');
+      expect(result.hasChanges).toBe(false);
+    });
+  });
+
+  describe('Headings the old text-matching applier could not find', () => {
+    const mintlify = {
+      options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
+    };
+
+    const wrap = (source: string, translated: string) =>
+      addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      ).content;
+
+    it('anchors headings indented inside a JSX block', () => {
+      const doc = `<Tabs>
+  <Tab title="Plain CSS">
+
+    ## Setup
+
+    Body text.
+
+  </Tab>
+</Tabs>
+`;
+      const out = wrap(doc, doc);
+
+      expect(out).toContain('    <div id="setup">\n      ## Setup\n    </div>');
+    });
+
+    it('anchors headings containing JSX elements', () => {
+      const doc =
+        '### <Badge color="yellow">Early Access</Badge> Use your own database\n';
+      const out = wrap(doc, doc);
+
+      expect(out).toContain('<div id="early-access-use-your-own-database">');
+    });
+
+    it('anchors headings containing escaped characters', () => {
+      const doc = '### country\\_code\n';
+      const out = wrap(doc, doc);
+
+      expect(out).toContain(
+        '<div id="country_code">\n  ### country\\_code\n</div>'
+      );
+    });
+
+    it('gives every repeated heading its own Mintlify-compatible ID', () => {
+      const doc = `### Response status codes
+
+### Response status codes
+
+### Response status codes
+`;
+      const headings = extractHeadingInfo(doc);
+      expect(headings.map((h) => h.slug)).toEqual([
+        'response-status-codes',
+        'response-status-codes-2',
+        'response-status-codes-3',
+      ]);
+
+      const out = wrap(doc, doc);
+      expect(out).toContain('<div id="response-status-codes">');
+      expect(out).toContain('<div id="response-status-codes-2">');
+      expect(out).toContain('<div id="response-status-codes-3">');
+    });
+
+    it('does not renumber author-written IDs', () => {
+      const doc = `## Setup {#setup-plain}
+
+## Setup {#setup-tailwind}
+`;
+      expect(extractHeadingInfo(doc).map((h) => h.slug)).toEqual([
+        'setup-plain',
+        'setup-tailwind',
+      ]);
+    });
+  });
+
+  describe('Source/translation heading alignment', () => {
+    it('does not shift IDs when the source uses custom IDs and the translation does not', () => {
+      // The source cannot be parsed as plain MDX, so before anchor-syntax
+      // tolerance it fell back to line scanning, which cannot see the heading
+      // nested in JSX. The translation parsed normally, so the two lists
+      // disagreed and IDs landed on the wrong headings.
+      const source = `## Alpha {#alpha}
+
+<Accordion>
+  ## Nested {#nested}
+</Accordion>
+
+## Beta {#beta}
+`;
+      const translated = `## Alpha-fr
+
+<Accordion>
+  ## Imbriqué-fr
+</Accordion>
+
+## Beta-fr
+`;
+
+      const sourceHeadings = extractHeadingInfo(source);
+      expect(sourceHeadings.map((h) => h.slug)).toEqual([
+        'alpha',
+        'nested',
+        'beta',
+      ]);
+
+      const result = addExplicitAnchorIds(
+        translated,
+        sourceHeadings,
+        { options: { experimentalAddHeaderAnchorIds: 'mintlify' as const } },
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      );
+
+      expect(result.content).toContain('## Alpha-fr {#alpha}');
+      expect(result.content).toContain('## Imbriqué-fr {#nested}');
+      expect(result.content).toContain('## Beta-fr {#beta}');
+    });
+  });
+  describe('Heading location is taken from the parser, not matched by shape', () => {
+    const mintlify = {
+      options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
+    };
+    const run = (doc: string, settings?: typeof mintlify) =>
+      addExplicitAnchorIds(
+        doc,
+        extractHeadingInfo(doc),
+        settings,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      ).content;
+
+    it('inserts an inline anchor before a closing hash sequence', () => {
+      // Appending after the closing `##` would stop it being a closing
+      // sequence, turning it into visible heading text.
+      expect(run('## Foo ##\n')).toBe('## Foo \\{#foo\\} ##\n');
+    });
+
+    it('recognizes an existing wrapper whatever shape its tag takes', () => {
+      const variants = [
+        '<div id="stale">\n  ## Foo\n</div>\n',
+        '<div className="x" id="stale">\n  ## Foo\n</div>\n',
+        "<div id='stale'>\n  ## Foo\n</div>\n",
+        '<div\n  id="stale"\n>\n  ## Foo\n</div>\n',
+        '<section id="stale">\n  ## Foo\n</section>\n',
+      ];
+
+      for (const variant of variants) {
+        const out = run(variant, mintlify);
+        // The stale ID is corrected in place; no second wrapper is nested.
+        expect(out).not.toContain('stale');
+        expect(out.match(/id=/g)).toHaveLength(1);
+        expect(out).toContain('id="foo"');
+      }
+    });
+
+    it('does not mistake an ordinary container for an anchor wrapper', () => {
+      // <Tab> carries an id-less title and holds the heading among other
+      // content, so the heading still needs its own wrapper.
+      const out = run(
+        '<Tabs>\n  <Tab title="x">\n\n    ## Foo\n\n    Body.\n\n  </Tab>\n</Tabs>\n',
+        mintlify
+      );
+      expect(out).toContain('    <div id="foo">\n      ## Foo\n    </div>');
+    });
+
+    it('does not treat a container holding more than the heading as a wrapper', () => {
+      const out = run(
+        '<div id="card">\n  ## Foo\n\n  Body.\n</div>\n',
+        mintlify
+      );
+      expect(out).toContain('<div id="foo">');
+      expect(out).toContain('id="card"');
+    });
   });
 });

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -976,6 +976,21 @@ Más contenido.`;
       expect(out).toContain('<div id="response-status-codes-3">');
     });
 
+    it('does not let a generated slug claim a later explicit ID', () => {
+      const doc = `## Setup
+
+## Configuration {#setup}
+`;
+      expect(extractHeadingInfo(doc).map((h) => h.slug)).toEqual([
+        'setup-2',
+        'setup',
+      ]);
+
+      const out = wrap(doc, doc);
+      expect(out).toContain('<div id="setup-2">');
+      expect(out).toContain('## Configuration {#setup}');
+    });
+
     it('does not renumber author-written IDs', () => {
       const doc = `## Setup {#setup-plain}
 

--- a/packages/cli/src/utils/__tests__/mdxAnchorSyntax.test.ts
+++ b/packages/cli/src/utils/__tests__/mdxAnchorSyntax.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import {
+  neutralizeAnchorIds,
+  restoreAnchorIds,
+  parseMdxTolerantly,
+  parseMdxForRoundTrip,
+} from '../mdxAnchorSyntax.js';
+import { visit } from 'unist-util-visit';
+
+describe('mdxAnchorSyntax', () => {
+  describe('neutralizeAnchorIds', () => {
+    it('escapes custom heading IDs so MDX can parse them', () => {
+      const { content, changed } = neutralizeAnchorIds('## Foo {#bar}');
+      expect(changed).toBe(true);
+      expect(content).toBe('## Foo \\{#bar\\}');
+    });
+
+    it('reports no change for a document without custom heading IDs', () => {
+      const input = '## Foo\n\nSome {expression} here.\n';
+      const { content, changed } = neutralizeAnchorIds(input);
+      expect(changed).toBe(false);
+      expect(content).toBe(input);
+    });
+
+    it('leaves already-escaped anchors alone', () => {
+      const { content, changed } = neutralizeAnchorIds('## Foo \\{#bar\\}');
+      expect(changed).toBe(false);
+      expect(content).toBe('## Foo \\{#bar\\}');
+    });
+
+    it('does not touch heading-like lines inside fenced code blocks', () => {
+      const input = '```sh\n# comment {#not-an-anchor}\n```\n';
+      expect(neutralizeAnchorIds(input).changed).toBe(false);
+    });
+
+    it('handles headings indented inside JSX blocks', () => {
+      const input =
+        '<Tabs>\n  <Tab title="x">\n\n    ## Foo {#bar}\n\n  </Tab>\n</Tabs>';
+      const { content, changed } = neutralizeAnchorIds(input);
+      expect(changed).toBe(true);
+      expect(content).toContain('    ## Foo \\{#bar\\}');
+    });
+
+    it('preserves line count so node line positions stay valid', () => {
+      const input = '# A {#a}\n\n## B {#b}\n\ntext\n';
+      expect(neutralizeAnchorIds(input).content.split('\n')).toHaveLength(
+        input.split('\n').length
+      );
+    });
+  });
+
+  describe('restoreAnchorIds', () => {
+    it('round-trips with neutralizeAnchorIds', () => {
+      const input = '## Foo {#bar}\n\n### Baz {#qux}\n';
+      expect(restoreAnchorIds(neutralizeAnchorIds(input).content)).toBe(input);
+    });
+
+    it('leaves escaped braces that are not anchors alone', () => {
+      const input = '### allowPasswordAutocomplete \\{Boolean}\n';
+      expect(restoreAnchorIds(input)).toBe(input);
+    });
+  });
+
+  describe('parseMdxTolerantly', () => {
+    it('parses a document that uses custom heading IDs', () => {
+      const ast = parseMdxTolerantly('## Foo {#bar}\n');
+      const texts: string[] = [];
+      visit(ast, 'heading', (node) => {
+        visit(node, 'text', (t: { value: string }) => texts.push(t.value));
+      });
+      expect(texts).toEqual(['Foo {#bar}']);
+    });
+
+    it('reports correct line positions for anchored headings in JSX', () => {
+      const ast = parseMdxTolerantly(
+        '<Tabs>\n  <Tab title="x">\n\n## Foo {#bar}\n\n  </Tab>\n</Tabs>\n'
+      );
+      const lines: number[] = [];
+      visit(ast, 'heading', (node) => lines.push(node.position!.start.line));
+      expect(lines).toEqual([4]);
+    });
+
+    it('still throws for genuinely invalid MDX', () => {
+      expect(() => parseMdxTolerantly('<Foo {...bad syntax} />\n')).toThrow();
+    });
+  });
+
+  describe('parseMdxForRoundTrip', () => {
+    it('flags when anchors were neutralized', () => {
+      expect(parseMdxForRoundTrip('## Foo {#bar}\n').neutralized).toBe(true);
+      expect(parseMdxForRoundTrip('## Foo\n').neutralized).toBe(false);
+    });
+  });
+});

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -1,18 +1,23 @@
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkMdx from 'remark-mdx';
-import remarkFrontmatter from 'remark-frontmatter';
-import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
-import type { Root, Heading, Literal, Node } from 'mdast';
+import type { Heading, Node } from 'mdast';
+import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import { logger } from '../console/logger.js';
-import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
-import { decode } from 'html-entities';
 import type { AdditionalOptions } from '../types/index.js';
+import {
+  forEachLineOutsideCodeFences,
+  mapLinesOutsideCodeFences,
+  parseMdxTolerantly,
+} from './mdxAnchorSyntax.js';
 
 type AnchorIdSettings = {
   options?: Pick<AdditionalOptions, 'experimentalAddHeaderAnchorIds'>;
 };
+
+/** An ATX heading line, split into indentation, marker and text. */
+const ATX_HEADING = /^([ \t]*)(#{1,6}[ \t]+)(.*)$/;
+
+/** A trailing custom anchor ID, in either the plain or MDX-escaped form. */
+const TRAILING_ANCHOR = /\s*(?:\\\{#[^}]+\\\}|\{#[^}]+\})\s*$/;
 
 /**
  * Generates a slug from heading text
@@ -43,58 +48,36 @@ function extractHeadingText(heading: Heading): string {
 }
 
 /**
- * Simple line-by-line heading extractor that skips fenced code blocks.
- * Used as a fallback when MDX parsing fails.
+ * Line-by-line heading extractor used when MDX parsing fails outright.
  */
 function extractHeadingsWithFallback(mdxContent: string): HeadingInfo[] {
   const headings: HeadingInfo[] = [];
-  const lines = mdxContent.split('\n');
-
   let position = 0;
-  let inFence = false;
-  let fenceChar: string | null = null;
 
-  for (const line of lines) {
-    const fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const fenceString = fenceMatch[2];
-      if (!inFence) {
-        inFence = true;
-        fenceChar = fenceString;
-      } else if (
-        fenceChar &&
-        fenceString[0] === fenceChar[0] &&
-        fenceString.length >= fenceChar.length
-      ) {
-        inFence = false;
-        fenceChar = null;
-      }
-      continue;
-    }
+  forEachLineOutsideCodeFences(mdxContent, (line, index) => {
+    const headingMatch = line.match(ATX_HEADING);
+    if (!headingMatch) return;
 
-    if (inFence) {
-      continue;
-    }
-
-    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
-    if (!headingMatch) {
-      continue;
-    }
-
-    const hashes = headingMatch[1];
-    const rawText = headingMatch[2];
+    const [, indent, marker, rawText] = headingMatch;
     const { cleanedText, explicitId } = parseHeadingContent(rawText);
+    if (!cleanedText && !explicitId) return;
 
-    if (cleanedText || explicitId) {
-      headings.push({
-        text: cleanedText,
-        level: hashes.length,
-        slug: explicitId ?? generateSlug(cleanedText),
-        position: position++,
-      });
-    }
-  }
+    headings.push({
+      text: cleanedText,
+      level: marker.trim().length,
+      slug: explicitId ?? generateSlug(cleanedText),
+      position: position++,
+      startLine: index + 1,
+      endLine: index + 1,
+      startColumn: indent.length + 1,
+      // Without a parser there is nothing finer to go on than end of line.
+      textEndColumn: line.length + 1,
+      wrapperId: null,
+      explicit: explicitId !== undefined,
+    });
+  });
 
+  assignUniqueSlugs(headings);
   return headings;
 }
 
@@ -116,14 +99,37 @@ function parseHeadingContent(text: string): {
 }
 
 /**
- * Checks if a heading is already wrapped in a div with id
+ * Suffixes repeated slugs `-2`, `-3`, ... as Mintlify does. Author-written IDs
+ * are never renumbered, only reserved.
  */
-function hasExplicitId(heading: Heading, _ast: Root): boolean {
-  const lastChild = heading.children[heading.children.length - 1];
-  if (lastChild?.type === 'text') {
-    return /(\{#[^}]+\}|\\\{#[^}]+\\\}|\[[^\]]+\])\s*$/.test(lastChild.value);
+function assignUniqueSlugs(headings: HeadingInfo[]): void {
+  const used = new Set<string>();
+
+  for (const heading of headings) {
+    if (heading.explicit) {
+      used.add(heading.slug);
+      continue;
+    }
+
+    // Headings with no slug-able characters would produce id="".
+    const base = heading.slug || 'section';
+    let slug = base;
+    let suffix = 1;
+    while (used.has(slug)) {
+      suffix += 1;
+      slug = `${base}-${suffix}`;
+    }
+
+    heading.slug = slug;
+    used.add(slug);
   }
-  return false;
+}
+
+/** A source range on a single line, as 1-based inclusive/exclusive columns. */
+interface ColumnRange {
+  line: number;
+  startColumn: number;
+  endColumn: number;
 }
 
 /**
@@ -134,44 +140,89 @@ export interface HeadingInfo {
   level: number;
   slug: string;
   position: number;
+  /** 1-based line the heading starts on. */
+  startLine: number;
+  /** 1-based line the heading ends on (differs from startLine for setext). */
+  endLine: number;
+  /** 1-based column of the heading marker; anything left of it is indentation. */
+  startColumn: number;
+  /** 1-based column just past the text, before any closing `##`; -1 if unknown. */
+  textEndColumn: number;
+  /** `id` attribute of a wrapper element already anchoring this heading. */
+  wrapperId: ColumnRange | null;
+  /** Whether the author wrote an explicit `{#id}`. */
+  explicit: boolean;
 }
 
 /**
- * Extracts heading information from content (read-only, no modifications)
+ * Finds the `id` of a wrapper element already anchoring this heading. Requiring
+ * the heading to be its only child rules out containers like `<Tab>`.
+ */
+function findWrapperId(
+  heading: Heading,
+  parent: Node | undefined
+): ColumnRange | null {
+  if (!parent || parent.type !== 'mdxJsxFlowElement') return null;
+
+  const element = parent as MdxJsxFlowElement;
+  if (element.children.length !== 1 || element.children[0] !== heading) {
+    return null;
+  }
+
+  const id = element.attributes.find(
+    (attribute) =>
+      attribute.type === 'mdxJsxAttribute' && attribute.name === 'id'
+  );
+  const position = id?.position;
+  if (!position || position.start.line !== position.end.line) return null;
+
+  return {
+    line: position.start.line,
+    startColumn: position.start.column,
+    endColumn: position.end.column,
+  };
+}
+
+/**
+ * Extracts heading information from content (read-only, no modifications).
+ * Source and translation are matched by position, so both must parse the same
+ * way — the fallback extractor misses headings nested in JSX.
  */
 export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
-  const headings: HeadingInfo[] = [];
-
-  // Parse the MDX content into an AST
-  let processedAst: Root;
+  let ast;
   try {
-    const parseProcessor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-
-    const ast = parseProcessor.parse(mdxContent);
-    processedAst = parseProcessor.runSync(ast) as Root;
+    ast = parseMdxTolerantly(mdxContent);
   } catch {
     // Fallback: line-by-line extraction skipping fenced code blocks
     return extractHeadingsWithFallback(mdxContent);
   }
 
+  const headings: HeadingInfo[] = [];
   let position = 0;
-  visit(processedAst, 'heading', (heading: Heading) => {
+
+  visit(ast, 'heading', (heading: Heading, _index, parent) => {
     const headingText = extractHeadingText(heading);
     const { cleanedText, explicitId } = parseHeadingContent(headingText);
-    if (cleanedText || explicitId) {
-      const slug = explicitId ?? generateSlug(cleanedText);
-      headings.push({
-        text: cleanedText,
-        level: heading.depth,
-        slug,
-        position: position++,
-      });
-    }
+    if (!cleanedText && !explicitId) return;
+
+    const lastChild = heading.children[heading.children.length - 1];
+
+    headings.push({
+      text: cleanedText,
+      level: heading.depth,
+      slug: explicitId ?? generateSlug(cleanedText),
+      position: position++,
+      startLine: heading.position?.start.line ?? -1,
+      endLine: heading.position?.end.line ?? -1,
+      startColumn: heading.position?.start.column ?? 1,
+      textEndColumn:
+        lastChild?.position?.end.column ?? heading.position?.end.column ?? -1,
+      wrapperId: findWrapperId(heading, parent),
+      explicit: explicitId !== undefined,
+    });
   });
 
+  assignUniqueSlugs(headings);
   return headings;
 }
 
@@ -214,26 +265,21 @@ export function addExplicitAnchorIds(
   }
 
   // Create ID mapping based on positional matching
-  const idMappings = new Map<number, string>();
+  const idMappings = new Map<number, { id: string; explicit: boolean }>();
   sourceHeadingMap.forEach((sourceHeading, index) => {
     const translatedHeading = translatedHeadings[index];
     // Match by position and level for safety
     if (translatedHeading && translatedHeading.level === sourceHeading.level) {
-      idMappings.set(index, sourceHeading.slug);
+      idMappings.set(index, {
+        id: sourceHeading.slug,
+        explicit: sourceHeading.explicit,
+      });
       addedIds.push({
         heading: translatedHeading.text,
         id: sourceHeading.slug,
       });
     }
   });
-
-  if (idMappings.size === 0) {
-    return {
-      content: translatedContent,
-      hasChanges: false,
-      addedIds: [],
-    };
-  }
 
   const translatedIsMdx = translatedPath
     ? translatedPath.toLowerCase().endsWith('.mdx')
@@ -245,20 +291,28 @@ export function addExplicitAnchorIds(
         ? false
         : translatedIsMdx;
 
-  // Apply IDs to translated content
-  let content: string;
-  if (useDivWrapping) {
-    content = applyDivWrappedIds(
-      translatedContent,
-      translatedHeadings,
-      idMappings
-    );
-  } else {
-    content = applyInlineIds(
-      translatedContent,
-      idMappings,
-      shouldEscapeAnchors
-    );
+  if (idMappings.size === 0) {
+    // Normalize anchors the translation carried over.
+    const content = useDivWrapping
+      ? translatedContent
+      : normalizeInlineAnchors(translatedContent, shouldEscapeAnchors);
+    return {
+      content,
+      hasChanges: content !== translatedContent,
+      addedIds: [],
+    };
+  }
+
+  let content = applyAnchorIds(
+    translatedContent,
+    translatedHeadings,
+    idMappings,
+    useDivWrapping,
+    shouldEscapeAnchors
+  );
+
+  if (!useDivWrapping) {
+    content = normalizeInlineAnchors(content, shouldEscapeAnchors);
   }
 
   return {
@@ -269,281 +323,96 @@ export function addExplicitAnchorIds(
 }
 
 /**
- * Adds inline {#id} syntax to headings (standard markdown approach)
+ * Writes anchor IDs onto the translated document, locating headings by parser
+ * line position rather than by text. Edits run bottom-up to keep lines valid.
  */
-function applyInlineIds(
-  translatedContent: string,
-  idMappings: Map<number, string>,
-  escapeAnchors: boolean
-): string {
-  const escapeInlineAnchors = (content: string): string => {
-    if (!escapeAnchors) return content;
-    return content.replace(
-      /\{#([A-Za-z0-9-_]+)\}/g,
-      (match, id, offset, str) => {
-        if (offset > 0 && str[offset - 1] === '\\') {
-          return match;
-        }
-        return `\\{#${id}\\}`;
-      }
-    );
-  };
-
-  // Parse the translated content
-  let processedAst: Root;
-  try {
-    const parseProcessor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-
-    const ast = parseProcessor.parse(translatedContent);
-    processedAst = parseProcessor.runSync(ast) as Root;
-  } catch {
-    return applyInlineIdsStringFallback(
-      translatedContent,
-      idMappings,
-      escapeAnchors
-    );
-  }
-
-  // Apply IDs to headings based on position
-  let headingIndex = 0;
-  let actuallyModifiedContent = false;
-
-  visit(processedAst, 'heading', (heading: Heading) => {
-    const id = idMappings.get(headingIndex);
-    if (id) {
-      // Skip if heading already has explicit ID
-      if (hasExplicitId(heading, processedAst)) {
-        if (escapeAnchors) {
-          // Normalize existing inline IDs to escaped form
-          const lastChild = heading.children[heading.children.length - 1];
-          if (lastChild?.type === 'text') {
-            const match = lastChild.value.match(/\{#([^}]+)\}\s*$/);
-            const alreadyEscaped = lastChild.value.match(/\\\{#[^}]+\\\}\s*$/);
-            if (match && !alreadyEscaped) {
-              const anchorId = match[1];
-              const base = lastChild.value.replace(/\s*\{#[^}]+\}\s*$/, '');
-              lastChild.value = `${base} \\{#${anchorId}\\}`;
-              actuallyModifiedContent = true;
-            }
-          }
-        }
-        headingIndex++;
-        return;
-      }
-
-      // Add the ID to the heading
-      const lastChild = heading.children[heading.children.length - 1];
-      if (lastChild?.type === 'text') {
-        lastChild.value += escapeAnchors ? ` \\{#${id}\\}` : ` {#${id}}`;
-      } else {
-        // If last child is not text, add a new text node
-        heading.children.push({
-          type: 'text',
-          value: escapeAnchors ? ` \\{#${id}\\}` : ` {#${id}}`,
-        });
-      }
-      actuallyModifiedContent = true;
-    }
-    headingIndex++;
-  });
-
-  // If we didn't modify any headings, return original content
-  if (!actuallyModifiedContent) {
-    const escaped = escapeInlineAnchors(translatedContent);
-    return escaped;
-  }
-
-  // Convert the modified AST back to MDX string
-  try {
-    const stringifyProcessor = unified()
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx)
-      .use(normalizeCJKCharacters)
-      .use(escapeHtmlInTextNodes)
-      .use(remarkStringify, {
-        handlers: {
-          // Custom handler to prevent escaping of {#id} syntax
-          text(node: Literal) {
-            return node.value;
-          },
-        },
-      });
-
-    const outTree = stringifyProcessor.runSync(processedAst) as Root;
-    let content = stringifyProcessor.stringify(outTree);
-
-    // Handle newline formatting to match original input
-    if (content.endsWith('\n') && !translatedContent.endsWith('\n')) {
-      content = content.slice(0, -1);
-    }
-
-    // Preserve leading newlines from original content
-    if (translatedContent.startsWith('\n') && !content.startsWith('\n')) {
-      content = '\n' + content;
-    }
-
-    return content;
-  } catch {
-    return translatedContent;
-  }
-}
-
-/**
- * Fallback string-based inline ID application when AST parsing fails
- */
-function applyInlineIdsStringFallback(
-  translatedContent: string,
-  idMappings: Map<number, string>,
-  escapeAnchors: boolean
-): string {
-  let headingIndex = 0;
-  let inFence = false;
-  let fenceChar: string | null = null;
-
-  const processedLines = translatedContent.split('\n').map((line) => {
-    const fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
-    if (fenceMatch) {
-      const fenceString = fenceMatch[2];
-      if (!inFence) {
-        inFence = true;
-        fenceChar = fenceString;
-      } else if (
-        fenceChar &&
-        fenceString[0] === fenceChar[0] &&
-        fenceString.length >= fenceChar.length
-      ) {
-        inFence = false;
-        fenceChar = null;
-      }
-      return line;
-    }
-
-    if (inFence) {
-      return line;
-    }
-
-    const headingMatch = line.match(/^(#{1,6}\s+)(.*)$/);
-    if (!headingMatch) {
-      return line;
-    }
-
-    const prefix = headingMatch[1];
-    const text = headingMatch[2];
-    const id = idMappings.get(headingIndex++);
-
-    if (!id) {
-      return line;
-    }
-
-    const hasEscaped = /\\\{#[^}]+\\\}\s*$/.test(text);
-    const hasUnescaped = /\{#[^}]+\}\s*$/.test(text);
-
-    if (hasEscaped) {
-      return line;
-    }
-
-    if (hasUnescaped) {
-      if (!escapeAnchors) {
-        return line;
-      }
-      return `${prefix}${text.replace(/\{#([^}]+)\}\s*$/, '\\{#$1\\}')}`;
-    }
-
-    const suffix = escapeAnchors ? ` \\{#${id}\\}` : ` {#${id}}`;
-    return `${prefix}${text}${suffix}`;
-  });
-
-  return processedLines.join('\n');
-}
-
-/**
- * Wraps headings in divs with IDs (Mintlify approach)
- */
-function applyDivWrappedIds(
+function applyAnchorIds(
   translatedContent: string,
   translatedHeadings: HeadingInfo[],
-  idMappings: Map<number, string>
+  idMappings: Map<number, { id: string; explicit: boolean }>,
+  useDivWrapping: boolean,
+  escapeAnchors: boolean
 ): string {
-  // Extract all heading lines from the translated markdown
   const lines = translatedContent.split('\n');
-  const headingLines: Array<{ line: string; level: number; index: number }> =
-    [];
 
-  lines.forEach((line, index) => {
-    const headingMatch = line.match(/^(#{1,6})\s+(.+)$/);
-    if (headingMatch) {
-      const level = headingMatch[1].length;
-      headingLines.push({ line, level, index });
+  const ordered = [...translatedHeadings].sort(
+    (a, b) => b.startLine - a.startLine
+  );
+
+  for (const heading of ordered) {
+    const mapping = idMappings.get(heading.position);
+    if (!mapping) continue;
+    if (heading.startLine < 1 || heading.endLine > lines.length) continue;
+
+    const index = heading.startLine - 1;
+
+    // Author-written IDs stay inline; derived ones go in a wrapper.
+    const inline = !useDivWrapping || mapping.explicit;
+
+    if (inline) {
+      // Setext headings have no column to append to.
+      if (heading.textEndColumn < 1) continue;
+
+      const escape = escapeAnchors && !mapping.explicit;
+      const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;
+      const line = lines[index];
+      const text = line
+        .slice(0, heading.textEndColumn - 1)
+        .replace(TRAILING_ANCHOR, '');
+      const trailer = line.slice(heading.textEndColumn - 1);
+
+      lines[index] = `${text} ${anchor}${trailer}`;
+      continue;
     }
-  });
 
-  // Use string-based approach to wrap headings in divs
-  let content = translatedContent;
-  const headingsToWrap: Array<{
-    originalLine: string;
-    id: string;
-  }> = [];
-
-  // Match translated headings with their corresponding lines by position and level
-  translatedHeadings.forEach((heading, position) => {
-    const id = idMappings.get(position);
-    if (id) {
-      // Find the corresponding original line for this heading
-      const matchingLine = headingLines.find((hl) => {
-        // Extract clean text from the original line for comparison
-        const lineCleanText = hl.line.replace(/^#{1,6}\s+/, '').trim();
-        // Create a version without markdown formatting for comparison
-        const cleanLineText = lineCleanText
-          .replace(/\*\*(.*?)\*\*/g, '$1') // Remove bold
-          .replace(/\*(.*?)\*/g, '$1') // Remove italic
-          .replace(/`(.*?)`/g, '$1') // Remove inline code
-          .replace(/\[(.*?)\]\(.*?\)/g, '$1') // Remove links, keep text
-          .trim();
-
-        const normalizedLineText = decode(cleanLineText).trim();
-        const normalizedHeadingText = decode(heading.text).trim();
-
-        return (
-          normalizedLineText === normalizedHeadingText &&
-          hl.level === heading.level
-        );
-      });
-
-      if (matchingLine) {
-        headingsToWrap.push({
-          originalLine: matchingLine.line,
-          id,
-        });
-      }
+    if (heading.wrapperId) {
+      // Already wrapped: fix the ID in place rather than nesting another.
+      const { line, startColumn, endColumn } = heading.wrapperId;
+      const wrapper = lines[line - 1];
+      lines[line - 1] =
+        wrapper.slice(0, startColumn - 1) +
+        `id="${mapping.id}"` +
+        wrapper.slice(endColumn - 1);
+      continue;
     }
-  });
 
-  if (headingsToWrap.length > 0) {
-    // Process headings from longest to shortest original line to avoid partial matches
-    const sortedHeadings = headingsToWrap.sort(
-      (a, b) => b.originalLine.length - a.originalLine.length
+    const indent = lines[index].slice(0, Math.max(0, heading.startColumn - 1));
+    const body = lines.slice(index, heading.endLine).map((line) => `  ${line}`);
+
+    lines.splice(
+      index,
+      heading.endLine - heading.startLine + 1,
+      `${indent}<div id="${mapping.id}">`,
+      ...body,
+      `${indent}</div>`
     );
-
-    for (const heading of sortedHeadings) {
-      // If already wrapped with this id, skip (idempotent)
-      if (content.includes(`<div id="${heading.id}">`)) {
-        continue;
-      }
-      // Escape the original line for use in regex
-      const escapedLine = heading.originalLine.replace(
-        /[.*+?^${}()|[\]\\]/g,
-        '\\$&'
-      );
-      const headingPattern = new RegExp(`^${escapedLine}\\s*$`, 'gm');
-
-      content = content.replace(headingPattern, (match) => {
-        return `<div id="${heading.id}">\n  ${match.trim()}\n</div>\n`;
-      });
-    }
   }
 
-  return content;
+  return lines.join('\n');
+}
+
+/**
+ * Normalizes every inline anchor: escaped for MDX, bare for Markdown.
+ */
+function normalizeInlineAnchors(
+  content: string,
+  escapeAnchors: boolean
+): string {
+  return mapLinesOutsideCodeFences(content, (line) => {
+    const atx = line.match(ATX_HEADING);
+    if (!atx) return line;
+
+    const escaped = atx[3].match(/\\\{#([A-Za-z0-9_-]+)\\\}\s*$/);
+    const bare = atx[3].match(/(?<!\\)\{#([A-Za-z0-9_-]+)\}\s*$/);
+
+    if (escapeAnchors && bare) {
+      const text = atx[3].replace(TRAILING_ANCHOR, '');
+      return `${atx[1]}${atx[2]}${text} \\{#${bare[1]}\\}`;
+    }
+    if (!escapeAnchors && escaped) {
+      const text = atx[3].replace(TRAILING_ANCHOR, '');
+      return `${atx[1]}${atx[2]}${text} {#${escaped[1]}}`;
+    }
+    return line;
+  });
 }

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -103,13 +103,16 @@ function parseHeadingContent(text: string): {
  * are never renumbered, only reserved.
  */
 function assignUniqueSlugs(headings: HeadingInfo[]): void {
-  const used = new Set<string>();
+  // Reserve every explicit ID up front, including ones later in the document,
+  // so a generated slug never claims an ID an author asked for.
+  const used = new Set(
+    headings
+      .filter((heading) => heading.explicit)
+      .map((heading) => heading.slug)
+  );
 
   for (const heading of headings) {
-    if (heading.explicit) {
-      used.add(heading.slug);
-      continue;
-    }
+    if (heading.explicit) continue;
 
     // Headings with no slug-able characters would produce id="".
     const base = heading.slug || 'section';

--- a/packages/cli/src/utils/localizeRelativeAssets.ts
+++ b/packages/cli/src/utils/localizeRelativeAssets.ts
@@ -1,13 +1,13 @@
 import * as fs from 'fs';
 import path from 'node:path';
 import { unified } from 'unified';
-import remarkParse from 'remark-parse';
 import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkStringify from 'remark-stringify';
 import { visit } from 'unist-util-visit';
 import type { Literal, Root } from 'mdast';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
+import { parseMdxForRoundTrip, restoreAnchorIds } from './mdxAnchorSyntax.js';
 import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 
@@ -63,12 +63,11 @@ export function localizeRelativeAssetsForContent(
   let changed = false;
 
   let ast: Root;
+  let neutralizedAnchors: boolean;
   try {
-    const processor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-    ast = processor.runSync(processor.parse(content)) as Root;
+    const parsed = parseMdxForRoundTrip(content);
+    ast = parsed.ast;
+    neutralizedAnchors = parsed.neutralized;
   } catch {
     return { content, hasChanges: false };
   }
@@ -146,6 +145,7 @@ export function localizeRelativeAssetsForContent(
       });
     const outTree = s.runSync(ast) as Root;
     let out = s.stringify(outTree);
+    if (neutralizedAnchors) out = restoreAnchorIds(out);
     if (out.endsWith('\n') && !content.endsWith('\n')) out = out.slice(0, -1);
     if (content.startsWith('\n') && !out.startsWith('\n')) out = '\n' + out;
     return { content: out, hasChanges: changed };

--- a/packages/cli/src/utils/localizeStaticImports.ts
+++ b/packages/cli/src/utils/localizeStaticImports.ts
@@ -6,13 +6,10 @@ import type {
 } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import micromatch from 'micromatch';
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkMdx from 'remark-mdx';
-import remarkFrontmatter from 'remark-frontmatter';
 import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 import type { MdxjsEsm } from 'mdast-util-mdxjs-esm';
+import { parseMdxTolerantly } from './mdxAnchorSyntax.js';
 
 const { isMatch } = micromatch;
 
@@ -442,13 +439,9 @@ function transformMdxImports(
   // Parse the MDX content into an AST
   let processedAst: Root;
   try {
-    const parseProcessor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-
-    const ast = parseProcessor.parse(mdxContent);
-    processedAst = parseProcessor.runSync(ast) as Root;
+    // Parsed only to locate import nodes; edits below are applied to the
+    // original string, so a neutralized parse cannot leak into the output.
+    processedAst = parseMdxTolerantly(mdxContent);
   } catch {
     return transformImportsStringFallback(
       mdxContent,

--- a/packages/cli/src/utils/localizeStaticUrls.ts
+++ b/packages/cli/src/utils/localizeStaticUrls.ts
@@ -3,7 +3,6 @@ import type { StaticLocalizationSettings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import micromatch from 'micromatch';
 import { unified } from 'unified';
-import remarkParse from 'remark-parse';
 import remarkMdx from 'remark-mdx';
 import remarkFrontmatter from 'remark-frontmatter';
 import remarkStringify from 'remark-stringify';
@@ -12,6 +11,7 @@ import type { Root, Link, Literal } from 'mdast';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx-jsx';
 import { escapeHtmlInTextNodes, normalizeCJKCharacters } from 'gt-remark';
 import { parse as parseBabel } from '@babel/parser';
+import { parseMdxForRoundTrip, restoreAnchorIds } from './mdxAnchorSyntax.js';
 
 const { isMatch } = micromatch;
 
@@ -500,14 +500,11 @@ function transformMdxUrls(
 
   // Parse the MDX content into an AST
   let processedAst: Root;
+  let neutralizedAnchors: boolean;
   try {
-    const parseProcessor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-
-    const ast = parseProcessor.parse(mdxContent);
-    processedAst = parseProcessor.runSync(ast) as Root;
+    const parsed = parseMdxForRoundTrip(mdxContent);
+    processedAst = parsed.ast;
+    neutralizedAnchors = parsed.neutralized;
   } catch {
     return {
       content: mdxContent,
@@ -739,6 +736,9 @@ function transformMdxUrls(
 
     const outTree = stringifyProcessor.runSync(processedAst) as Root;
     content = stringifyProcessor.stringify(outTree);
+    if (neutralizedAnchors) {
+      content = restoreAnchorIds(content);
+    }
   } catch (error) {
     console.warn(
       `Failed to stringify MDX content: ${error instanceof Error ? error.message : String(error)}`

--- a/packages/cli/src/utils/mdxAnchorSyntax.ts
+++ b/packages/cli/src/utils/mdxAnchorSyntax.ts
@@ -1,0 +1,147 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkMdx from 'remark-mdx';
+import remarkFrontmatter from 'remark-frontmatter';
+import type { Root } from 'mdast';
+
+/**
+ * Custom heading IDs (`## Heading {#id}`) break MDX parsing: remark-mdx passes
+ * `{#id}` to acorn. Escaping the braces makes the document parse without
+ * changing its line count, so mdast line positions still map 1:1 (columns do
+ * not). https://mintlify.com/docs/create/headers#custom-heading-ids
+ */
+
+/** A heading line ending in an unescaped `{#id}`. */
+const UNESCAPED_ANCHOR =
+  /^([ \t]*#{1,6}[ \t]+.*?)[ \t]*\{#([A-Za-z0-9_-]+)\}[ \t]*$/;
+
+/** A heading line ending in an escaped `\{#id\}`. */
+const ESCAPED_ANCHOR =
+  /^([ \t]*#{1,6}[ \t]+.*?)[ \t]*\\\{#([A-Za-z0-9_-]+)\\\}[ \t]*$/;
+
+/** Matches an opening or closing fenced-code-block marker. */
+const CODE_FENCE = /^\s*(`{3,}|~{3,})/;
+
+/** Returns a predicate telling whether a line sits outside a code fence. */
+function createFenceTracker(): (line: string) => boolean {
+  let inFence = false;
+  let fence: string | null = null;
+
+  return (line: string): boolean => {
+    const match = line.match(CODE_FENCE);
+    if (!match) return !inFence;
+
+    const marker = match[1];
+    if (!inFence) {
+      inFence = true;
+      fence = marker;
+    } else if (
+      fence &&
+      marker[0] === fence[0] &&
+      marker.length >= fence.length
+    ) {
+      inFence = false;
+      fence = null;
+    }
+    return false;
+  };
+}
+
+/** Maps over a document's lines, leaving fenced code blocks untouched. */
+export function mapLinesOutsideCodeFences(
+  content: string,
+  mapLine: (line: string) => string
+): string {
+  const isContent = createFenceTracker();
+  return content
+    .split('\n')
+    .map((line) => (isContent(line) ? mapLine(line) : line))
+    .join('\n');
+}
+
+/** Visits a document's lines with their 0-based index, skipping code fences. */
+export function forEachLineOutsideCodeFences(
+  content: string,
+  visitLine: (line: string, index: number) => void
+): void {
+  const isContent = createFenceTracker();
+  content.split('\n').forEach((line, index) => {
+    if (isContent(line)) visitLine(line, index);
+  });
+}
+
+/**
+ * Escapes `## Heading {#id}` to `## Heading \{#id\}` so MDX can parse it.
+ */
+export function neutralizeAnchorIds(content: string): {
+  content: string;
+  changed: boolean;
+} {
+  let changed = false;
+
+  const next = mapLinesOutsideCodeFences(content, (line) => {
+    const match = line.match(UNESCAPED_ANCHOR);
+    if (!match) return line;
+    changed = true;
+    return `${match[1]} \\{#${match[2]}\\}`;
+  });
+
+  return { content: next, changed };
+}
+
+/**
+ * Unescapes anchors back to `{#id}`; Mintlify renders `\{` as a literal brace.
+ */
+export function restoreAnchorIds(content: string): string {
+  return mapLinesOutsideCodeFences(content, (line) => {
+    const match = line.match(ESCAPED_ANCHOR);
+    if (!match) return line;
+    return `${match[1]} {#${match[2]}}`;
+  });
+}
+
+/** Builds the parse-only MDX processor shared by every parse site. */
+export function createMdxParseProcessor() {
+  return unified()
+    .use(remarkParse)
+    .use(remarkFrontmatter, ['yaml', 'toml'])
+    .use(remarkMdx);
+}
+
+/**
+ * Parses MDX, retrying with anchors escaped; rethrows any other parse error.
+ */
+export function parseMdxTolerantly(content: string): Root {
+  const processor = createMdxParseProcessor();
+  try {
+    return processor.runSync(processor.parse(content)) as Root;
+  } catch (error) {
+    const { content: neutralized, changed } = neutralizeAnchorIds(content);
+    if (!changed) throw error;
+    return processor.runSync(processor.parse(neutralized)) as Root;
+  }
+}
+
+/**
+ * Parses MDX for a pass that stringifies the tree back out. `neutralized` tells
+ * the caller whether to run {@link restoreAnchorIds} on its output.
+ */
+export function parseMdxForRoundTrip(content: string): {
+  ast: Root;
+  neutralized: boolean;
+} {
+  const processor = createMdxParseProcessor();
+  try {
+    return {
+      ast: processor.runSync(processor.parse(content)) as Root,
+      neutralized: false,
+    };
+  } catch (error) {
+    const { content: neutralized, changed } = neutralizeAnchorIds(content);
+    if (!changed) throw error;
+    return {
+      ast: processor.runSync(processor.parse(neutralized)) as Root,
+      neutralized: true,
+    };
+  }
+}

--- a/packages/cli/src/utils/validateMdx.ts
+++ b/packages/cli/src/utils/validateMdx.ts
@@ -1,10 +1,12 @@
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkMdx from 'remark-mdx';
-import remarkFrontmatter from 'remark-frontmatter';
+import { parseMdxTolerantly } from './mdxAnchorSyntax.js';
 
 /**
  * Validates if an MDX file content can be parsed as a valid AST
+ *
+ * Mintlify-style custom heading IDs (`## Heading {#id}`) are tolerated: they are
+ * not valid MDX expressions, but the CLI supports them end-to-end, so a document
+ * whose only parse error comes from them is considered valid.
+ *
  * @param content - The MDX file content to validate
  * @param filePath - The file path for error reporting
  * @returns object with isValid boolean and optional error message
@@ -17,13 +19,7 @@ export function isValidMdx(
   error?: string;
 } {
   try {
-    const parseProcessor = unified()
-      .use(remarkParse)
-      .use(remarkFrontmatter, ['yaml', 'toml'])
-      .use(remarkMdx);
-
-    const ast = parseProcessor.parse(content);
-    parseProcessor.runSync(ast);
+    parseMdxTolerantly(content);
     return { isValid: true };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds tolerant handling and preservation of Mintlify custom heading IDs across MD/MDX validation and post-processing, and moves anchor processing after other document transforms.

- Introduces shared helpers for neutralizing, parsing, and restoring custom anchor syntax.
- Applies anchors using parser-derived heading positions while preserving the original document text.
- Adds coverage for custom IDs, nested headings, repeated headings, wrappers, and closing hash sequences.
- Leaves an order-dependent duplicate-ID case when a generated slug precedes a matching explicit ID.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the order-dependent duplicate-anchor collision is fixed; the remaining format-transformation concern is non-blocking.

A generated heading slug can claim an ID that a later author-written heading must preserve, causing the output to contain duplicate anchors and ambiguous fragment navigation.

**Files Needing Attention:** packages/cli/src/utils/addExplicitAnchorIds.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/addExplicitAnchorIds.ts | Replaces AST reserialization with position-based anchor insertion, but generated slugs can collide with explicit IDs appearing later in the document. |
| packages/cli/src/utils/mdxAnchorSyntax.ts | Adds tolerant custom-anchor parsing and round-trip restoration using line-oriented transformations. |
| packages/cli/src/cli/commands/translate.ts | Reorders static-import and anchor processing so anchor placement runs after MD/MDX reserialization passes. |
| packages/cli/src/utils/localizeRelativeAssets.ts | Uses tolerant parsing and restores neutralized custom anchors after serialization. |
| packages/cli/src/utils/localizeStaticUrls.ts | Preserves custom heading IDs while parsing and reserializing localized URLs. |
| packages/cli/src/utils/localizeStaticImports.ts | Uses tolerant parsing only for source positions while continuing to edit the original string. |
| packages/cli/src/utils/validateMdx.ts | Treats Mintlify custom heading IDs as supported syntax during MDX validation. |
| packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts | Adds broad focused anchor tests but omits the generated-before-explicit slug collision. |
| packages/cli/src/utils/__tests__/mdxAnchorSyntax.test.ts | Covers neutralization, restoration, fence handling, parser positions, and invalid-MDX rejection. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant CLI as Translate command
  participant Passes as URL/asset/import passes
  participant Parser as Tolerant MDX parser
  participant Anchors as Anchor processor
  participant File as Translated file
  CLI->>Passes: Post-process translated MD/MDX
  Passes->>Parser: Parse with custom IDs neutralized
  Parser-->>Passes: AST and round-trip state
  Passes->>Anchors: Process anchors last
  Anchors->>Parser: Extract source and translated headings
  Parser-->>Anchors: Ordered headings and positions
  Anchors->>File: Insert inline IDs or wrappers
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232221%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2221&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A105-126%0A**Later%20explicit%20IDs%20collide**%0A%0AWhen%20a%20generated%20heading%20precedes%20a%20heading%20whose%20explicit%20ID%20matches%20its%20slug%2C%20%60assignUniqueSlugs%60%20assigns%20both%20headings%20the%20same%20ID%2C%20causing%20ambiguous%20fragment%20navigation%20in%20the%20translated%20document.%0A%0A%60%60%60suggestion%0Afunction%20assignUniqueSlugs%28headings%3A%20HeadingInfo%5B%5D%29%3A%20void%20%7B%0A%20%20const%20used%20%3D%20new%20Set%28%0A%20%20%20%20headings.filter%28%28heading%29%20%3D%3E%20heading.explicit%29.map%28%28heading%29%20%3D%3E%20heading.slug%29%0A%20%20%29%3B%0A%0A%20%20for%20%28const%20heading%20of%20headings%29%20%7B%0A%20%20%20%20if%20%28heading.explicit%29%20continue%3B%0A%0A%20%20%20%20%2F%2F%20Headings%20with%20no%20slug-able%20characters%20would%20produce%20id%3D%22%22.%0A%20%20%20%20const%20base%20%3D%20heading.slug%20%7C%7C%20'section'%3B%0A%20%20%20%20let%20slug%20%3D%20base%3B%0A%20%20%20%20let%20suffix%20%3D%201%3B%0A%20%20%20%20while%20%28used.has%28slug%29%29%20%7B%0A%20%20%20%20%20%20suffix%20%2B%3D%201%3B%0A%20%20%20%20%20%20slug%20%3D%20%60%24%7Bbase%7D-%24%7Bsuffix%7D%60%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20heading.slug%20%3D%20slug%3B%0A%20%20%20%20used.add%28slug%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A359-388%0A**MDX%20is%20rewritten%20textually**%0A%0AThe%20new%20anchor%20path%20edits%20structured%20MDX%20through%20line-oriented%20regexes%20and%20raw%20string%20splices%2C%20requiring%20incomplete%20textual%20representations%20of%20MDX%20syntax%20to%20remain%20synchronized%20and%20increasing%20the%20maintenance%20cost%20of%20preserving%20valid%20forms%20outside%20the%20covered%20cases.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fmixed-anchor-handling%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fmixed-anchor-handling%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A105-126%0A**Later%20explicit%20IDs%20collide**%0A%0AWhen%20a%20generated%20heading%20precedes%20a%20heading%20whose%20explicit%20ID%20matches%20its%20slug%2C%20%60assignUniqueSlugs%60%20assigns%20both%20headings%20the%20same%20ID%2C%20causing%20ambiguous%20fragment%20navigation%20in%20the%20translated%20document.%0A%0A%60%60%60suggestion%0Afunction%20assignUniqueSlugs%28headings%3A%20HeadingInfo%5B%5D%29%3A%20void%20%7B%0A%20%20const%20used%20%3D%20new%20Set%28%0A%20%20%20%20headings.filter%28%28heading%29%20%3D%3E%20heading.explicit%29.map%28%28heading%29%20%3D%3E%20heading.slug%29%0A%20%20%29%3B%0A%0A%20%20for%20%28const%20heading%20of%20headings%29%20%7B%0A%20%20%20%20if%20%28heading.explicit%29%20continue%3B%0A%0A%20%20%20%20%2F%2F%20Headings%20with%20no%20slug-able%20characters%20would%20produce%20id%3D%22%22.%0A%20%20%20%20const%20base%20%3D%20heading.slug%20%7C%7C%20'section'%3B%0A%20%20%20%20let%20slug%20%3D%20base%3B%0A%20%20%20%20let%20suffix%20%3D%201%3B%0A%20%20%20%20while%20%28used.has%28slug%29%29%20%7B%0A%20%20%20%20%20%20suffix%20%2B%3D%201%3B%0A%20%20%20%20%20%20slug%20%3D%20%60%24%7Bbase%7D-%24%7Bsuffix%7D%60%3B%0A%20%20%20%20%7D%0A%0A%20%20%20%20heading.slug%20%3D%20slug%3B%0A%20%20%20%20used.add%28slug%29%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A359-388%0A**MDX%20is%20rewritten%20textually**%0A%0AThe%20new%20anchor%20path%20edits%20structured%20MDX%20through%20line-oriented%20regexes%20and%20raw%20string%20splices%2C%20requiring%20incomplete%20textual%20representations%20of%20MDX%20syntax%20to%20remain%20synchronized%20and%20increasing%20the%20maintenance%20cost%20of%20preserving%20valid%20forms%20outside%20the%20covered%20cases.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/utils/addExplicitAnchorIds.ts:105-126
**Later explicit IDs collide**

When a generated heading precedes a heading whose explicit ID matches its slug, `assignUniqueSlugs` assigns both headings the same ID, causing ambiguous fragment navigation in the translated document.

```suggestion
function assignUniqueSlugs(headings: HeadingInfo[]): void {
  const used = new Set(
    headings.filter((heading) => heading.explicit).map((heading) => heading.slug)
  );

  for (const heading of headings) {
    if (heading.explicit) continue;

    // Headings with no slug-able characters would produce id="".
    const base = heading.slug || 'section';
    let slug = base;
    let suffix = 1;
    while (used.has(slug)) {
      suffix += 1;
      slug = `${base}-${suffix}`;
    }

    heading.slug = slug;
    used.add(slug);
  }
}
```

### Issue 2
packages/cli/src/utils/addExplicitAnchorIds.ts:359-388
**MDX is rewritten textually**

The new anchor path edits structured MDX through line-oriented regexes and raw string splices, requiring incomplete textual representations of MDX syntax to remain synchronized and increasing the maintenance cost of preserving valid forms outside the covered cases.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): preserve custom heading IDs in..."](https://github.com/generaltranslation/gt/commit/06cc2591e2632a162b4a69c0b248b8b0243b8774) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59234796)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - For JSON, YAML, HTML, SVG, XML, MDX, source code, ... ([source](https://app.greptile.com/generaltranslation/-/custom-context?memory=498f44d3-3036-4f80-9c20-3c643887e413))

<!-- /greptile_comment -->