### PR TITLE
fix(next): [6/7] support catch-all middleware paths

### DIFF
--- a/.changeset/index-middleware-paths.md
+++ b/.changeset/index-middleware-paths.md
@@ -1,0 +1,9 @@
+---
+'gt-next': patch
+---
+
+Support catch-all middleware paths and index dynamic route matching by segment.
+
+Keep locale prefixes out of shared route parameters, preserve static route precedence across localized and shared paths, and support dotted parameter names.
+
+Preserve the source route when switching from a locale alias and remove the target default-locale prefix correctly.

--- a/.changeset/index-middleware-paths.md
+++ b/.changeset/index-middleware-paths.md
@@ -7,3 +7,5 @@ Support catch-all middleware paths and index dynamic route matching by segment.
 Keep locale prefixes out of shared route parameters, preserve static route precedence across localized and shared paths, and support dotted parameter names.
 
 Preserve the source route when switching from a locale alias and remove the target default-locale prefix correctly.
+
+Resolve bare locale roots such as `/fr` to configured homepage aliases while preserving the request's trailing-slash style.

--- a/packages/next/src/middleware-dir/__tests__/catchallTrailingSlashRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/catchallTrailingSlashRegression.edge.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { defaultLocaleHeaderName } from '../../utils/headers';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+const origin = 'http://localhost:3000';
+const query = '?tag=a&tag=b&raw=%2F%252F';
+
+describe.each(['[...slug]', '[[...slug]]'])(
+  'catchall trailing delimiter, %s',
+  (segment) => {
+    it.each(['', 'one', 'one/two', 'a%2Fb/a%252Fb'])(
+      'routes %s without redirecting to a double trailing slash',
+      (tail) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: true,
+          pathConfig: {
+            [`/catalog/[category]/${segment}/`]: {
+              en: `/catalog/[category]/${segment}/`,
+              fr: `/catalogue/[category]/${segment}/`,
+            },
+          },
+        });
+        for (const slash of ['', '/']) {
+          const suffix = `/science${tail ? '/' + tail : ''}${slash}`;
+          const sharedUrl = origin + '/fr/catalog' + suffix + query;
+          const localizedUrl = origin + '/fr/catalogue' + suffix + query;
+          const localized = middleware(new NextRequest(localizedUrl));
+          const shared = middleware(new NextRequest(sharedUrl));
+          if (!tail && segment === '[...slug]') {
+            for (const response of [localized, shared]) {
+              expect(response.headers.get('location')).toBeNull();
+              expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+              expect(response.headers.get('x-middleware-next')).toBe('1');
+            }
+            continue;
+          }
+          expect(localized.headers.get(defaultLocaleHeaderName)).toBe('fr');
+          expect(localized.headers.get('location')).toBeNull();
+          expect(localized.headers.get('x-middleware-rewrite')).toBe(sharedUrl);
+          expect(shared.headers.get('location')).toBe(localizedUrl);
+          const followed = middleware(
+            new NextRequest(shared.headers.get('location')!)
+          );
+          expect(followed.headers.get('location')).toBeNull();
+          expect(followed.headers.get('x-middleware-rewrite')).toBe(sharedUrl);
+        }
+      }
+    );
+  }
+);
+
+it('preserves singular parameters beside configured trailing slashes', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: true,
+    pathConfig: {
+      '/catalog/[category]/[id]/': {
+        fr: '/catalogue/[category]/[id]/',
+      },
+    },
+  });
+  const response = middleware(
+    new NextRequest(origin + '/fr/catalogue/science/a%2Fb/' + query)
+  );
+  expect(response.headers.get('location')).toBeNull();
+  expect(response.headers.get('x-middleware-rewrite')).toBe(
+    origin + '/fr/catalog/science/a%2Fb/' + query
+  );
+});

--- a/packages/next/src/middleware-dir/__tests__/defaultRootAliasRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/defaultRootAliasRegression.edge.test.ts
@@ -3,7 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
 import { defaultLocaleHeaderName } from '../../utils/headers';
 import { createNextMiddleware } from '../createNextMiddleware';
