### PR TITLE
fix(gt-sanity): handle deleted content metadata

### DIFF
--- a/.changeset/cyan-jars-marry.md
+++ b/.changeset/cyan-jars-marry.md
@@ -1,0 +1,17 @@
+---
+'gt-sanity': patch
+---
+
+Recreate a translation when `translation.metadata` points at a deleted document.
+
+References in `translation.metadata` are weak, so deleting a translated
+document leaves its entry behind. Importing a translation for that locale then
+resolved the stale reference to nothing and threw `Cannot read properties of
+undefined (reading '_id')`, surfacing as "could not be imported. This document
+was not changed." on every retry, with nothing to repair the metadata. The
+import now falls through to creating a fresh translated document, which
+replaces the stale entry.
+
+`findLatestDraft` is also typed `SanityDocument | undefined` to match what it
+actually returns, and a missing source document now throws a readable
+diagnostic instead of a `TypeError`.

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.test.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.test.ts
@@ -165,4 +165,105 @@ describe('documentLevelPatch', () => {
       expect.any(Function)
     );
   });
+  test('recreates the translation when metadata points at a deleted document', async () => {
+    vi.spyOn(pluginConfig, 'getSourceLocale').mockReturnValue('en');
+    vi.spyOn(pluginConfig, 'getIgnoreFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getSkipFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getDedupeFields').mockReturnValue([]);
+    vi.spyOn(pluginConfig, 'getSingletons').mockReturnValue([]);
+
+    const sourceDoc = {
+      _id: 'article-1',
+      _type: 'article',
+      _rev: 'source-rev',
+      title: 'Hello',
+    };
+    /*
+     * References in `translation.metadata` are weak, so deleting a translated
+     * document leaves its entry behind. The de-DE entry below points at a
+     * document that no longer resolves.
+     */
+    const metadata = {
+      _id: 'translation.metadata.article-1',
+      _type: 'translation.metadata',
+      translations: [
+        { language: 'en', value: { _type: 'reference', _ref: 'article-1' } },
+        {
+          language: 'de-DE',
+          value: { _type: 'reference', _ref: 'article-1-de' },
+        },
+      ],
+    };
+
+    const fetch = vi.fn(async (query: string, params?: { id?: string }) => {
+      if (query.includes('translation.metadata')) return metadata;
+      if (params?.id === 'article-1') return [sourceDoc];
+      return [];
+    });
+
+    const commit = vi.fn().mockResolvedValue({});
+    const patch = vi.fn().mockReturnValue({ commit });
+    const transactionPatch = vi.fn().mockReturnValue({ commit });
+    const create = vi
+      .fn()
+      .mockResolvedValue({ _id: 'drafts.article-1-de-new', _type: 'article' });
+
+    const client = {
+      fetch,
+      patch,
+      create,
+      transaction: () => ({ patch: transactionPatch, commit }),
+    } as unknown as SanityClient;
+
+    await documentLevelPatch(
+      { documentId: 'article-1' },
+      {
+        _id: 'article-1',
+        _type: 'article',
+        _rev: 'translated-rev',
+        _createdAt: '2024-01-01T00:00:00Z',
+        _updatedAt: '2024-01-01T00:00:00Z',
+        title: 'Hallo',
+      } as SanityDocument,
+      'de-DE',
+      client
+    );
+
+    // A fresh translated document replaces the dangling reference rather than
+    // the import throwing on the missing document.
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({
+      _id: 'drafts.',
+      _type: 'article',
+      language: 'de-DE',
+    });
+    expect(transactionPatch).toHaveBeenCalledWith(
+      'translation.metadata.article-1',
+      expect.any(Function)
+    );
+  });
+
+  test('throws a readable error when the source document is gone', async () => {
+    vi.spyOn(pluginConfig, 'getSourceLocale').mockReturnValue('en');
+
+    const client = {
+      fetch: vi.fn().mockResolvedValue([]),
+    } as unknown as SanityClient;
+
+    await expect(
+      documentLevelPatch(
+        { documentId: 'article-gone' },
+        {
+          _id: 'article-gone',
+          _type: 'article',
+          _rev: 'rev',
+          _createdAt: '2024-01-01T00:00:00Z',
+          _updatedAt: '2024-01-01T00:00:00Z',
+          title: 'Gone',
+        } as SanityDocument,
+        'de-DE',
+        client
+      )
+    ).rejects.toThrow(/Could not find the document to translate/);
+  });
 });

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts
@@ -4,7 +4,7 @@ import { SanityClient, SanityDocument, SanityDocumentLike } from 'sanity';
 import { BaseDocumentMerger } from '../../serialization/BaseDocumentMerger';
 
 import { findLatestDraft } from '../utils/findLatestDraft';
