### PR TITLE
feat(android-strings): cli handling

### DIFF
--- a/packages/api/spec/openapi.json
+++ b/packages/api/spec/openapi.json
@@ -73,7 +73,8 @@
           "LOTTIE",
           "SVG",
           "DOT_STRINGS",
-          "DOT_STRINGSDICT"
+          "DOT_STRINGSDICT",
+          "ANDROID_STRINGS"
         ]
       },
       "ModelProvider": {
@@ -618,7 +619,8 @@
                                 "LOTTIE",
                                 "SVG",
                                 "DOT_STRINGS",
-                                "DOT_STRINGSDICT"
+                                "DOT_STRINGSDICT",
+                                "ANDROID_STRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -932,7 +934,8 @@
                                 "LOTTIE",
                                 "SVG",
                                 "DOT_STRINGS",
-                                "DOT_STRINGSDICT"
+                                "DOT_STRINGSDICT",
+                                "ANDROID_STRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -1004,7 +1007,8 @@
                                   "LOTTIE",
                                   "SVG",
                                   "DOT_STRINGS",
-                                  "DOT_STRINGSDICT"
+                                  "DOT_STRINGSDICT",
+                                  "ANDROID_STRINGS"
                                 ]
                               },
                               "dataFormat": {
@@ -1032,7 +1036,8 @@
                                   "LOTTIE",
                                   "SVG",
                                   "DOT_STRINGS",
-                                  "DOT_STRINGSDICT"
+                                  "DOT_STRINGSDICT",
+                                  "ANDROID_STRINGS"
                                 ]
                               }
                             },
@@ -2318,7 +2323,8 @@
                             "LOTTIE",
                             "SVG",
                             "DOT_STRINGS",
-                            "DOT_STRINGSDICT"
+                            "DOT_STRINGSDICT",
+                            "ANDROID_STRINGS"
                           ]
                         }
                       },

--- a/packages/api/src/generated/types.gen.ts
+++ b/packages/api/src/generated/types.gen.ts
@@ -24,7 +24,8 @@ export type FileFormat =
   | 'LOTTIE'
   | 'SVG'
   | 'DOT_STRINGS'
-  | 'DOT_STRINGSDICT';
+  | 'DOT_STRINGSDICT'
+  | 'ANDROID_STRINGS';
 
 export type ModelProvider = 'ANTHROPIC' | 'OPENAI' | 'XAI' | 'GOOGLE';
 
@@ -212,7 +213,8 @@ export type UploadSourceFilesData = {
           | 'LOTTIE'
           | 'SVG'
           | 'DOT_STRINGS'
-          | 'DOT_STRINGSDICT';
+          | 'DOT_STRINGSDICT'
+          | 'ANDROID_STRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -328,7 +330,8 @@ export type UploadTranslationsData = {
           | 'LOTTIE'
           | 'SVG'
           | 'DOT_STRINGS'
-          | 'DOT_STRINGSDICT';
+          | 'DOT_STRINGSDICT'
+          | 'ANDROID_STRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -359,7 +362,8 @@ export type UploadTranslationsData = {
           | 'LOTTIE'
           | 'SVG'
           | 'DOT_STRINGS'
-          | 'DOT_STRINGSDICT';
+          | 'DOT_STRINGSDICT'
+          | 'ANDROID_STRINGS';
         dataFormat?: string;
         locale: string;
         transformFormat?:
@@ -378,7 +382,8 @@ export type UploadTranslationsData = {
           | 'LOTTIE'
           | 'SVG'
           | 'DOT_STRINGS'
-          | 'DOT_STRINGSDICT';
+          | 'DOT_STRINGSDICT'
+          | 'ANDROID_STRINGS';
       }>;
     }>;
     sourceLocale?: string;
@@ -852,7 +857,8 @@ export type EnqueueFileTranslationsData = {
         | 'LOTTIE'
         | 'SVG'
         | 'DOT_STRINGS'
-        | 'DOT_STRINGSDICT';
+        | 'DOT_STRINGSDICT'
+        | 'ANDROID_STRINGS';
     }>;
     targetLocales?: Array<string>;
     sourceLocale?: string;

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -740,6 +740,81 @@ describe('aggregateFiles - Empty File Handling', () => {
     });
   });
 