-import type { PathConfig } from '../utils';
+import {
+  createPathMatcher,
+  createPathToSharedPathMap,
+  getSharedPath,
+  type PathConfig,
+} from '../utils';
 
 beforeEach(() => {
   vi.stubEnv(
@@ -18,24 +23,58 @@ afterEach(() => vi.unstubAllEnvs());
 
 const origin = 'http://localhost:3000';
 const query = '?tag=a&tag=b&raw=%2F%252F';
-const configurations: { name: string; pathConfig: PathConfig }[] = [
+const configurations: {
+  name: string;
+  pathConfig: PathConfig;
+  localizedRoot: string;
+}[] = [
   {
     name: 'French-only homepage alias',
     pathConfig: { '/': { fr: '/accueil' } },
+    localizedRoot: '/accueil',
   },
   {
     name: 'explicit default homepage alias',
     pathConfig: { '/': { en: '/', fr: '/accueil' } },
+    localizedRoot: '/accueil',
   },
   {
     name: 'empty optional root catchall',
     pathConfig: {
       '/[[...slug]]': { en: '/[[...slug]]', fr: '/pages/[[...slug]]' },
     },
+    localizedRoot: '/pages',
   },
 ];
 
-describe.each(configurations)('$name', ({ pathConfig }) => {
+describe.each(configurations)('$name', ({ pathConfig, localizedRoot }) => {
+  describe.each([false, true])(
+    'prefixDefaultLocale=%s',
+    (prefixDefaultLocale) => {
+      it.each(['', '/'])(
+        'redirects the locale root to its alias with slash "%s"',
+        (slash) => {
+          const middleware = createNextMiddleware({
+            prefixDefaultLocale,
+            pathConfig,
+          });
+          const response = middleware(
+            new NextRequest(origin + '/fr' + slash + query)
+          );
+          const destination = origin + '/fr' + localizedRoot + slash + query;
+
+          expect(response.status).toBe(307);
+          expect(response.headers.get('location')).toBe(destination);
+          const followed = middleware(new NextRequest(destination));
+          expect(followed.headers.get('location')).toBeNull();
+          expect(followed.headers.get('x-middleware-rewrite')).toBe(
+            origin + '/fr' + slash + query
+          );
+        }
+      );
+    }
+  );
+
   it('rewrites the unprefixed homepage without redirecting to itself', () => {
     const middleware = createNextMiddleware({
       prefixDefaultLocale: false,
@@ -54,15 +93,49 @@ describe.each(configurations)('$name', ({ pathConfig }) => {
     expect(response.headers.get(defaultLocaleHeaderName)).toBe('en');
   });
 
-  it('keeps the explicitly prefixed homepage as a terminating control', () => {
-    const middleware = createNextMiddleware({
-      prefixDefaultLocale: true,
-      pathConfig,
-    });
-    const response = middleware(new NextRequest(origin + '/en/' + query));
+  it.each(['', '/'])(
+    'keeps the prefixed homepage with slash "%s" as a terminating control',
+    (slash) => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig,
+      });
+      const response = middleware(
+        new NextRequest(origin + '/en' + slash + query)
+      );
 
-    expect(response.headers.get('location')).toBeNull();
-    expect(response.headers.get('x-middleware-next')).toBe('1');
-    expect(response.headers.get(defaultLocaleHeaderName)).toBe('en');
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-next')).toBe('1');
+      expect(response.headers.get(defaultLocaleHeaderName)).toBe('en');
+    }
+  );
+});
+
+describe('bare locale root lookup', () => {
+  it.each([false, true])(
+    'matches the shared root with localizedRoot=%s',
+    (localized) => {
+      const matcher = localized
+        ? createPathToSharedPathMap({ '/': { fr: '/accueil' } }, false, 'en')
+            .pathToSharedPath
+        : createPathMatcher([['/', '/']]);
+
+      expect(getSharedPath('/fr', matcher, 'fr')).toEqual({
+        sharedPath: '/',
+        pathTemplate: '/',
+        matchedPathname: '/',
+      });
+      expect(getSharedPath('', matcher, undefined)).toBeUndefined();
+    }
+  );
+
+  it('prefers the static root over an optional catch-all', () => {
+    const matcher = createPathToSharedPathMap(
+      { '/': { fr: '/accueil' }, '/[[...slug]]': { fr: '/pages/[[...slug]]' } },
+      false,
+      'en'
+    ).pathToSharedPath;
+
+    expect(getSharedPath('/fr', matcher, 'fr')?.sharedPath).toBe('/');
   });
 });

--- a/packages/next/src/middleware-dir/__tests__/defaultRootAliasRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/defaultRootAliasRegression.edge.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { defaultLocaleHeaderName } from '../../utils/headers';
+import { createNextMiddleware } from '../createNextMiddleware';
+import type { PathConfig } from '../utils';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+const origin = 'http://localhost:3000';
+const query = '?tag=a&tag=b&raw=%2F%252F';
+const configurations: { name: string; pathConfig: PathConfig }[] = [
+  {
+    name: 'French-only homepage alias',
+    pathConfig: { '/': { fr: '/accueil' } },
+  },
+  {
+    name: 'explicit default homepage alias',
+    pathConfig: { '/': { en: '/', fr: '/accueil' } },
+  },
+  {
+    name: 'empty optional root catchall',
+    pathConfig: {
+      '/[[...slug]]': { en: '/[[...slug]]', fr: '/pages/[[...slug]]' },
+    },
+  },
+];
+
+describe.each(configurations)('$name', ({ pathConfig }) => {
+  it('rewrites the unprefixed homepage without redirecting to itself', () => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: false,
+      pathConfig,
+    });
+    const response = middleware(new NextRequest(origin + '/' + query));
+
+    expect(response.headers.get('location')).toBeNull();
+    const rewrite = response.headers.get('x-middleware-rewrite');
+    expect(rewrite).not.toBeNull();
+    const destination = new URL(rewrite!);
+    // Either internal root slash style is valid; the public URL must terminate.
+    expect(destination.pathname.replace(/\/$/, '')).toBe('/en');
+    expect(destination.origin).toBe(origin);
+    expect(destination.search).toBe(query);
+    expect(response.headers.get(defaultLocaleHeaderName)).toBe('en');
+  });
+
+  it('keeps the explicitly prefixed homepage as a terminating control', () => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: true,
+      pathConfig,
+    });
+    const response = middleware(new NextRequest(origin + '/en/' + query));
+
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('x-middleware-next')).toBe('1');
+    expect(response.headers.get(defaultLocaleHeaderName)).toBe('en');
+  });
+});

--- a/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/localeResolution.edge.test.ts
@@ -2,7 +2,11 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { NextRequest } from 'next/server';
 import { GT } from 'generaltranslation';
-import { getLocaleFromRequest } from '../utils';
+import {
+  createPathMatcher,
+  getLocaleFromRequest,
+  type PathMatcher,
+} from '../utils';
 
 // ---- Cookie Constants ----
 const LOCALE_COOKIE = 'generaltranslation.locale';
@@ -45,7 +49,7 @@ function callGetLocaleFromRequest(
     localeRouting?: boolean;
     gtServicesEnabled?: boolean;
     prefixDefaultLocale?: boolean;
-    defaultLocalePaths?: string[];
+    defaultLocalePaths?: PathMatcher;
   } = {}
 ) {
   const gt = new GT();
@@ -56,7 +60,7 @@ function callGetLocaleFromRequest(
     overrides.localeRouting ?? true,
     overrides.gtServicesEnabled ?? false,
     overrides.prefixDefaultLocale ?? false,
-    overrides.defaultLocalePaths ?? [],
+    overrides.defaultLocalePaths ?? createPathMatcher([]),
     REFERRER_COOKIE,
     LOCALE_COOKIE,
     RESET_COOKIE,
@@ -202,7 +206,7 @@ describe('Locale Resolution (Category 1)', () => {
     const req = createRequest('/about-us');
     const result = callGetLocaleFromRequest(req, {
       prefixDefaultLocale: false,
-      defaultLocalePaths: ['/about-us'],
+      defaultLocalePaths: createPathMatcher([['/about-us', '/about']]),
     });
 
     expect(result.userLocale).toBe('en');

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -200,6 +200,114 @@ describe('Middleware Integration Tests', () => {
       expect(res.headers.get(LOCALE_HEADER)).toBe('en');
     });
 
+    it('supports catch-all and optional catch-all pathConfig routes', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/docs/[...slug]': { fr: '/knowledge/base/[...slug]' },
+          '/news/[[...slug]]': {
+            fr: '/international/actualites/[[...slug]]',
+          },
+        },
+      });
+
+      const catchAllResponse = middleware(
+        createRequest('/fr/knowledge/base/guides/start')
+      );
+      const catchAllRedirect = middleware(
+        createRequest('/fr/docs/guides/start')
+      );
+      const optionalRootResponse = middleware(
+        createRequest('/fr/international/actualites')
+      );
+      const optionalNestedResponse = middleware(
+        createRequest('/fr/international/actualites/world/latest')
+      );
+
+      expect(getResponseType(catchAllResponse)).toBe('rewrite');
+      expect(getResponsePath(catchAllResponse)).toBe('/fr/docs/guides/start');
+      expect(getResponseType(catchAllRedirect)).toBe('redirect');
+      expect(getResponsePath(catchAllRedirect)).toBe(
+        '/fr/knowledge/base/guides/start'
+      );
+      expect(getResponseType(optionalRootResponse)).toBe('rewrite');
+      expect(getResponsePath(optionalRootResponse)).toBe('/fr/news');
+      expect(getResponseType(optionalNestedResponse)).toBe('rewrite');
+      expect(getResponsePath(optionalNestedResponse)).toBe(
+        '/fr/news/world/latest'
+      );
+    });
+
+    it('treats regex metacharacters in dynamic paths literally', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/releases/v1.0/[slug]': {
+            fr: '/versions/v1.0/[slug]',
+          },
+          '/language/c++/[slug]': {
+            fr: '/langage/c++/[slug]',
+          },
+        },
+      });
+
+      const dotResponse = middleware(createRequest('/fr/versions/v1.0/notes'));
+      const falsePositiveResponse = middleware(
+        createRequest('/fr/versions/v1x0/notes')
+      );
+      const plusResponse = middleware(
+        createRequest('/fr/langage/c++/templates')
+      );
+
+      expect(getResponseType(dotResponse)).toBe('rewrite');
+      expect(getResponsePath(dotResponse)).toBe('/fr/releases/v1.0/notes');
+      expect(getResponseType(falsePositiveResponse)).toBe('next');
+      expect(getResponseType(plusResponse)).toBe('rewrite');
+      expect(getResponsePath(plusResponse)).toBe('/fr/language/c++/templates');
+    });
+
+    it('matches encoded requests against Unicode pathConfig entries', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/café/[slug]': {
+            fr: '/café-français/[slug]',
+          },
+        },
+      });
+
+      const res = middleware(
+        createRequest('/fr/caf%C3%A9-fran%C3%A7ais/article')
+      );
+
+      expect(getResponseType(res)).toBe('rewrite');
+      expect(getResponsePath(res)).toBe('/fr/caf%C3%A9/article');
+    });
+
+    it('preserves trailing slashes while rewriting pathConfig routes', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/about': { fr: '/a-propos' },
+          '/docs/[...slug]': { fr: '/documentation/[...slug]' },
+        },
+      });
+
+      const staticResponse = middleware(createRequest('/fr/a-propos/'));
+      const catchAllResponse = middleware(
+        createRequest('/fr/documentation/guides/start/')
+      );
+
+      expect(getResponseType(staticResponse)).toBe('rewrite');
+      expect(getResponsePath(staticResponse)).toBe('/fr/about/');
+      expect(getResponseType(catchAllResponse)).toBe('rewrite');
+      expect(getResponsePath(catchAllResponse)).toBe('/fr/docs/guides/start/');
+    });
+
     it('2.6: localeRouting=false → next()', () => {
       setEnvConfig();
       const middleware = createNextMiddleware({

--- a/packages/next/src/middleware-dir/__tests__/routingRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/routingRegression.edge.test.ts
@@ -1,0 +1,231 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+import { createPathToSharedPathMap, getSharedPath } from '../utils';
+import { getDynamicSegmentType } from '../createPathMatcher';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr', 'de', 'pt-BR'],
+    })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+function request(path: string) {
+  return new NextRequest(new URL(path, 'http://localhost:3000'));
+}
+
+describe.each([false, true])(
+  'root routes with prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    for (const template of [
+      '/[slug]',
+      '/[section]/[slug]',
+      '/[...slug]',
+      '/[[...slug]]',
+    ]) {
+      const suffix =
+        template === '/[section]/[slug]' ? '/about/team' : '/about';
+      it.each(['en', 'fr', 'de', 'pt-BR'])(
+        `excludes %s from shared ${template} parameters`,
+        (locale) => {
+          const middleware = createNextMiddleware({
+            prefixDefaultLocale,
+            pathConfig: { [template]: { en: template } },
+          });
+          const pathname =
+            !prefixDefaultLocale && locale === 'en'
+              ? suffix
+              : `/${locale}${suffix}`;
+          const res = middleware(request(pathname + '?tag=one&tag=two'));
+          expect(res.headers.get('location')).toBeNull();
+          expect(res.headers.get('x-generaltranslation-locale')).toBe(locale);
+          const rewrite = res.headers.get('x-middleware-rewrite');
+          if (rewrite)
+            expect(new URL(rewrite).pathname).toBe(`/${locale}${suffix}`);
+          expect(res.status).toBe(200);
+        }
+      );
+    }
+
+    it.each(['/[...slug]', '/[[...slug]]'])(
+      'terminates redirect chains for %s',
+      (template) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: { [template]: { en: template } },
+        });
+        let path = '/fr/about';
+        const visited = new Set<string>();
+        for (let hop = 0; hop < 4; hop++) {
+          expect(visited.has(path)).toBe(false);
+          visited.add(path);
+          const response = middleware(request(path));
+          const location = response.headers.get('location');
+          if (!location) {
+            expect(path).toBe('/fr/about');
+            return;
+          }
+          expect(new URL(location).origin).toBe('http://localhost:3000');
+          path = new URL(location).pathname;
+        }
+        expect.fail('The redirect chain did not terminate within four hops');
+      }
+    );
+  }
+);
+
+describe('localized and shared route specificity', () => {
+  it.each(['/[section]/[slug]', '/[...slug]', '/[[...slug]]'])(
+    'prefers shared /about over %s even without a French alias',
+    (template) => {
+      const config = {
+        [template]: { en: template },
+        '/about': { en: '/about' },
+      };
+      const matcher = createPathToSharedPathMap(
+        config,
+        true,
+        'en'
+      ).pathToSharedPath;
+      expect(getSharedPath('/fr/about', matcher, 'fr')).toMatchObject({
+        sharedPath: '/about',
+        matchedPathname: '/about',
+      });
+      expect(
+        createNextMiddleware({ pathConfig: config, prefixDefaultLocale: true })(
+          request('/fr/about')
+        ).headers.get('location')
+      ).toBeNull();
+    }
+  );
+  it('does not let a localized root catch-all hide a shared static route', () => {
+    const config = {
+      '/cms/[...slug]': { fr: '/[...slug]' },
+      '/about': { en: '/about' },
+    };
+    const matcher = createPathToSharedPathMap(
+      config,
+      true,
+      'en'
+    ).pathToSharedPath;
+    expect(getSharedPath('/fr/about', matcher, 'fr')?.sharedPath).toBe(
+      '/about'
+    );
+  });
+  it('prefers an explicit localized path when specificity ties', () => {
+    const config = {
+      '/a/[id]': { fr: '/b/[id]' },
+      '/b/[id]': { en: '/b/[id]' },
+    };
+    const matcher = createPathToSharedPathMap(
+      config,
+      true,
+      'en'
+    ).pathToSharedPath;
+    expect(getSharedPath('/fr/b/123', matcher, 'fr')).toMatchObject({
+      sharedPath: '/a/[id]',
+      matchedPathname: '/fr/b/123',
+    });
+  });
+  it('does not add a trailing slash to an unconfigured locale landing page', () => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: true,
+      pathConfig: { '/': { en: '/' } },
+    });
+    expect(middleware(request('/fr')).headers.get('location')).toBeNull();
+  });
+});
+
+describe('Next.js parameter names', () => {
+  it.each(['post.id', 'post[id', 'post..id', '章.節'])(
+    'supports catch-all parameter name %s',
+    (name) => {
+      for (const optional of [false, true]) {
+        const segment = optional ? `[[...${name}]]` : `[...${name}]`;
+        expect(getDynamicSegmentType(segment)).toBe(
+          optional ? 'optional-catch-all' : 'catch-all'
+        );
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: true,
+          pathConfig: { [`/posts/${segment}`]: { fr: `/articles/${segment}` } },
+        });
+        for (const tail of ['one', 'one/two/three']) {
+          const response = middleware(request('/fr/articles/' + tail));
+          expect(response.headers.get('location')).toBeNull();
+          expect(response.headers.get('x-middleware-rewrite')).toBe(
+            'http://localhost:3000/fr/posts/' + tail
+          );
+        }
+      }
+    }
+  );
+  it.each(['post.id', 'post..id', 'post.', 'post[id', 'a-b', 'a_b', '章.節'])(
+    'recognizes and rewrites [%s]',
+    (name) => {
+      expect(getDynamicSegmentType(`[${name}]`)).toBe('dynamic');
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: { [`/posts/[${name}]`]: { fr: `/articles/[${name}]` } },
+      });
+      const res = middleware(request('/fr/articles/123'));
+      expect(res.headers.get('location')).toBeNull();
+      expect(res.headers.get('x-middleware-rewrite')).toBe(
+        'http://localhost:3000/fr/posts/123'
+      );
+    }
+  );
+  it.each(['[.id]', '[..id]', '[[id]]', '[]', '[id/slug]'])(
+    'does not classify invalid ordinary segment %s as dynamic',
+    (segment) => {
+      expect(getDynamicSegmentType(segment)).not.toBe('dynamic');
+    }
+  );
+});
+
+describe('locale switching from a standardized alias', () => {
+  it.each([
+    [true, 'fr', '/fr/a-propos'],
+    [false, 'fr', '/fr/a-propos'],
+    [true, 'en', '/en/about-us'],
+    [false, 'en', '/about-us'],
+  ] as const)(
+    'prefix=%s, target=%s keeps the original shared route',
+    (prefixDefaultLocale, target, expected) => {
+      vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'true');
+      vi.stubEnv(
+        '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+        JSON.stringify({
+          defaultLocale: 'en',
+          locales: ['en', 'fr', 'fil'],
+        })
+      );
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: {
+          '/about': { en: '/about-us', fr: '/a-propos', fil: '/tungkol' },
+        },
+      });
+      const req = request('/tl/tungkol?tag=one&tag=two');
+      req.cookies.set('generaltranslation.locale', target);
+      req.cookies.set('generaltranslation.locale-reset', 'true');
+      const response = middleware(req);
+      expect(response.headers.get('location')).toBe(
+        'http://localhost:3000' + expected + '?tag=one&tag=two'
+      );
+      const next = middleware(request(expected));
+      expect(next.headers.get('location')).toBeNull();
+      expect(next.headers.get('x-middleware-rewrite')).toBe(
+        'http://localhost:3000/' + target + '/about'
+      );
+    }
+  );
+});

