### PR TITLE
fix(next): [4/5] preserve middleware base paths

### DIFF
--- a/.changeset/preserve-middleware-base-path.md
+++ b/.changeset/preserve-middleware-base-path.md
@@ -1,0 +1,7 @@
+---
+'gt-next': patch
+---
+
+Preserve the configured Next.js base path in middleware rewrites and redirects.
+
+Handle app routes and locale prefixes that repeat the base path without dropping a segment or redirecting to themselves.

--- a/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+const origin = 'http://localhost:3000';
+
+describe.each(['/docs', '/fr', '/en', '/corp/nested'])(
+  'basePath=%s',
+  (basePath) => {
+    it.each(['', '/'])(
+      'retains a same-named app route (trailing slash "%s")',
+      (slash) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: false,
+          pathConfig: {
+            '/about': { en: basePath + '/about', fr: '/a-propos' },
+          },
+        });
+        const request = (path: string) =>
+          new NextRequest(origin + basePath + path, {
+            nextConfig: { basePath },
+          });
+        const response = middleware(request('/about' + slash + '?tag=a&tag=b'));
+        expect(response.headers.get('location')).toBe(
+          origin + basePath + basePath + '/about' + slash + '?tag=a&tag=b'
+        );
+      }
+    );
+    it('retains a locale prefix identical to the base path', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: { '/posts/[id]': { fr: '/articles/[id]' } },
+      });
+      const response = middleware(
+        new NextRequest(origin + basePath + '/fr/articles/123', {
+          nextConfig: { basePath },
+        })
+      );
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        origin + basePath + '/fr/posts/123'
+      );
+    });
+  }
+);

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -35,6 +35,7 @@ function createRequest(
     cookies?: Record<string, string>;
     acceptLanguage?: string;
     search?: string;
+    basePath?: string;
   } = {}
 ): NextRequest {
   const url = new URL(pathname, 'http://localhost:3000');
@@ -45,7 +46,10 @@ function createRequest(
     headers.set('accept-language', opts.acceptLanguage);
   }
 
-  const req = new NextRequest(url, { headers });
+  const req = new NextRequest(url, {
+    headers,
+    nextConfig: opts.basePath ? { basePath: opts.basePath } : undefined,
+  });
   if (opts.cookies) {
     for (const [name, value] of Object.entries(opts.cookies)) {
       req.cookies.set(name, value);
@@ -405,6 +409,32 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('redirect');
       expect(getResponseSearch(res)).toBe('?page=2');
+    });
+
+    it('preserves basePath on rewrites and redirects', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/about': { fr: '/a-propos' },
+        },
+      });
+
+      const rewriteResponse = middleware(
+        createRequest('/corp/fr/a-propos', {
+          basePath: '/corp',
+          search: 'preview=true',
+        })
+      );
+      const redirectResponse = middleware(
+        createRequest('/corp/fr/about', { basePath: '/corp' })
+      );
+
+      expect(getResponseType(rewriteResponse)).toBe('rewrite');
+      expect(getResponsePath(rewriteResponse)).toBe('/corp/fr/about');
+      expect(getResponseSearch(rewriteResponse)).toBe('?preview=true');
+      expect(getResponseType(redirectResponse)).toBe('redirect');
+      expect(getResponsePath(redirectResponse)).toBe('/corp/fr/a-propos');
     });
 
     it('sets locale header on rewrite responses', () => {

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -46,6 +46,15 @@ function createPathPattern(pathname: string): string {
     .join('');
 }
 
+function applyBasePath(responseUrl: URL, originalUrl: NextURL) {
+  const { basePath } = originalUrl;
+  if (!basePath || responseUrl.origin !== originalUrl.origin) {
+    return;
+  }
+  // Middleware targets are app-relative, even when a route repeats the base path.
+  responseUrl.pathname = `${basePath}${responseUrl.pathname}`;
+}
+
 /** Applies the request pathname's trailing-slash style to a target path. */
 function applyTrailingSlash(pathname: string, targetPathname: string): string {
   const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
@@ -79,6 +88,7 @@ export function getResponse({
     });
   } else {
     const responseUrl = new URL(responsePath, originalUrl);
+    applyBasePath(responseUrl, originalUrl);
     responseUrl.search = originalUrl.search;
     response =
       type === 'rewrite'


### PR DESCRIPTION
> Continued in #2267 after stack restructuring. GitHub marked this PR merged into an intermediate branch; the scoped change is being reviewed against its intended base in the replacement PR.

## Summary

- preserve Next.js `basePath` when constructing middleware rewrite and redirect URLs
- avoid double-prefixing paths that already contain the configured base path
- retain query strings while routing under a base path

## Testing

- `pnpm --filter gt-next test:js` — passed, 298 tests
- `pnpm --filter gt-next typecheck` — passed
- targeted `oxfmt` and `oxlint` — passed

## Notes

- Changeset: patch release for `gt-next`.
- Stack: based on #2245; locale route overrides follow this PR.










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves the configured Next.js `basePath` when middleware constructs same-origin rewrite and redirect URLs.
- Adds the base path to app-relative middleware destinations without relying on pathname-text inference.
- Preserves query strings and repeated base-path route segments.
- Adds focused edge-runtime regression coverage for rewrites, redirects, trailing slashes, repeated route segments, and locale/base-path collisions.
- Adds a patch changeset for `gt-next`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the prior base-path collision finding is resolved and no new actionable failures remain.

The middleware now applies the configured base path based on request metadata rather than inferring whether it is present from target pathname text, preserving legitimate repeated segments while limiting prefixing to same-origin URLs. Focused tests cover the corrected collision and query-string behavior. The previous thread was manually resolved after the implementation stopped using the problematic pathname-prefix guard.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Adds explicit same-origin base-path application when constructing middleware rewrite and redirect URLs. |
| packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts | Covers repeated base-path route segments, locale collisions, trailing slashes, and query preservation. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Extends integration coverage to base-path-aware rewrites and redirects. |
| .changeset/preserve-middleware-base-path.md | Records the middleware base-path correction as a patch release. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Incoming URL with basePath] --> B[Locale middleware]
    B --> C{Response type}
    C -->|next| D[Continue request]
    C -->|rewrite or redirect| E[Construct app-relative target]
    E --> F[Prefix same-origin target with basePath]
    F --> G[Restore original query string]
    G --> H[Next.js response]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["Merge branch &#39;e/next/support-trailing-sl..."](https://github.com/generaltranslation/gt/commit/e89f394242f99f85f64cb273ec6581ab01a9df00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60630122)</sub>

**Context used:**

- Knowledge Base — [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)

<!-- /greptile_comment -->