### PR TITLE
feat(cli): save-local config

### DIFF
--- a/.changeset/silent-weeks-pull.md
+++ b/.changeset/silent-weeks-pull.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Add `saveLocal` to `gt.config.json`

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -782,6 +782,11 @@
           "description": "Flattens JSON files into a single file",
           "default": false
         },
+        "saveLocal": {
+          "type": "boolean",
+          "description": "Detect and save local edits to translated output before enqueuing translations. Can be overridden per run with --save-local / --no-save-local.",
+          "default": true
+        },
         "baseDomain": {
           "type": "string",
           "format": "uri",

--- a/packages/cli/src/cli/__tests__/flags.test.ts
+++ b/packages/cli/src/cli/__tests__/flags.test.ts
@@ -13,8 +13,8 @@ function parseTranslateFlags(args: string[] = []) {
 }
 
 describe('attachTranslateFlags', () => {
-  it('saves local edits by default', () => {
-    expect(parseTranslateFlags().saveLocal).toBe(true);
+  it('leaves save-local unset by default so config can decide', () => {
+    expect(parseTranslateFlags().saveLocal).toBeUndefined();
   });
 
   it('keeps the explicit save-local flag enabled', () => {

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -49,8 +49,7 @@ export function attachTranslateFlags(command: Command) {
     )
     .option(
       '--save-local',
-      'Detect and save local edits before enqueuing translations',
-      true
+      'Detect and save local edits before enqueuing translations (default: true; configurable via options.saveLocal in gt.config.json)'
     )
     .option(
       '--no-save-local',

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -262,6 +262,55 @@ describe('generateSettings - composite patterns', () => {
     );
   });
 
+  describe('options.saveLocal', () => {
+    it('defaults to true when neither flag nor config sets it', async () => {
+      const settings = await generateSettings({}, '/test/cwd');
+      expect(settings.options?.saveLocal).toBe(true);
+    });
+
+    it('reads options.saveLocal from gt.config.json', async () => {
+      mockResolveConfig.mockReturnValueOnce({
+        config: {
+          defaultLocale: 'en',
+          locales: ['fr', 'es'],
+          options: { saveLocal: false },
+        },
+        path: '/test/gt.config.json',
+      });
+      const settings = await generateSettings({}, '/test/cwd');
+      expect(settings.options?.saveLocal).toBe(false);
+    });
+
+    it('lets --no-save-local override a config value of true', async () => {
+      mockResolveConfig.mockReturnValueOnce({
+        config: {
+          defaultLocale: 'en',
+          locales: ['fr', 'es'],
+          options: { saveLocal: true },
+        },
+        path: '/test/gt.config.json',
+      });
+      const settings = await generateSettings(
+        { saveLocal: false },
+        '/test/cwd'
+      );
+      expect(settings.options?.saveLocal).toBe(false);
+    });
+
+    it('lets --save-local override a config value of false', async () => {
+      mockResolveConfig.mockReturnValueOnce({
+        config: {
+          defaultLocale: 'en',
+          locales: ['fr', 'es'],
+          options: { saveLocal: false },
+        },
+        path: '/test/gt.config.json',
+      });
+      const settings = await generateSettings({ saveLocal: true }, '/test/cwd');
+      expect(settings.options?.saveLocal).toBe(true);
+    });
+  });
+
   it('should handle mixed composite and non-composite patterns', async () => {
     const options = {
       files: {

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -57,6 +57,7 @@ type GenerateSettingsInput = Partial<Omit<Settings, 'tag'>> & {
   files?: unknown;
   publish?: boolean;
   omitConfigIds?: boolean;
+  saveLocal?: boolean;
   tag?: string | boolean;
   message?: string;
   branch?: string;
@@ -322,6 +323,7 @@ export async function generateSettings(
       flags.experimentalClearLocaleDirs,
     clearLocaleDirsExclude:
       gtConfig.options?.clearLocaleDirsExclude || flags.clearLocaleDirsExclude,
+    saveLocal: flags.saveLocal ?? gtConfig.options?.saveLocal ?? true,
   };
 
   if (

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -337,6 +337,7 @@ export type AdditionalOptions = {
     replace: string; // replacement prefix, can include [locale] or [defaultLocale]
   }>;
   experimentalCanonicalLocaleKeys?: boolean; // For composite JSON schemas with locale keys, force canonical locale even when alias provided
+  saveLocal?: boolean; // if true, detect and save local edits to translated output before enqueuing translations (default: true)
 };
 
 export type SharedStaticAssetsConfig = {

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -32,7 +32,7 @@ vi.mock('../steps/BranchStep.js', () => ({
 }));
 vi.mock('../steps/UploadSourcesStep.js', () => ({
   UploadSourcesStep: vi.fn(() => ({
-    run: vi.fn(async () => []),
+    run: vi.fn(async ({ files }: { files: unknown[] }) => files),
     wait: vi.fn(),
   })),
 }));
@@ -48,8 +48,11 @@ vi.mock('../steps/EnqueueStep.js', () => ({
 vi.mock('../steps/TagStep.js', () => ({
   TagStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
 }));
+const { userEditDiffsRun } = vi.hoisted(() => ({
+  userEditDiffsRun: vi.fn(),
+}));
 vi.mock('../steps/UserEditDiffsStep.js', () => ({
-  UserEditDiffsStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
+  UserEditDiffsStep: vi.fn(() => ({ run: userEditDiffsRun, wait: vi.fn() })),
 }));
 vi.mock('../utils/filterFilesForEnqueue.js', () => ({
   filterFilesForEnqueue: vi.fn(async ({ files }: { files: unknown[] }) => ({
@@ -117,5 +120,53 @@ describe('runStageFilesWorkflow font sync', () => {
       expect.stringContaining('Font sync failed')
     );
     expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+  });
+});
+
+describe('runStageFilesWorkflow save-local gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(collectFonts).mockResolvedValue([]);
+  });
+
+  it('saves local edits when options.saveLocal is true', async () => {
+    await runStageFilesWorkflow({
+      files,
+      options,
+      settings: { ...settings, options: { saveLocal: true } } as Settings,
+    });
+
+    expect(userEditDiffsRun).toHaveBeenCalledTimes(1);
+    expect(userEditDiffsRun).toHaveBeenCalledWith(files);
+  });
+
+  it('skips saving local edits when options.saveLocal is false', async () => {
+    const result = await runStageFilesWorkflow({
+      files,
+      options,
+      settings: { ...settings, options: { saveLocal: false } } as Settings,
+    });
+
+    expect(userEditDiffsRun).not.toHaveBeenCalled();
+    // The rest of the workflow still runs
+    expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
+  });
+
+  it('saves local edits when options.saveLocal is not set', async () => {
+    await runStageFilesWorkflow({ files, options, settings });
+
+    expect(userEditDiffsRun).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores the raw flag and uses the resolved setting', async () => {
+    // generateSettings folds the flag into settings.options.saveLocal; the
+    // workflow must not read the unresolved flag directly.
+    await runStageFilesWorkflow({
+      files,
+      options: { ...options, saveLocal: true } as TranslateFlags,
+      settings: { ...settings, options: { saveLocal: false } } as Settings,
+    });
+
+    expect(userEditDiffsRun).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -65,7 +65,7 @@ export async function runStageFilesWorkflow({
     const uploadedFiles = await uploadStep.run({ files, branchData });
 
     // optionally run the user edit diffs step
-    if (options?.saveLocal) {
+    if (settings.options?.saveLocal !== false) {
       await userEditDiffsStep.run(uploadedFiles);
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes local-edit submission configurable through `options.saveLocal` while preserving the existing default-enabled behavior.
- Adds `saveLocal` to the configuration schema and CLI settings types.
- Resolves explicit CLI flags ahead of configuration and the default value.
- Gates local-edit submission on the resolved setting.
- Adds direct workflow tests covering enabled, disabled, unset, and flag-resolution behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the previously missing workflow coverage has been added and no new actionable issues were identified.

The current tests directly exercise local-edit submission when the resolved setting is enabled, disabled, or absent, and confirm that the workflow consumes resolved settings rather than raw flags. The previous finding is fully fixed.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Resolves `saveLocal` using flag-over-config precedence with a default of true. |
| packages/cli/src/workflows/stage.ts | Uses the resolved setting to decide whether local translation edits are submitted. |
| packages/cli/src/workflows/__tests__/stage.test.ts | Adds focused coverage for all branches of the local-edit submission gate. |
| packages/cli/src/cli/flags.ts | Leaves the positive flag unset by default so project configuration can control behavior. |
| assets/config-schema.json | Documents and validates the new boolean configuration option. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[CLI save-local flag] --> C[Generate resolved settings]
    B[gt.config.json options.saveLocal] --> C
    C --> D{settings.options.saveLocal is false?}
    D -->|No| E[Submit local edit diffs]
    D -->|Yes| F[Skip local edit submission]
    E --> G[Continue staging and enqueue]
    F --> G
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): cover save-local gate in stag..."](https://github.com/generaltranslation/gt/commit/65f85db7ca34721a2014e8cc9234e803099c9308) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61310940)</sub>

**Context used:**

- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)

<!-- /greptile_comment -->