### PR TITLE
feat(cli): register the Apple .stringsdict file format

### DIFF
--- a/.changeset/apple-stringsdict-cli-format.md
+++ b/.changeset/apple-stringsdict-cli-format.md
@@ -1,0 +1,7 @@
+---
+'gt': minor
+'generaltranslation': patch
+'@generaltranslation/api': patch
+---
+
+Add Apple `.stringsdict` support to the CLI. Configure a `stringsdict` entry under `files` in `gt.config.json` to upload `.stringsdict` plural rule sources and download the translated per-locale files.

--- a/packages/api/spec/openapi.json
+++ b/packages/api/spec/openapi.json
@@ -72,7 +72,8 @@
           "TWILIO_CONTENT_JSON",
           "LOTTIE",
           "SVG",
-          "APPLE_STRINGS"
+          "APPLE_STRINGS",
+          "APPLE_STRINGSDICT"
         ]
       },
       "ModelProvider": {
@@ -616,7 +617,8 @@
                                 "TWILIO_CONTENT_JSON",
                                 "LOTTIE",
                                 "SVG",
-                                "APPLE_STRINGS"
+                                "APPLE_STRINGS",
+                                "APPLE_STRINGSDICT"
                               ]
                             },
                             "dataFormat": {
@@ -929,7 +931,8 @@
                                 "TWILIO_CONTENT_JSON",
                                 "LOTTIE",
                                 "SVG",
-                                "APPLE_STRINGS"
+                                "APPLE_STRINGS",
+                                "APPLE_STRINGSDICT"
                               ]
                             },
                             "dataFormat": {
@@ -1000,7 +1003,8 @@
                                   "TWILIO_CONTENT_JSON",
                                   "LOTTIE",
                                   "SVG",
-                                  "APPLE_STRINGS"
+                                  "APPLE_STRINGS",
+                                  "APPLE_STRINGSDICT"
                                 ]
                               },
                               "dataFormat": {
@@ -1027,7 +1031,8 @@
                                   "TWILIO_CONTENT_JSON",
                                   "LOTTIE",
                                   "SVG",
-                                  "APPLE_STRINGS"
+                                  "APPLE_STRINGS",
+                                  "APPLE_STRINGSDICT"
                                 ]
                               }
                             },
@@ -2312,7 +2317,8 @@
                             "TWILIO_CONTENT_JSON",
                             "LOTTIE",
                             "SVG",
-                            "APPLE_STRINGS"
+                            "APPLE_STRINGS",
+                            "APPLE_STRINGSDICT"
                           ]
                         }
                       },

--- a/packages/api/src/generated/types.gen.ts
+++ b/packages/api/src/generated/types.gen.ts
@@ -23,7 +23,8 @@ export type FileFormat =
   | 'TWILIO_CONTENT_JSON'
   | 'LOTTIE'
   | 'SVG'
-  | 'APPLE_STRINGS';
+  | 'APPLE_STRINGS'
+  | 'APPLE_STRINGSDICT';
 
 export type ModelProvider = 'ANTHROPIC' | 'OPENAI' | 'XAI' | 'GOOGLE';
 
@@ -210,7 +211,8 @@ export type UploadSourceFilesData = {
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
           | 'SVG'
-          | 'APPLE_STRINGS';
+          | 'APPLE_STRINGS'
+          | 'APPLE_STRINGSDICT';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -325,7 +327,8 @@ export type UploadTranslationsData = {
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
           | 'SVG'
-          | 'APPLE_STRINGS';
+          | 'APPLE_STRINGS'
+          | 'APPLE_STRINGSDICT';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -355,7 +358,8 @@ export type UploadTranslationsData = {
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
           | 'SVG'
-          | 'APPLE_STRINGS';
+          | 'APPLE_STRINGS'
+          | 'APPLE_STRINGSDICT';
         dataFormat?: string;
         locale: string;
         transformFormat?:
@@ -373,7 +377,8 @@ export type UploadTranslationsData = {
           | 'TWILIO_CONTENT_JSON'
           | 'LOTTIE'
           | 'SVG'
-          | 'APPLE_STRINGS';
+          | 'APPLE_STRINGS'
+          | 'APPLE_STRINGSDICT';
       }>;
     }>;
     sourceLocale?: string;
@@ -846,7 +851,8 @@ export type EnqueueFileTranslationsData = {
         | 'TWILIO_CONTENT_JSON'
         | 'LOTTIE'
         | 'SVG'
-        | 'APPLE_STRINGS';
+        | 'APPLE_STRINGS'
+        | 'APPLE_STRINGSDICT';
     }>;
     targetLocales?: Array<string>;
     sourceLocale?: string;

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -664,6 +664,79 @@ describe('aggregateFiles - Empty File Handling', () => {
     });
   });
 
