### PR TITLE
feat(android-strings): write Android resource directory qualifiers

### DIFF
--- a/.changeset/android-strings-cli.md
+++ b/.changeset/android-strings-cli.md
@@ -1,0 +1,9 @@
+---
+'gt': minor
+'generaltranslation': patch
+'@generaltranslation/api': patch
+---
+
+Add Android `strings.xml` support to the CLI. Configure an `androidStrings` entry under `files` in `gt.config.json` to upload Android string resources and download the translated per-locale files.
+
+Translations are written to the resource directory the platform expects, so `fr-CA` becomes `values-fr-rCA` and `zh-Hans` becomes `values-b+zh+Hans`. Android reads the locale out of the directory name and fails the build on one it cannot parse.

--- a/packages/cli/src/formats/files/__tests__/androidLocale.test.ts
+++ b/packages/cli/src/formats/files/__tests__/androidLocale.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from 'vitest';
+
+import { androidLocaleQualifier } from '../androidLocale.js';
+import { localeForFilePath } from '../localePath.js';
+
+// Every platform locale with the directory name aapt2 2.19 accepts for it,
+// each one confirmed by compiling `res/values-<qualifier>`. A change here is a
+// claim about what the Android build accepts.
+const PLATFORM_LOCALES: [locale: string, qualifier: string][] = [
+  ['af', 'af'],
+  ['am', 'am'],
+  ['ar', 'ar'],
+  ['ar-AE', 'ar-rAE'],
+  ['ar-EG', 'ar-rEG'],
+  ['ar-LB', 'ar-rLB'],
+  ['ar-MA', 'ar-rMA'],
+  ['ar-OM', 'ar-rOM'],
+  ['ar-SA', 'ar-rSA'],
+  ['az', 'az'],
+  ['bg', 'bg'],
+  ['bn', 'bn'],
+  ['bs', 'bs'],
+  ['ca', 'ca'],
+  ['ca-ES', 'ca-rES'],
+  ['cnr', 'cnr'],
+  ['cs', 'cs'],
+  ['cy', 'cy'],
+  ['da', 'da'],
+  ['de', 'de'],
+  ['de-DE', 'de-rDE'],
+  ['de-AT', 'de-rAT'],
+  ['de-CH', 'de-rCH'],
+  ['el', 'el'],
+  ['el-EL', 'el-rEL'],
+  ['el-CY', 'el-rCY'],
+  ['en', 'en'],
+  ['en-AU', 'en-rAU'],
+  ['en-CA', 'en-rCA'],
+  ['en-GB', 'en-rGB'],
+  ['en-NZ', 'en-rNZ'],
+  ['en-US', 'en-rUS'],
+  ['eo', 'eo'],
+  ['es', 'es'],
+  ['es-ES', 'es-rES'],
+  ['es-419', 'b+es+419'],
+  ['es-AR', 'es-rAR'],
+  ['es-CL', 'es-rCL'],
+  ['es-CO', 'es-rCO'],
+  ['es-MX', 'es-rMX'],
+  ['es-PE', 'es-rPE'],
+  ['es-US', 'es-rUS'],
+  ['es-VE', 'es-rVE'],
+  ['et', 'et'],
+  ['eu', 'eu'],
+  ['eu-ES', 'eu-rES'],
+  ['fa', 'fa'],
+  ['fi', 'fi'],
+  ['fil', 'fil'],
+  ['fr', 'fr'],
+  ['fr-FR', 'fr-rFR'],
+  ['fr-BE', 'fr-rBE'],
+  ['fr-CM', 'fr-rCM'],
+  ['fr-CA', 'fr-rCA'],
+  ['fr-CH', 'fr-rCH'],
+  ['fr-SN', 'fr-rSN'],
+  ['gl', 'gl'],
+  ['gl-ES', 'gl-rES'],
+  ['gu', 'gu'],
+  ['ha', 'ha'],
+  ['hi', 'hi'],
+  ['he', 'he'],
+  ['hr', 'hr'],
+  ['hu', 'hu'],
+  ['hy', 'hy'],
+  ['id', 'id'],
+  ['ig', 'ig'],
+  ['is', 'is'],
+  ['it', 'it'],
+  ['it-IT', 'it-rIT'],
+  ['it-CH', 'it-rCH'],
+  ['ja', 'ja'],
+  ['ka', 'ka'],
+  ['kk', 'kk'],
+  ['kn', 'kn'],
+  ['ko', 'ko'],
+  ['la', 'la'],
+  ['lt', 'lt'],
+  ['lv', 'lv'],
+  ['mk', 'mk'],
+  ['ml', 'ml'],
+  ['mn', 'mn'],
+  ['mr', 'mr'],
+  ['ms', 'ms'],
+  ['my', 'my'],
+  ['nl', 'nl'],
+  ['nl-NL', 'nl-rNL'],
+  ['nl-BE', 'nl-rBE'],
+  ['nb', 'nb'],
+  ['nb-NO', 'nb-rNO'],
+  ['no', 'no'],
+  ['no-NO', 'no-rNO'],
+  ['nn', 'nn'],
+  ['nn-NO', 'nn-rNO'],
+  ['pa', 'pa'],
+  ['pl', 'pl'],
+  ['pt', 'pt'],
+  ['pt-BR', 'pt-rBR'],
+  ['pt-PT', 'pt-rPT'],
+  ['ro', 'ro'],
+  ['ru', 'ru'],
+  ['sk', 'sk'],
+  ['sl', 'sl'],
+  ['so', 'so'],
+  ['sq', 'sq'],
+  ['sr', 'sr'],
+  ['sv', 'sv'],
+  ['sw', 'sw'],
+  ['sw-KE', 'sw-rKE'],
+  ['sw-TZ', 'sw-rTZ'],
+  ['ta', 'ta'],
+  ['te', 'te'],
+  ['th', 'th'],
+  ['tl', 'tl'],
+  ['tr', 'tr'],
+  ['uk', 'uk'],
+  ['ur', 'ur'],
+  ['uz', 'uz'],
+  ['vi', 'vi'],
+  ['yo', 'yo'],
+  ['zgh', 'zgh'],
+  ['zh', 'zh'],
+  ['zh-CN', 'zh-rCN'],
+  ['zh-Hans', 'b+zh+Hans'],
+  ['zh-Hant', 'b+zh+Hant'],
+  ['zh-HK', 'zh-rHK'],
+  ['zh-SG', 'zh-rSG'],
+  ['zh-TW', 'zh-rTW'],
+  ['qbr', 'qbr'],
+];
+
+describe('androidLocaleQualifier', () => {
+  it.each(PLATFORM_LOCALES)('%s -> values-%s', (locale, qualifier) => {
+    expect(androidLocaleQualifier(locale)).toBe(qualifier);
+  });
+
+  it('uses the legacy form wherever one exists', () => {
+    // `b+` requires API 24. Only a script subtag and a numeric region lack a
+    // narrower spelling.
+    const needsBcp47 = PLATFORM_LOCALES.filter(([, q]) => q.startsWith('b+'));
+    expect(needsBcp47.map(([locale]) => locale).sort()).toEqual([
+      'es-419',
+      'zh-Hans',
+      'zh-Hant',
+    ]);
+  });
+
+  it('does not respell a language the way CLDR would', () => {
+    // `Intl.Locale` resolves `tl` to `fil` and `cnr` to `sr-ME`. Android
+    // accepts all four as written, and older devices report `tl`.
+    expect(androidLocaleQualifier('tl')).toBe('tl');
+    expect(androidLocaleQualifier('cnr')).toBe('cnr');
+  });
+
+  it('normalises case the way the platform writes it', () => {
+    expect(androidLocaleQualifier('fr-ca')).toBe('fr-rCA');
+    expect(androidLocaleQualifier('ZH-hans')).toBe('b+zh+Hans');
+  });
+
+  it('leaves a tag it cannot parse exactly as written', () => {
+    // A bad tag names a bad directory. It must not fail the run.
+    for (const bad of ['', 'not a locale', '!!']) {
+      expect(androidLocaleQualifier(bad)).toBe(bad);
+    }
+  });
+});
+
+describe('localeForFilePath', () => {
+  it('applies the Android spelling only to Android paths', () => {
+    expect(localeForFilePath('androidStrings', 'fr-CA')).toBe('fr-rCA');
+  });
+
+  it('leaves every other file type verbatim', () => {
+    // The registry is opt-in. Only Android is listed.
+    for (const fileType of [
+      'json',
+      'strings',
+      'stringsdict',
+      'pot',
+      'mdx',
+    ] as const) {
+      expect(localeForFilePath(fileType, 'fr-CA'), fileType).toBe('fr-CA');
+    }
+  });
+});

