### PR TITLE
fix(core): use unified API domain

### DIFF
--- a/.changeset/bright-apis-unify.md
+++ b/.changeset/bright-apis-unify.md
@@ -1,0 +1,5 @@
+---
+'generaltranslation': patch
+---
+
+Send default API and runtime translation requests to `https://api.gtx.dev` while preserving their existing paths and custom URL overrides.

--- a/packages/core/src/projects/__tests__/getProjectData.test.ts
+++ b/packages/core/src/projects/__tests__/getProjectData.test.ts
@@ -107,7 +107,7 @@ describe.sequential('_getProjectData', () => {
 
     expect(fetchWithTimeout).toHaveBeenCalledWith(
       expect.stringContaining(
-        'https://api2.gtx.dev/v2/project/info/test-project-123'
+        'https://api.gtx.dev/v2/project/info/test-project-123'
       ),
       expect.any(Object),
       expect.any(Number)

--- a/packages/core/src/settings/settingsUrls.ts
+++ b/packages/core/src/settings/settingsUrls.ts
@@ -1,3 +1,3 @@
 export const defaultCacheUrl = 'https://cdn.gtx.dev' as const;
-export const defaultBaseUrl = 'https://api2.gtx.dev' as const;
-export const defaultRuntimeApiUrl = 'https://runtime2.gtx.dev' as const;
+export const defaultBaseUrl = 'https://api.gtx.dev' as const;
+export const defaultRuntimeApiUrl = 'https://api.gtx.dev' as const;

--- a/scripts/check-library-defaults.mjs
+++ b/scripts/check-library-defaults.mjs
@@ -126,12 +126,27 @@ export const defaultGroups = [
   {
     name: 'defaultBaseUrl',
     declarations: ['packages/core/src/settings/settingsUrls.ts'],
-    exceptions: [],
+    exceptions: [
+      {
+        path: 'packages/core/src/settings/settingsUrls.ts',
+        reason:
+          'The runtime API intentionally uses the same unified API origin.',
+        matches: isWithinVariableDeclaration('defaultRuntimeApiUrl'),
+        expectedMatches: 1,
+      },
+    ],
   },
   {
     name: 'defaultRuntimeApiUrl',
     declarations: ['packages/core/src/settings/settingsUrls.ts'],
-    exceptions: [],
+    exceptions: [
+      {
+        path: 'packages/core/src/settings/settingsUrls.ts',
+        reason: 'The primary API intentionally uses the same unified origin.',
+        matches: isWithinVariableDeclaration('defaultBaseUrl'),
+        expectedMatches: 1,
+      },
+    ],
   },
   {
     name: 'defaultLocaleCookieName',


### PR DESCRIPTION
## Summary

- point both the default API origin and the default runtime translation origin at `https://api.gtx.dev`
- preserve every existing request path, the CDN origin, and custom URL overrides
- allow the canonical-defaults check to recognize that the two distinct endpoint defaults intentionally share one origin

## Testing

- `pnpm build` — passed (24 packages)
- `pnpm --filter generaltranslation test` — passed (31 files, 508 tests)
- `pnpm check:library-defaults` — passed (13 defaults across 973 production source files; 4 guard tests)
- `pnpm lint` — passed (existing warnings only)
- compared the complete `gt` OpenAPI method/path set with the app-generated `gt-cloud` contract at `3e5ae8191e8a3990d2c8eddfa8ea692741c90578` — all 26 client operations match; cloud has one additional API-key route

## Notes

- includes a patch changeset for `generaltranslation`
- `cdn.gtx.dev` is unchanged


<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR unifies the core API and runtime translation defaults on `https://api.gtx.dev` while retaining the CDN origin, request paths, and custom overrides.
- Updates both core service-origin constants.
- Adjusts the project-data URL assertion.
- Allows the canonical-default checker to recognize the intentionally shared origin.
- Adds a patch changeset for `generaltranslation`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issue identified.

The unified host is consistent with the repository’s canonical API contract, custom URL overrides remain intact, and the defaults checker narrowly permits only the intended shared declaration values.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/core/src/settings/settingsUrls.ts | Replaces the two legacy service origins with the canonical unified API origin while leaving the CDN default unchanged. |
| scripts/check-library-defaults.mjs | Adds narrowly scoped, count-checked reciprocal exceptions for the two defaults that now intentionally share a literal. |
| packages/core/src/projects/__tests__/getProjectData.test.ts | Updates the project-information request assertion to expect the unified API origin. |
| .changeset/bright-apis-unify.md | Correctly records the externally visible default-origin change as a patch release for the owning package. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(core): use unified API domain"](https://github.com/generaltranslation/gt/commit/0e5d7e0efd48f98659a8229f7e48273070981f5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60226756)</sub>

<!-- /greptile_comment -->