### PR TITLE
refactor(cli): standardize dot strings test names

### DIFF
--- a/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts
@@ -20,9 +20,9 @@ vi.mock('../../utils/gt.js', () => ({
   },
 }));
 
-const SOURCE = 'Guardian/en.lproj/Localizable.strings';
+const DOT_STRINGS_SOURCE = 'Guardian/en.lproj/Localizable.strings';
 
-const TRANSLATION =
+const DOT_STRINGS_TRANSLATION =
   '/* Localizable.strings */\n' +
   '"app.title" = "Pocket Café";\n' +
   '"welcome" = "¡Bienvenido!";\n';
@@ -61,7 +61,7 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
       _branchId: 'branch1',
       files: {
         resolvedPaths: {
-          dotStrings: [path.join(tempDir, SOURCE)],
+          dotStrings: [path.join(tempDir, DOT_STRINGS_SOURCE)],
         },
         placeholderPaths: {
           dotStrings: [
@@ -99,7 +99,7 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     });
 
   /** Writes the translated output the user would have downloaded and edited. */
-  const writeTranslation = (bytes: Buffer) => {
+  const writeDotStringsTranslation = (bytes: Buffer) => {
     const outputPath = path.join(
       tempDir,
       'Guardian',
@@ -140,7 +140,7 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
 
   const filesUnderTest = (fileFormat: string): FileReference[] => [
     {
-      fileName: SOURCE,
+      fileName: DOT_STRINGS_SOURCE,
       fileFormat,
       branchId: 'branch1',
       fileId: 'file1',
@@ -151,9 +151,9 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   it('reports no edit when an untouched .strings translation matches the server', async () => {
     const settings = buildSettings();
     seedLockFile();
-    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    writeDotStringsTranslation(Buffer.from(DOT_STRINGS_TRANSLATION, 'utf8'));
     mockServerDownload(
-      Buffer.from(TRANSLATION, 'utf8').toString('base64'),
+      Buffer.from(DOT_STRINGS_TRANSLATION, 'utf8').toString('base64'),
       'DOT_STRINGS'
     );
 
@@ -170,11 +170,14 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   it('diffs an edited .strings translation against the decoded server text', async () => {
     const settings = buildSettings();
     seedLockFile();
-    writeTranslation(
-      Buffer.from(TRANSLATION.replace('¡Bienvenido!', '¡Hola!'), 'utf8')
+    writeDotStringsTranslation(
+      Buffer.from(
+        DOT_STRINGS_TRANSLATION.replace('¡Bienvenido!', '¡Hola!'),
+        'utf8'
+      )
     );
     mockServerDownload(
-      Buffer.from(TRANSLATION, 'utf8').toString('base64'),
+      Buffer.from(DOT_STRINGS_TRANSLATION, 'utf8').toString('base64'),
       'DOT_STRINGS'
     );
 
@@ -191,7 +194,7 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   it('submits the edit when the recorded server baseline is empty', async () => {
     const settings = buildSettings();
     seedLockFile();
-    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    writeDotStringsTranslation(Buffer.from(DOT_STRINGS_TRANSLATION, 'utf8'));
     // An empty payload is a baseline of "nothing", not a missing download.
     // Treating the two alike drops everything the user wrote against it.
     mockServerDownload('', 'DOT_STRINGS');
@@ -201,13 +204,13 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
     expect(gt.submitUserEditDiffs).toHaveBeenCalledTimes(1);
     const [{ diffs }] = vi.mocked(gt.submitUserEditDiffs).mock.calls[0];
     expect(diffs[0].diff).toContain('+"welcome" = "¡Bienvenido!";');
-    expect(diffs[0].localContent).toBe(TRANSLATION);
+    expect(diffs[0].localContent).toBe(DOT_STRINGS_TRANSLATION);
   });
 
   it('skips silently when the batch download returned no copy of the file', async () => {
     const settings = buildSettings();
     seedLockFile();
-    writeTranslation(Buffer.from(TRANSLATION, 'utf8'));
+    writeDotStringsTranslation(Buffer.from(DOT_STRINGS_TRANSLATION, 'utf8'));
     vi.mocked(gt.queryFileData).mockResolvedValue({
       translatedFiles: [
         {
@@ -233,11 +236,11 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   it('warns instead of submitting a UTF-16 .strings edit it cannot represent as text', async () => {
     const settings = buildSettings();
     seedLockFile();
-    writeTranslation(
-      utf16leWithBom(TRANSLATION.replace('¡Bienvenido!', '¡Hola!'))
+    writeDotStringsTranslation(
+      utf16leWithBom(DOT_STRINGS_TRANSLATION.replace('¡Bienvenido!', '¡Hola!'))
     );
     mockServerDownload(
-      utf16leWithBom(TRANSLATION).toString('base64'),
+      utf16leWithBom(DOT_STRINGS_TRANSLATION).toString('base64'),
       'DOT_STRINGS'
     );
 
@@ -261,8 +264,8 @@ describe('collectAndSendUserEditDiffs - base64-carried formats', () => {
   it('stays quiet when a translation is byte-identical to the server copy', async () => {
     const settings = buildSettings();
     seedLockFile();
-    const unchanged = utf16leWithBom(TRANSLATION);
-    writeTranslation(unchanged);
+    const unchanged = utf16leWithBom(DOT_STRINGS_TRANSLATION);
+    writeDotStringsTranslation(unchanged);
     mockServerDownload(unchanged.toString('base64'), 'DOT_STRINGS');
 
     await collectAndSendUserEditDiffs(filesUnderTest('DOT_STRINGS'), settings);

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -590,9 +590,9 @@ describe('aggregateFiles - Empty File Handling', () => {
 
   describe('.strings files', () => {
     // The escapes below are load-bearing: they must reach the API verbatim.
-    const stringsContent =
+    const dotStringsContent =
       '/* Greeting */\n"hello" = "Line1\\nLine2 \\"quoted\\" 100%%";\n';
-    const stringsBase64 = Buffer.from(stringsContent, 'utf8').toString(
+    const dotStringsBase64 = Buffer.from(dotStringsContent, 'utf8').toString(
       'base64'
     );
 
@@ -616,7 +616,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadBinaryFileBase64.mockReturnValueOnce(stringsBase64);
+      mockReadBinaryFileBase64.mockReturnValueOnce(dotStringsBase64);
 
       const { files: result } = await aggregateTestFiles(settings);
 
@@ -626,14 +626,14 @@ describe('aggregateFiles - Empty File Handling', () => {
         fileFormat: 'DOT_STRINGS',
         locale: 'en',
       });
-      expect(result[0].content).toBe(stringsBase64);
+      expect(result[0].content).toBe(dotStringsBase64);
       expect(Buffer.from(result[0].content, 'base64').toString('utf8')).toBe(
-        stringsContent
+        dotStringsContent
       );
       expect(result[0].fileId).toBe(
         hashStringSync('en.lproj/Localizable.strings')
       );
-      expect(result[0].versionId).toBe(hashVersionId(stringsBase64, false));
+      expect(result[0].versionId).toBe(hashVersionId(dotStringsBase64, false));
     });
 
     it('should skip empty .strings files and log a warning', async () => {
@@ -655,7 +655,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         .mockReturnValueOnce(
           Buffer.from('   \n\t  ', 'utf8').toString('base64')
         ) // whitespace only
-        .mockReturnValueOnce(stringsBase64); // valid file
+        .mockReturnValueOnce(dotStringsBase64); // valid file
 
       const { files: result } = await aggregateTestFiles(settings);
 
@@ -669,7 +669,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
   describe('.stringsdict files', () => {
     // The escapes below are load-bearing: they must reach the API verbatim.
-    const stringsdictContent =
+    const dotStringsdictContent =
       '<?xml version="1.0" encoding="UTF-8"?>\n<plist version="1.0">\n<dict>\n  <key>%d file(s) \\"quoted\\"</key>\n</dict>\n</plist>\n';
 
     beforeEach(() => {
@@ -692,7 +692,7 @@ describe('aggregateFiles - Empty File Handling', () => {
         defaultLocale: 'en',
       };
 
-      mockReadFile.mockReturnValueOnce(stringsdictContent);
+      mockReadFile.mockReturnValueOnce(dotStringsdictContent);
 
       const { files: result } = await aggregateTestFiles(settings);
 
@@ -702,12 +702,12 @@ describe('aggregateFiles - Empty File Handling', () => {
         fileFormat: 'DOT_STRINGSDICT',
         locale: 'en',
       });
-      expect(result[0].content).toBe(stringsdictContent);
+      expect(result[0].content).toBe(dotStringsdictContent);
       expect(result[0].fileId).toBe(
         hashStringSync('en.lproj/Localizable.stringsdict')
       );
       expect(result[0].versionId).toBe(
-        hashVersionId(stringsdictContent, false)
+        hashVersionId(dotStringsdictContent, false)
       );
     });
 
@@ -728,7 +728,7 @@ describe('aggregateFiles - Empty File Handling', () => {
 
       mockReadFile
         .mockReturnValueOnce('   \n\t  ') // whitespace only
-        .mockReturnValueOnce(stringsdictContent); // valid file
+        .mockReturnValueOnce(dotStringsdictContent); // valid file
 
       const { files: result } = await aggregateTestFiles(settings);
 

--- a/packages/cli/src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts
@@ -9,7 +9,7 @@ import type { Settings } from '../../../types/index.js';
 // Exercises the real filesystem helpers rather than mocks: the bug this covers
 // was in how the bytes were read, so a mocked read cannot see it.
 
-const BODY =
+const DOT_STRINGS_BODY =
   '/* Localizable.strings */\n' +
   '"app.title" = "Pocket Café";\n' +
   '"welcome" = "¡Bienvenido — te echábamos de menos!";\n' +
@@ -18,16 +18,19 @@ const BODY =
 const utf16le = (text: string) => Buffer.from(text, 'utf16le');
 
 // Byte layouts Xcode has shipped over the years, byte order marks included.
-const FIXTURES: Record<string, Buffer> = {
-  'utf16le.strings': Buffer.concat([Buffer.from([0xff, 0xfe]), utf16le(BODY)]),
+const DOT_STRINGS_FIXTURES: Record<string, Buffer> = {
+  'utf16le.strings': Buffer.concat([
+    Buffer.from([0xff, 0xfe]),
+    utf16le(DOT_STRINGS_BODY),
+  ]),
   'utf16be.strings': Buffer.concat([
     Buffer.from([0xfe, 0xff]),
-    utf16le(BODY).swap16(),
+    utf16le(DOT_STRINGS_BODY).swap16(),
   ]),
-  'utf8.strings': Buffer.from(BODY, 'utf8'),
+  'utf8.strings': Buffer.from(DOT_STRINGS_BODY, 'utf8'),
   'utf8-bom.strings': Buffer.concat([
     Buffer.from([0xef, 0xbb, 0xbf]),
-    Buffer.from(BODY, 'utf8'),
+    Buffer.from(DOT_STRINGS_BODY, 'utf8'),
   ]),
 };
 
@@ -50,7 +53,7 @@ describe('aggregateFiles - .strings encodings', () => {
 
   beforeAll(() => {
     dir = fs.mkdtempSync(path.join(os.tmpdir(), 'gt-dot-strings-'));
-    for (const [name, bytes] of Object.entries(FIXTURES)) {
+    for (const [name, bytes] of Object.entries(DOT_STRINGS_FIXTURES)) {
       fs.writeFileSync(path.join(dir, name), bytes);
     }
   });
@@ -60,7 +63,7 @@ describe('aggregateFiles - .strings encodings', () => {
   });
 
   /** The base64 the SDK puts on the wire for a single aggregated source file. */
-  async function wireBytesFor(name: string): Promise<Buffer> {
+  async function dotStringsWireBytesFor(name: string): Promise<Buffer> {
     const { files } = await aggregateFiles({
       files: {
         resolvedPaths: { dotStrings: [path.join(dir, name)] },
@@ -80,25 +83,25 @@ describe('aggregateFiles - .strings encodings', () => {
     return Buffer.from(wire, 'base64');
   }
 
-  it.each(Object.keys(FIXTURES))(
+  it.each(Object.keys(DOT_STRINGS_FIXTURES))(
     'delivers %s to the API byte for byte',
     async (name) => {
-      const bytes = await wireBytesFor(name);
-      expect(bytes.equals(FIXTURES[name])).toBe(true);
-      expect(decodeByBom(bytes)).toBe(BODY);
+      const bytes = await dotStringsWireBytesFor(name);
+      expect(bytes.equals(DOT_STRINGS_FIXTURES[name])).toBe(true);
+      expect(decodeByBom(bytes)).toBe(DOT_STRINGS_BODY);
       expect(decodeByBom(bytes)).not.toContain('�');
     }
   );
 
   it('keeps the byte order mark the API decodes by', async () => {
     expect(
-      (await wireBytesFor('utf16le.strings')).subarray(0, 2)
+      (await dotStringsWireBytesFor('utf16le.strings')).subarray(0, 2)
     ).toStrictEqual(Buffer.from([0xff, 0xfe]));
     expect(
-      (await wireBytesFor('utf16be.strings')).subarray(0, 2)
+      (await dotStringsWireBytesFor('utf16be.strings')).subarray(0, 2)
     ).toStrictEqual(Buffer.from([0xfe, 0xff]));
     expect(
-      (await wireBytesFor('utf8-bom.strings')).subarray(0, 3)
+      (await dotStringsWireBytesFor('utf8-bom.strings')).subarray(0, 3)
     ).toStrictEqual(Buffer.from([0xef, 0xbb, 0xbf]));
   });
 });


### PR DESCRIPTION
## Summary

- Standardize the remaining `.strings` and `.stringsdict` test filename, fixtures, and helper variables on the `dotStrings` naming introduced in #2226.
- Keep the on-disk extensions and CLI behavior unchanged while removing ambiguous internal names.

## Testing

- `pnpm exec turbo run build --filter=gt... --ui stream` — passed (9/9 tasks)
- `pnpm --filter gt exec vitest run --config=./vitest.config.ts src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts src/formats/files/__tests__/aggregateFiles.test.ts src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts` — passed (3 files, 40 tests)
- `pnpm --filter gt typecheck` — passed
- `pnpm exec oxlint packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts packages/cli/src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts` — passed
- `pnpm exec oxfmt --check packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts packages/cli/src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts` — passed

## Notes

- Changeset: intentionally omitted because this is an internal test-only naming cleanup with no published package behavior change.
- The historical changelog explanation of the old `APPLE_STRINGS` name remains unchanged.


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR standardizes `.strings` and `.stringsdict` test names around the `dotStrings` terminology without changing test inputs, assertions, file extensions, or CLI behavior.

- Renames test-local constants and helper functions for clearer format-specific naming.
- Renames the encoding test file while retaining standard Vitest discovery conventions.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it only performs consistent test naming changes while preserving test discovery and behavior.

The renamed symbols are test-local, their values and uses remain aligned, and no stale reference prevents the renamed encoding test from running.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/api/__tests__/collectUserEditDiffsBinaryContent.test.ts | Renames `.strings` test constants and a helper while preserving all values, setup, and assertions. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Renames `.strings` and `.stringsdict` fixture variables consistently without changing test behavior. |
| packages/cli/src/formats/files/__tests__/aggregateFilesDotStringsEncoding.test.ts | Renames the test file and its local symbols; the new filename remains covered by normal Vitest test discovery. |

</details>

<sub>Reviews (1): Last reviewed commit: ["refactor(cli): standardize dot strings t..."](https://github.com/generaltranslation/gt/commit/ec4e5082426b747cbb0b9f23af9fb80220c6ea99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60055940)</sub>

<!-- /greptile_comment -->