### PR TITLE
fix(next): [3/5] support trailing slash middleware paths

### DIFF
--- a/.changeset/support-trailing-slash-paths.md
+++ b/.changeset/support-trailing-slash-paths.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Match middleware paths with trailing slashes and preserve them in rewrites.

--- a/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+const origin = 'http://localhost:3000';
+describe.each([true, false])(
+  'prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    describe.each(['', '/'])('configured slash="%s"', (configuredSlash) => {
+      it.each(['', '/'])('preserves request slash="%s"', (slash) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: {
+            ['/about' + configuredSlash]: {
+              en: '/company' + configuredSlash,
+              fr: '/a-propos' + configuredSlash,
+            },
+            ['/posts/[id]' + configuredSlash]: {
+              en: '/entries/[id]' + configuredSlash,
+              fr: '/articles/[id]' + configuredSlash,
+            },
+          },
+        });
+        for (const locale of ['en', 'fr']) {
+          const prefix =
+            locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+          const aliases =
+            locale === 'en'
+              ? ['/company', '/entries/123']
+              : ['/a-propos', '/articles/123'];
+          for (const [index, shared] of ['/about', '/posts/123'].entries()) {
+            const publicPath = prefix + aliases[index] + slash;
+            const response = middleware(
+              new NextRequest(origin + publicPath + '?tag=a&tag=b')
+            );
+            expect(response.headers.get('location')).toBeNull();
+            expect(response.headers.get('x-middleware-rewrite')).toBe(
+              origin + '/' + locale + shared + slash + '?tag=a&tag=b'
+            );
+            const redirect = middleware(
+              new NextRequest(origin + prefix + shared + slash)
+            );
+            expect(redirect.headers.get('location')).toBe(origin + publicPath);
+          }
+        }
+      });
+    });
+  }
+);
+
+it('keeps the locale landing slash when matching the shared root', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: true,
+    pathConfig: { '/': { fr: '/home' } },
+  });
+  const response = middleware(new NextRequest(origin + '/fr/'));
+  expect(response.headers.get('location')).toBe(origin + '/fr/home/');
+});

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -13,3 +13,8 @@ export function normalizePathname(pathname: string): string {
     })
     .join('/');
 }
+
+/** Removes trailing slashes while keeping the root pathname distinct. */
+export function stripTrailingSlashes(pathname: string): string {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') || '/' : pathname;
+}

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -3,7 +3,7 @@ import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
-import { normalizePathname } from './pathname';
+import { normalizePathname, stripTrailingSlashes } from './pathname';
 
 export { normalizePathname };
 
