### PR TITLE
feat(cli): register the Apple .strings file format

### DIFF
--- a/.changeset/apple-strings-cli-format.md
+++ b/.changeset/apple-strings-cli-format.md
@@ -5,3 +5,5 @@
 ---
 
 Add Apple `.strings` support to the CLI. Configure a `strings` entry under `files` in `gt.config.json` to upload `.strings` sources and download the translated per-locale files. `.strings` files written as UTF-16 by older versions of Xcode upload correctly: their bytes are sent unmodified so the API can read the byte order mark.
+
+Fix `save-local` for formats whose content travels base64. It compared the local file against the still-encoded server copy, so a Lottie translation reported an edit on every run. Unchanged files are now recognised, and an edited file whose bytes are not valid UTF-8 is reported by name rather than submitted as unreadable text.

--- a/.changeset/apple-strings-cli-format.md
+++ b/.changeset/apple-strings-cli-format.md
@@ -4,4 +4,4 @@
 '@generaltranslation/api': patch
 ---
 
-Add Apple `.strings` support to the CLI. Configure a `strings` entry under `files` in `gt.config.json` to upload `.strings` sources and download the translated per-locale files.
+Add Apple `.strings` support to the CLI. Configure a `strings` entry under `files` in `gt.config.json` to upload `.strings` sources and download the translated per-locale files. `.strings` files written as UTF-16 by older versions of Xcode upload correctly: their bytes are sent unmodified so the API can read the byte order mark.

--- a/.changeset/apple-strings-cli-format.md
+++ b/.changeset/apple-strings-cli-format.md
@@ -1,0 +1,7 @@
+---
+'gt': minor
+'generaltranslation': patch
+'@generaltranslation/api': patch
+---
+
+Add Apple `.strings` support to the CLI. Configure a `strings` entry under `files` in `gt.config.json` to upload `.strings` sources and download the translated per-locale files.

--- a/packages/api/spec/openapi.json
+++ b/packages/api/spec/openapi.json
@@ -71,7 +71,8 @@
           "POT",
           "TWILIO_CONTENT_JSON",
           "LOTTIE",
-          "SVG"
+          "SVG",
+          "APPLE_STRINGS"
         ]
       },
       "ModelProvider": {
@@ -614,7 +615,8 @@
                                 "POT",
                                 "TWILIO_CONTENT_JSON",
                                 "LOTTIE",
-                                "SVG"
+                                "SVG",
+                                "APPLE_STRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -926,7 +928,8 @@
                                 "POT",
                                 "TWILIO_CONTENT_JSON",
                                 "LOTTIE",
-                                "SVG"
+                                "SVG",
+                                "APPLE_STRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -996,7 +999,8 @@
                                   "POT",
                                   "TWILIO_CONTENT_JSON",
                                   "LOTTIE",
-                                  "SVG"
+                                  "SVG",
+                                  "APPLE_STRINGS"
                                 ]
                               },
                               "dataFormat": {
@@ -1022,7 +1026,8 @@
                                   "POT",
                                   "TWILIO_CONTENT_JSON",
                                   "LOTTIE",
-                                  "SVG"
+                                  "SVG",
+                                  "APPLE_STRINGS"
                                 ]
                               }
                             },
@@ -2306,7 +2311,8 @@
                             "POT",
                             "TWILIO_CONTENT_JSON",
                             "LOTTIE",
-                            "SVG"
+                            "SVG",
+                            "APPLE_STRINGS"
                           ]
                         }
                       },

--- a/packages/api/src/generated/types.gen.ts
+++ b/packages/api/src/generated/types.gen.ts
@@ -22,7 +22,8 @@ export type FileFormat =
   | 'POT'
   | 'TWILIO_CONTENT_JSON'
   | 'LOTTIE'
-  | 'SVG';
+  | 'SVG'
+  | 'APPLE_STRINGS';
 
 export type ModelProvider = 'ANTHROPIC' | 'OPENAI' | 'XAI' | 'GOOGLE';
 
@@ -208,7 +209,8 @@ export type UploadSourceFilesData = {
           | 'POT'
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
-          | 'SVG';
+          | 'SVG'
+          | 'APPLE_STRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -322,7 +324,8 @@ export type UploadTranslationsData = {
           | 'POT'
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
-          | 'SVG';
+          | 'SVG'
+          | 'APPLE_STRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -351,7 +354,8 @@ export type UploadTranslationsData = {
           | 'POT'
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
-          | 'SVG';
+          | 'SVG'
+          | 'APPLE_STRINGS';
         dataFormat?: string;
         locale: string;
         transformFormat?:
@@ -368,7 +372,8 @@ export type UploadTranslationsData = {
           | 'POT'
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
-          | 'SVG';
+          | 'SVG'
+          | 'APPLE_STRINGS';
       }>;
     }>;
     sourceLocale?: string;
@@ -840,7 +845,8 @@ export type EnqueueFileTranslationsData = {
         | 'POT'
         | 'TWILIO_CONTENT_JSON'
         | 'LOTTIE'
-        | 'SVG';
+        | 'SVG'
+        | 'APPLE_STRINGS';
     }>;
     targetLocales?: Array<string>;
     sourceLocale?: string;

--- a/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
@@ -5,6 +5,8 @@ import os from 'node:os';
 import { collectAndSendUserEditDiffs } from '../collectUserEditDiffs.js';
 import { createMockSettings } from '../__mocks__/settings.js';
 import { gt } from '../../utils/gt.js';
+import { logger } from '../../console/logger.js';
+import { clearWarnings, getWarnings } from '../../state/translateWarnings.js';
 import type { FileReference } from 'generaltranslation/types';
 import type { DownloadedVersionsV1 } from '../../fs/config/downloadedVersions.js';
 
@@ -31,6 +33,7 @@ const utf16leWithBom = (text: string) =>
 describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   const originalCwd = process.cwd();
   let tempDir: string;
+  let warn: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     tempDir = fs.realpathSync(
@@ -38,11 +41,14 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     );
     process.chdir(tempDir);
     vi.clearAllMocks();
+    clearWarnings();
+    warn = vi.spyOn(logger, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     process.chdir(originalCwd);
     fs.rmSync(tempDir, { recursive: true, force: true });
+    clearWarnings();
     vi.resetAllMocks();
   });
 