--- a/packages/next/src/middleware-dir/__tests__/sameOriginRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/sameOriginRegression.edge.test.ts
@@ -1,0 +1,70 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+import { getResponse } from '../utils';
+
+const origin = 'https://app.example';
+const query = '?tag=a&tag=b&raw=%2F';
+
+describe.each(['redirect', 'rewrite'] as const)('%s destinations', (type) => {
+  describe.each(['', '/corp'])('basePath="%s"', (basePath) => {
+    it.each(['//evil.example/x', '/\\evil.example/x'])(
+      'keeps %s on the request origin',
+      (responsePath) => {
+        const request = new NextRequest(origin + basePath + '/source' + query, {
+          nextConfig: { basePath },
+        });
+        const response = getResponse({
+          type,
+          originalUrl: request.nextUrl,
+          responsePath,
+          userLocale: 'en',
+          clearResetCookie: false,
+          headerList: new Headers(),
+          localeRouting: true,
+          localeRoutingEnabledCookieName: 'locale-routing',
+          resetLocaleCookieName: 'reset-locale',
+          localeHeaderName: 'x-locale',
+        });
+
+        expect(response.status).toBe(type === 'redirect' ? 307 : 200);
+        expect(
+          response.headers.get(
+            type === 'redirect' ? 'location' : 'x-middleware-rewrite'
+          )
+        ).toBe(origin + basePath + '//evil.example/x' + query);
+      }
+    );
+  });
+});
+
+describe('catch-all alias redirects', () => {
+  beforeEach(() => {
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+    );
+    vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+    vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+    vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it.each(['/docs//evil.example/x', '/docs/\\evil.example/x'])(
+    'keeps the redirect for %s on the request origin without cookies',
+    (pathname) => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: false,
+        pathConfig: { '/docs/[...slug]': { en: '/[...slug]' } },
+      });
+      const response = middleware(new NextRequest(origin + pathname + query));
+
+      expect(response.status).toBe(307);
+      expect(response.headers.get('location')).toBe(
+        origin + '//evil.example/x' + query
+      );
+    }
+  );
+});

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -4,10 +4,15 @@ import {
   extractDynamicParams,
   replaceDynamicSegments,
   getLocalizedPath,
+  createPathMatcher,
   createPathToSharedPathMap,
-  getSharedPath,
+  getSharedPath as matchSharedPath,
   type PathConfig,
 } from '../utils';