+  describe('Apple .stringsdict files', () => {
+    // The escapes below are load-bearing: they must reach the API verbatim.
+    const stringsdictContent =
+      '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n  <key>%d file(s) \\"quoted\\"</key>\n</dict>\n</plist>\n';
+
+    beforeEach(() => {
+      // Make any trip through the markdown-oriented sanitizer detectable: it
+      // would strip the backslash escapes the assertions below depend on.
+      mockSanitizeFileContent.mockImplementation((content) =>
+        content.replace(/\\/g, '')
+      );
+    });
+
+    it('should upload .stringsdict files verbatim with the APPLE_STRINGSDICT format', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            stringsdict: ['/full/path/en.lproj/Localizable.stringsdict'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce(stringsdictContent);
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        fileName: 'en.lproj/Localizable.stringsdict',
+        fileFormat: 'APPLE_STRINGSDICT',
+        locale: 'en',
+      });
+      expect(result[0].content).toBe(stringsdictContent);
+      expect(result[0].fileId).toBe(
+        hashStringSync('en.lproj/Localizable.stringsdict')
+      );
+      expect(result[0].versionId).toBe(
+        hashVersionId(stringsdictContent, false)
+      );
+    });
+
+    it('should skip empty .stringsdict files and log a warning', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            stringsdict: [
+              '/full/path/empty.stringsdict',
+              '/full/path/valid.stringsdict',
+            ],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile
+        .mockReturnValueOnce('   \n\t  ') // whitespace only
+        .mockReturnValueOnce(stringsdictContent); // valid file
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Skipping empty.stringsdict: File is empty'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('valid.stringsdict');
+    });
+  });
+
   describe('Mixed file types with empty files', () => {
     it('should skip empty files across all file types and process valid ones', async () => {
       const settings = {

--- a/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
+++ b/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
@@ -18,3 +18,21 @@ describe('transformFormat - Apple .strings', () => {
     expect(getFileExtensionForFormat('APPLE_STRINGS')).toBe('strings');
   });
 });
+
+describe('transformFormat - Apple .stringsdict', () => {
+  it('maps the config file key to the API file format enum value', () => {
+    expect(CONFIG_FILE_TYPE_TO_FILE_FORMAT.stringsdict).toBe(
+      'APPLE_STRINGSDICT'
+    );
+  });
+
+  it('maps the API file format enum value back to the config file key', () => {
+    expect(FILE_FORMAT_TO_CONFIG_FILE_TYPE.APPLE_STRINGSDICT).toBe(
+      'stringsdict'
+    );
+  });
+
+  it('writes translated files with the matching extension', () => {
+    expect(getFileExtensionForFormat('APPLE_STRINGSDICT')).toBe('stringsdict');
+  });
+});

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -8,6 +8,7 @@ import {
   readFile,
   readBinaryFileBase64,
 } from '../../fs/findFilepath.js';
+import { isBinaryFileFormat } from 'generaltranslation/types';
 import { Settings } from '../../types/index.js';
 import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
@@ -395,40 +396,50 @@ export async function aggregateFiles(
     files.push(...lottieFiles);
   }
 
-  // Apple .strings files are uploaded verbatim. Their backslash escapes and
-  // format specifiers must survive byte-for-byte, so they skip the generic
-  // markdown-oriented preprocessing below.
-  //
-  // The raw bytes are carried base64 rather than read as UTF-8 because older
-  // Xcode wrote .strings as UTF-16. The API selects a decoder from the byte
-  // order mark, so decoding here would destroy the only signal it has.
-  if (filePaths.strings) {
-    const stringsFiles = filePaths.strings
+  // Apple .strings/.stringsdict files are uploaded verbatim. Their backslash
+  // escapes and format specifiers must survive byte-for-byte, so they skip the
+  // generic markdown-oriented preprocessing below.
+  for (const [fileType, fileFormat] of [
+    ['strings', 'APPLE_STRINGS'],
+    ['stringsdict', 'APPLE_STRINGSDICT'],
+  ] as const) {
+    if (!filePaths[fileType]) continue;
+    // Content must already be base64 exactly when the format is binary, or the
+    // upload path encodes it a second time. Only .strings qualifies today: its
+    // UTF-16 bytes reach an API decoder that reads the byte order mark, and
+    // .stringsdict has no such decoder yet.
+    const readsRawBytes = isBinaryFileFormat(fileFormat);
+    const appleFiles = filePaths[fileType]
       .map((filePath) => {
-        const content = readBinaryFileBase64(filePath);
+        const content = readsRawBytes
+          ? readBinaryFileBase64(filePath)
+          : readFile(filePath);
         const relativePath = getRelative(filePath);
         return {
           content,
           fileName: relativePath,
-          fileFormat: 'APPLE_STRINGS' as const,
-          ...getTransformFormatProperty(settings, 'strings'),
+          fileFormat,
+          ...getTransformFormatProperty(settings, fileType),
           fileId: hashStringSync(relativePath),
           versionId: hashVersionId(content, requiresReviewPaths.has(filePath)),
           locale: settings.defaultLocale,
         } satisfies FileToUpload;
       })
       .filter((file) => {
-        // The bytes travel untouched; they are read as UTF-8 here only to spot
-        // a file with nothing to translate. UTF-16 reads as non-blank, which is
-        // the safe default — the API decodes it properly.
-        if (!Buffer.from(file.content, 'base64').toString('utf8').trim()) {
+        // Blank check only; the content itself travels untouched. A UTF-16
+        // file reads as non-blank here, which is the safe default — the API
+        // decodes it properly.
+        const text = readsRawBytes
+          ? Buffer.from(file.content, 'base64').toString('utf8')
+          : file.content;
+        if (!text.trim()) {
           logger.warn(`Skipping ${file.fileName}: File is empty`);
           recordWarning('skipped_file', file.fileName, 'File is empty');
           return false;
         }
         return true;
       });
-    files.push(...stringsFiles);
+    files.push(...appleFiles);
   }
 
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
@@ -437,7 +448,8 @@ export async function aggregateFiles(
       fileType === 'yaml' ||
       fileType === 'twilioContentJson' ||
       fileType === 'lottie' ||
-      fileType === 'strings'
+      fileType === 'strings' ||
+      fileType === 'stringsdict'
     )
       continue;
     if (filePaths[fileType]) {

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -11,6 +11,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'twilioContentJson',
   'lottie',
   'strings',
+  'stringsdict',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -26,4 +27,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   twilioContentJson: 'Twilio Content JSON',
   lottie: 'Lottie',
   strings: 'Apple .strings',
+  stringsdict: 'Apple .stringsdict',
 };

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -22,6 +22,7 @@ export const CONFIG_FILE_TYPE_TO_FILE_FORMAT = {
   twilioContentJson: 'TWILIO_CONTENT_JSON',
   lottie: 'LOTTIE',
   strings: 'APPLE_STRINGS',
+  stringsdict: 'APPLE_STRINGSDICT',
 } as const satisfies Record<SupportedFileExtension, FileFormat>;
 
 /**
@@ -40,6 +41,7 @@ export const FILE_FORMAT_TO_CONFIG_FILE_TYPE = {
   TWILIO_CONTENT_JSON: 'twilioContentJson',
   LOTTIE: 'lottie',
   APPLE_STRINGS: 'strings',
+  APPLE_STRINGSDICT: 'stringsdict',
 } as const satisfies Partial<Record<FileFormat, SupportedFileExtension>>;
 
 /**
@@ -61,6 +63,7 @@ const FILE_FORMAT_EXTENSIONS = {
   LOTTIE: 'lottie',
   SVG: 'svg',
   APPLE_STRINGS: 'strings',
+  APPLE_STRINGSDICT: 'stringsdict',
 } as const satisfies Record<FileFormat, string>;
 
 /**

--- a/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
+++ b/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
@@ -18,6 +18,7 @@ describe('isSupportedFileFormatTransform', () => {
     'TWILIO_CONTENT_JSON',
     'SVG',
     'APPLE_STRINGS',
+    'APPLE_STRINGSDICT',
   ];
 
   it('supports identity transforms by default', () => {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -17,6 +17,7 @@ const SUPPORTED_TRANSFORMATIONS = {
   LOTTIE: ['LOTTIE'],
   SVG: ['SVG'],
   APPLE_STRINGS: ['APPLE_STRINGS'],
+  APPLE_STRINGSDICT: ['APPLE_STRINGSDICT'],
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**


### PR DESCRIPTION
## Summary

- Registers Apple's `.stringsdict` format in the CLI. A `stringsdict` entry under `files` in `gt.config.json` is now discovered, uploaded as `APPLE_STRINGSDICT`, and downloaded back per locale.
- `.stringsdict` is XML rather than the old-style plist text of `.strings`, but from the CLI's point of view it is the same shape: one file per locale (`en.lproj/Localizable.stringsdict` vs `es.lproj/Localizable.stringsdict`), uploaded verbatim, no content transform and no new path machinery.
- `.strings` and `.stringsdict` now share one aggregation loop rather than two near-identical blocks. They still *read* the file differently, deliberately — see "Encoding" below.

## Two traps this avoids

- The generic upload branch derives `fileFormat = fileType.toUpperCase()`, which would silently upload the invalid enum value `STRINGSDICT`. `.stringsdict` joins the explicit aggregation branch instead, pinned by a mutation check: dropping it from that branch turns the wire-format test red with `fileFormat: 'STRINGSDICT'`.
- `preprocessContent`'s sanitization is markdown-oriented, and `.stringsdict` bytes must reach the API verbatim. The byte-equality test uses an escape-laden XML fixture and a sanitizer mock that strips backslashes, so any accidental preprocessing fails it.

## Encoding: why the two formats still read differently

#2222 changed `.strings` to upload as raw base64 bytes. Older Xcode wrote `.strings` as UTF-16, and reading those bytes as UTF-8 replaces every non-ASCII character with U+FFFD before the API's byte-order-mark decoder ever sees a mark to act on.

`.stringsdict` is **not** given the same treatment in this PR, on purpose. The corruption mechanism is identical — a UTF-16 XML plist is perfectly legal and would be mangled the same way — but the API has no `APPLE_STRINGSDICT` branch. In `validateSourceFile.ts`, `decodeAppleStringsBuffer` is wired only for `APPLE_STRINGS`; every other format falls through to `bytes.toString('utf-8')`. Preserving `.stringsdict` bytes in the CLI without the matching server decoder is half a fix — it would relocate a UTF-16 failure rather than remove it. So `.stringsdict` keeps exactly the read it had before this branch was rebased, and its behaviour is unchanged by this PR.

The loop expresses the difference as `isBinaryFileFormat(fileFormat)` rather than a hand-maintained per-format flag. That is the same set the upload path consults before it base64-encodes, so the read cannot drift out of agreement with the wire contract. A mismatch in either direction corrupts the payload: double-encoded one way, mojibake the other.

### Follow-up, deliberately not in this PR

Supporting UTF-16 `.stringsdict` should land as a single change across both repos:

1. **gt-cloud** — `apps/api/src/routers/files/upload/validators/validateSourceFile.ts`: extend the decode branch so `APPLE_STRINGSDICT` also runs through `decodeAppleStringsBuffer`. The decoder is already format-agnostic; it only inspects the byte order mark.
2. **gt** — `packages/core/src/types-dir/api/file.ts`: add `APPLE_STRINGSDICT` to `BINARY_FILE_FORMATS`. No change to `aggregateFiles.ts` is needed; the loop picks it up. That one entry also switches the download path in `packages/cli/src/api/downloadFileBatch.ts` to write bytes instead of taking the text merge path, so both directions need covering.

One XML-specific wrinkle to settle there: `.stringsdict` is stored verbatim and egress is a passthrough, so a decoded UTF-16 file would still carry `encoding="UTF-16"` in its XML declaration while the stored text is UTF-8. That declaration has to be rewritten, or the round trip is dishonest. `.strings` has no equivalent self-describing header, which is why it was safe to land on its own.

## Testing

- `pnpm --filter gt test` — 2298/2298 passed
- `pnpm --filter generaltranslation test` — 516/516 passed
- `pnpm --filter @generaltranslation/api test` — 25/25 passed
- `pnpm exec turbo typecheck --filter=gt --filter=generaltranslation --filter=@generaltranslation/api` — passed
- `pnpm lint` — passed (oxlint, oxfmt, library-defaults check)
- Mutation check — removing `.stringsdict` from the Apple aggregation branch turns 2 tests red; restoring it turns them green. Re-verified after the rebase.

## Notes

- Stacked on #2222 (`e/cli/apple-strings`). Review and merge that one first; this PR's base is its branch, not `main`.
- Rebased onto #2222's UTF-16 fix. The only conflict was the Apple aggregation block, which both PRs rewrote; resolved by keeping this PR's loop and moving the byte-preserving read inside it, gated on `isBinaryFileFormat`.
- Re-based again onto #2222's review fixes (`collectUserEditDiffs` byte comparison, encoding warning, empty-baseline handling). Those touch no file this PR changes, so the diff against the base branch is unchanged.
- Changeset: added (`gt` minor, `generaltranslation` patch, `@generaltranslation/api` patch).
- `packages/api/src/generated/types.gen.ts` is regenerated output from `pnpm --filter @generaltranslation/api codegen`, not hand-edited.
- No new per-locale path test here: the `[locale]` mid-segment `.lproj` regression test added in #2222 covers the resolver, which is format-agnostic.
- Supersedes the `.stringsdict` portion of #2216. `XCSTRINGS` is deliberately out of scope — a `.xcstrings` catalog holds every locale in one file and needs client-side slicing before it can go through the per-locale pipeline.











<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR registers Apple `.stringsdict` as a supported CLI and API file format while preserving its UTF-8 XML content through the text upload and download paths.

- Adds `APPLE_STRINGSDICT` to the OpenAPI contract and generated API types.
- Adds CLI discovery, aggregation, extension, and bidirectional format mappings.
- Adds identity-transform support and focused aggregation and mapping tests.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/aggregateFiles.ts | Adds explicit verbatim `.stringsdict` aggregation while retaining the existing binary-specific handling for `.strings`. |
| packages/cli/src/formats/files/transformFormat.ts | Adds consistent configuration, API-format, and output-extension mappings for `.stringsdict`. |
| packages/cli/src/formats/files/supportedFiles.ts | Registers `.stringsdict` in the canonical supported-file list used by configuration and discovery. |
| packages/core/src/utils/isSupportedFileFormatTransform.ts | Allows the new format's same-format translation flow. |
| packages/api/spec/openapi.json | Extends the public file-format enum with `APPLE_STRINGSDICT`. |
| packages/api/src/generated/types.gen.ts | Regenerates API request types to reflect the updated OpenAPI enum. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Verifies wire-format selection, verbatim content handling, identity generation, and empty-file behavior. |
| packages/cli/src/formats/files/__tests__/transformFormat.test.ts | Covers forward and reverse format mappings and the translated-file extension. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[gt.config.json stringsdict entry] --> D[CLI discovery]
  D --> A[Aggregate UTF-8 XML verbatim]
  A --> U[Upload as APPLE_STRINGSDICT]
  U --> S[Translation service]
  S --> X[Download translated text]
  X --> P[Resolve locale output path]
  P --> W[Write .stringsdict file]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["feat(cli): register the Apple .stringsdi..."](https://github.com/generaltranslation/gt/commit/b8a96797860f2bb7b12f3c307d47c9b1fead2096) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59299173)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
- Knowledge Base — [Translation API client and service bindings](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-api-client.md)
- Knowledge Base — [Localization runtime and shared domain](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/localization-runtime.md)
</details>


<!-- /greptile_comment -->