@@ -32,6 +32,7 @@ function normalizePathForMatching(pathname: string): string {
 
 /** Classifies placeholders before decoding static path content. */
 function createPathPattern(pathname: string): string {
+  pathname = stripTrailingSlashes(pathname);
   if (!/\[([^\]]+)\]/.test(pathname)) {
     return normalizePathForMatching(pathname);
   }
@@ -43,6 +44,17 @@ function createPathPattern(pathname: string): string {
         : normalizePathForMatching(part).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     )
     .join('');
+}
+
+/** Applies the request pathname's trailing-slash style to a target path. */
+function applyTrailingSlash(pathname: string, targetPathname: string): string {
+  const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
+  if (sourceHasTrailingSlash) {
+    return targetPathname === '/' || targetPathname.endsWith('/')
+      ? targetPathname
+      : `${targetPathname}/`;
+  }
+  return stripTrailingSlashes(targetPathname);
 }
 
 export function getResponse({
@@ -131,14 +143,16 @@ export function replaceDynamicSegments(
   path: string,
   templatePath: string
 ): string {
-  if (!templatePath.includes('[')) return templatePath;
+  if (!templatePath.includes('[')) {
+    return applyTrailingSlash(path, templatePath);
+  }
 
   const params = extractDynamicParams(templatePath, path);
   let paramIndex = 0;
   const result = templatePath.replace(/\[([^\]]+)\]/g, (match: string) => {
     return params[paramIndex++] || match;
   });
-  return result;
+  return applyTrailingSlash(path, result);
 }
 
 /**
@@ -210,16 +224,20 @@ export function getSharedPath(
   pathnameLocale: string | undefined
 ): string | undefined {
   standardizedPathname = normalizePathForMatching(standardizedPathname);
+  const pathnameWithoutTrailingSlash =
+    stripTrailingSlashes(standardizedPathname);
   // Try exact match first
-  if (pathToSharedPath[standardizedPathname]) {
-    return pathToSharedPath[standardizedPathname];
+  if (pathToSharedPath[pathnameWithoutTrailingSlash]) {
+    return pathToSharedPath[pathnameWithoutTrailingSlash];
   }
 
   // Without locale prefix
   let pathnameWithoutLocale = undefined;
   // Only remove locale prefix if the locale prefix is valid
   if (pathnameLocale) {
-    pathnameWithoutLocale = standardizedPathname.replace(/^\/[^/]+/, '');
+    pathnameWithoutLocale = stripTrailingSlashes(
+      standardizedPathname.replace(/^\/[^/]+/, '')
+    );
     if (pathToSharedPath[pathnameWithoutLocale]) {
       return pathToSharedPath[pathnameWithoutLocale];
     }
@@ -232,7 +250,7 @@ export function getSharedPath(
       // Convert the pattern to a strict regex that matches the exact path structure
       const regex = new RegExp(`^${pattern}$`);
       // Exact match
-      if (regex.test(standardizedPathname)) {
+      if (regex.test(pathnameWithoutTrailingSlash)) {
         return sharedPath;
       }
       // Without locale prefix
@@ -259,7 +277,7 @@ function inDefaultLocalePaths(
   pathname: string,
   defaultLocalePaths: string[]
 ): boolean {
-  pathname = normalizePathForMatching(pathname);
+  pathname = stripTrailingSlashes(normalizePathForMatching(pathname));
   // Try exact match first
   if (defaultLocalePaths.includes(pathname)) {
     return true;


### PR DESCRIPTION
> Continued in #2266 after stack restructuring. GitHub marked this PR merged into an intermediate branch; the scoped change is being reviewed against its intended base in the replacement PR.

## Summary

- match configured middleware paths with or without a trailing slash
- preserve the incoming slash style in static, dynamic, and catch-all rewrites
- avoid redirect loops between middleware output and Next.js `trailingSlash` canonicalization

## Testing

- `pnpm --filter gt-next test:js` — passed, 297 tests
- `pnpm --filter gt-next typecheck` — passed
- targeted `oxfmt` and `oxlint` — passed

## Notes

- Changeset: patch release for `gt-next`.
- Stack: based on #2244; base-path preservation and locale route overrides follow this PR.










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates middleware path matching and rewrite generation to support trailing-slash requests without triggering conflicting canonicalization.
- Removes trailing slashes before matcher-trie traversal.
- Preserves the incoming slash style across static, dynamic, and catch-all rewrites.
- Adds focused matcher, rewrite, and middleware integration tests.
- Includes a patch changeset for `gt-next`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the trailing-slash matching and rewrite behavior covered and no outstanding findings.

The prior catch-all finding was resolved, and the current implementation safely handles supported Next.js catch-all route shapes while preserving the incoming slash style. No new actionable correctness, security, or repository-rule violations remain.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/createPathMatcher.ts | Separates trailing-slash removal from per-segment Unicode and URI normalization while retaining consistent trie insertion and lookup behavior. |
| packages/next/src/middleware-dir/utils.ts | Applies the request pathname’s trailing-slash style to static and parameterized rewrite targets. |
| packages/next/src/middleware-dir/__tests__/utils.test.ts | Adds focused coverage for slash-preserving rewrites and slash-insensitive route matching. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Verifies end-to-end trailing-slash preservation for static and catch-all path-config rewrites. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Incoming pathname] --> B[Strip trailing slashes for matching]
  B --> C[Match static or dynamic route]
  C --> D[Extract dynamic parameters]
  D --> E[Build rewrite target]
  E --> F[Apply incoming trailing-slash style]
  F --> G[Next.js rewrite response]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;e/next/normalize-middlewar..."](https://github.com/generaltranslation/gt/commit/21deb2daac90f7c75c6ba7f27e2cb99f0cae1c25) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60630118)</sub>

<!-- /greptile_comment -->