+
+function getSharedPath(...args: Parameters<typeof matchSharedPath>) {
+  return matchSharedPath(...args)?.sharedPath;
+}
 
 describe('extractLocale', () => {
   it('should extract locale from various pathname formats', () => {
@@ -95,6 +100,16 @@ describe('extractDynamicParams', () => {
     expect(extractDynamicParams('/[param]', '/')).toEqual(['']);
     expect(extractDynamicParams('/static', '/different')).toEqual([]);
   });
+
+  it('should extract catch-all parameters', () => {
+    expect(extractDynamicParams('/docs/[...slug]', '/docs/api/auth')).toEqual([
+      'api/auth',
+    ]);
+    expect(
+      extractDynamicParams('/posts/[[...slug]]', '/posts/2023/article')
+    ).toEqual(['2023/article']);
+    expect(extractDynamicParams('/posts/[[...slug]]', '/posts')).toEqual(['']);
+  });
 });
 
 describe('replaceDynamicSegments', () => {
@@ -126,6 +141,14 @@ describe('replaceDynamicSegments', () => {
     ).toBe('/api/users/123/settings');
   });
 
+  it('should preserve the request trailing-slash style', () => {
+    expect(replaceDynamicSegments('/blog/123/', '/articles/[id]')).toBe(
+      '/articles/123/'
+    );
+    expect(replaceDynamicSegments('/about/', '/company')).toBe('/company/');
+    expect(replaceDynamicSegments('/about', '/company/')).toBe('/company');
+  });
+
   it('should return template path when no dynamic segments', () => {
     expect(replaceDynamicSegments('/blog/123', '/about')).toBe('/about');
     expect(replaceDynamicSegments('/any/path', '/static/path')).toBe(
@@ -140,16 +163,26 @@ describe('replaceDynamicSegments', () => {
     expect(replaceDynamicSegments('/one', '/[a]/[b]/[c]')).toBe('/one/[b]/[c]');
   });
 
-  it('should handle various dynamic segment formats', () => {
+  it('should handle catch-all segment formats', () => {
     expect(
       replaceDynamicSegments('/category/tech', '/category/[category]')
     ).toBe('/category/tech');
     expect(replaceDynamicSegments('/docs/api/auth', '/docs/[...slug]')).toBe(
-      '/docs/api'
+      '/docs/api/auth'
     );
     expect(
       replaceDynamicSegments('/posts/2023/article', '/posts/[[...slug]]')
-    ).toBe('/posts/2023]');
+    ).toBe('/posts/2023/article');
+    expect(replaceDynamicSegments('/posts', '/posts/[[...slug]]')).toBe(
+      '/posts'
+    );
+    expect(
+      replaceDynamicSegments(
+        '/fr/knowledge/base/api/auth',
+        '/fr/docs/[...slug]',
+        '/fr/knowledge/base/[...slug]'
+      )
+    ).toBe('/fr/docs/api/auth');
   });
 });
 
@@ -249,10 +282,18 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/about']).toBe('/about');
-    expect(result.pathToSharedPath['/contact']).toBe('/contact');
-    expect(result.pathToSharedPath['/services']).toBe('/services');
-    expect(result.defaultLocalePaths).toEqual([]);
+    expect(getSharedPath('/about', result.pathToSharedPath, undefined)).toBe(
+      '/about'
+    );
+    expect(getSharedPath('/contact', result.pathToSharedPath, undefined)).toBe(
+      '/contact'
+    );
+    expect(getSharedPath('/services', result.pathToSharedPath, undefined)).toBe(
+      '/services'
+    );
+    expect(
+      getSharedPath('/about-us', result.defaultLocalePaths, undefined)
+    ).toBe(undefined);
   });
 
   it('should create mapping for object-based paths with locale prefixing', () => {
@@ -266,10 +307,18 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/about']).toBe('/about');
-    expect(result.pathToSharedPath['/en/about-us']).toBe('/about');
-    expect(result.pathToSharedPath['/fr/a-propos']).toBe('/about');
-    expect(result.pathToSharedPath['/es/acerca-de']).toBe('/about');
+    expect(getSharedPath('/about', result.pathToSharedPath, undefined)).toBe(
+      '/about'
+    );
+    expect(getSharedPath('/en/about-us', result.pathToSharedPath, 'en')).toBe(
+      '/about'
+    );
+    expect(getSharedPath('/fr/a-propos', result.pathToSharedPath, 'fr')).toBe(
+      '/about'
+    );
+    expect(getSharedPath('/es/acerca-de', result.pathToSharedPath, 'es')).toBe(
+      '/about'
+    );
   });
 
   it('should handle default locale without prefix', () => {
@@ -286,15 +335,27 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, false, 'en');
 
-    expect(result.pathToSharedPath['/about-us']).toBe('/about');
-    expect(result.pathToSharedPath['/contact-us']).toBe('/contact');
-    expect(result.pathToSharedPath['/fr/a-propos']).toBe('/about');
-    expect(result.pathToSharedPath['/fr/contactez-nous']).toBe('/contact');
-    expect(result.defaultLocalePaths).toContain('/about-us');
-    expect(result.defaultLocalePaths).toContain('/contact-us');
+    expect(getSharedPath('/about-us', result.pathToSharedPath, undefined)).toBe(
+      '/about'
+    );
+    expect(
+      getSharedPath('/contact-us', result.pathToSharedPath, undefined)
+    ).toBe('/contact');
+    expect(getSharedPath('/fr/a-propos', result.pathToSharedPath, 'fr')).toBe(
+      '/about'
+    );
+    expect(
+      getSharedPath('/fr/contactez-nous', result.pathToSharedPath, 'fr')
+    ).toBe('/contact');
+    expect(
+      getSharedPath('/about-us', result.defaultLocalePaths, undefined)
+    ).toBe('/about');
+    expect(
+      getSharedPath('/contact-us', result.defaultLocalePaths, undefined)
+    ).toBe('/contact');
   });
 
-  it('should handle dynamic paths with regex patterns', () => {
+  it('should index dynamic paths', () => {
     const pathConfig: PathConfig = {
       '/blog/[id]': {
         en: '/blog/[id]',
@@ -308,12 +369,18 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/blog/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/en/blog/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/fr/article/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/user/[^/]+/post/[^/]+']).toBe(
-      '/user/[userId]/post/[postId]'
+    expect(getSharedPath('/blog/1', result.pathToSharedPath, undefined)).toBe(
+      '/blog/[id]'
     );
+    expect(getSharedPath('/en/blog/2', result.pathToSharedPath, 'en')).toBe(
+      '/blog/[id]'
+    );
+    expect(getSharedPath('/fr/article/3', result.pathToSharedPath, 'fr')).toBe(
+      '/blog/[id]'
+    );
+    expect(
+      getSharedPath('/user/4/post/5', result.pathToSharedPath, undefined)
+    ).toBe('/user/[userId]/post/[postId]');
   });
 
   it('should handle mixed static and dynamic configurations', () => {
@@ -327,26 +394,40 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/static-page']).toBe('/static-page');
-    expect(result.pathToSharedPath['/dynamic/[^/]+']).toBe('/dynamic/[id]');
-    expect(result.pathToSharedPath['/en/dynamic/[^/]+']).toBe('/dynamic/[id]');
-    expect(result.pathToSharedPath['/fr/dynamique/[^/]+']).toBe(
+    expect(
+      getSharedPath('/static-page', result.pathToSharedPath, undefined)
+    ).toBe('/static-page');
+    expect(
+      getSharedPath('/dynamic/1', result.pathToSharedPath, undefined)
+    ).toBe('/dynamic/[id]');
+    expect(getSharedPath('/en/dynamic/2', result.pathToSharedPath, 'en')).toBe(
       '/dynamic/[id]'
     );
+    expect(
+      getSharedPath('/fr/dynamique/3', result.pathToSharedPath, 'fr')
+    ).toBe('/dynamic/[id]');
   });
 });
 
 describe('getSharedPath', () => {
-  const pathToSharedPath = {
-    '/about': '/about',
-    '/en/about-us': '/about',
-    '/fr/a-propos': '/about',
-    '/es/acerca-de': '/about',
-    '/blog/[^/]+': '/blog/[id]',
-    '/en/blog/[^/]+': '/blog/[id]',
-    '/fr/article/[^/]+': '/blog/[id]',
-    '/user/[^/]+/settings': '/user/[id]/settings',
-  };
+  const pathToSharedPath = createPathMatcher([
+    ['/about', '/about'],
+    ['/en/about-us', '/about'],
+    ['/fr/a-propos', '/about'],
+    ['/es/acerca-de', '/about'],
+    ['/blog/[id]', '/blog/[id]'],
+    ['/en/blog/[id]', '/blog/[id]'],
+    ['/fr/article/[id]', '/blog/[id]'],
+    ['/user/[id]/settings', '/user/[id]/settings'],
+  ]);
+
+  it('returns the shared path and matched source route', () => {
+    expect(matchSharedPath('/fr/article/789', pathToSharedPath, 'fr')).toEqual({
+      matchedPathname: '/fr/article/789',
+      pathTemplate: '/fr/article/[id]',
+      sharedPath: '/blog/[id]',
+    });
+  });
 
   it('should find exact matches first', () => {
     expect(getSharedPath('/about', pathToSharedPath, undefined)).toBe('/about');
@@ -382,16 +463,92 @@ describe('getSharedPath', () => {
     ).toBe('/user/[id]/settings');
   });
 
-  it('should preserve regex metacharacter matching outside dynamic segments', () => {
-    const pathMap = {
-      '/files/v.+/[^/]+': '/files/[version]/[id]',
-    };
+  it('treats regex metacharacters as literal path content', () => {
+    const pathMatcher = createPathMatcher([
+      ['/files/v1.0/[id]', '/files/[version]/[id]'],
+      ['/language/c++/[slug]', '/language/[slug]'],
+    ]);
 
-    expect(getSharedPath('/files/v12/report', pathMap, undefined)).toBe(
+    expect(getSharedPath('/files/v1.0/report', pathMatcher, undefined)).toBe(
       '/files/[version]/[id]'
     );
-    expect(getSharedPath('/files/v.+/report', pathMap, undefined)).toBe(
-      '/files/[version]/[id]'
+    expect(getSharedPath('/files/v1x0/report', pathMatcher, undefined)).toBe(
+      undefined
+    );
+    expect(getSharedPath('/language/c++/guide', pathMatcher, undefined)).toBe(
+      '/language/[slug]'
+    );
+  });
+
+  it('normalizes encoded and Unicode path segments', () => {
+    const pathMatcher = createPathMatcher([
+      ['/café/[slug]', '/café/[slug]'],
+      ['/articles/e\u0301lite/[slug]', '/articles/élite/[slug]'],
+      ['/files/%2F/[slug]', '/files/%2F/[slug]'],
+    ]);
+
+    expect(getSharedPath('/caf%C3%A9/guide', pathMatcher, undefined)).toBe(
+      '/café/[slug]'
+    );
+    expect(getSharedPath('/café/guide', pathMatcher, undefined)).toBe(
+      '/café/[slug]'
+    );
+    expect(
+      getSharedPath('/articles/%C3%A9lite/guide', pathMatcher, undefined)
+    ).toBe('/articles/élite/[slug]');
+    expect(getSharedPath('/files/%2F/guide', pathMatcher, undefined)).toBe(
+      '/files/%2F/[slug]'
+    );
+  });
+
+  it('matches paths with or without a trailing slash', () => {
+    const pathMatcher = createPathMatcher([
+      ['/about', '/about'],
+      ['/docs/[slug]', '/docs/[slug]'],
+    ]);
+
+    expect(getSharedPath('/about/', pathMatcher, undefined)).toBe('/about');
+    expect(getSharedPath('/docs/guide/', pathMatcher, undefined)).toBe(
+      '/docs/[slug]'
+    );
+  });
+
+  it('matches catch-all and optional catch-all paths', () => {
+    const pathMatcher = createPathMatcher([
+      ['/docs/[...slug]', '/docs/[...slug]'],
+      ['/news/[[...slug]]', '/news/[[...slug]]'],
+    ]);
+
+    expect(getSharedPath('/docs/intro', pathMatcher, undefined)).toBe(
+      '/docs/[...slug]'
+    );
+    expect(getSharedPath('/docs/guides/start', pathMatcher, undefined)).toBe(
+      '/docs/[...slug]'
+    );
+    expect(getSharedPath('/docs', pathMatcher, undefined)).toBe(undefined);
+    expect(getSharedPath('/news', pathMatcher, undefined)).toBe(
+      '/news/[[...slug]]'
+    );
+    expect(getSharedPath('/news/world/latest', pathMatcher, undefined)).toBe(
+      '/news/[[...slug]]'
+    );
+  });
+
+  it('prioritizes static, dynamic, and catch-all paths', () => {
+    const pathMatcher = createPathMatcher([
+      ['/docs/[...slug]', '/docs/[...slug]'],
+      ['/docs/[section]', '/docs/[section]'],
+      ['/docs/getting-started', '/docs/getting-started'],
+    ]);
+
+    expect(getSharedPath('/docs/getting-started', pathMatcher, undefined)).toBe(
+      '/docs/getting-started'
+    );
+    expect(getSharedPath('/docs/api', pathMatcher, undefined)).toBe(
+      '/docs/[section]'
+    );
+    expect(getSharedPath('/docs/api/auth', pathMatcher, undefined)).toBe(
+      '/docs/[...slug]'
     );
   });
 
@@ -408,11 +565,11 @@ describe('getSharedPath', () => {
   });
 
   it('should prioritize exact matches over regex matches', () => {
-    const pathMap = {
-      '/about': '/about',
-      '/[^/]+': '/dynamic',
-    };
-    expect(getSharedPath('/about', pathMap, undefined)).toBe('/about');
+    const pathMatcher = createPathMatcher([
+      ['/about', '/about'],
+      ['/[slug]', '/dynamic'],
+    ]);
+    expect(getSharedPath('/about', pathMatcher, undefined)).toBe('/about');
   });
 
   it('should handle edge cases', () => {

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -112,6 +112,36 @@ describe('extractDynamicParams', () => {
   });
 });
 
+describe.each(['[...slug]', '[[...slug]]'])(
+  'trailing delimiters with %s',
+  (segment) => {
+    it.each(['', 'one', 'one/two', 'a%2Fb/a%252Fb'])(
+      'extracts raw parameters without a terminal delimiter: %s',
+      (tail) => {
+        expect(
+          extractDynamicParams(
+            `/catalog/[category]/${segment}/`,
+            `/catalog/science/${tail}${tail ? '/' : ''}`
+          )
+        ).toEqual(['science', tail]);
+      }
+    );
+
+    it.each(['one', 'one/two', 'a%2Fb/a%252Fb'])(
+      'reconstructs one trailing delimiter after %s',
+      (tail) => {
+        expect(
+          replaceDynamicSegments(
+            `/catalogue/science/${tail}/`,
+            `/catalog/[category]/${segment}/`,
+            `/catalogue/[category]/${segment}/`
+          )
+        ).toBe(`/catalog/science/${tail}/`);
+      }
+    );
+  }
+);
+
 describe('replaceDynamicSegments', () => {
   it('should replace single dynamic segment', () => {
     expect(replaceDynamicSegments('/blog/123', '/blog/[id]')).toBe('/blog/123');

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -341,18 +341,19 @@ export function createNextMiddleware({
             );
           }
         } else {
+          const localizedPublicPath =
+            localizedPathWithParameters.replace(
+              new RegExp(`^/${userLocale}`),
+              ''
+            ) || '/';
+
           // REDIRECT CASE: unprefixed pathname is wrong (/about -> /en-about)
           if (
             !pathnameLocale &&
-            normalizePathname(localizedPathWithParameters) !==
-              normalizePathname(`/${userLocale}${pathname}`)
+            normalizePathname(localizedPublicPath) !==
+              normalizePathname(pathname)
           ) {
-            return getRedirectResponse(
-              localizedPathWithParameters.replace(
-                new RegExp(`^/${userLocale}`),
-                ''
-              ) || '/'
-            );
+            return getRedirectResponse(localizedPublicPath);
           }
 
           // REWRITE CASE: displaying correct path (/blog -> /en/blog)

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -13,6 +13,7 @@ import {
 } from '@generaltranslation/react-core/pure';
 import {
   PathConfig,
+  applyTrailingSlash,
   normalizePathname,
   getSharedPath,
   replaceDynamicSegments,
@@ -236,25 +237,28 @@ export function createNextMiddleware({
         pathnameLocale && pathnameLocale !== unstandardizedPathnameLocale
           ? pathname.replace(
               new RegExp(`^/${unstandardizedPathnameLocale}`),
-              `/${userLocale}`
+              `/${pathnameLocale}`
             )
           : pathname;
 
       // Get the shared path for the unprefixed pathname
-      const sharedPath = getSharedPath(
+      const sharedPathMatch = getSharedPath(
         standardizedPathname,
         pathToSharedPath,
         pathnameLocale
       );
+      const sharedPath = sharedPathMatch?.sharedPath;
 
       // Get shared path with parameters (/en/dashboard/1/custom), for rewriting localized paths
       const sharedPathWithParameters =
-        sharedPath !== undefined
-          ? replaceDynamicSegments(
-              pathnameLocale
-                ? standardizedPathname
-                : `/${userLocale}${standardizedPathname}`,
-              `/${userLocale}${sharedPath}`
+        sharedPathMatch !== undefined
+          ? applyTrailingSlash(
+              standardizedPathname,
+              replaceDynamicSegments(
+                sharedPathMatch.matchedPathname,
+                `/${userLocale}${sharedPath}`,
+                sharedPathMatch.pathTemplate
+              )
             )
           : undefined;
 
@@ -266,12 +270,14 @@ export function createNextMiddleware({
 
       // Combine localized path with dynamic parameters (/en/blog, /fr/fr-about, /fr/dashboard/1/fr-custom)
       const localizedPathWithParameters =
-        localizedPath !== undefined
-          ? replaceDynamicSegments(
-              pathnameLocale
-                ? standardizedPathname
-                : `/${userLocale}${standardizedPathname}`,
-              localizedPath
+        localizedPath !== undefined && sharedPathMatch !== undefined
+          ? applyTrailingSlash(
+              standardizedPathname,
+              replaceDynamicSegments(
+                sharedPathMatch.matchedPathname,
+                localizedPath,
+                sharedPathMatch.pathTemplate
+              )
             )
           : undefined;
 
@@ -329,7 +335,7 @@ export function createNextMiddleware({
           if (clearResetCookie) {
             return getRedirectResponse(
               localizedPathWithParameters.replace(
-                new RegExp(`^/${unstandardizedPathnameLocale}`),
+                new RegExp(`^/${userLocale}`),
                 ``
               ) || '/'
             );

--- a/packages/next/src/middleware-dir/createPathMatcher.ts
+++ b/packages/next/src/middleware-dir/createPathMatcher.ts
@@ -1,0 +1,140 @@
+import { normalizePathname, stripTrailingSlashes } from './pathname';
+
+export { normalizePathname };
+
+export type PathConfig = {
+  [key: string]: string | { [key: string]: string };
+};
+
+export type PathMatch = {
+  pathTemplate: string;
+  sharedPath: string;
+};
+
+export type PathMatcherNode = {
+  staticSegments: Map<string, PathMatcherNode>;
+  dynamicSegment?: PathMatcherNode;
+  catchAllSegment?: PathMatcherNode;
+  optionalCatchAllSegment?: PathMatcherNode;
+  match?: PathMatch;
+};
+
+export type PathMatcher = {
+  root: PathMatcherNode;
+  localizedRoot?: PathMatcherNode;
+  defaultLocaleRoot?: PathMatcherNode;
+};
+
+export type DynamicSegmentType = 'dynamic' | 'catch-all' | 'optional-catch-all';
+
+const DYNAMIC_SEGMENT_PATTERN = /^\[[^.[\]/][^\]/]*\]$/;
+const CATCH_ALL_SEGMENT_PATTERN = /^\[\.\.\.[^\]/]+\]$/;
+const OPTIONAL_CATCH_ALL_SEGMENT_PATTERN = /^\[\[\.\.\.[^\]/]+\]\]$/;
+
+/** Creates an empty node in the pathname matcher trie. */
+function createPathMatcherNode(): PathMatcherNode {
+  return { staticSegments: new Map() };
+}
+
+/** Identifies the supported Next.js dynamic segment syntax. */
+export function getDynamicSegmentType(
+  segment: string
+): DynamicSegmentType | undefined {
+  if (OPTIONAL_CATCH_ALL_SEGMENT_PATTERN.test(segment)) {
+    return 'optional-catch-all';
+  }
+  if (CATCH_ALL_SEGMENT_PATTERN.test(segment)) return 'catch-all';
+  if (DYNAMIC_SEGMENT_PATTERN.test(segment)) return 'dynamic';
+  return undefined;
+}
+
+/** Splits a pathname without interpreting encoded literals as route syntax. */
+export function getPathSegments(pathname: string): string[] {
+  if (pathname === '') return [];
+  const normalizedPathname = stripTrailingSlashes(pathname);
+  const pathnameWithoutLeadingSlash = normalizedPathname.startsWith('/')
+    ? normalizedPathname.slice(1)
+    : normalizedPathname;
+  return pathnameWithoutLeadingSlash.split('/');
+}
+
+/** Inserts a pathname template and its shared path into the matcher trie. */
+function insertPath(
+  matcher: PathMatcher,
+  pathname: string,
+  sharedPath: string
+) {
+  let node = matcher.root;
+
+  for (const segment of getPathSegments(pathname)) {
+    const segmentType = getDynamicSegmentType(segment);
+    if (segmentType === 'dynamic') {
+      node.dynamicSegment ||= createPathMatcherNode();
+      node = node.dynamicSegment;
+    } else if (segmentType === 'catch-all') {
+      node.catchAllSegment ||= createPathMatcherNode();
+      node = node.catchAllSegment;
+    } else if (segmentType === 'optional-catch-all') {
+      node.optionalCatchAllSegment ||= createPathMatcherNode();
+      node = node.optionalCatchAllSegment;
+    } else {
+      const staticSegment = normalizePathname(segment);
+      const staticNode =
+        node.staticSegments.get(staticSegment) || createPathMatcherNode();
+      node.staticSegments.set(staticSegment, staticNode);
+      node = staticNode;
+    }
+  }
+
+  // Match the previous map behavior when two parameter names describe the
+  // same path shape: the later entry wins.
+  node.match = { pathTemplate: pathname, sharedPath };
+}
+
+/** Builds a segment trie from pathname-to-shared-path entries. */
+export function createPathMatcher(
+  pathEntries: ReadonlyArray<readonly [string, string]>
+): PathMatcher {
+  const matcher: PathMatcher = { root: createPathMatcherNode() };
+  for (const [pathname, sharedPath] of pathEntries) {
+    insertPath(matcher, pathname, sharedPath);
+  }
+  return matcher;
+}
+
+/** Creates matchers for localized paths and unprefixed default-locale paths. */
+export function createPathToSharedPathMap(
+  pathConfig: PathConfig,
+  prefixDefaultLocale: boolean,
+  defaultLocale: string
+): {
+  pathToSharedPath: PathMatcher;
+  defaultLocalePaths: PathMatcher;
+} {
+  const pathEntries: Array<readonly [string, string]> = [];
+  const localizedEntries: Array<readonly [string, string]> = [];
+  const defaultLocaleEntries: Array<readonly [string, string]> = [];
+
+  for (const [sharedPath, localizedPaths] of Object.entries(pathConfig)) {
+    pathEntries.push([sharedPath, sharedPath]);
+
+    if (typeof localizedPaths === 'object') {
+      for (const [locale, localizedPath] of Object.entries(localizedPaths)) {
+        localizedEntries.push([`/${locale}${localizedPath}`, sharedPath]);
+        if (!prefixDefaultLocale && locale === defaultLocale) {
+          defaultLocaleEntries.push([localizedPath, sharedPath]);
+        }
+      }
+    }
+  }
+
+  const defaultLocalePaths = createPathMatcher(defaultLocaleEntries);
+  return {
+    pathToSharedPath: {
+      ...createPathMatcher(pathEntries),
+      localizedRoot: createPathMatcher(localizedEntries).root,
+      defaultLocaleRoot: defaultLocalePaths.root,
+    },
+    defaultLocalePaths,
+  };
+}

--- a/packages/next/src/middleware-dir/matchPath.ts
+++ b/packages/next/src/middleware-dir/matchPath.ts
@@ -17,8 +17,10 @@ function matchPathSegments(
   pathSegments: string[],
   segmentIndex: number
 ): PathMatch | undefined {
+  // Base case: we're at the end of the segments
   if (segmentIndex === pathSegments.length) {
     if (node.match !== undefined) return node.match;
+    // Recursive case 4: edge case - see below
     if (node.optionalCatchAllSegment) {
       return matchPathSegments(
         node.optionalCatchAllSegment,
@@ -29,13 +31,17 @@ function matchPathSegments(
     return undefined;
   }
 
+  // Get the segment at the current index
   const segment = pathSegments[segmentIndex];
+
+  // Recursive case 1: match a static segment
   const staticNode = node.staticSegments.get(segment);
   if (staticNode) {
     const match = matchPathSegments(staticNode, pathSegments, segmentIndex + 1);
     if (match !== undefined) return match;
   }
 
+  // Recursive case 2: match a dynamic segement
   if (segment && node.dynamicSegment) {
     const match = matchPathSegments(
       node.dynamicSegment,
@@ -45,7 +51,16 @@ function matchPathSegments(
     if (match !== undefined) return match;
   }
 
+  // Recursive case 3: match a catch-all segment
   if (node.catchAllSegment) {
+    /**
+     * Technically, this loop isn't necessary. This would handle cases
+     * where we have static segments after the catch-all segment. Which
+     * does not occur in Next.js routing. (`/docs/[...slug]/authors`)
+     *
+     * That means this loop only iterates once for a catch-all segment,
+     * so costs only scale linearlly which is acceptable.
+     */
     for (
       let nextSegmentIndex = pathSegments.length;
       nextSegmentIndex > segmentIndex;
@@ -67,7 +82,11 @@ function matchPathSegments(
     }
   }
 
+  // Recursive case 4: match an optional catch-all segment
   if (node.optionalCatchAllSegment) {
+    /**
+     * See note in recursive case 3.
+     */
     for (
       let nextSegmentIndex = pathSegments.length;
       nextSegmentIndex >= segmentIndex;
@@ -138,16 +157,20 @@ export function getSharedPath(
   pathnameLocale: string | undefined
 ): SharedPathMatch | undefined {
   if (pathToSharedPath.localizedRoot) {
+    // Is this a "shared path" (e.g. `/home`)?
     const pathnameWithoutLocale = pathnameLocale
       ? standardizedPathname.replace(/^\/[^/]+/, '')
       : standardizedPathname;
     const sharedMatch = matchPath(pathnameWithoutLocale, pathToSharedPath);
+
+    // Is this a "localized path" (e.g. `/inicio`)?
     const localizedRoot = pathnameLocale
       ? pathToSharedPath.localizedRoot
       : pathToSharedPath.defaultLocaleRoot;
     const localizedMatch = localizedRoot
       ? matchPath(standardizedPathname, { root: localizedRoot })
       : undefined;
+
     if (
       sharedMatch &&
       (!localizedMatch ||

--- a/packages/next/src/middleware-dir/matchPath.ts
+++ b/packages/next/src/middleware-dir/matchPath.ts
@@ -1,0 +1,177 @@
+import {
+  getDynamicSegmentType,
+  getPathSegments,
+  normalizePathname,
+  type PathMatch,
+  type PathMatcher,
+  type PathMatcherNode,
+} from './createPathMatcher';
+
+export type SharedPathMatch = PathMatch & {
+  matchedPathname: string;
+};
+
+/** Recursively matches segments in static, dynamic, then catch-all order. */
+function matchPathSegments(
+  node: PathMatcherNode,
+  pathSegments: string[],
+  segmentIndex: number
+): PathMatch | undefined {
+  if (segmentIndex === pathSegments.length) {
+    if (node.match !== undefined) return node.match;
+    if (node.optionalCatchAllSegment) {
+      return matchPathSegments(
+        node.optionalCatchAllSegment,
+        pathSegments,
+        segmentIndex
+      );
+    }
+    return undefined;
+  }
+
+  const segment = pathSegments[segmentIndex];
+  const staticNode = node.staticSegments.get(segment);
+  if (staticNode) {
+    const match = matchPathSegments(staticNode, pathSegments, segmentIndex + 1);
+    if (match !== undefined) return match;
+  }
+
+  if (segment && node.dynamicSegment) {
+    const match = matchPathSegments(
+      node.dynamicSegment,
+      pathSegments,
+      segmentIndex + 1
+    );
+    if (match !== undefined) return match;
+  }
+
+  if (node.catchAllSegment) {
+    for (
+      let nextSegmentIndex = pathSegments.length;
+      nextSegmentIndex > segmentIndex;
+      nextSegmentIndex--
+    ) {
+      if (
+        !pathSegments
+          .slice(segmentIndex, nextSegmentIndex)
+          .some((segment) => segment.length > 0)
+      ) {
+        continue;
+      }
+      const match = matchPathSegments(
+        node.catchAllSegment,
+        pathSegments,
+        nextSegmentIndex
+      );
+      if (match !== undefined) return match;
+    }
+  }
+
+  if (node.optionalCatchAllSegment) {
+    for (
+      let nextSegmentIndex = pathSegments.length;
+      nextSegmentIndex >= segmentIndex;
+      nextSegmentIndex--
+    ) {
+      const match = matchPathSegments(
+        node.optionalCatchAllSegment,
+        pathSegments,
+        nextSegmentIndex
+      );
+      if (match !== undefined) return match;
+    }
+  }
+
+  return undefined;
+}
+
+/** Looks up the route entry associated with a concrete pathname. */
+function matchPath(pathname: string, matcher: PathMatcher) {
+  return matchPathSegments(
+    matcher.root,
+    getPathSegments(pathname).map(normalizePathname),
+    0
+  );
+}
+
+/** Ranks route segments in the same order as trie traversal. */
+function segmentPriority(segment: string | undefined): number {
+  if (segment === undefined) return -1;
+  switch (getDynamicSegmentType(segment)) {
+    case 'dynamic':
+      return 1;
+    case 'catch-all':
+      return 2;
+    case 'optional-catch-all':
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+/** Compares shared and localized candidates without counting the locale prefix. */
+function isSharedMoreSpecific(
+  shared: PathMatch,
+  localized: PathMatch,
+  pathnameLocale: string | undefined
+): boolean {
+  const sharedSegments = getPathSegments(shared.pathTemplate);
+  const localizedSegments = getPathSegments(localized.pathTemplate);
+  if (pathnameLocale) localizedSegments.shift();
+  for (
+    let index = 0;
+    index < Math.max(sharedSegments.length, localizedSegments.length);
+    index++
+  ) {
+    const difference =
+      segmentPriority(sharedSegments[index]) -
+      segmentPriority(localizedSegments[index]);
+    if (difference !== 0) return difference < 0;
+  }
+  return false;
+}
+
+/** Gets the shared route and source template matching a concrete pathname. */
+export function getSharedPath(
+  standardizedPathname: string,
+  pathToSharedPath: PathMatcher,
+  pathnameLocale: string | undefined
+): SharedPathMatch | undefined {
+  if (pathToSharedPath.localizedRoot) {
+    const pathnameWithoutLocale = pathnameLocale
+      ? standardizedPathname.replace(/^\/[^/]+/, '')
+      : standardizedPathname;
+    const sharedMatch = matchPath(pathnameWithoutLocale, pathToSharedPath);
+    const localizedRoot = pathnameLocale
+      ? pathToSharedPath.localizedRoot
+      : pathToSharedPath.defaultLocaleRoot;
+    const localizedMatch = localizedRoot
+      ? matchPath(standardizedPathname, { root: localizedRoot })
+      : undefined;
+    if (
+      sharedMatch &&
+      (!localizedMatch ||
+        isSharedMoreSpecific(sharedMatch, localizedMatch, pathnameLocale))
+    ) {
+      return { ...sharedMatch, matchedPathname: pathnameWithoutLocale };
+    }
+    if (localizedMatch) {
+      return { ...localizedMatch, matchedPathname: standardizedPathname };
+    }
+    return undefined;
+  }
+
+  const directMatch = matchPath(standardizedPathname, pathToSharedPath);
+  if (directMatch !== undefined) {
+    return { ...directMatch, matchedPathname: standardizedPathname };
+  }
+
+  if (pathnameLocale) {
+    const pathnameWithoutLocale = standardizedPathname.replace(/^\/[^/]+/, '');
+    const unprefixedMatch = matchPath(pathnameWithoutLocale, pathToSharedPath);
+    if (unprefixedMatch !== undefined) {
+      return { ...unprefixedMatch, matchedPathname: pathnameWithoutLocale };
+    }
+  }
+  return undefined;
+}

--- a/packages/next/src/middleware-dir/matchPath.ts
+++ b/packages/next/src/middleware-dir/matchPath.ts
@@ -159,7 +159,7 @@ export function getSharedPath(
   if (pathToSharedPath.localizedRoot) {
     // Is this a "shared path" (e.g. `/home`)?
     const pathnameWithoutLocale = pathnameLocale
-      ? standardizedPathname.replace(/^\/[^/]+/, '')
+      ? standardizedPathname.replace(/^\/[^/]+/, '') || '/'
       : standardizedPathname;
     const sharedMatch = matchPath(pathnameWithoutLocale, pathToSharedPath);
 
@@ -190,7 +190,8 @@ export function getSharedPath(
   }
 
   if (pathnameLocale) {
-    const pathnameWithoutLocale = standardizedPathname.replace(/^\/[^/]+/, '');
+    const pathnameWithoutLocale =
+      standardizedPathname.replace(/^\/[^/]+/, '') || '/';
     const unprefixedMatch = matchPath(pathnameWithoutLocale, pathToSharedPath);
     if (unprefixedMatch !== undefined) {
       return { ...unprefixedMatch, matchedPathname: pathnameWithoutLocale };

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -66,7 +66,10 @@ export function getResponse({
       },
     });
   } else {
-    const responseUrl = new URL(responsePath, originalUrl);
+    // Assign the pathname to preserve the request origin: resolving a path
+    // starting with // or /\ as a URL can turn it into an external destination.
+    const responseUrl = new URL(originalUrl);
+    responseUrl.pathname = responsePath;
     applyBasePath(responseUrl, originalUrl);
     responseUrl.search = originalUrl.search;
     response =

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -12,7 +12,7 @@ import {
   type PathMatcher,
 } from './createPathMatcher';
 import { getSharedPath } from './matchPath';
-import { applyTrailingSlash } from './pathname';
+import { applyTrailingSlash, stripTrailingSlashes } from './pathname';
 
 export {
   createPathMatcher,
@@ -113,7 +113,7 @@ export function extractDynamicParams(
   if (!templatePath.includes('[')) return [];
 
   const params: string[] = [];
-  const pathSegments = path.split('/');
+  const pathSegments = stripTrailingSlashes(path).split('/');
   const sharedSegments = templatePath.split('/');
 
   sharedSegments.forEach((segment, index) => {

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -3,13 +3,24 @@ import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
-import { normalizePathname, stripTrailingSlashes } from './pathname';
+import {
+  createPathMatcher,
+  createPathToSharedPathMap,
+  getDynamicSegmentType,
+  normalizePathname,
+  type PathConfig,
+  type PathMatcher,
+} from './createPathMatcher';
+import { getSharedPath } from './matchPath';
+import { stripTrailingSlashes } from './pathname';
 
-export { normalizePathname };
-
-export type PathConfig = {
-  [key: string]: string | { [key: string]: string };
+export {
+  createPathMatcher,
+  createPathToSharedPathMap,
+  getSharedPath,
+  normalizePathname,
 };
+export type { PathConfig, PathMatcher };
 
 export type ResponseConfig = {
   type: 'next' | 'rewrite' | 'redirect';
@@ -24,28 +35,6 @@ export type ResponseConfig = {
   localeHeaderName: string;
 };
 
-const DYNAMIC_PATH_SEGMENT_PATTERN = '/[^/]+';
-/** Normalizes each segment once without decoding encoded separators. */
-function normalizePathForMatching(pathname: string): string {
-  return pathname.split('/').map(normalizePathname).join('/');
-}
-
-/** Classifies placeholders before decoding static path content. */
-function createPathPattern(pathname: string): string {
-  pathname = stripTrailingSlashes(pathname);
-  if (!/\[([^\]]+)\]/.test(pathname)) {
-    return normalizePathForMatching(pathname);
-  }
-  return pathname
-    .split(/(\[[^\]]+\])/)
-    .map((part, index) =>
-      index % 2
-        ? '[^/]+'
-        : normalizePathForMatching(part).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-    )
-    .join('');
-}
-
 function applyBasePath(responseUrl: URL, originalUrl: NextURL) {
   const { basePath } = originalUrl;
   if (!basePath || responseUrl.origin !== originalUrl.origin) {
@@ -56,7 +45,10 @@ function applyBasePath(responseUrl: URL, originalUrl: NextURL) {
 }
 
 /** Applies the request pathname's trailing-slash style to a target path. */
-function applyTrailingSlash(pathname: string, targetPathname: string): string {
+export function applyTrailingSlash(
+  pathname: string,
+  targetPathname: string
+): string {
   const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
   if (sourceHasTrailingSlash) {
     return targetPathname === '/' || targetPathname.endsWith('/')
@@ -65,7 +57,7 @@ function applyTrailingSlash(pathname: string, targetPathname: string): string {
   }
   return stripTrailingSlashes(targetPathname);
 }
-
+/** Creates a middleware response and attaches GT routing state. */
 export function getResponse({
   type,
   originalUrl,
@@ -125,7 +117,7 @@ export function extractLocale(pathname: string): string | null {
 }
 
 /**
- * Extracts dynamic parameters from a path based on a shared path pattern
+ * Extracts dynamic parameters from a path based on a shared path pattern.
  */
 export function extractDynamicParams(
   templatePath: string,
@@ -138,7 +130,10 @@ export function extractDynamicParams(
   const sharedSegments = templatePath.split('/');
 
   sharedSegments.forEach((segment, index) => {
-    if (segment.startsWith('[') && segment.endsWith(']')) {
+    const segmentType = getDynamicSegmentType(segment);
+    if (segmentType === 'catch-all' || segmentType === 'optional-catch-all') {
+      params.push(pathSegments.slice(index).join('/'));
+    } else if (segmentType === 'dynamic') {
       params.push(pathSegments[index]);
     }
   });
@@ -147,26 +142,46 @@ export function extractDynamicParams(
 }
 
 /**
- * Replaces dynamic segments in a path with their actual values
+ * Replaces dynamic segments in a path with their actual values.
  */
 export function replaceDynamicSegments(
   path: string,
-  templatePath: string
+  templatePath: string,
+  sourceTemplatePath = templatePath
 ): string {
   if (!templatePath.includes('[')) {
     return applyTrailingSlash(path, templatePath);
   }
 
-  const params = extractDynamicParams(templatePath, path);
+  const params = extractDynamicParams(sourceTemplatePath, path);
   let paramIndex = 0;
-  const result = templatePath.replace(/\[([^\]]+)\]/g, (match: string) => {
-    return params[paramIndex++] || match;
-  });
-  return applyTrailingSlash(path, result);
+  const resultSegments: string[] = [];
+
+  for (const segment of templatePath.split('/')) {
+    const segmentType = getDynamicSegmentType(segment);
+    if (!segmentType) {
+      resultSegments.push(segment);
+      continue;
+    }
+
+    const param = params[paramIndex++];
+    if (segmentType === 'optional-catch-all' && !param) continue;
+    if (!param) {
+      resultSegments.push(segment);
+      continue;
+    }
+    if (segmentType === 'catch-all' || segmentType === 'optional-catch-all') {
+      resultSegments.push(...param.split('/'));
+    } else {
+      resultSegments.push(param);
+    }
+  }
+
+  return applyTrailingSlash(path, resultSegments.join('/') || '/');
 }
 
 /**
- * Gets the full localized path given a shared path and locale
+ * Gets the full localized path given a shared path and locale.
  */
 export function getLocalizedPath(
   sharedPath: string,
@@ -188,125 +203,20 @@ export function getLocalizedPath(
 }
 
 /**
- * Creates a map of localized paths to shared paths using regex patterns
+ * Checks whether a pathname matches an unprefixed default-locale path.
  */
-export function createPathToSharedPathMap(
-  pathConfig: PathConfig,
-  prefixDefaultLocale: boolean,
-  defaultLocale: string
-): {
-  pathToSharedPath: { [key: string]: string };
-  defaultLocalePaths: string[];
-} {
-  return Object.entries(pathConfig).reduce<{
-    pathToSharedPath: { [key: string]: string };
-    defaultLocalePaths: string[];
-  }>(
-    (acc, [sharedPath, localizedPaths]) => {
-      const { pathToSharedPath, defaultLocalePaths } = acc;
-      // Preserve raw templates for parameter substitution and output URLs.
-      pathToSharedPath[createPathPattern(sharedPath)] = sharedPath;
-
-      if (typeof localizedPaths === 'object') {
-        Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
-          // Convert the localized path to a regex pattern
-          // Replace [param] with [^/]+ to match any non-slash characters
-          const pattern = createPathPattern(localizedPath);
-          pathToSharedPath[`/${locale}${pattern}`] = sharedPath;
-          if (!prefixDefaultLocale && locale === defaultLocale) {
-            pathToSharedPath[pattern] = sharedPath;
-            defaultLocalePaths.push(pattern);
-          }
-        });
-      }
-      return acc;
-    },
-    { pathToSharedPath: {}, defaultLocalePaths: [] }
+function inDefaultLocalePaths(
+  pathname: string,
+  defaultLocalePaths: PathMatcher
+): boolean {
+  return (
+    getSharedPath(pathname, defaultLocalePaths, undefined)?.sharedPath !==
+    undefined
   );
 }
 
 /**
- * Gets the shared path from a given pathname, handling both static and dynamic paths
- */
-export function getSharedPath(
-  standardizedPathname: string,
-  pathToSharedPath: { [key: string]: string },
-  pathnameLocale: string | undefined
-): string | undefined {
-  standardizedPathname = normalizePathForMatching(standardizedPathname);
-  const pathnameWithoutTrailingSlash =
-    stripTrailingSlashes(standardizedPathname);
-  // Try exact match first
-  if (pathToSharedPath[pathnameWithoutTrailingSlash]) {
-    return pathToSharedPath[pathnameWithoutTrailingSlash];
-  }
-
-  // Without locale prefix
-  let pathnameWithoutLocale = undefined;
-  // Only remove locale prefix if the locale prefix is valid
-  if (pathnameLocale) {
-    pathnameWithoutLocale = stripTrailingSlashes(
-      standardizedPathname.replace(/^\/[^/]+/, '')
-    );
-    if (pathToSharedPath[pathnameWithoutLocale]) {
-      return pathToSharedPath[pathnameWithoutLocale];
-    }
-  }
-
-  // Try regex pattern match
-  let candidateSharedPath = undefined;
-  for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
-    if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
-      // Convert the pattern to a strict regex that matches the exact path structure
-      const regex = new RegExp(`^${pattern}$`);
-      // Exact match
-      if (regex.test(pathnameWithoutTrailingSlash)) {
-        return sharedPath;
-      }
-      // Without locale prefix
-      if (
-        !candidateSharedPath &&
-        pathnameLocale &&
-        regex.test(pathnameWithoutLocale as string)
-      ) {
-        candidateSharedPath = sharedPath;
-      }
-    }
-  }
-  return candidateSharedPath;
-}
-
-/**
- * Checks if the pathname is in the default locale paths
- * @param pathname - The pathname to check
- * @param defaultLocalePaths - The default locale paths
- * @returns true if the pathname is in the default locale paths, false otherwise
- */
-
-function inDefaultLocalePaths(
-  pathname: string,
-  defaultLocalePaths: string[]
-): boolean {
-  pathname = stripTrailingSlashes(normalizePathForMatching(pathname));
-  // Try exact match first
-  if (defaultLocalePaths.includes(pathname)) {
-    return true;
-  }
-
-  // Try regex pattern match
-  for (const path of defaultLocalePaths) {
-    if (path.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
-      const regex = new RegExp(`^${path}$`);
-      if (regex.test(pathname)) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-/**
- * Gets the locale from the request using various sources
+ * Resolves the request locale from its pathname, cookies, and headers.
  */
 export function getLocaleFromRequest(
   req: NextRequest,
@@ -315,7 +225,7 @@ export function getLocaleFromRequest(
   localeRouting: boolean,
   gtServicesEnabled: boolean,
   prefixDefaultLocale: boolean,
-  defaultLocalePaths: string[],
+  defaultLocalePaths: PathMatcher,
   referrerLocaleCookieName: string,
   localeCookieName: string,
   resetLocaleCookieName: string,


### PR DESCRIPTION
`pathConfig` entries may now use `[...slug]` and `[[...slug]]`. main compiled each configured route to a regex in which every bracket group matched one segment, so a catch-all alias such as `{'/docs/[...slug]': {fr: '/documentation/[...slug]'}}` was accepted and matched exactly one segment.

**matching.** `createPathMatcher.ts` builds a segment trie. each node holds static children, one dynamic child, one catch-all child and one optional catch-all child (`createPathMatcher.ts:14`). `matchPath.ts:15` walks the request segments in that order and backtracks when a deeper branch fails, so a static route beats a dynamic one at every depth. shared paths, localized aliases and unprefixed default-locale aliases live in three roots (`createPathMatcher.ts:22`), so a locale prefix is never consumed as a parameter. when a shared path and an alias both match, the shared path wins only when it is more specific segment by segment (`matchPath.ts:132`). parameter names may contain dots after the first character (`createPathMatcher.ts:30`).

**reconstruction.** parameters are read from the template that matched (`utils.ts:116`), so a shared path and its alias may differ in depth. catch-all values are split back into segments (`utils.ts:167`) and the request's slash style is reapplied, including on `/fr/`. a reset switch to the unprefixed default locale strips the target prefix directly (`createNextMiddleware.ts:337`), so `/fr/proj/123` reaches `/proj/123` in one hop.

**also here.** d362734ed sets the destination pathname on a clone of the request url, so a computed path that starts with `//` or `/\` stays on the request origin; `sameOriginRegression.edge.test.ts` holds 10 cases across redirect and rewrite with and without a basePath. 7d8096077 makes a bare `/fr` match a root alias (`|| '/'` at `matchPath.ts:162` and `:194`), with 24 cases in `defaultRootAliasRegression.edge.test.ts`.

**verified.** 18,000 fuzz cases against next's own route sorter, 0 mismatches. 108 non-override cases against main 11.1.24: 102 identical, 6 differ, all intended (catch-all aliases match, and the reset hop below). @eoinest's #2277 harness passes 15/15 on the stack and 7/15 on main (depth 0/6, catch-all 0/2). trie p50 4.2ms on an alias hit, 1.2ms on a 20-segment miss. 0 wrong pages and 0 loops on live requests. four new regression files: `catchallTrailingSlashRegression.edge.test.ts`, `defaultRootAliasRegression.edge.test.ts`, `routingRegression.edge.test.ts` and `sameOriginRegression.edge.test.ts`.

```
/fr/proj/123 + en reset   head: 307 /proj/123
                          main: 307 /en/proj/123 -> 307 /proj/123
```

stacked on #2271; #2242 follows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces linear middleware route scans with a segment trie and adds support for required and optional catch-all paths while preserving localized-route precedence and parameter extraction.
- Matches static, dynamic, catch-all, and optional catch-all routes in specificity order.
- Carries the matched localized template into parameter substitution, fixing differing source and localized segment depths.
- Treats regex metacharacters in configured path segments as literal URL content.
- Adds focused middleware and regression coverage for localized routing, catch-all parameters, route precedence, and locale switching.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable regression remains at the current head.

The prior catch-all parameter-shift finding is fully addressed by extracting values from the matched localized source template, and the latest parameter-name adjustment introduces no established failure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/createPathMatcher.ts | Builds the segment trie and classifies static, dynamic, catch-all, and optional catch-all route segments. |
| packages/next/src/middleware-dir/matchPath.ts | Traverses shared and localized route tries with explicit specificity ordering and returns the matched source template. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Uses matched source templates to preserve parameters correctly across localized rewrites and redirects. |
| packages/next/src/middleware-dir/utils.ts | Extends parameter extraction and replacement to handle required and optional catch-all values. |
| packages/next/src/middleware-dir/__tests__/routingRegression.edge.test.ts | Covers locale-prefix exclusion, route precedence, parameter-name handling, redirect termination, and alias switching. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Incoming pathname] --> B[Resolve and standardize locale]
    B --> C[Segment-trie lookup]
    C --> D{Best route match}
    D -->|Shared route| E[Use unprefixed shared template]
    D -->|Localized route| F[Use matched localized template]
    E --> G[Extract dynamic parameters]
    F --> G
    G --> H[Build shared and localized paths]
    H --> I{Routing decision}
    I -->|Canonical URL differs| J[Redirect]
    I -->|Localized public path| K[Rewrite to shared route]
    I -->|No path change| L[Continue request]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(next): accept brackets inside catch-..."](https://github.com/generaltranslation/gt/commit/09969f3b7fd2de8d159ca09485ee9d8613c4a915) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60630128)</sub>

**Context used:**

- Knowledge Base — [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)

<!-- /greptile_comment -->