--- a/packages/cli/src/formats/files/__tests__/androidLocale.test.ts
+++ b/packages/cli/src/formats/files/__tests__/androidLocale.test.ts
@@ -183,8 +183,8 @@ describe('localeForFilePath', () => {
     // The registry is opt-in. Only Android is listed.
     for (const fileType of [
       'json',
-      'strings',
-      'stringsdict',
+      'dotStrings',
+      'dotStringsdict',
       'pot',
       'mdx',
     ] as const) {

--- a/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
+++ b/packages/cli/src/formats/files/__tests__/fileMapping.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import path from 'node:path';
 import { createFileMapping } from '../fileMapping.js';
 import { TEMPLATE_FILE_NAME } from '../../../utils/constants.js';
+import { getRelative } from '../../../fs/findFilepath.js';
 
 describe('createFileMapping', () => {
   it('uses a relative output path for GTJSON template files', () => {
@@ -122,6 +123,76 @@ describe('createFileMapping', () => {
       });
 
       expect(mapping['fr-ca']['docs/guide.mdx']).toBe('docs/fr-CA/guide.mdx');
+    });
+  });
+
+  describe('Android resource directory qualifiers', () => {
+    // A transform runs against the already-resolved translated path, so the
+    // form that matters is a placeholder with no [locale] in it: the transform
+    // is what routes the file per locale, and its `{locale}` has to spell the
+    // directory the same way `resolveLocaleFiles` would.
+    const source = path.resolve('res/values/strings.xml');
+    const unlocalized = path.resolve('res/values/strings.xml');
+
+    const androidMapping = (
+      transform: Record<string, unknown>,
+      locale: string
+    ) =>
+      createFileMapping(
+        { androidStrings: [source] },
+        { androidStrings: [unlocalized] },
+        { androidStrings: transform } as never,
+        {},
+        [locale],
+        'en'
+      )[locale][getRelative(source)];
+
+    it('uses the qualifier in an array-form transform', () => {
+      expect(
+        androidMapping(
+          [{ match: 'res/values/(.*)', replace: 'res/values-{locale}/$1' }],
+          'fr-CA'
+        )
+      ).toBe('res/values-fr-rCA/strings.xml');
+    });
+
+    it('uses the qualifier in an object-form transform', () => {
+      expect(
+        androidMapping(
+          { match: 'res/values/(.*)', replace: 'res/values-{locale}/$1' },
+          'zh-Hans'
+        )
+      ).toBe('res/values-b+zh+Hans/strings.xml');
+    });
+
+    it('uses the qualifier with the [locale] placeholder', () => {
+      const placeholder = path.resolve('res/values-[locale]/strings.xml');
+      const mapping = createFileMapping(
+        { androidStrings: [path.resolve('res/values-en/strings.xml')] },
+        { androidStrings: [placeholder] },
+        {},
+        {},
+        ['fr-CA'],
+        'en'
+      );
+      expect(
+        mapping['fr-CA'][getRelative(path.resolve('res/values-en/strings.xml'))]
+      ).toBe('res/values-fr-rCA/strings.xml');
+    });
+
+    it('leaves every other file type verbatim', () => {
+      const jsonSource = path.resolve('i18n/source.json');
+      const mapping = createFileMapping(
+        { json: [jsonSource] },
+        { json: [jsonSource] },
+        {
+          json: [{ match: 'i18n/source.json', replace: 'i18n/{locale}.json' }],
+        },
+        {},
+        ['fr-CA'],
+        'en'
+      );
+      expect(mapping['fr-CA'][getRelative(jsonSource)]).toBe('i18n/fr-CA.json');
     });
   });
 });

--- a/packages/cli/src/formats/files/androidLocale.ts
+++ b/packages/cli/src/formats/files/androidLocale.ts
@@ -16,10 +16,12 @@ export function androidLocaleQualifier(locale: string): string {
     return locale;
   }
 
-  // Subtags come from the tag as written. `Intl.Locale` resolves CLDR aliases,
-  // reading `tl` as `fil` and `cnr` as `sr-ME`, and Android matches those
-  // directories to different devices. `getLocaleProperties` is also wrong here
-  // because it maximizes, reporting script `Latn` and region `ES` for `es`.
+  // Subtags come from the tag as written. The locale helpers in
+  // `@generaltranslation/format` each answer a different question and give the
+  // wrong directory here: `standardizeLocale` reads `tl` as `fil` and `cnr` as
+  // `sr-ME`, which Android matches to different devices, `getLocaleProperties`
+  // maximizes and reports script `Latn` for a bare `es`, and `isValidLocale`
+  // rejects supported locales including `el-EL`.
   const [language, ...rest] = locale.split('-');
   const script = rest.find((part) => /^[A-Za-z]{4}$/.test(part));
   const region = rest.find(

--- a/packages/cli/src/formats/files/androidLocale.ts
+++ b/packages/cli/src/formats/files/androidLocale.ts
@@ -1,0 +1,53 @@
+// Android resource directory qualifiers.
+//
+// Android parses the locale out of a `values-*` directory name and fails the
+// build on a name it cannot parse.
+
+/**
+ * Returns the qualifier for a locale, without the `values-` prefix.
+ *
+ * `es` gives `es`, `fr-CA` gives `fr-rCA`, and `zh-Hans` gives `b+zh+Hans`.
+ * A tag that does not parse is returned unchanged.
+ */
+export function androidLocaleQualifier(locale: string): string {
+  try {
+    new Intl.Locale(locale);
+  } catch {
+    return locale;
+  }
+
+  // Subtags come from the tag as written. `Intl.Locale` resolves CLDR aliases,
+  // reading `tl` as `fil` and `cnr` as `sr-ME`, and Android matches those
+  // directories to different devices. `getLocaleProperties` is also wrong here
+  // because it maximizes, reporting script `Latn` and region `ES` for `es`.
+  const [language, ...rest] = locale.split('-');
+  const script = rest.find((part) => /^[A-Za-z]{4}$/.test(part));
+  const region = rest.find(
+    (part) => /^[A-Za-z]{2}$/.test(part) || /^\d{3}$/.test(part)
+  );
+
+  // A script subtag or a numeric region such as `es-419` has no other
+  // spelling. The legacy forms below carry no API level requirement, so they
+  // are used wherever they can express the tag.
+  if (script !== undefined || (region !== undefined && /^\d/.test(region))) {
+    return [
+      'b',
+      language.toLowerCase(),
+      toScriptCase(script),
+      region?.toUpperCase(),
+    ]
+      .filter((part) => part !== undefined && part !== '')
+      .join('+');
+  }
+
+  return region === undefined
+    ? language.toLowerCase()
+    : `${language.toLowerCase()}-r${region.toUpperCase()}`;
+}
+
+/** Returns a script subtag in title case, so `hans` and `HANS` give `Hans`. */
+function toScriptCase(script: string | undefined): string | undefined {
+  return script === undefined
+    ? undefined
+    : script[0].toUpperCase() + script.slice(1).toLowerCase();
+}

--- a/packages/cli/src/formats/files/fileMapping.ts
+++ b/packages/cli/src/formats/files/fileMapping.ts
@@ -14,6 +14,7 @@ import {
 import { FileMapping } from '../../types/files.js';
 import { TEMPLATE_FILE_NAME } from '../../utils/constants.js';
 import { replaceFileExtensionForFormat } from './transformFormat.js';
+import { localeForFilePath } from './localePath.js';
 
 /**
  * Creates a mapping between source files and their translated counterparts for each locale
@@ -58,13 +59,16 @@ export function createFileMapping(
 
       if (transformPath) {
         if (typeof transformPath === 'string') {
+          // Must match the spelling `resolveLocaleFiles` uses, or a configured
+          // transform names a file nothing else writes to.
+          const pathLocale = localeForFilePath(typeIndex, locale);
           translatedFiles = translatedFiles.map((filePath) => {
             const directory = path.dirname(filePath);
             const fileName = path.basename(filePath);
             const baseName = fileName.split('.')[0];
             const transformedFileName = transformPath
               .replace('*', baseName)
-              .replace('[locale]', locale);
+              .replace('[locale]', pathLocale);
             return path.join(directory, transformedFileName);
           });
         } else if (Array.isArray(transformPath)) {

--- a/packages/cli/src/formats/files/fileMapping.ts
+++ b/packages/cli/src/formats/files/fileMapping.ts
@@ -58,10 +58,21 @@ export function createFileMapping(
       const transformFormat = transformFormats?.[typeIndex];
 
       if (transformPath) {
+        // `[locale]` and `{locale}` both name a path here, so both take the
+        // spelling `resolveLocaleFiles` uses. Otherwise a configured transform
+        // names a file nothing else writes to. The match side takes it too: it
+        // runs against a source path already in that spelling.
+        const pathLocale = localeForFilePath(typeIndex, locale);
+        const targetLocaleProperties = {
+          ...getConfiguredLocaleProperties(locale),
+          code: pathLocale,
+        };
+        const defaultLocaleProperties = {
+          ...getConfiguredLocaleProperties(defaultLocale),
+          code: localeForFilePath(typeIndex, defaultLocale),
+        };
+
         if (typeof transformPath === 'string') {
-          // Must match the spelling `resolveLocaleFiles` uses, or a configured
-          // transform names a file nothing else writes to.
-          const pathLocale = localeForFilePath(typeIndex, locale);
           translatedFiles = translatedFiles.map((filePath) => {
             const directory = path.dirname(filePath);
             const fileName = path.basename(filePath);
@@ -72,11 +83,6 @@ export function createFileMapping(
             return path.join(directory, transformedFileName);
           });
         } else if (Array.isArray(transformPath)) {
-          // transformPath is an array of TransformOption objects
-          const targetLocaleProperties = getConfiguredLocaleProperties(locale);
-          const defaultLocaleProperties =
-            getConfiguredLocaleProperties(defaultLocale);
-
           translatedFiles = translatedFiles.map((filePath) => {
             const relativePath = getRelative(filePath);
 
@@ -119,10 +125,6 @@ export function createFileMapping(
             return filePath;
           });
         } else {
-          // transformPath is an object
-          const targetLocaleProperties = getConfiguredLocaleProperties(locale);
-          const defaultLocaleProperties =
-            getConfiguredLocaleProperties(defaultLocale);
           if (
             !transformPath.replace ||
             typeof transformPath.replace !== 'string'

--- a/packages/cli/src/formats/files/localePath.ts
+++ b/packages/cli/src/formats/files/localePath.ts
@@ -1,0 +1,24 @@
+import { androidLocaleQualifier } from './androidLocale.js';
+
+import type { SupportedFileExtension } from '../../types/index.js';
+
+/**
+ * How each file type spells a locale inside a path.
+ *
+ * A file type belongs here only when its own tooling reads the locale back out
+ * of the path. Everything else must stay verbatim, because a transform or a
+ * static URL that spells a locale differently points at a file nothing wrote.
+ */
+const LOCALE_PATH_SPELLING: Partial<
+  Record<SupportedFileExtension, (locale: string) => string>
+> = {
+  androidStrings: androidLocaleQualifier,
+};
+
+/** Returns the locale as `fileType` spells it in a path. */
+export function localeForFilePath(
+  fileType: SupportedFileExtension,
+  locale: string
+): string {
+  return LOCALE_PATH_SPELLING[fileType]?.(locale) ?? locale;
+}

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -60,6 +60,33 @@ describe('parseFilesConfig', () => {
       });
     });
 
+    it('spells the locale as an Android resource qualifier, and only there', () => {
+      // Only Android is respelled. Every other file type keeps the locale as
+      // configured, which transforms and static URLs also depend on.
+      const files = {
+        androidStrings: ['res/values-[locale]/strings.xml'],
+        json: ['src/[locale]/messages.json'],
+        strings: ['[locale].lproj/Localizable.strings'],
+        gt: 'dist/[locale].json',
+      };
+
+      expect(resolveLocaleFiles(files, 'fr-CA')).toMatchObject({
+        androidStrings: ['res/values-fr-rCA/strings.xml'],
+        json: ['src/fr-CA/messages.json'],
+        strings: ['fr-CA.lproj/Localizable.strings'],
+        gt: 'dist/fr-CA.json',
+      });
+    });
+
+    it('leaves a plain language alone for Android', () => {
+      expect(
+        resolveLocaleFiles(
+          { androidStrings: ['res/values-[locale]/s.xml'] },
+          'es'
+        )
+      ).toMatchObject({ androidStrings: ['res/values-es/s.xml'] });
+    });
+
     it('should handle empty file arrays', () => {
       const files = {
         json: [],

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -66,14 +66,14 @@ describe('parseFilesConfig', () => {
       const files = {
         androidStrings: ['res/values-[locale]/strings.xml'],
         json: ['src/[locale]/messages.json'],
-        strings: ['[locale].lproj/Localizable.strings'],
+        dotStrings: ['[locale].lproj/Localizable.strings'],
         gt: 'dist/[locale].json',
       };
 
       expect(resolveLocaleFiles(files, 'fr-CA')).toMatchObject({
         androidStrings: ['res/values-fr-rCA/strings.xml'],
         json: ['src/fr-CA/messages.json'],
-        strings: ['fr-CA.lproj/Localizable.strings'],
+        dotStrings: ['fr-CA.lproj/Localizable.strings'],
         gt: 'dist/fr-CA.json',
       });
     });

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -21,6 +21,7 @@ import {
   GT_PARSING_FLAGS_DEFAULT,
 } from '../../config/defaults.js';
 import { resolveTransformationFormat } from '../../formats/files/transformFormat.js';
+import { localeForFilePath } from '../../formats/files/localePath.js';
 
 /**
  * Resolves the files from the files object
@@ -37,8 +38,9 @@ export function resolveLocaleFiles(
   const result: ResolvedFiles = {};
 
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    const replacement = localeForFilePath(fileType, locale);
     result[fileType] = files[fileType]?.map((filepath) =>
-      filepath.replace(/\[locale\]/g, locale)
+      filepath.replace(/\[locale\]/g, replacement)
     );
   }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds Android resource-directory locale qualifiers and consistently applies them to configured paths and path transforms.
- Converts regional locales such as `fr-CA` to `fr-rCA`.
- Uses BCP 47 Android qualifiers for script and numeric-region locales.
- Adds focused coverage for direct placeholders and array-, object-, and string-form path mapping.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported transform-form divergence is addressed by using the Android path locale for transform replacement properties, with focused tests covering array and object forms.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/androidLocale.ts | Adds a focused locale-to-Android-resource-qualifier conversion helper with normalization and invalid-input handling. |
| packages/cli/src/formats/files/localePath.ts | Centralizes file-type-specific locale spelling while preserving existing behavior for non-Android formats. |
| packages/cli/src/formats/files/fileMapping.ts | Applies Android qualifier spelling to direct placeholders and transform replacement properties, resolving the previously reported transform-form divergence. |
| packages/cli/src/fs/config/parseFilesConfig.ts | Expands Android locale placeholders using resource-directory qualifier spelling while leaving other file types unchanged. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(android-strings): spell the locale t..."](https://github.com/generaltranslation/gt/commit/91c7685d98fa902d5f660ef7b4bab31281a0006a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59729842)</sub>

<!-- /greptile_comment -->