### PR TITLE
ci: require admin authorization for releases

### DIFF
--- a/.github/workflows/release-authorization.yml
+++ b/.github/workflows/release-authorization.yml
@@ -1,0 +1,96 @@
+name: Release Authorization
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-authorization-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  release-authorization:
+    name: release-authorization
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check for current admin approval
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              core.setFailed('This workflow requires a pull request event.');
+              return;
+            }
+
+            const repository = `${context.repo.owner}/${context.repo.repo}`;
+            const isReleasePullRequest =
+              pullRequest.head.repo?.full_name === repository &&
+              pullRequest.head.ref.startsWith('changeset-release/');
+
+            if (!isReleasePullRequest) {
+              core.info('This pull request does not require release authorization.');
+              return;
+            }
+
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              ...context.repo,
+              pull_number: pullRequest.number,
+              per_page: 100,
+            });
+            const latestDecisiveReviewByUser = new Map();
+
+            for (const review of reviews) {
+              const login = review.user?.login;
+              if (
+                login &&
+                ['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)
+              ) {
+                latestDecisiveReviewByUser.set(login, review);
+              }
+            }
+
+            const currentApprovals = [...latestDecisiveReviewByUser.values()].filter(
+              (review) =>
+                review.state === 'APPROVED' &&
+                review.commit_id === pullRequest.head.sha
+            );
+            const adminApprovers = [];
+
+            for (const review of currentApprovals) {
+              let permission;
+              try {
+                const response =
+                  await github.rest.repos.getCollaboratorPermissionLevel({
+                    ...context.repo,
+                    username: review.user.login,
+                  });
+                permission = response.data.permission;
+              } catch (error) {
+                if (error.status === 404) {
+                  core.info(`${review.user.login} is not a repository collaborator.`);
+                  continue;
+                }
+                throw error;
+              }
+
+              if (permission === 'admin') {
+                adminApprovers.push(review.user.login);
+              }
+            }
+
+            if (adminApprovers.length === 0) {
+              core.setFailed(
+                'A repository admin must approve the current release commit.'
+              );
+              return;
+            }
+
+            core.info(`Release authorized by: ${adminApprovers.join(', ')}`);


### PR DESCRIPTION
Release PRs must pass the normal required CI checks and receive approval from a repository admin before merging. Add a lightweight `release-authorization` check that requires an admin's approval of the current commit for same-repository `changeset-release/*` PRs. Ordinary PRs pass this additional check immediately.

Authorization is reevaluated when the branch changes or reviews are submitted, edited, or dismissed. A maintainer can merge once CI passes and an admin approves. The workflow uses read-only permissions and does not check out PR code.

Validation: workflow formatting and actionlint previously passed, along with six authorization cases covering missing, maintainer, stale, current, withdrawn, and comment-followed approvals. The authorization workflow is unchanged by the parent update that restores normal release CI.

Stacked on #2236 and should merge after it. Once the workflow is available on `main`, add `release-authorization` to its required status checks while retaining existing required CI checks. Existing PRs may need a new workflow-triggering event to report the check. No changeset is needed for repository automation.