@@ -185,7 +191,7 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     expect(diffs[0].localContent).toContain('"welcome" = "¡Hola!";');
   });
 
-  it('submits nothing for a UTF-16 .strings translation it cannot represent as text', async () => {
+  it('warns instead of submitting a UTF-16 .strings edit it cannot represent as text', async () => {
     const settings = buildSettings();
     seedLockFile();
     writeTranslation(
@@ -202,11 +208,39 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     );
 
     // Reading UTF-16 bytes as UTF-8 yields U+FFFD, so there is no faithful
-    // diff or localContent to send. Sending nothing beats sending mojibake.
+    // diff or localContent to send. Sending nothing beats sending mojibake,
+    // but dropping the edit without saying so is its own failure.
     expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('Guardian/es.lproj/Localizable.strings')
+    );
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('UTF-8'));
+    expect(getWarnings()).toContainEqual({
+      category: 'skipped_file',
+      fileName: 'Guardian/es.lproj/Localizable.strings',
+      reason: expect.stringContaining('UTF-8'),
+    });
   });
 
-  it('submits nothing for a Lottie bundle, whose bytes have no text form', async () => {
+  it('stays quiet when a translation is byte-identical to the server copy', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    const unchanged = utf16leWithBom(TRANSLATION);
+    writeTranslation(unchanged);
+    mockServerDownload(unchanged.toString('base64'), 'APPLE_STRINGS');
+
+    await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    // Nothing was edited, so there is nothing to warn about.
+    expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    expect(getWarnings()).toHaveLength(0);
+  });
+
+  it('warns instead of submitting a changed Lottie bundle, whose bytes have no text form', async () => {
     const settings = createMockSettings({
       configDirectory: tempDir,
       config: path.join(tempDir, 'gt.config.json'),
@@ -247,5 +281,10 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     );
 
     expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(getWarnings()).toContainEqual({
+      category: 'skipped_file',
+      fileName: 'anim/es/spinner.lottie',
+      reason: expect.stringContaining('UTF-8'),
+    });
   });
 });

--- a/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import os from 'node:os';
+import { collectAndSendUserEditDiffs } from '../collectUserEditDiffs.js';
+import { createMockSettings } from '../__mocks__/settings.js';
+import { gt } from '../../utils/gt.js';
+import type { FileReference } from 'generaltranslation/types';
+import type { DownloadedVersionsV1 } from '../../fs/config/downloadedVersions.js';
+
+// Runs the real `git diff --no-index` rather than mocking it: the defect here is
+// what gets written to the comparison file, which a mocked differ cannot see.
+vi.mock('../../utils/gt.js', () => ({
+  gt: {
+    queryFileData: vi.fn(),
+    downloadFileBatch: vi.fn(),
+    submitUserEditDiffs: vi.fn(),
+  },
+}));
+
+const SOURCE = 'Guardian/en.lproj/Localizable.strings';
+
+const TRANSLATION =
+  '/* Localizable.strings */\n' +
+  '"app.title" = "Pocket Café";\n' +
+  '"welcome" = "¡Bienvenido!";\n';
+
+const utf16leWithBom = (text: string) =>
+  Buffer.concat([Buffer.from([0xff, 0xfe]), Buffer.from(text, 'utf16le')]);
+
+describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
+  const originalCwd = process.cwd();
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'gt-user-edit-'))
+    );
+    process.chdir(tempDir);
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.resetAllMocks();
+  });
+
+  const buildSettings = () =>
+    createMockSettings({
+      configDirectory: tempDir,
+      config: path.join(tempDir, 'gt.config.json'),
+      defaultLocale: 'en',
+      locales: ['es'],
+      _branchId: 'branch1',
+      files: {
+        resolvedPaths: {
+          strings: [path.join(tempDir, SOURCE)],
+        },
+        placeholderPaths: {
+          strings: [
+            path.join(
+              tempDir,
+              'Guardian',
+              '[locale].lproj',
+              'Localizable.strings'
+            ),
+          ],
+        },
+        transformPaths: {},
+      },
+    });
+
+  const writeLockFile = (content: DownloadedVersionsV1) => {
+    fs.writeFileSync(
+      path.join(tempDir, 'gt-lock.json'),
+      JSON.stringify(content, null, 2)
+    );
+  };
+
+  const seedLockFile = () =>
+    writeLockFile({
+      version: 1,
+      entries: {
+        branch1: {
+          file1: {
+            version1: {
+              es: { updatedAt: new Date().toISOString() },
+            },
+          },
+        },
+      },
+    });
+
+  /** Writes the translated output the user would have downloaded and edited. */
+  const writeTranslation = (bytes: Buffer) => {
+    const outputPath = path.join(
+      tempDir,
+      'Guardian',
+      'es.lproj',
+      'Localizable.strings'
+    );
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, bytes);
+    return outputPath;
+  };
+
+  /** Mirrors core's downloadFileBatch, which leaves base64 formats encoded. */
+  const mockServerDownload = (base64Data: string, fileFormat: string) => {
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: 'es',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: 'es',
+          fileFormat,
+          data: base64Data,
+        },
+      ],
+    } as unknown as Awaited<ReturnType<typeof gt.downloadFileBatch>>);
+  };
+
+  const filesUnderTest = (fileFormat: string): FileReference[] => [
+    {
+      fileName: SOURCE,
+      fileFormat,
+      branchId: 'branch1',
+      fileId: 'file1',
+      versionId: 'version1',
+    } as FileReference,
+  ];
+
+  it('reports no edit when an untouched .strings translation matches the server', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    mockServerDownload(
+      Buffer.from(TRANSLATION, 'utf8').toString('base64'),
+      'APPLE_STRINGS'
+    );
+
+    const hadDiffs = await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    expect(gt.downloadFileBatch).toHaveBeenCalledTimes(1);
+    expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(hadDiffs).toBe(false);
+  });
+
+  it('diffs an edited .strings translation against the decoded server text', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    writeTranslation(
+      Buffer.from(TRANSLATION.replace('¡Bienvenido!', '¡Hola!'), 'utf8')
+    );
+    mockServerDownload(
+      Buffer.from(TRANSLATION, 'utf8').toString('base64'),
+      'APPLE_STRINGS'
+    );
+
+    await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+    const [{ diffs }] = vi.mocked(gt.submitUserEditDiffs).mock.calls[0];
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0].diff).toContain('-"welcome" = "¡Bienvenido!";');
+    expect(diffs[0].diff).toContain('+"welcome" = "¡Hola!";');
+    expect(diffs[0].localContent).toContain('"welcome" = "¡Hola!";');
+  });
+
+  it('submits nothing for a UTF-16 .strings translation it cannot represent as text', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    writeTranslation(
+      utf16leWithBom(TRANSLATION.replace('¡Bienvenido!', '¡Hola!'))
+    );
+    mockServerDownload(
+      utf16leWithBom(TRANSLATION).toString('base64'),
+      'APPLE_STRINGS'
+    );
+
+    await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    // Reading UTF-16 bytes as UTF-8 yields U+FFFD, so there is no faithful
+    // diff or localContent to send. Sending nothing beats sending mojibake.
+    expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+  });
+
+  it('submits nothing for a Lottie bundle, whose bytes have no text form', async () => {
+    const settings = createMockSettings({
+      configDirectory: tempDir,
+      config: path.join(tempDir, 'gt.config.json'),
+      defaultLocale: 'en',
+      locales: ['es'],
+      _branchId: 'branch1',
+      files: {
+        resolvedPaths: {
+          lottie: [path.join(tempDir, 'anim', 'en', 'spinner.lottie')],
+        },
+        placeholderPaths: {
+          lottie: [path.join(tempDir, 'anim', '[locale]', 'spinner.lottie')],
+        },
+        transformPaths: {},
+      },
+    });
+    seedLockFile();
+
+    // A zip local header: 0x50 0x4b 0x03 0x04 followed by non-UTF-8 bytes.
+    const serverZip = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x00]);
+    const localZip = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0xfe, 0x01]);
+    const outputPath = path.join(tempDir, 'anim', 'es', 'spinner.lottie');
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, localZip);
+    mockServerDownload(serverZip.toString('base64'), 'LOTTIE');
+
+    await collectAndSendUserEditDiffs(
+      [
+        {
+          fileName: 'anim/en/spinner.lottie',
+          fileFormat: 'LOTTIE',
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+        } as FileReference,
+      ],
+      settings
+    );
+
+    expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
@@ -191,6 +191,54 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     expect(diffs[0].localContent).toContain('"welcome" = "¡Hola!";');
   });
 
