### PR TITLE
fix(dot-strings 4): read .stringsdict as raw bytes so UTF-16 files survive upload

### DIFF
--- a/.changeset/stringsdict-binary-format.md
+++ b/.changeset/stringsdict-binary-format.md
@@ -1,0 +1,12 @@
+---
+'generaltranslation': patch
+'gt': patch
+---
+
+Fix UTF-16 `.stringsdict` files being corrupted before upload.
+
+Older Xcode wrote `.stringsdict` as UTF-16, and legacy repositories still contain them. Such a file is valid — `plutil` accepts it and it renders correctly on device — but the CLI read every `.stringsdict` as UTF-8 text, which replaced those bytes with U+FFFD before the file ever left the machine. The API could not repair what it never received.
+
+`DOT_STRINGSDICT` now joins `LOTTIE` and `DOT_STRINGS` in `BINARY_FILE_FORMATS`, so its bytes travel base64-encoded end to end and the API picks a decoder from the byte order mark.
+
+UTF-8 `.stringsdict` files, with or without a byte order mark, upload the same bytes as before. Their version id changes once, because it is now hashed from the base64 payload rather than the decoded text, so each file re-translates a single time.

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -671,6 +671,9 @@ describe('aggregateFiles - Empty File Handling', () => {
     // The escapes below are load-bearing: they must reach the API verbatim.
     const stringsdictContent =
       '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n  <key>%d file(s) \\"quoted\\"</key>\n</dict>\n</plist>\n';
+    const stringsdictBase64 = Buffer.from(stringsdictContent, 'utf8').toString(
+      'base64'
+    );
 
     beforeEach(() => {
       // Make any trip through the markdown-oriented sanitizer detectable: it
@@ -692,7 +695,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadFile.mockReturnValueOnce(stringsdictContent);
+      mockReadBinaryFileBase64.mockReturnValueOnce(stringsdictBase64);
 
       const { files: result } = await aggregateTestFiles(settings);
 
@@ -702,13 +705,14 @@ describe('aggregateFiles - Empty File Handling', () => {
         fileFormat: 'DOT_STRINGSDICT',
         locale: 'en',
       });
-      expect(result[0].content).toBe(stringsdictContent);
+      expect(result[0].content).toBe(stringsdictBase64);
+      expect(Buffer.from(result[0].content, 'base64').toString('utf8')).toBe(
+        stringsdictContent
+      );
       expect(result[0].fileId).toBe(
         hashStringSync('en.lproj/Localizable.stringsdict')
       );
-      expect(result[0].versionId).toBe(
-        hashVersionId(stringsdictContent, false)
-      );
+      expect(result[0].versionId).toBe(hashVersionId(stringsdictBase64, false));
     });
 
     it('should skip empty .stringsdict files and log a warning', async () => {
@@ -726,9 +730,11 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadFile
-        .mockReturnValueOnce('   \n\t  ') // whitespace only
-        .mockReturnValueOnce(stringsdictContent); // valid file
+      mockReadBinaryFileBase64
+        .mockReturnValueOnce(
+          Buffer.from('   \n\t  ', 'utf8').toString('base64')
+        ) // whitespace only
+        .mockReturnValueOnce(stringsdictBase64); // valid file
 
       const { files: result } = await aggregateTestFiles(settings);
 

--- a/packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts
@@ -9,27 +9,47 @@ import type { Settings } from '../../../types/index.js';
 // Exercises the real filesystem helpers rather than mocks: the bug this covers
 // was in how the bytes were read, so a mocked read cannot see it.
 
-const BODY =
+const STRINGS_BODY =
   '/* Localizable.strings */\n' +
   '"app.title" = "Pocket Café";\n' +
   '"welcome" = "¡Bienvenido — te echábamos de menos!";\n' +
   '"celebrate" = "¡Pedido realizado! 🎉";\n';
 
+const STRINGSDICT_BODY =
+  '<?xml version="1.0" encoding="UTF-8"?>\n' +
+  '<plist version="1.0">\n' +
+  '<dict>\n' +
+  '\t<key>note.count</key>\n' +
+  '\t<dict>\n' +
+  '\t\t<key>NSStringLocalizedFormatKey</key>\n' +
+  '\t\t<string>%#@n@</string>\n' +
+  '\t\t<key>n</key>\n' +
+  '\t\t<dict>\n' +
+  '\t\t\t<key>NSStringFormatSpecTypeKey</key>\n' +
+  '\t\t\t<string>NSStringPluralRuleType</string>\n' +
+  '\t\t\t<key>one</key>\n' +
+  '\t\t\t<string>%lld observación 🎉</string>\n' +
+  '\t\t\t<key>other</key>\n' +
+  '\t\t\t<string>%lld observaciones — ¡bien!</string>\n' +
+  '\t\t</dict>\n' +
+  '\t</dict>\n' +
+  '</dict>\n' +
+  '</plist>\n';
+
 const utf16le = (text: string) => Buffer.from(text, 'utf16le');
 
-// Byte layouts Xcode has shipped over the years, byte order marks included.
-const FIXTURES: Record<string, Buffer> = {
-  'utf16le.strings': Buffer.concat([Buffer.from([0xff, 0xfe]), utf16le(BODY)]),
-  'utf16be.strings': Buffer.concat([
-    Buffer.from([0xfe, 0xff]),
-    utf16le(BODY).swap16(),
-  ]),
-  'utf8.strings': Buffer.from(BODY, 'utf8'),
-  'utf8-bom.strings': Buffer.concat([
-    Buffer.from([0xef, 0xbb, 0xbf]),
-    Buffer.from(BODY, 'utf8'),
-  ]),
-};
+/** Byte layouts Xcode has shipped over the years, byte order marks included. */
+function encodings(body: string): Record<string, Buffer> {
+  return {
+    utf16le: Buffer.concat([Buffer.from([0xff, 0xfe]), utf16le(body)]),
+    utf16be: Buffer.concat([Buffer.from([0xfe, 0xff]), utf16le(body).swap16()]),
+    utf8: Buffer.from(body, 'utf8'),
+    'utf8-bom': Buffer.concat([
+      Buffer.from([0xef, 0xbb, 0xbf]),
+      Buffer.from(body, 'utf8'),
+    ]),
+  };
+}
 
 /** Mirrors the API's byte-order-mark-directed decode. */
 function decodeByBom(bytes: Buffer): string {
@@ -45,60 +65,83 @@ function decodeByBom(bytes: Buffer): string {
   return bytes.toString('utf8');
 }
 
-describe('aggregateFiles - .strings encodings', () => {
-  let dir: string;
+const CASES = [
+  {
+    label: '.strings',
+    settingsKey: 'dotStrings',
+    fileFormat: 'DOT_STRINGS',
+    extension: 'strings',
+    body: STRINGS_BODY,
+  },
+  {
+    label: '.stringsdict',
+    settingsKey: 'dotStringsdict',
+    fileFormat: 'DOT_STRINGSDICT',
+    extension: 'stringsdict',
+    body: STRINGSDICT_BODY,
+  },
+] as const;
 
-  beforeAll(() => {
-    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-dot-strings-'));
-    for (const [name, bytes] of Object.entries(FIXTURES)) {
-      fs.writeFileSync(path.join(dir, name), bytes);
+describe.each(CASES)(
+  'aggregateFiles - $label encodings',
+  ({ settingsKey, fileFormat, extension, body }) => {
+    const FIXTURES = encodings(body);
+    let dir: string;
+
+    beforeAll(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), `gt-${extension}-`));
+      for (const [name, bytes] of Object.entries(FIXTURES)) {
+        fs.writeFileSync(path.join(dir, `${name}.${extension}`), bytes);
+      }
+    });
+
+    afterAll(() => {
+      fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    /** The base64 the SDK puts on the wire for a single aggregated source file. */
+    async function wireBytesFor(name: string): Promise<Buffer> {
+      const { files } = await aggregateFiles({
+        files: {
+          resolvedPaths: {
+            [settingsKey]: [path.join(dir, `${name}.${extension}`)],
+          },
+          placeholderPaths: {},
+        },
+        options: {},
+        defaultLocale: 'en',
+      } as unknown as Settings);
+
+      expect(files).toHaveLength(1);
+      expect(files[0].fileFormat).toBe(fileFormat);
+
+      // Same branch _uploadSourceFiles takes when building the request body.
+      const wire = isBinaryFileFormat(files[0].fileFormat)
+        ? files[0].content
+        : Buffer.from(files[0].content, 'utf8').toString('base64');
+      return Buffer.from(wire, 'base64');
     }
-  });
 
-  afterAll(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
-  });
+    it.each(Object.keys(FIXTURES))(
+      'delivers %s to the API byte for byte',
+      async (name) => {
+        const bytes = await wireBytesFor(name);
+        expect(bytes.equals(FIXTURES[name])).toBe(true);
+        expect(decodeByBom(bytes)).toBe(body);
+        expect(decodeByBom(bytes)).not.toContain('�');
+      }
+    );
 
-  /** The base64 the SDK puts on the wire for a single aggregated source file. */
-  async function wireBytesFor(name: string): Promise<Buffer> {
-    const { files } = await aggregateFiles({
-      files: {
-        resolvedPaths: { dotStrings: [path.join(dir, name)] },
-        placeholderPaths: {},
-      },
-      options: {},
-      defaultLocale: 'en',
-    } as unknown as Settings);
-
-    expect(files).toHaveLength(1);
-    expect(files[0].fileFormat).toBe('DOT_STRINGS');
-
-    // Same branch _uploadSourceFiles takes when building the request body.
-    const wire = isBinaryFileFormat(files[0].fileFormat)
-      ? files[0].content
-      : Buffer.from(files[0].content, 'utf8').toString('base64');
-    return Buffer.from(wire, 'base64');
+    it('keeps the byte order mark the API decodes by', async () => {
+      expect((await wireBytesFor('utf16le')).subarray(0, 2)).toStrictEqual(
+        Buffer.from([0xff, 0xfe])
+      );
+      expect((await wireBytesFor('utf16be')).subarray(0, 2)).toStrictEqual(
+        Buffer.from([0xfe, 0xff])
+      );
+      expect((await wireBytesFor('utf8-bom')).subarray(0, 3)).toStrictEqual(
+        Buffer.from([0xef, 0xbb, 0xbf])
+      );
+    });
   }
-
-  it.each(Object.keys(FIXTURES))(
-    'delivers %s to the API byte for byte',
-    async (name) => {
-      const bytes = await wireBytesFor(name);
-      expect(bytes.equals(FIXTURES[name])).toBe(true);
-      expect(decodeByBom(bytes)).toBe(BODY);
-      expect(decodeByBom(bytes)).not.toContain('�');
-    }
-  );
-
-  it('keeps the byte order mark the API decodes by', async () => {
-    expect(
-      (await wireBytesFor('utf16le.strings')).subarray(0, 2)
-    ).toStrictEqual(Buffer.from([0xff, 0xfe]));
-    expect(
-      (await wireBytesFor('utf16be.strings')).subarray(0, 2)
-    ).toStrictEqual(Buffer.from([0xfe, 0xff]));
-    expect(
-      (await wireBytesFor('utf8-bom.strings')).subarray(0, 3)
-    ).toStrictEqual(Buffer.from([0xef, 0xbb, 0xbf]));
-  });
-});
+);

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -405,9 +405,8 @@ export async function aggregateFiles(
   ] as const) {
     if (!filePaths[fileType]) continue;
     // Content must already be base64 exactly when the format is binary, or the
-    // upload path encodes it a second time. Only .strings qualifies today: its
-    // UTF-16 bytes reach an API decoder that reads the byte order mark, and
-    // .stringsdict has no such decoder yet.
+    // upload path encodes it a second time. Both formats qualify: their UTF-16
+    // bytes reach an API decoder that reads the byte order mark.
     const readsRawBytes = isBinaryFileFormat(fileFormat);
     const verbatimFiles = filePaths[fileType]
       .map((filePath) => {

--- a/packages/core/src/types-dir/api/file.ts
+++ b/packages/core/src/types-dir/api/file.ts
@@ -9,13 +9,13 @@ export type FileFormat = import('@generaltranslation/api').FileFormat;
  * base64-encoded, so the usual UTF-8 encode/decode steps are skipped and the
  * bytes reach the API unaltered.
  *
- * LOTTIE qualifies because it is a zip bundle. DOT_STRINGS qualifies because
- * older Xcode wrote `.strings` as UTF-16: the API chooses a decoder from the
- * byte order mark, and a UTF-8 round trip anywhere in between replaces those
- * bytes with U+FFFD.
+ * LOTTIE qualifies because it is a zip bundle. DOT_STRINGS and DOT_STRINGSDICT
+ * qualify because older Xcode wrote both as UTF-16: the API chooses a decoder
+ * from the byte order mark, and a UTF-8 round trip anywhere in between
+ * replaces those bytes with U+FFFD.
  */
 export const BINARY_FILE_FORMATS: ReadonlySet<FileFormat> = new Set<FileFormat>(
-  ['LOTTIE', 'DOT_STRINGS']
+  ['LOTTIE', 'DOT_STRINGS', 'DOT_STRINGSDICT']
 );
 
 /**


### PR DESCRIPTION
## Problem

Older Xcode wrote `.stringsdict` as UTF-16, and legacy repositories still contain them. The CLI read every `.stringsdict` with `readFile(path)` — `readFileSync(path, 'utf8')` — so a UTF-16 file became U+FFFD replacement characters before it ever left the machine. The API cannot repair what it never received.

`.strings` was fixed for exactly this reason. `.stringsdict` was left out because there was no API-side decoder for it; the companion PR adds one.

## Change

`DOT_STRINGSDICT` joins `LOTTIE` and `DOT_STRINGS` in `BINARY_FILE_FORMATS`.

That set is the only switch. Every consumer is already parameterised on it:

| Site | Effect |
| --- | --- |
| `aggregateFiles.ts:411` | reads raw bytes via `readBinaryFileBase64` instead of `readFile` |
| `aggregateFiles.ts:432` | emptiness check decodes the base64 before testing for blankness |
| `uploadSourceFiles.ts:32`, `uploadTranslations.ts:38,52` | skip the second `encode()` so the bytes are not re-encoded |
| `downloadFileBatch.ts:38` (core) / `:289` (cli) | content stays base64 and is written with `Buffer.from(data, 'base64')` |
| `collectUserEditDiffs.ts:168` | builds the comparison buffer from base64 rather than UTF-8 |
| `upload.ts:124` | locally supplied translations read as bytes too |

So the diff is one array entry, two comment corrections, and the tests.

## Tests

`aggregateFilesStringsEncoding.test.ts` already covered `.strings` across four real on-disk encodings using the real filesystem helpers rather than mocks. Rather than copy it, it is now table-driven over both formats — same assertions, both extensions, 10 cases.

Run against the pre-change set, 3 of the 5 new `.stringsdict` cases fail:

```
✓ .strings     > delivers utf16le / utf16be / utf8 / utf8-bom byte for byte
✓ .strings     > keeps the byte order mark the API decodes by
× .stringsdict > delivers utf16le to the API byte for byte
× .stringsdict > delivers utf16be to the API byte for byte
✓ .stringsdict > delivers utf8 to the API byte for byte
✓ .stringsdict > delivers utf8-bom to the API byte for byte
× .stringsdict > keeps the byte order mark the API decodes by
```

The two that pass are the honest result, and worth stating plainly: `readFileSync(path, 'utf8')` does not strip a UTF-8 byte order mark, so for both UTF-8 layouts the old text path was already byte-preserving. Only UTF-16 was ever corrupted.

`aggregateFiles.test.ts` `.stringsdict` cases move from `mockReadFile` to `mockReadBinaryFileBase64`, matching how the `.strings` cases are written.

Full suite: 48 tasks, all passing.

## Migration cost

The version id for a `.stringsdict` is `hashVersionId(content, ...)`, and `content` is now base64 rather than decoded text. Every existing `.stringsdict` therefore gets a new version id and re-translates once. `.strings` already paid this when it joined the set.

## Companion

Needs `generaltranslation/gt-cloud#4642`, which teaches the API to pick a decoder from the byte order mark for `.stringsdict`. Shipping this one alone would send correct UTF-16 bytes to an API that still reads them as UTF-8 — the upload would fail rather than corrupt, but it would fail.

Part of GEN-894




<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR routes `.stringsdict` files through the existing binary-content pipeline so their original bytes and byte-order marks survive upload.
- Adds `DOT_STRINGSDICT` to the shared binary-format set.
- Extends filesystem-backed encoding coverage across UTF-8, UTF-8 BOM, UTF-16LE, and UTF-16BE.
- Updates aggregation tests and documents the resulting one-time version-ID change.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains in the reviewed changes.

No blocking failure remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/types-dir/api/file.ts | Classifies `DOT_STRINGSDICT` as binary so existing upload and download consumers preserve its raw bytes. |
| packages/cli/src/formats/files/aggregateFiles.ts | The shared binary classification now sends `.stringsdict` files through raw-byte aggregation. |
| packages/cli/src/formats/files/__tests__/aggregateFilesStringsEncoding.test.ts | Generalizes real-filesystem encoding tests to verify byte preservation for `.strings` and `.stringsdict`. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Updates `.stringsdict` aggregation expectations to use base64 content and binary filesystem mocks. |
| .changeset/stringsdict-binary-format.md | Documents UTF-16 preservation and the intentional one-time version-ID migration. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    File[.stringsdict file] --> Read[Read raw bytes]
    Read --> Encode[Base64 content]
    Encode --> Upload[Upload without second encoding]
    Upload --> API[API decodes using BOM]
    API --> Download[Return base64 content]
    Download --> Write[Write decoded raw bytes]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(cli): read .stringsdict as raw bytes..."](https://github.com/generaltranslation/gt/commit/a9348d33b0ce79785334acb70a4dd49727408110) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59731327)</sub>

<!-- /greptile_comment -->