-import { findDocumentAtRevision } from '../utils/findDocumentAtRevision';
+import { requireSourceDocument } from '../utils/requireSourceDocument';
 import { createI18nDocAndPatchMetadata } from './helpers/createI18nDocAndPatchMetadata';
 import { getOrCreateTranslationMetadata } from './helpers/getOrCreateTranslationMetadata';
 import { patchI18nDoc } from './helpers/patchI18nDoc';
@@ -27,27 +27,21 @@ export const documentLevelPatch = async (
   mergeWithTargetLocale: boolean = false
 ): Promise<void> => {
   const baseLanguage = pluginConfig.getSourceLocale();
-  //this is the document we use to merge with the translated fields
-  let baseDoc: SanityDocument | null = null;
 
   //this is the document that will serve as the translated doc
-  let i18nDoc: SanityDocument | null = null;
+  let i18nDoc: SanityDocument | undefined;
 
   /*
    * we send over the _rev with our translation file so we can
    * accurately coalesce the translations in case something has
    * changed in the base document since translating
    */
-  if (docInfo.documentId && docInfo.versionId) {
-    baseDoc = await findDocumentAtRevision(
-      docInfo.documentId,
-      docInfo.versionId,
-      client
-    );
-  }
-  if (!baseDoc) {
-    baseDoc = await findLatestDraft(docInfo.documentId, client);
-  }
+  //this is the document we use to merge with the translated fields
+  let baseDoc = await requireSourceDocument(
+    docInfo.documentId,
+    docInfo.versionId,
+    client
+  );
 
   /* first, check our metadata to see if a translated document exists
    * if no metadata exists, we create it atomically
@@ -81,15 +75,11 @@ export const documentLevelPatch = async (
      * accurately coalesce the translations in case something has
      * changed in the base document since translating
      */
-    baseDoc = await findDocumentAtRevision(
+    baseDoc = await requireSourceDocument(
       docInfo.documentId,
       docInfo.versionId,
       client
     );
-  }
-
-  if (!baseDoc) {
-    baseDoc = await findLatestDraft(docInfo.documentId, client);
   }
   /*
    * we then merge the translation with the base document
@@ -127,8 +117,11 @@ export const documentLevelPatch = async (
       (translation) => translation.language === localeId
     )?.value?._ref;
 
-    if (freshI18nDocId) {
-      const freshI18nDoc = await findLatestDraft(freshI18nDocId, client);
+    const freshI18nDoc = freshI18nDocId
+      ? await findLatestDraft(freshI18nDocId, client)
+      : undefined;
+
+    if (freshI18nDoc) {
       await patchI18nDoc(
         docInfo.documentId,
         freshI18nDoc._id,
@@ -141,6 +134,14 @@ export const documentLevelPatch = async (
       return;
     }
 
+    /*
+     * A metadata entry for this locale can outlive the document it points at.
+     * Since the references are weak, deleting a translation leaves the entry
+     * behind.
+     *
+     * `createI18nDocAndPatchMetadata` replaces the existing entry for the
+     * locale.
+     */
     await createI18nDocAndPatchMetadata(
       baseDoc,
       merged,

--- a/packages/sanity/src/configuration/baseDocumentLevelConfig/index.ts
+++ b/packages/sanity/src/configuration/baseDocumentLevelConfig/index.ts
@@ -5,7 +5,7 @@ import {
   GTSerializedDocument,
   ImportTranslation,
 } from '../../types';
-import { findLatestDraft } from '../utils/findLatestDraft';
+import { requireLatestDraft } from '../utils/requireSourceDocument';
 import { pluginConfig } from '../../adapter/core';
 import { importDocument } from '../../translation/importDocument';
 import { serializeDocument } from '../../utils/serialize';
@@ -17,7 +17,7 @@ export const baseDocumentLevelConfig = {
   ): Promise<GTSerializedDocument> => {
     const { client, schema } = context;
     const languageField = pluginConfig.getLanguageField();
-    const doc = await findLatestDraft(docInfo.documentId, client);
+    const doc = await requireLatestDraft(docInfo.documentId, client);
     delete doc[languageField];
     const baseLanguage = pluginConfig.getSourceLocale();
     const serialized = serializeDocument(doc, schema, baseLanguage);

--- a/packages/sanity/src/configuration/baseFieldLevelConfig.ts
+++ b/packages/sanity/src/configuration/baseFieldLevelConfig.ts
@@ -9,8 +9,10 @@ import type {
   GTSerializedDocument,
   ImportTranslation,
 } from '../types';
-import { findLatestDraft } from './utils/findLatestDraft';
-import { findDocumentAtRevision } from './utils/findDocumentAtRevision';
+import {
+  requireLatestDraft,
+  requireSourceDocument,
+} from './utils/requireSourceDocument';
 import { pluginConfig } from '../adapter/core';
 import { deserializeDocument, serializeDocument } from '../utils/serialize';
 
@@ -21,17 +23,12 @@ export const fieldLevelPatch = async (
   client: SanityClient,
   mergeWithTargetLocale: boolean = false
 ): Promise<void> => {
-  let baseDoc: SanityDocument;
   const baseLanguage = pluginConfig.getSourceLocale();
-  if (docInfo.documentId && docInfo.versionId) {
-    baseDoc = await findDocumentAtRevision(
-      docInfo.documentId,
-      docInfo.versionId,
-      client
-    );
-  } else {
-    baseDoc = await findLatestDraft(docInfo.documentId, client);
-  }
+  const baseDoc = await requireSourceDocument(
+    docInfo.documentId,
+    docInfo.versionId,
+    client
+  );
 
   const merged = BaseDocumentMerger.fieldLevelMerge(
     translatedFields,
@@ -50,7 +47,7 @@ export const baseFieldLevelConfig = {
   ): Promise<GTSerializedDocument> => {
     const baseLanguage = pluginConfig.getSourceLocale();
     const { client, schema } = context;
-    const doc = await findLatestDraft(docInfo.documentId, client);
+    const doc = await requireLatestDraft(docInfo.documentId, client);
     const serialized = serializeDocument(doc, schema, baseLanguage);
     return {
       content: serialized.content,

--- a/packages/sanity/src/configuration/utils/findLatestDraft.ts
+++ b/packages/sanity/src/configuration/utils/findLatestDraft.ts
@@ -3,11 +3,14 @@
 import { SanityClient, SanityDocument } from 'sanity';
 import { getPublishedId } from '../../utils/documentIds';
 
-//use perspectives in the future
+/**
+ * Resolves the draft for a document id, falling back to the published copy.
+ * Returns `undefined` when neither exists.
+ */
 export const findLatestDraft = (
   documentId: string,
   client: SanityClient
-): Promise<SanityDocument> => {
+): Promise<SanityDocument | undefined> => {
   const publishedId = getPublishedId(documentId);
   const query = `*[_id == $id || _id == $draftId]`;
   const params = { id: publishedId, draftId: `drafts.${publishedId}` };

--- a/packages/sanity/src/configuration/utils/requireSourceDocument.ts
+++ b/packages/sanity/src/configuration/utils/requireSourceDocument.ts
@@ -1,0 +1,56 @@
+import { SanityClient, SanityDocument } from 'sanity';
+import { createDiagnosticMessage } from 'generaltranslation/internal';
+import { findLatestDraft } from './findLatestDraft';
+import { findDocumentAtRevision } from './findDocumentAtRevision';
+
+/**
+ * Resolves the document a translation is written against, preferring the
+ * revision the translation was produced from and falling back to the latest
+ * draft or published copy.
+ *
+ * Throws when nothing resolves.
+ */
+export async function requireSourceDocument(
+  documentId: string,
+  versionId: string | undefined,
+  client: SanityClient
+): Promise<SanityDocument> {
+  let doc: SanityDocument | null | undefined = null;
+
+  if (documentId && versionId) {
+    doc = await findDocumentAtRevision(documentId, versionId, client);
+  }
+  if (!doc) {
+    doc = await findLatestDraft(documentId, client);
+  }
+  if (!doc) {
+    throw new Error(missingDocumentDiagnostic(documentId));
+  }
+
+  return doc;
+}
+
+/**
+ * Resolves a document that must already exist, without the revision lookup.
+ */
+export async function requireLatestDraft(
+  documentId: string,
+  client: SanityClient
+): Promise<SanityDocument> {
+  const doc = await findLatestDraft(documentId, client);
+  if (!doc) {
+    throw new Error(missingDocumentDiagnostic(documentId));
+  }
+  return doc;
+}
+
+function missingDocumentDiagnostic(documentId: string): string {
+  return createDiagnosticMessage({
+    source: 'gt-sanity',
+    severity: 'Error',
+    whatHappened: 'Could not find the document to translate',
+    why: 'no draft or published version of it exists in this dataset',
+    fix: 'Check that the document was not deleted, and that the Studio is pointed at the dataset that holds it',
+    details: [`Document ID: ${documentId}`],
+  });
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR improves missing-document handling in the Sanity integration and accurately types document lookup failures.
- Recreates a translated draft when translation metadata contains a dangling weak reference.
- Adds shared helpers that provide readable diagnostics when source documents no longer exist.
- Updates document lookup typing and adds focused tests for deleted translations and sources.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with deleted-document paths now producing recovery behavior or an actionable diagnostic.

The changed lookup and import paths preserve draft-first behavior, prevent undefined documents from reaching mergers, and correctly replace dangling locale metadata references without introducing an established failure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.ts | Safely gates patching on a resolved translated document and otherwise creates a replacement draft for dangling metadata. |
| packages/sanity/src/configuration/utils/requireSourceDocument.ts | Centralizes revision fallback and missing-document diagnostics while guaranteeing callers receive a document. |
| packages/sanity/src/configuration/utils/findLatestDraft.ts | Corrects the return type to represent an empty lookup without changing draft-preference behavior. |
| packages/sanity/src/configuration/baseFieldLevelConfig.ts | Adopts guarded source-document lookup for field-level imports and exports. |
| packages/sanity/src/configuration/baseDocumentLevelConfig/documentLevelPatch.test.ts | Adds focused coverage for dangling translated-document references and deleted source documents. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Import translated content] --> B[Require source document]
  B -->|Missing| C[Throw readable diagnostic]
  B -->|Found| D[Read translation metadata]
  D --> E{Locale reference resolves?}
  E -->|Yes| F[Patch existing translated draft]
  E -->|No or dangling| G[Create fresh translated draft]
  G --> H[Replace locale metadata reference]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(gt-sanity): handle deleted content m..."](https://github.com/generaltranslation/gt/commit/f23664a7b290b3756fe9ced751969096f35e6940) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60074574)</sub>

**Context used:**

- Knowledge Base — [Translation operations and developer tools](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-operations.md)

<!-- /greptile_comment -->