+  it('submits the edit when the recorded server baseline is empty', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    // An empty payload is a baseline of "nothing", not a missing download.
+    // Treating the two alike drops everything the user wrote against it.
+    mockServerDownload('', 'APPLE_STRINGS');
+
+    await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+    const [{ diffs }] = vi.mocked(gt.submitUserEditDiffs).mock.calls[0];
+    expect(diffs[0].diff).toContain('+"welcome" = "¡Bienvenido!";');
+    expect(diffs[0].localContent).toBe(TRANSLATION);
+  });
+
+  it('skips silently when the batch download returned no copy of the file', async () => {
+    const settings = buildSettings();
+    seedLockFile();
+    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    vi.mocked(gt.queryFileData).mockResolvedValue({
+      translatedFiles: [
+        {
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: 'es',
+          completedAt: new Date().toISOString(),
+        },
+      ],
+    });
+    vi.mocked(gt.downloadFileBatch).mockResolvedValue({
+      files: [],
+    } as unknown as Awaited<ReturnType<typeof gt.downloadFileBatch>>);
+
+    await collectAndSendUserEditDiffs(
+      filesUnderTest('APPLE_STRINGS'),
+      settings
+    );
+
+    // No baseline at all, so there is nothing to diff and nothing to report.
+    expect(gt.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
   it('warns instead of submitting a UTF-16 .strings edit it cannot represent as text', async () => {
     const settings = buildSettings();
     seedLockFile();

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -19,6 +19,9 @@ import { randomUUID } from 'node:crypto';
 import { hashStringSync } from '../utils/hash.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
+import { logger } from '../console/logger.js';
+import { recordWarning } from '../state/translateWarnings.js';
+import { getRelative } from '../fs/findFilepath.js';
 
 type LatestDownloadedVersion = {
   versionId: string;
@@ -180,11 +183,22 @@ export async function collectAndSendUserEditDiffs(
       try {
         const localBytes = await fs.promises.readFile(c.outputPath);
 
+        // Nothing was edited, so there is no diff to compute or report.
+        if (localBytes.equals(serverBytes)) continue;
+
         // A unified diff and localContent are both UTF-8 text. Content that is
         // not valid UTF-8 — a Lottie zip, a UTF-16 .strings file — has no
         // faithful text form here, and sending mojibake upstream is worse than
-        // sending nothing.
-        if (!isUtf8Text(serverBytes) || !isUtf8Text(localBytes)) continue;
+        // sending nothing. Say so: the edit is real and will be lost on the
+        // next download.
+        if (!isUtf8Text(serverBytes) || !isUtf8Text(localBytes)) {
+          const relativePath = getRelative(c.outputPath);
+          const reason =
+            'Edited file is not valid UTF-8, so its changes cannot be submitted';
+          logger.warn(`Skipping local edits to ${relativePath}: ${reason}`);
+          recordWarning('skipped_file', relativePath, reason);
+          continue;
+        }
 
         const safeName = Buffer.from(
           `${c.branchId}:${c.fileId}:${c.versionId}:${c.locale}`

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -178,7 +178,10 @@ export async function collectAndSendUserEditDiffs(
     for (const c of candidates) {
       const key = `${c.branchId}:${c.fileId}:${c.versionId}:${c.locale}`;
       const serverBytes = serverContentByKey.get(key);
-      if (!serverBytes?.length) continue;
+      // Absent means the batch did not return this file, so there is no
+      // baseline. An empty payload is a baseline of nothing, which the user
+      // may well have written against.
+      if (!serverBytes) continue;
 
       try {
         const localBytes = await fs.promises.readFile(c.outputPath);

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -9,7 +9,11 @@ import { Settings } from '../types/index.js';
 import { createFileMapping } from '../formats/files/fileMapping.js';
 import { getGitUnifiedDiff } from '../utils/gitDiff.js';
 import { gt } from '../utils/gt.js';
-import { FileReference, SubmitUserEditDiff } from 'generaltranslation/types';
+import {
+  FileReference,
+  isBinaryFileFormat,
+  SubmitUserEditDiff,
+} from 'generaltranslation/types';
 import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { hashStringSync } from '../utils/hash.js';
@@ -19,6 +23,18 @@ import { extractYaml } from '../formats/yaml/extractYaml.js';
 type LatestDownloadedVersion = {
   versionId: string;
   entry: DownloadedTranslation;
+};
+
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
+
+/** Whether these bytes round trip as UTF-8 text. */
+const isUtf8Text = (bytes: Buffer): boolean => {
+  try {
+    utf8Decoder.decode(bytes);
+    return true;
+  } catch {
+    return false;
+  }
 };
 
 const findLatestDownloadedVersion = (
@@ -130,7 +146,7 @@ export async function collectAndSendUserEditDiffs(
     const translatedFiles =
       checkResponse.translatedFiles?.filter((t) => t.completedAt) ?? [];
 
-    const serverContentByKey = new Map<string, string>();
+    const serverContentByKey = new Map<string, Buffer>();
     try {
       const resp = await gt.downloadFileBatch(
         translatedFiles.map((file) => ({
@@ -144,7 +160,11 @@ export async function collectAndSendUserEditDiffs(
       for (const f of files) {
         serverContentByKey.set(
           `${f.branchId}:${f.fileId}:${f.versionId}:${f.locale}`,
-          f.data
+          // Formats in BINARY_FILE_FORMATS are still base64 at this point;
+          // everything else has already been decoded to a UTF-8 string.
+          isBinaryFileFormat(f.fileFormat)
+            ? Buffer.from(f.data, 'base64')
+            : Buffer.from(f.data, 'utf8')
         );
       }
     } catch {
@@ -154,17 +174,25 @@ export async function collectAndSendUserEditDiffs(
     // Compute diffs using fetched server contents
     for (const c of candidates) {
       const key = `${c.branchId}:${c.fileId}:${c.versionId}:${c.locale}`;
-      const serverContent = serverContentByKey.get(key);
-      if (!serverContent) continue;
+      const serverBytes = serverContentByKey.get(key);
+      if (!serverBytes?.length) continue;
 
       try {
+        const localBytes = await fs.promises.readFile(c.outputPath);
+
+        // A unified diff and localContent are both UTF-8 text. Content that is
+        // not valid UTF-8 — a Lottie zip, a UTF-16 .strings file — has no
+        // faithful text form here, and sending mojibake upstream is worse than
+        // sending nothing.
+        if (!isUtf8Text(serverBytes) || !isUtf8Text(localBytes)) continue;
+
         const safeName = Buffer.from(
           `${c.branchId}:${c.fileId}:${c.versionId}:${c.locale}`
         )
           .toString('base64')
           .replace(/=+$/g, '');
         const tempServerFile = path.join(tempDir, `${safeName}.server`);
-        await fs.promises.writeFile(tempServerFile, serverContent, 'utf8');
+        await fs.promises.writeFile(tempServerFile, serverBytes);
 
         const diff = await getGitUnifiedDiff(tempServerFile, c.outputPath);
         try {
@@ -174,10 +202,7 @@ export async function collectAndSendUserEditDiffs(
         }
 
         if (diff && diff.trim().length > 0) {
-          const rawLocalContent = await fs.promises.readFile(
-            c.outputPath,
-            'utf8'
-          );
+          const rawLocalContent = localBytes.toString('utf8');
 
           // For JSON files with jsonSchema config, extract to composite format
           let localContent = rawLocalContent;

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -7,6 +7,7 @@ import parseYaml from '../../yaml/parseYaml.js';
 import sanitizeFileContent from '../../../utils/sanitizeFileContent.js';
 import { determineLibrary } from '../../../fs/determineFramework/index.js';
 import { isValidMdx } from '../../../utils/validateMdx.js';
+import { hashStringSync, hashVersionId } from '../../../utils/hash.js';
 import type { Settings } from '../../../types/index.js';
 
 const aggregateTestFiles = (settings: Partial<Settings>) =>
@@ -579,6 +580,74 @@ describe('aggregateFiles - Empty File Handling', () => {
       expect(mockLogWarning).not.toHaveBeenCalled();
       expect(result).toHaveLength(1);
       expect(result[0].fileName).toBe('invalid.json');
+    });
+  });
+
+  describe('Apple .strings files', () => {
+    // The escapes below are load-bearing: they must reach the API verbatim.
+    const stringsContent =
+      '/* Greeting */\n"hello" = "Line1\\nLine2 \\"quoted\\" 100%%";\n';
+
+    beforeEach(() => {
+      // Make any trip through the markdown-oriented sanitizer detectable: it
+      // would strip the backslash escapes the assertions below depend on.
+      mockSanitizeFileContent.mockImplementation((content) =>
+        content.replace(/\\/g, '')
+      );
+    });
+
+    it('should upload .strings files verbatim with the APPLE_STRINGS format', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            strings: ['/full/path/en.lproj/Localizable.strings'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce(stringsContent);
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        fileName: 'en.lproj/Localizable.strings',
+        fileFormat: 'APPLE_STRINGS',
+        locale: 'en',
+      });
+      expect(result[0].content).toBe(stringsContent);
+      expect(result[0].fileId).toBe(
+        hashStringSync('en.lproj/Localizable.strings')
+      );
+      expect(result[0].versionId).toBe(hashVersionId(stringsContent, false));
+    });
+
+    it('should skip empty .strings files and log a warning', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            strings: ['/full/path/empty.strings', '/full/path/valid.strings'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile
+        .mockReturnValueOnce('   \n\t  ') // whitespace only
+        .mockReturnValueOnce(stringsContent); // valid file
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Skipping empty.strings: File is empty'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('valid.strings');
     });
   });
 

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { aggregateFiles } from '../aggregateFiles.js';
 import { logger } from '../../../console/logger.js';
-import { readFile, getRelative } from '../../../fs/findFilepath.js';
+import {
+  readFile,
+  readBinaryFileBase64,
+  getRelative,
+} from '../../../fs/findFilepath.js';
 import { parseJson } from '../../json/parseJson.js';
 import parseYaml from '../../yaml/parseYaml.js';
 import sanitizeFileContent from '../../../utils/sanitizeFileContent.js';
@@ -28,6 +32,7 @@ vi.mock('../../../utils/validateMdx.js');
 
 const mockLogWarning = vi.mocked(logger.warn);
 const mockReadFile = vi.mocked(readFile);
+const mockReadBinaryFileBase64 = vi.mocked(readBinaryFileBase64);
 const mockGetRelative = vi.mocked(getRelative);
 const mockParseJson = vi.mocked(parseJson);
 const mockParseYaml = vi.mocked(parseYaml);
@@ -587,6 +592,9 @@ describe('aggregateFiles - Empty File Handling', () => {
     // The escapes below are load-bearing: they must reach the API verbatim.
     const stringsContent =
       '/* Greeting */\n"hello" = "Line1\\nLine2 \\"quoted\\" 100%%";\n';
+    const stringsBase64 = Buffer.from(stringsContent, 'utf8').toString(
+      'base64'
+    );
 
     beforeEach(() => {
       // Make any trip through the markdown-oriented sanitizer detectable: it
@@ -608,7 +616,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadFile.mockReturnValueOnce(stringsContent);
+      mockReadBinaryFileBase64.mockReturnValueOnce(stringsBase64);
 
       const { files: result } = await aggregateTestFiles(settings);
 
@@ -618,11 +626,14 @@ describe('aggregateFiles - Empty File Handling', () => {
         fileFormat: 'APPLE_STRINGS',
         locale: 'en',
       });
-      expect(result[0].content).toBe(stringsContent);
+      expect(result[0].content).toBe(stringsBase64);
+      expect(Buffer.from(result[0].content, 'base64').toString('utf8')).toBe(
+        stringsContent
+      );
       expect(result[0].fileId).toBe(
         hashStringSync('en.lproj/Localizable.strings')
       );
-      expect(result[0].versionId).toBe(hashVersionId(stringsContent, false));
+      expect(result[0].versionId).toBe(hashVersionId(stringsBase64, false));
     });
 
     it('should skip empty .strings files and log a warning', async () => {
@@ -637,9 +648,11 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadFile
-        .mockReturnValueOnce('   \n\t  ') // whitespace only
-        .mockReturnValueOnce(stringsContent); // valid file
+      mockReadBinaryFileBase64
+        .mockReturnValueOnce(
+          Buffer.from('   \n\t  ', 'utf8').toString('base64')
+        ) // whitespace only
+        .mockReturnValueOnce(stringsBase64); // valid file
 
       const { files: result } = await aggregateTestFiles(settings);
 

--- a/packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { isBinaryFileFormat } from 'generaltranslation/types';
+import { aggregateFiles } from '../aggregateFiles.js';
+import type { Settings } from '../../../types/index.js';
+
+// Exercises the real filesystem helpers rather than mocks: the bug this covers
+// was in how the bytes were read, so a mocked read cannot see it.
+
+const BODY =
+  '/* Localizable.strings */\n' +
+  '"app.title" = "Pocket Café";\n' +
+  '"welcome" = "¡Bienvenido — te echábamos de menos!";\n' +
+  '"celebrate" = "¡Pedido realizado! 🎉";\n';
+
+const utf16le = (text: string) => Buffer.from(text, 'utf16le');
+
+// Byte layouts Xcode has shipped over the years, byte order marks included.
+const FIXTURES: Record<string, Buffer> = {
+  'utf16le.strings': Buffer.concat([Buffer.from([0xff, 0xfe]), utf16le(BODY)]),
+  'utf16be.strings': Buffer.concat([
+    Buffer.from([0xfe, 0xff]),
+    utf16le(BODY).swap16(),
+  ]),
+  'utf8.strings': Buffer.from(BODY, 'utf8'),
+  'utf8-bom.strings': Buffer.concat([
+    Buffer.from([0xef, 0xbb, 0xbf]),
+    Buffer.from(BODY, 'utf8'),
+  ]),
+};
+
+/** Mirrors the API's byte-order-mark-directed decode. */
+function decodeByBom(bytes: Buffer): string {
+  if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+    return bytes.subarray(2).toString('utf16le');
+  }
+  if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+    return Buffer.from(bytes.subarray(2)).swap16().toString('utf16le');
+  }
+  if (bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return bytes.subarray(3).toString('utf8');
+  }
+  return bytes.toString('utf8');
+}
+
+describe('aggregateFiles - Apple .strings encodings', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-apple-strings-'));
+    for (const [name, bytes] of Object.entries(FIXTURES)) {
+      fs.writeFileSync(path.join(dir, name), bytes);
+    }
+  });
+
+  afterAll(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  /** The base64 the SDK puts on the wire for a single aggregated source file. */
+  async function wireBytesFor(name: string): Promise<Buffer> {
+    const { files } = await aggregateFiles({
+      files: {
+        resolvedPaths: { strings: [path.join(dir, name)] },
+        placeholderPaths: {},
+      },
+      options: {},
+      defaultLocale: 'en',
+    } as unknown as Settings);
+
+    expect(files).toHaveLength(1);
+    expect(files[0].fileFormat).toBe('APPLE_STRINGS');
+
+    // Same branch _uploadSourceFiles takes when building the request body.
+    const wire = isBinaryFileFormat(files[0].fileFormat)
+      ? files[0].content
+      : Buffer.from(files[0].content, 'utf8').toString('base64');
+    return Buffer.from(wire, 'base64');
+  }
+
+  it.each(Object.keys(FIXTURES))(
+    'delivers %s to the API byte for byte',
+    async (name) => {
+      const bytes = await wireBytesFor(name);
+      expect(bytes.equals(FIXTURES[name])).toBe(true);
+      expect(decodeByBom(bytes)).toBe(BODY);
+      expect(decodeByBom(bytes)).not.toContain('�');
+    }
+  );
+
+  it('keeps the byte order mark the API decodes by', async () => {
+    expect(
+      (await wireBytesFor('utf16le.strings')).subarray(0, 2)
+    ).toStrictEqual(Buffer.from([0xff, 0xfe]));
+    expect(
+      (await wireBytesFor('utf16be.strings')).subarray(0, 2)
+    ).toStrictEqual(Buffer.from([0xfe, 0xff]));
+    expect(
+      (await wireBytesFor('utf8-bom.strings')).subarray(0, 3)
+    ).toStrictEqual(Buffer.from([0xef, 0xbb, 0xbf]));
+  });
+});

--- a/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
+++ b/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CONFIG_FILE_TYPE_TO_FILE_FORMAT,
+  FILE_FORMAT_TO_CONFIG_FILE_TYPE,
+  getFileExtensionForFormat,
+} from '../transformFormat.js';
+
+describe('transformFormat - Apple .strings', () => {
+  it('maps the config file key to the API file format enum value', () => {
+    expect(CONFIG_FILE_TYPE_TO_FILE_FORMAT.strings).toBe('APPLE_STRINGS');
+  });
+
+  it('maps the API file format enum value back to the config file key', () => {
+    expect(FILE_FORMAT_TO_CONFIG_FILE_TYPE.APPLE_STRINGS).toBe('strings');
+  });
+
+  it('writes translated files with the matching extension', () => {
+    expect(getFileExtensionForFormat('APPLE_STRINGS')).toBe('strings');
+  });
+});

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -395,12 +395,42 @@ export async function aggregateFiles(
     files.push(...lottieFiles);
   }
 
+  // Apple .strings files are uploaded verbatim. Their backslash escapes and
+  // format specifiers must survive byte-for-byte, so they skip the generic
+  // markdown-oriented preprocessing below.
+  if (filePaths.strings) {
+    const stringsFiles = filePaths.strings
+      .map((filePath) => {
+        const content = readFile(filePath);
+        const relativePath = getRelative(filePath);
+        return {
+          content,
+          fileName: relativePath,
+          fileFormat: 'APPLE_STRINGS' as const,
+          ...getTransformFormatProperty(settings, 'strings'),
+          fileId: hashStringSync(relativePath),
+          versionId: hashVersionId(content, requiresReviewPaths.has(filePath)),
+          locale: settings.defaultLocale,
+        } satisfies FileToUpload;
+      })
+      .filter((file) => {
+        if (!file.content.trim()) {
+          logger.warn(`Skipping ${file.fileName}: File is empty`);
+          recordWarning('skipped_file', file.fileName, 'File is empty');
+          return false;
+        }
+        return true;
+      });
+    files.push(...stringsFiles);
+  }
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (
       fileType === 'json' ||
       fileType === 'yaml' ||
       fileType === 'twilioContentJson' ||
-      fileType === 'lottie'
+      fileType === 'lottie' ||
+      fileType === 'strings'
     )
       continue;
     if (filePaths[fileType]) {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -398,10 +398,14 @@ export async function aggregateFiles(
   // Apple .strings files are uploaded verbatim. Their backslash escapes and
   // format specifiers must survive byte-for-byte, so they skip the generic
   // markdown-oriented preprocessing below.
+  //
+  // The raw bytes are carried base64 rather than read as UTF-8 because older
+  // Xcode wrote .strings as UTF-16. The API selects a decoder from the byte
+  // order mark, so decoding here would destroy the only signal it has.
   if (filePaths.strings) {
     const stringsFiles = filePaths.strings
       .map((filePath) => {
-        const content = readFile(filePath);
+        const content = readBinaryFileBase64(filePath);
         const relativePath = getRelative(filePath);
         return {
           content,
@@ -414,7 +418,10 @@ export async function aggregateFiles(
         } satisfies FileToUpload;
       })
       .filter((file) => {
-        if (!file.content.trim()) {
+        // The bytes travel untouched; they are read as UTF-8 here only to spot
+        // a file with nothing to translate. UTF-16 reads as non-blank, which is
+        // the safe default — the API decodes it properly.
+        if (!Buffer.from(file.content, 'base64').toString('utf8').trim()) {
           logger.warn(`Skipping ${file.fileName}: File is empty`);
           recordWarning('skipped_file', file.fileName, 'File is empty');
           return false;

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -10,6 +10,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'txt',
   'twilioContentJson',
   'lottie',
+  'strings',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -24,4 +25,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   txt: 'Text',
   twilioContentJson: 'Twilio Content JSON',
   lottie: 'Lottie',
+  strings: 'Apple .strings',
 };

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -21,6 +21,7 @@ export const CONFIG_FILE_TYPE_TO_FILE_FORMAT = {
   txt: 'TXT',
   twilioContentJson: 'TWILIO_CONTENT_JSON',
   lottie: 'LOTTIE',
+  strings: 'APPLE_STRINGS',
 } as const satisfies Record<SupportedFileExtension, FileFormat>;
 
 /**
@@ -38,6 +39,7 @@ export const FILE_FORMAT_TO_CONFIG_FILE_TYPE = {
   TXT: 'txt',
   TWILIO_CONTENT_JSON: 'twilioContentJson',
   LOTTIE: 'lottie',
+  APPLE_STRINGS: 'strings',
 } as const satisfies Partial<Record<FileFormat, SupportedFileExtension>>;
 
 /**
@@ -58,6 +60,7 @@ const FILE_FORMAT_EXTENSIONS = {
   TWILIO_CONTENT_JSON: 'json',
   LOTTIE: 'lottie',
   SVG: 'svg',
+  APPLE_STRINGS: 'strings',
 } as const satisfies Record<FileFormat, string>;
 
 /**

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -154,6 +154,36 @@ describe('parseFilesConfig', () => {
       ]);
     });
 
+    it('should handle [locale] embedded mid-segment (Apple .lproj layout)', () => {
+      const files = {
+        strings: {
+          include: ['Guardian/[locale].lproj/Localizable.strings'],
+        },
+      };
+
+      vi.mocked(fg.sync).mockReturnValue([
+        '/project/Guardian/en.lproj/Localizable.strings',
+      ]);
+
+      const result = resolveFiles(files, 'en', defaultLocales, '/project');
+
+      expect(fg.sync).toHaveBeenCalledWith(
+        '/project/Guardian/en.lproj/Localizable.strings',
+        { absolute: true, ignore: [] }
+      );
+      expect(result.resolvedPaths.strings).toEqual([
+        '/project/Guardian/en.lproj/Localizable.strings',
+      ]);
+      expect(result.placeholderPaths.strings).toEqual([
+        '/project/Guardian/[locale].lproj/Localizable.strings',
+      ]);
+
+      const localized = resolveLocaleFiles(result.placeholderPaths, 'es');
+      expect(localized.strings).toEqual([
+        '/project/Guardian/es.lproj/Localizable.strings',
+      ]);
+    });
+
     it('should handle GT output files', () => {
       const files = {
         gt: {

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -5,17 +5,22 @@ import type { JsonObject } from './json';
 export type FileFormat = import('@generaltranslation/api').FileFormat;
 
 /**
- * File formats whose content is binary (e.g. zip bundles) rather than text.
- * Their content travels through the pipeline already base64-encoded, so the
- * usual UTF-8 encode/decode steps must be skipped to avoid corrupting bytes.
+ * File formats whose content travels through the pipeline already
+ * base64-encoded, so the usual UTF-8 encode/decode steps are skipped and the
+ * bytes reach the API unaltered.
+ *
+ * LOTTIE qualifies because it is a zip bundle. APPLE_STRINGS qualifies because
+ * older Xcode wrote `.strings` as UTF-16: the API chooses a decoder from the
+ * byte order mark, and a UTF-8 round trip anywhere in between replaces those
+ * bytes with U+FFFD.
  */
 export const BINARY_FILE_FORMATS: ReadonlySet<FileFormat> = new Set<FileFormat>(
-  ['LOTTIE']
+  ['LOTTIE', 'APPLE_STRINGS']
 );
 
 /**
- * Whether a file format's content is binary (carried as base64 end-to-end)
- * rather than a UTF-8 text string.
+ * Whether a file format's content is carried as base64 end-to-end rather than
+ * as a UTF-8 text string.
  */
 export function isBinaryFileFormat(fileFormat: FileFormat): boolean {
   return BINARY_FILE_FORMATS.has(fileFormat);

--- a/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
+++ b/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
@@ -17,6 +17,7 @@ describe('isSupportedFileFormatTransform', () => {
     'TXT',
     'TWILIO_CONTENT_JSON',
     'SVG',
+    'APPLE_STRINGS',
   ];
 
   it('supports identity transforms by default', () => {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -16,6 +16,7 @@ const SUPPORTED_TRANSFORMATIONS = {
   TWILIO_CONTENT_JSON: ['TWILIO_CONTENT_JSON'],
   LOTTIE: ['LOTTIE'],
   SVG: ['SVG'],
+  APPLE_STRINGS: ['APPLE_STRINGS'],
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**


### PR DESCRIPTION
## Summary

- Registers Apple's `.strings` format in the CLI. A `strings` entry under `files` in `gt.config.json` is now discovered, uploaded as `APPLE_STRINGS`, and downloaded back per locale.
- `.strings` is one file per locale (`en.lproj/Localizable.strings` vs `es.lproj/Localizable.strings`), the same model the CLI already uses for JSON, YAML, and PO. No content transform, no slicing, no new path machinery — the existing `[locale]` resolver already handles the `.lproj` layout.

## UTF-16 `.strings` are delivered byte for byte

Older Xcode wrote `.strings` as UTF-16, so real legacy `.lproj` repositories — the exact projects this feature is for — are full of UTF-16LE and UTF-16BE files. The API decides how to decode a `.strings` upload by reading its byte order mark, and that only works if the bytes arrive intact.

So the CLI reads `.strings` with `readBinaryFileBase64` and `APPLE_STRINGS` is marked as a format whose content travels base64 end to end, skipping the pipeline's UTF-8 encode/decode steps. The read is the whole fix: `readFile` is `fs.readFileSync(filePath, 'utf8')`, which replaced 21 bytes of a real UTF-16LE Spanish fixture with U+FFFD before the content was ever base64-encoded. The upload still returned 201 and the failure surfaced later, at enqueue, as an opaque 500.

**Byte preservation rather than client-side decoding is deliberate.** The CLI does not decode UTF-16 and re-encode as UTF-8. Encoding normalisation belongs to the API, which already owns it and has tests for it; a second implementation in the CLI would be a second place to get it wrong, and the two would drift. The CLI's job is to hand over the bytes unchanged.

UTF-8 `.strings`, with and without a byte order mark, produce exactly the same wire bytes as before — for those files base64-of-raw-bytes and base64-of-the-UTF-8-re-encode are identical, so this is a fix for UTF-16 and a no-op for everything else.

Preservation is one-directional, which is worth stating plainly. The API decodes on ingress and its egress hands back text, so a translated `.strings` file is written to disk as UTF-8 even when its source was UTF-16. Nothing is corrupted — modern Xcode reads UTF-8 `.strings` — but a legacy `.lproj` tree will end up with a UTF-16 source next to UTF-8 translations. Re-encoding the download to match the source would need an encoding channel the contract does not have, so it is out of scope here.

One naming note for reviewers: `APPLE_STRINGS` joins `LOTTIE` in `BINARY_FILE_FORMATS`. `.strings` is text, not binary, but the set's actual meaning is "content is carried base64 so nothing in between can re-encode it", which is precisely what `.strings` needs. Reusing the existing seam keeps this to a two-line change instead of introducing a second, overlapping predicate; the doc comment now states the rule rather than the name's original intent.

## Two traps this avoids

- The generic upload branch derives `fileFormat = fileType.toUpperCase()`, which would silently upload the invalid enum value `STRINGS`. `.strings` gets an explicit aggregation branch instead, pinned by a mutation check: routing it back through the generic path turns the wire-format test red.
- `preprocessContent`'s sanitization is markdown-oriented, and `.strings` bytes must reach the API verbatim. The byte-equality test uses an escape-laden fixture and a sanitizer mock that strips backslashes, so any accidental preprocessing fails it.

## Also pins previously-untested behavior

`[locale]` embedded mid-path-segment (`Guardian/[locale].lproj/Localizable.strings`) already worked in the resolver but had no test — every existing test used whole-segment placeholders. A regression test now pins glob expansion, placeholder-path reconstruction, and per-locale resolution for the `.lproj` layout.

## Testing

- `pnpm --filter gt test` — 2293/2293 passed
- `pnpm --filter generaltranslation test` — 516/516 passed
- `pnpm --filter @generaltranslation/api test` — 25/25 passed
- `pnpm exec turbo typecheck --filter=gt --filter=generaltranslation --filter=@generaltranslation/api` — passed
- `pnpm lint` — passed (oxlint, oxfmt, library-defaults check)
- `aggregateFilesStringsEncoding.test.ts` writes real UTF-16LE, UTF-16BE, UTF-8, and UTF-8-with-BOM bytes to disk, runs them through the real filesystem helpers, and asserts the upload payload base64-decodes back to the original bytes with its byte order mark intact.
- Mutation check — against the pre-fix code the two UTF-16 cases and the byte-order-mark assertion go red while both UTF-8 cases stay green, confirming the test catches the bug and that UTF-8 behaviour is unchanged. Reverting either half alone (the read, or the format's base64 passthrough) turns all five red.
- Mutation check — removing the explicit `.strings` aggregation branch turns 2 tests red (`fileFormat` becomes `STRINGS`, content loses its escapes); restoring it turns them green.
- Verified against real Xcode-written fixtures (UTF-16LE, UTF-16BE, UTF-8+BOM, plain UTF-8): all round-trip byte for byte through `aggregateFiles`.

## Review round: local edits for base64-carried formats

Greptile flagged the `save-local` path, and it was right — with a wider blast radius than the report suggested. Adding `APPLE_STRINGS` to `BINARY_FILE_FORMATS` means `_downloadFileBatch` hands back `data` still base64, and `collectUserEditDiffs` assumed decoded text throughout. So the comparison file received base64 and **every** `.strings` translation looked edited, ASCII ones included. `LOTTIE` had the same shape already, unreported.

`collectUserEditDiffs` now keeps server content as a `Buffer`, decoding base64 only for formats in `BINARY_FILE_FORMATS`, compares bytes before doing anything else, and warns by name when a file that genuinely changed has no faithful UTF-8 text form:

```
Skipping local edits to Guardian/es.lproj/Localizable.strings: Edited file
is not valid UTF-8, so its changes cannot be submitted
```

The warning also goes through `recordWarning('skipped_file', …)` so it appears in the run summary.

**The CLI still does not transcode UTF-16.** `getGitUnifiedDiff` compares two paths and the diff header names them, so representing a UTF-16 file as text would mean diffing a temporary transcoded copy and submitting a diff that names a file the user does not have. `localContent` is an unqualified `string` on `SubmitUserEditDiff` with no encoding channel, so a transcode would be unmarked at the other end. Warning is the honest outcome, and encoding normalisation stays with the API as it does on the upload path.

A follow-up round separated an *empty* server baseline from a *missing* one. The guard was `if (!serverContent) continue;`, and `''` is falsy, so a completed translation that came back empty discarded everything the user had written against it. That predates this branch, but the byte comparison added here makes the distinction cheap to state, so it is fixed rather than carried forward.

Seven tests in `collectUserEditDiffsBinaryContent.test.ts` run the real `git diff --no-index` rather than mocking it, because the defect was in what reached the comparison file. Each was committed red before its fix.


## Notes

- Changeset: added (`gt` minor, `generaltranslation` patch, `@generaltranslation/api` patch), and updated to mention UTF-16 handling.
- `packages/api/src/generated/types.gen.ts` is regenerated output from `pnpm --filter @generaltranslation/api codegen`, not hand-edited. The spec change mirrors the server contract.
- Supersedes the `.strings` portion of #2216. `.stringsdict` follows in a stacked PR on top of this branch (#2223), which rewrites this aggregation branch into a loop and has been rebased onto this head.
- `XCSTRINGS` is deliberately out of scope. A `.xcstrings` catalog holds every locale in one file and needs client-side slicing before it can go through the per-locale pipeline; registering it here would only add a gate with no working path behind it.












<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR registers Apple `.strings` throughout the CLI and API contracts while preserving UTF-16 source bytes. It also corrects local-edit comparison for base64-carried formats and distinguishes empty server baselines from missing downloads.

- Adds `APPLE_STRINGS` format registration, configuration mapping, extension handling, and identity-transform support.
- Uploads `.strings` content as byte-preserving base64 without markdown preprocessing.
- Compares downloaded and local content as bytes before generating UTF-8 diffs, warning when changed content cannot be represented faithfully.
- Adds focused coverage for UTF-16LE/BE, UTF-8 BOM handling, locale-path resolution, binary comparisons, warnings, and empty baselines.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/api/collectUserEditDiffs.ts | Correctly compares base64-carried downloads as bytes, preserves empty baselines, and reports changed non-UTF-8 files instead of submitting corrupted text. |
| packages/cli/src/formats/files/aggregateFiles.ts | Adds a dedicated APPLE_STRINGS aggregation path that preserves source bytes and avoids inappropriate text preprocessing. |
| packages/core/src/types-dir/api/file.ts | Extends the shared base64-carried format predicate to APPLE_STRINGS so upload and download encoding remain symmetric. |
| packages/cli/src/formats/files/transformFormat.ts | Adds consistent config, API-format, and extension mappings for APPLE_STRINGS. |
| packages/api/spec/openapi.json | Extends the API file-format contract with APPLE_STRINGS consistently across affected operations. |
| packages/api/src/generated/types.gen.ts | Regenerated API types match the updated OpenAPI APPLE_STRINGS contract. |
| packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts | Provides focused regression coverage for unchanged, edited, empty, missing, UTF-16, and Lottie local-edit states. |
| packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts | Verifies byte-for-byte preservation across UTF-16LE, UTF-16BE, UTF-8, and UTF-8-with-BOM fixtures. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Configured .strings source] --> B[Read raw bytes]
    B --> C[Carry content as base64]
    C --> D[Upload as APPLE_STRINGS]
    D --> E[API decodes using BOM]
    E --> F[Download locale translation]
    F --> G[Decode base64 to Buffer]
    G --> H{Local bytes changed?}
    H -->|No| I[Skip quietly]
    H -->|Yes, valid UTF-8| J[Generate and submit diff]
    H -->|Yes, non-UTF-8| K[Record named warning]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(cli): keep an empty server baseline ..."](https://github.com/generaltranslation/gt/commit/4facba4b13cc527dcacff4681ba352f39c4cfc4a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59299156)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
- Knowledge Base — [Translation API client and service bindings](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-api-client.md)
</details>


<!-- /greptile_comment -->