+  describe('Android strings.xml files', () => {
+    // The escapes below are load-bearing: AAPT requires \' and \", and the
+    // API relies on receiving them exactly as authored.
+    const androidStringsContent =
+      '<?xml version="1.0" encoding="utf-8"?>\n<resources>\n  <string name="greeting">You can\\\'t say \\\"no\\\"</string>\n</resources>\n';
+
+    beforeEach(() => {
+      // Make any trip through the markdown-oriented sanitizer detectable: it
+      // would strip the backslash escapes the assertions below depend on.
+      mockSanitizeFileContent.mockImplementation((content) =>
+        content.replace(/\\/g, '')
+      );
+    });
+
+    it('should upload strings.xml files verbatim with the ANDROID_STRINGS format', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            androidStrings: ['/full/path/res/values/strings.xml'],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile.mockReturnValueOnce(androidStringsContent);
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      // Exactly one entry: the generic preprocessing loop must skip this file
+      // type, or it uploads a second copy under the bogus format
+      // `fileType.toUpperCase()`.
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        fileName: 'res/values/strings.xml',
+        fileFormat: 'ANDROID_STRINGS',
+        locale: 'en',
+      });
+      expect(result[0].content).toBe(androidStringsContent);
+      expect(result[0].fileId).toBe(hashStringSync('res/values/strings.xml'));
+      expect(result[0].versionId).toBe(
+        hashVersionId(androidStringsContent, false)
+      );
+    });
+
+    it('should skip empty strings.xml files and log a warning', async () => {
+      const settings = {
+        files: {
+          resolvedPaths: {
+            androidStrings: [
+              '/full/path/empty.xml',
+              '/full/path/res/values/strings.xml',
+            ],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      };
+
+      mockReadFile
+        .mockReturnValueOnce('   \n\t  ') // whitespace only
+        .mockReturnValueOnce(androidStringsContent); // valid file
+
+      const { files: result } = await aggregateTestFiles(settings);
+
+      expect(mockLogWarning).toHaveBeenCalledWith(
+        'Skipping empty.xml: File is empty'
+      );
+      expect(result).toHaveLength(1);
+      expect(result[0].fileName).toBe('res/values/strings.xml');
+    });
+  });
+
   describe('Mixed file types with empty files', () => {
     it('should skip empty files across all file types and process valid ones', async () => {
       const settings = {

--- a/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
+++ b/packages/cli/src/formats/files/__tests__/transformFormat.test.ts
@@ -36,3 +36,21 @@ describe('transformFormat - .stringsdict', () => {
     expect(getFileExtensionForFormat('DOT_STRINGSDICT')).toBe('stringsdict');
   });
 });
+
+describe('transformFormat - Android strings.xml', () => {
+  it('maps the config file key to the API file format enum value', () => {
+    expect(CONFIG_FILE_TYPE_TO_FILE_FORMAT.androidStrings).toBe(
+      'ANDROID_STRINGS'
+    );
+  });
+
+  it('maps the API file format enum value back to the config file key', () => {
+    expect(FILE_FORMAT_TO_CONFIG_FILE_TYPE.ANDROID_STRINGS).toBe(
+      'androidStrings'
+    );
+  });
+
+  it('writes translated files with the matching extension', () => {
+    expect(getFileExtensionForFormat('ANDROID_STRINGS')).toBe('xml');
+  });
+});

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -396,18 +396,19 @@ export async function aggregateFiles(
     files.push(...lottieFiles);
   }
 
-  // .strings and .stringsdict files are uploaded verbatim. Their backslash
-  // escapes and format specifiers must survive byte-for-byte, so they skip the
-  // generic markdown-oriented preprocessing below.
+  // These formats are uploaded verbatim. Their backslash escapes and format
+  // specifiers must survive byte-for-byte, so they skip the generic
+  // markdown-oriented preprocessing below.
   for (const [fileType, fileFormat] of [
     ['dotStrings', 'DOT_STRINGS'],
     ['dotStringsdict', 'DOT_STRINGSDICT'],
+    ['androidStrings', 'ANDROID_STRINGS'],
   ] as const) {
     if (!filePaths[fileType]) continue;
     // Content must already be base64 exactly when the format is binary, or the
     // upload path encodes it a second time. Only .strings qualifies today: its
-    // UTF-16 bytes reach an API decoder that reads the byte order mark, and
-    // .stringsdict has no such decoder yet.
+    // UTF-16 bytes reach an API decoder that reads the byte order mark.
+    // .stringsdict has no such decoder yet, and strings.xml is always UTF-8.
     const readsRawBytes = isBinaryFileFormat(fileFormat);
     const verbatimFiles = filePaths[fileType]
       .map((filePath) => {
@@ -449,7 +450,8 @@ export async function aggregateFiles(
       fileType === 'twilioContentJson' ||
       fileType === 'lottie' ||
       fileType === 'dotStrings' ||
-      fileType === 'dotStringsdict'
+      fileType === 'dotStringsdict' ||
+      fileType === 'androidStrings'
     )
       continue;
     if (filePaths[fileType]) {

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -12,6 +12,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'lottie',
   'dotStrings',
   'dotStringsdict',
+  'androidStrings',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -28,4 +29,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   lottie: 'Lottie',
   dotStrings: '.strings',
   dotStringsdict: '.stringsdict',
+  androidStrings: 'Android strings.xml',
 };

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -23,6 +23,7 @@ export const CONFIG_FILE_TYPE_TO_FILE_FORMAT = {
   lottie: 'LOTTIE',
   dotStrings: 'DOT_STRINGS',
   dotStringsdict: 'DOT_STRINGSDICT',
+  androidStrings: 'ANDROID_STRINGS',
 } as const satisfies Record<SupportedFileExtension, FileFormat>;
 
 /**
@@ -42,6 +43,7 @@ export const FILE_FORMAT_TO_CONFIG_FILE_TYPE = {
   LOTTIE: 'lottie',
   DOT_STRINGS: 'dotStrings',
   DOT_STRINGSDICT: 'dotStringsdict',
+  ANDROID_STRINGS: 'androidStrings',
 } as const satisfies Partial<Record<FileFormat, SupportedFileExtension>>;
 
 /**
@@ -64,6 +66,7 @@ const FILE_FORMAT_EXTENSIONS = {
   SVG: 'svg',
   DOT_STRINGS: 'strings',
   DOT_STRINGSDICT: 'stringsdict',
+  ANDROID_STRINGS: 'xml',
 } as const satisfies Record<FileFormat, string>;
 
 /**

--- a/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
+++ b/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
@@ -19,6 +19,7 @@ describe('isSupportedFileFormatTransform', () => {
     'SVG',
     'DOT_STRINGS',
     'DOT_STRINGSDICT',
+    'ANDROID_STRINGS',
   ];
 
   it('supports identity transforms by default', () => {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -18,6 +18,7 @@ const SUPPORTED_TRANSFORMATIONS = {
   SVG: ['SVG'],
   DOT_STRINGS: ['DOT_STRINGS'],
   DOT_STRINGSDICT: ['DOT_STRINGSDICT'],
+  ANDROID_STRINGS: ['ANDROID_STRINGS'],
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Android `strings.xml` support to the CLI and shared file-format contract.
- Registers `androidStrings` in CLI configuration, upload aggregation, reverse mappings, and output-extension handling.
- Extends the OpenAPI and generated TypeScript format unions with `ANDROID_STRINGS`.
- Enables identity transforms and adds focused tests for verbatim content preservation, empty files, and format mappings.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the CLI, shared types, transform validation, and API specification consistently updated for Android string resources.

The supported-format registration flows through the mapped configuration and file-mapping paths, while explicit aggregation mappings preserve Android XML content and prevent duplicate generic processing; no concrete blocking or non-blocking defect remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/aggregateFiles.ts | Adds Android XML to the verbatim text upload path, skips generic sanitization, and preserves existing file identity and empty-file handling. |
| packages/cli/src/formats/files/transformFormat.ts | Adds consistent config-to-API, API-to-config, and `.xml` extension mappings for Android resources. |
| packages/cli/src/formats/files/supportedFiles.ts | Registers `androidStrings` in the canonical supported-file list and display labels used by mapped CLI configuration types. |
| packages/api/spec/openapi.json | Extends all relevant public API file-format enums with `ANDROID_STRINGS`. |
| packages/api/src/generated/types.gen.ts | Keeps generated request and shared file-format types synchronized with the OpenAPI specification. |
| packages/core/src/utils/isSupportedFileFormatTransform.ts | Enables the expected identity transform for the new Android file format. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config["gt.config.json<br/>androidStrings"] --> Resolve["Resolve source and locale paths"]
  Resolve --> Aggregate["Read strings.xml verbatim"]
  Aggregate --> Upload["Upload as ANDROID_STRINGS"]
  Upload --> API["Translation API"]
  API --> Download["Download translated XML"]
  Download --> Output["Write locale-specific .xml file"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat(android-strings): cli handling"](https://github.com/generaltranslation/gt/commit/3e5d687f321eaca1ceb9aa5247e79986b3c44a70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59687389)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
- Knowledge Base — [Translation operations and developer tools](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-operations.md)
- Knowledge Base — [Translation API client and service bindings](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-api-client.md)
- Knowledge Base — [Localization runtime and shared domain](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/localization-runtime.md)
</details>


<!-- /greptile_comment -->