### PR TITLE
feat(cli) 2/5: slice catalogs into a source upload and per-locale translation uploads

### DIFF
--- a/.changeset/xcstrings-slice-upload.md
+++ b/.changeset/xcstrings-slice-upload.md
@@ -1,7 +1,0 @@
----
-'@generaltranslation/api': minor
-'generaltranslation': minor
-'gt': minor
----
-
-Add Apple `.xcstrings` catalog upload support to the CLI. An `.xcstrings` catalog holds every locale in one file; on upload the CLI extracts a source-only slice (only the catalog's `sourceLanguage` localization per entry) and uploads that as the source document. The slice is serialized with a pinned byte layout and hashed into its `versionId`, so an unchanged catalog re-slices byte-identically and does not re-upload. Configure it under `files.xcstrings` in `gt.config.json`; patterns without `[locale]` are expected because the catalog is shared across locales.

--- a/.changeset/xcstrings-slice-upload.md
+++ b/.changeset/xcstrings-slice-upload.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/api': minor
+'generaltranslation': minor
+'gt': minor
+---
+
+Add Apple `.xcstrings` catalog upload support to the CLI. An `.xcstrings` catalog holds every locale in one file; on upload the CLI extracts a source-only slice (only the catalog's `sourceLanguage` localization per entry) and uploads that as the source document. The slice is serialized with a pinned byte layout and hashed into its `versionId`, so an unchanged catalog re-slices byte-identically and does not re-upload. Configure it under `files.xcstrings` in `gt.config.json`; patterns without `[locale]` are expected because the catalog is shared across locales.

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -71,6 +71,7 @@ import { createFileMapping } from '../../../formats/files/fileMapping.js';
 import { logger } from '../../../console/logger.js';
 import { existsSync, readFileSync } from 'node:fs';
 import { logErrorAndExit } from '../../../console/logging.js';
+import { gt } from '../../../utils/gt.js';
 
 function setMockFiles(files: Record<string, string>) {
   (vi as unknown).__mockFiles = files;
@@ -719,6 +720,29 @@ describe('upload - Apple .xcstrings catalogs', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it('slices an aliased locale by its canonical tag and uploads it under the alias', async () => {
+    setMockFiles({ [CATALOG]: catalogContent });
+    vi.mocked(createFileMapping).mockReturnValue({
+      french: { [CATALOG]: CATALOG },
+    });
+    gt.setConfig({ customMapping: { french: { code: 'fr' } } });
+    try {
+      await uploadWithFiles(
+        { xcstrings: [CATALOG] },
+        makeSettings({ locales: ['french'], options: {} })
+      );
+    } finally {
+      gt.setConfig({ customMapping: {} });
+    }
+
+    expect(logErrorAndExit).not.toHaveBeenCalled();
+    const { translations } = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0]
+      .files[0];
+    expect(translations.map((t) => t.locale)).toEqual(['french']);
+    const slice = JSON.parse(translations[0].content) as Catalog;
+    expect(Object.keys(slice.strings.greeting.localizations!)).toEqual(['fr']);
   });
 
   it('uploads one single-locale slice per locale the catalog carries', async () => {

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -663,3 +663,152 @@ describe('upload - Apple .strings translations that cannot be decoded', () => {
     expect(uploaded?.translations).toHaveLength(0);
   });
 });
+
+describe('upload - Apple .xcstrings catalogs', () => {
+  const CATALOG = 'App/Localizable.xcstrings';
+  const catalogContent = JSON.stringify({
+    sourceLanguage: 'en',
+    unknownRoot: { keep: true },
+    strings: {
+      Save: {},
+      greeting: {
+        comment: 'Home screen',
+        unknownEntryField: 7,
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: 'Hello' } },
+          de: { stringUnit: { state: 'translated', value: 'Hallo' } },
+          fr: { stringUnit: { state: 'translated', value: 'Bonjour' } },
+          ar: {
+            stringUnit: { state: 'translated', value: 'مرحبا' },
+            unknownLocalizationField: { deep: 'value' },
+          },
+        },
+      },
+      'items.count': {
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: '%d items' } },
+          de: { stringUnit: { state: 'translated', value: '%d Elemente' } },
+        },
+      },
+    },
+    version: '1.0',
+  });
+
+  type Catalog = {
+    sourceLanguage: string;
+    strings: Record<
+      string,
+      { localizations?: Record<string, unknown>; [key: string]: unknown }
+    >;
+    [key: string]: unknown;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue('');
+    // Every locale maps to the shared catalog path; the file always exists,
+    // which is exactly what used to make the whole catalog upload per locale.
+    vi.mocked(createFileMapping).mockReturnValue({
+      de: { [CATALOG]: CATALOG },
+      fr: { [CATALOG]: CATALOG },
+      ar: { [CATALOG]: CATALOG },
+      ja: { [CATALOG]: CATALOG },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads one single-locale slice per locale the catalog carries', async () => {
+    setMockFiles({ [CATALOG]: catalogContent });
+
+    await uploadWithFiles(
+      { xcstrings: [CATALOG] },
+      makeSettings({ locales: ['de', 'fr', 'ar', 'ja'], options: {} })
+    );
+
+    expect(logErrorAndExit).not.toHaveBeenCalled();
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    const { source, translations } = call.files[0];
+
+    expect(source.fileFormat).toBe('XCSTRINGS');
+    const sourceSlice = JSON.parse(source.content) as Catalog;
+    expect(Object.keys(sourceSlice.strings)).toEqual([
+      'Save',
+      'greeting',
+      'items.count',
+    ]);
+    expect(Object.keys(sourceSlice.strings.greeting.localizations!)).toEqual([
+      'en',
+    ]);
+
+    // ja is configured but absent from the catalog, so it is skipped
+    expect(translations.map((t) => t.locale)).toEqual(['de', 'fr', 'ar']);
+    for (const translation of translations) {
+      expect(translation.fileName).toBe(CATALOG);
+      expect(translation.fileFormat).toBe('XCSTRINGS');
+      expect(translation.fileId).toBe(source.fileId);
+      expect(translation.versionId).toBe(source.versionId);
+      const slice = JSON.parse(translation.content) as Catalog;
+      expect(slice.sourceLanguage).toBe('en');
+      for (const entry of Object.values(slice.strings)) {
+        expect(Object.keys(entry.localizations!)).toEqual([translation.locale]);
+      }
+    }
+
+    const de = JSON.parse(translations[0].content) as Catalog;
+    const ar = JSON.parse(translations[2].content) as Catalog;
+    // Entries without the locale are absent; the implicit "Save" never appears
+    expect(Object.keys(de.strings)).toEqual(['greeting', 'items.count']);
+    expect(Object.keys(ar.strings)).toEqual(['greeting']);
+    expect(de.strings.greeting.localizations!.de).toEqual({
+      stringUnit: { state: 'translated', value: 'Hallo' },
+    });
+
+    // Unknown fields survive at every level; entry-level fields travel along
+    expect(ar.unknownRoot).toEqual({ keep: true });
+    expect(ar.version).toBe('1.0');
+    expect(ar.strings.greeting.comment).toBe('Home screen');
+    expect(ar.strings.greeting.unknownEntryField).toBe(7);
+    expect(ar.strings.greeting.localizations!.ar).toEqual({
+      stringUnit: { state: 'translated', value: 'مرحبا' },
+      unknownLocalizationField: { deep: 'value' },
+    });
+
+    // The whole catalog is never uploaded as a translation
+    for (const translation of translations) {
+      expect(translation.content).not.toBe(catalogContent);
+      expect(translation.content).toBe(
+        JSON.stringify(JSON.parse(translation.content), null, 2) + '\n'
+      );
+    }
+  });
+
+  it('uploads the source alone when the catalog carries no target locale', async () => {
+    setMockFiles({
+      [CATALOG]: JSON.stringify({
+        sourceLanguage: 'en',
+        strings: {
+          Save: {},
+          greeting: {
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Hello' } },
+            },
+          },
+        },
+      }),
+    });
+
+    await uploadWithFiles(
+      { xcstrings: [CATALOG] },
+      makeSettings({ locales: ['de', 'fr'], options: {} })
+    );
+
+    const call = vi.mocked(runUploadFilesWorkflow).mock.calls[0][0];
+    expect(call.files).toHaveLength(1);
+    expect(call.files[0].translations).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -24,6 +24,7 @@ import {
   sliceTranslationCatalog,
   type XcstringsCatalog,
 } from '../../formats/xcstrings/parseXcstrings.js';
+import { gt } from '../../utils/gt.js';
 
 /**
  * Sends multiple files to the API for translation
@@ -117,7 +118,11 @@ export async function upload(
 
     for (const locale of locales) {
       if (xcstringsCatalog) {
-        const slice = sliceTranslationCatalog(xcstringsCatalog, locale);
+        // Catalog keys are canonical tags; the configured locale may be an alias.
+        const slice = sliceTranslationCatalog(
+          xcstringsCatalog,
+          gt.resolveCanonicalLocale(locale)
+        );
         // A locale the catalog does not carry has nothing to upload
         if (!slice) continue;
         translations.push({

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -18,6 +18,12 @@ import { hasValidCredentials } from './utils/validation.js';
 import { runPublishWorkflow } from '../../workflows/publish.js';
 import { aggregateFiles } from '../../formats/files/aggregateFiles.js';
 import { recordWarning } from '../../state/translateWarnings.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+  type XcstringsCatalog,
+} from '../../formats/xcstrings/parseXcstrings.js';
 
 /**
  * Sends multiple files to the API for translation
@@ -42,13 +48,13 @@ export async function upload(
   // Reuse the same source aggregation path as translate/stage so source
   // parsing behavior stays consistent across commands.
   const { files: allFiles, publishMap } = await aggregateFiles(settings);
+  const sourceFileNames = new Set(allFiles.map((file) => file.fileName));
   const compositeJsonFiles = new Map<
     string,
     { filePath: string; content: string }
   >();
 
   if (filePaths.json) {
-    const sourceFileNames = new Set(allFiles.map((file) => file.fileName));
     for (const filePath of filePaths.json) {
       const relativePath = getRelative(filePath);
       if (!sourceFileNames.has(relativePath)) continue;
@@ -60,6 +66,21 @@ export async function upload(
           content: readFile(filePath),
         });
       }
+    }
+  }
+
+  // An .xcstrings catalog carries its own translations, so each locale's
+  // upload is a slice of the same file rather than a separate translation
+  // file. Catalogs aggregateFiles could not parse are already reported.
+  const xcstringsCatalogs = new Map<string, XcstringsCatalog>();
+  if (filePaths.xcstrings) {
+    for (const filePath of filePaths.xcstrings) {
+      const relativePath = getRelative(filePath);
+      if (!sourceFileNames.has(relativePath)) continue;
+      xcstringsCatalogs.set(
+        relativePath,
+        parseXcstringsCatalog(readFile(filePath))
+      );
     }
   }
 
@@ -92,9 +113,23 @@ export async function upload(
 
     const translations: FileToUpload[] = [];
     const compositeInfo = compositeJsonFiles.get(file.fileName);
+    const xcstringsCatalog = xcstringsCatalogs.get(file.fileName);
 
     for (const locale of locales) {
-      if (compositeInfo) {
+      if (xcstringsCatalog) {
+        const slice = sliceTranslationCatalog(xcstringsCatalog, locale);
+        // A locale the catalog does not carry has nothing to upload
+        if (!slice) continue;
+        translations.push({
+          content: serializeXcstringsSlice(slice),
+          fileName: file.fileName,
+          fileFormat: file.transformFormat ?? file.fileFormat,
+          dataFormat: file.dataFormat,
+          locale,
+          fileId: file.fileId,
+          versionId: file.versionId,
+        });
+      } else if (compositeInfo) {
         // Composite JSON: extract translations from the same source file
         const extracted = extractJson(
           compositeInfo.content,

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -445,6 +445,19 @@ export const lottieExpressionsError = (files: string[]): string =>
       '\n'
     )}\nRe-export the animation with expressions baked into keyframes (or removed), then try again.`;
 
+export const xcstringsSourceLanguageMismatchError = (
+  catalogs: { file: string; sourceLanguage: string }[],
+  defaultLocale: string
+): string =>
+  `The following .xcstrings catalog(s) declare a sourceLanguage that does not match the configured defaultLocale "${defaultLocale}":\n${catalogs
+    .map(
+      ({ file, sourceLanguage }) =>
+        `  - ${file} (sourceLanguage "${sourceLanguage}")`
+    )
+    .join(
+      '\n'
+    )}\nSet defaultLocale in gt.config.json to the catalog's sourceLanguage, or change the catalog's source language in Xcode, then try again.`;
+
 export const fileEncodingSkipReason = (error: unknown): string =>
   `File could not be decoded: ${error instanceof Error ? error.message : String(error)}`;
 

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { aggregateFiles } from '../aggregateFiles.js';
 import { logger } from '../../../console/logger.js';
+import { logErrorAndExit } from '../../../console/logging.js';
 import { readFile, getRelative } from '../../../fs/findFilepath.js';
 import { readFileContent } from '../../../fs/fileContent.js';
 import { parseJson } from '../../json/parseJson.js';
@@ -27,8 +28,15 @@ vi.mock('../../yaml/parseYaml.js');
 vi.mock('../../../utils/sanitizeFileContent.js');
 vi.mock('../../../fs/determineFramework/index.js');
 vi.mock('../../../utils/validateMdx.js');
+// Surface logErrorAndExit as a throw so tests can assert on it
+vi.mock('../../../console/logging.js', () => ({
+  logErrorAndExit: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+}));
 
 const mockLogWarning = vi.mocked(logger.warn);
+const mockLogErrorAndExit = vi.mocked(logErrorAndExit);
 const mockReadFile = vi.mocked(readFile);
 const mockReadFileContent = vi.mocked(readFileContent);
 const mockGetRelative = vi.mocked(getRelative);
@@ -879,5 +887,79 @@ describe('aggregateFiles - Empty File Handling', () => {
       expect(result[0].fileName).toBe('valid.json');
       expect(result[0].content).toBe('parsed content');
     });
+  });
+});
+
+describe('aggregateFiles - Apple .xcstrings catalogs', () => {
+  const catalog = (sourceLanguage: string) =>
+    JSON.stringify({
+      sourceLanguage,
+      version: '1.0',
+      strings: {
+        greeting: {
+          localizations: {
+            [sourceLanguage]: {
+              stringUnit: { state: 'translated', value: 'Hello' },
+            },
+          },
+        },
+      },
+    });
+
+  const settingsFor = (contents: Record<string, string>) => {
+    mockReadFile.mockImplementation((filePath) => contents[filePath] ?? '');
+    return {
+      files: {
+        resolvedPaths: { xcstrings: Object.keys(contents) },
+        placeholderPaths: {},
+      },
+      options: {},
+      defaultLocale: 'en',
+    };
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRelative.mockImplementation((path) =>
+      path.replace('/full/path/', '')
+    );
+  });
+
+  it('stops the run before anything is uploaded when a catalog sourceLanguage does not match defaultLocale', async () => {
+    const settings = settingsFor({
+      '/full/path/App/Localizable.xcstrings': catalog('en'),
+      '/full/path/Legacy/Localizable.xcstrings': catalog('de'),
+    });
+
+    await expect(aggregateTestFiles(settings)).rejects.toThrow();
+
+    expect(mockLogErrorAndExit).toHaveBeenCalledTimes(1);
+    const message = mockLogErrorAndExit.mock.calls[0][0];
+    expect(message).toContain('Legacy/Localizable.xcstrings');
+    expect(message).toContain('sourceLanguage "de"');
+    expect(message).toContain('defaultLocale "en"');
+    expect(message).toContain('gt.config.json');
+    expect(message).not.toContain('App/Localizable.xcstrings');
+    // A configuration error is not reported as a skipped file
+    expect(mockLogWarning).not.toHaveBeenCalled();
+  });
+
+  it('skips a catalog that cannot be parsed and uploads the rest', async () => {
+    const settings = settingsFor({
+      '/full/path/Broken/Localizable.xcstrings': '{"strings": {}}',
+      '/full/path/App/Localizable.xcstrings': catalog('en'),
+    });
+
+    const { files } = await aggregateTestFiles(settings);
+
+    expect(mockLogErrorAndExit).not.toHaveBeenCalled();
+    expect(mockLogWarning).toHaveBeenCalledTimes(1);
+    expect(mockLogWarning).toHaveBeenCalledWith(
+      expect.stringMatching(/^Skipping Broken\/Localizable\.xcstrings: /)
+    );
+    expect(files.map((file) => file.fileName)).toEqual([
+      'App/Localizable.xcstrings',
+    ]);
+    expect(files[0].fileFormat).toBe('XCSTRINGS');
   });
 });

--- a/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
+++ b/packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts
@@ -10,6 +10,7 @@ import sanitizeFileContent from '../../../utils/sanitizeFileContent.js';
 import { determineLibrary } from '../../../fs/determineFramework/index.js';
 import { isValidMdx } from '../../../utils/validateMdx.js';
 import { hashStringSync, hashVersionId } from '../../../utils/hash.js';
+import { gt } from '../../../utils/gt.js';
 import type { Settings } from '../../../types/index.js';
 
 const aggregateTestFiles = (settings: Partial<Settings>) =>
@@ -906,7 +907,10 @@ describe('aggregateFiles - Apple .xcstrings catalogs', () => {
       },
     });
 
-  const settingsFor = (contents: Record<string, string>) => {
+  const settingsFor = (
+    contents: Record<string, string>,
+    defaultLocale = 'en'
+  ) => {
     mockReadFile.mockImplementation((filePath) => contents[filePath] ?? '');
     return {
       files: {
@@ -914,7 +918,7 @@ describe('aggregateFiles - Apple .xcstrings catalogs', () => {
         placeholderPaths: {},
       },
       options: {},
-      defaultLocale: 'en',
+      defaultLocale,
     };
   };
 
@@ -923,6 +927,10 @@ describe('aggregateFiles - Apple .xcstrings catalogs', () => {
     mockGetRelative.mockImplementation((path) =>
       path.replace('/full/path/', '')
     );
+  });
+
+  afterEach(() => {
+    gt.setConfig({ customMapping: {} });
   });
 
   it('stops the run before anything is uploaded when a catalog sourceLanguage does not match defaultLocale', async () => {
@@ -942,6 +950,24 @@ describe('aggregateFiles - Apple .xcstrings catalogs', () => {
     expect(message).not.toContain('App/Localizable.xcstrings');
     // A configuration error is not reported as a skipped file
     expect(mockLogWarning).not.toHaveBeenCalled();
+  });
+
+  it('accepts a defaultLocale alias whose canonical tag is the catalog sourceLanguage', async () => {
+    gt.setConfig({ customMapping: { french: { code: 'fr' } } });
+    const settings = settingsFor(
+      { '/full/path/App/Localizable.xcstrings': catalog('fr') },
+      'french'
+    );
+
+    const { files } = await aggregateTestFiles(settings);
+
+    expect(mockLogErrorAndExit).not.toHaveBeenCalled();
+    expect(mockLogWarning).not.toHaveBeenCalled();
+    expect(files.map((file) => file.fileName)).toEqual([
+      'App/Localizable.xcstrings',
+    ]);
+    // The upload keeps the configured locale, as translation slices do
+    expect(files[0].locale).toBe('french');
   });
 
   it('skips a catalog that cannot be parsed and uploads the rest', async () => {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -17,6 +17,11 @@ import type { FileFormat, DataFormat, FileToUpload } from '../../types/data.js';
 import { SUPPORTED_FILE_EXTENSIONS } from './supportedFiles.js';
 import { parseJson } from '../json/parseJson.js';
 import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceSourceCatalog,
+} from '../xcstrings/parseXcstrings.js';
+import {
   resolveMintlifyRefs,
   shouldResolveRefs,
 } from '../../utils/resolveMintlifyRefs.js';
@@ -446,6 +451,55 @@ export async function aggregateFiles(
     files.push(...verbatimFiles.filter((file) => file !== null));
   }
 
+  // Process Apple .xcstrings catalogs. One catalog holds every locale; only the
+  // source-language slice is uploaded as the source document. The slice is
+  // hashed into versionId, so an unchanged catalog re-slices byte-identically
+  // and does not re-upload.
+  if (filePaths.xcstrings) {
+    const xcstringsFiles = filePaths.xcstrings
+      .map((filePath) => {
+        const content = readFile(filePath);
+        const relativePath = getRelative(filePath);
+
+        let sourceSlice: string;
+        try {
+          const catalog = parseXcstringsCatalog(content);
+          // Slicing follows the catalog's own sourceLanguage while the upload
+          // is labeled settings.defaultLocale; a mismatch would upload
+          // mislabeled source content, so treat it as a config error.
+          if (catalog.sourceLanguage !== settings.defaultLocale) {
+            throw new Error(
+              `catalog sourceLanguage "${catalog.sourceLanguage}" does not match the configured defaultLocale "${settings.defaultLocale}"`
+            );
+          }
+          sourceSlice = serializeXcstringsSlice(sliceSourceCatalog(catalog));
+        } catch (error) {
+          const reason =
+            error instanceof Error
+              ? error.message
+              : 'xcstrings file is not parsable';
+          logger.warn(`Skipping ${relativePath}: ${reason}`);
+          recordWarning('skipped_file', relativePath, reason);
+          return null;
+        }
+
+        return {
+          content: sourceSlice,
+          fileName: relativePath,
+          fileFormat: 'XCSTRINGS' as const,
+          ...getTransformFormatProperty(settings, 'xcstrings'),
+          fileId: hashStringSync(relativePath),
+          versionId: hashVersionId(
+            sourceSlice,
+            requiresReviewPaths.has(filePath)
+          ),
+          locale: settings.defaultLocale,
+        } satisfies FileToUpload;
+      })
+      .filter((file) => file !== null);
+    files.push(...xcstringsFiles);
+  }
+
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
     if (
       fileType === 'json' ||
@@ -454,7 +508,8 @@ export async function aggregateFiles(
       fileType === 'lottie' ||
       fileType === 'dotStrings' ||
       fileType === 'dotStringsdict' ||
-      fileType === 'androidStrings'
+      fileType === 'androidStrings' ||
+      fileType === 'xcstrings'
     )
       continue;
     if (filePaths[fileType]) {

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -3,6 +3,7 @@ import { logErrorAndExit } from '../../console/logging.js';
 import {
   fileEncodingSkipReason,
   lottieExpressionsError,
+  xcstringsSourceLanguageMismatchError,
 } from '../../console/index.js';
 import { recordWarning } from '../../state/translateWarnings.js';
 import { lottieHasExpressions } from './detectLottieExpressions.js';
@@ -20,6 +21,7 @@ import {
   parseXcstringsCatalog,
   serializeXcstringsSlice,
   sliceSourceCatalog,
+  type XcstringsCatalog,
 } from '../xcstrings/parseXcstrings.js';
 import {
   resolveMintlifyRefs,
@@ -456,23 +458,16 @@ export async function aggregateFiles(
   // hashed into versionId, so an unchanged catalog re-slices byte-identically
   // and does not re-upload.
   if (filePaths.xcstrings) {
+    const sourceLanguageMismatches: { file: string; sourceLanguage: string }[] =
+      [];
     const xcstringsFiles = filePaths.xcstrings
       .map((filePath) => {
         const content = readFile(filePath);
         const relativePath = getRelative(filePath);
 
-        let sourceSlice: string;
+        let catalog: XcstringsCatalog;
         try {
-          const catalog = parseXcstringsCatalog(content);
-          // Slicing follows the catalog's own sourceLanguage while the upload
-          // is labeled settings.defaultLocale; a mismatch would upload
-          // mislabeled source content, so treat it as a config error.
-          if (catalog.sourceLanguage !== settings.defaultLocale) {
-            throw new Error(
-              `catalog sourceLanguage "${catalog.sourceLanguage}" does not match the configured defaultLocale "${settings.defaultLocale}"`
-            );
-          }
-          sourceSlice = serializeXcstringsSlice(sliceSourceCatalog(catalog));
+          catalog = parseXcstringsCatalog(content);
         } catch (error) {
           const reason =
             error instanceof Error
@@ -482,6 +477,20 @@ export async function aggregateFiles(
           recordWarning('skipped_file', relativePath, reason);
           return null;
         }
+        // Slicing follows the catalog's own sourceLanguage while the upload is
+        // labeled settings.defaultLocale; a mismatch would upload mislabeled
+        // source content, so it is a configuration error that stops the run
+        // rather than a skipped file.
+        if (catalog.sourceLanguage !== settings.defaultLocale) {
+          sourceLanguageMismatches.push({
+            file: relativePath,
+            sourceLanguage: catalog.sourceLanguage,
+          });
+          return null;
+        }
+        const sourceSlice = serializeXcstringsSlice(
+          sliceSourceCatalog(catalog)
+        );
 
         return {
           content: sourceSlice,
@@ -497,6 +506,14 @@ export async function aggregateFiles(
         } satisfies FileToUpload;
       })
       .filter((file) => file !== null);
+    if (sourceLanguageMismatches.length > 0) {
+      logErrorAndExit(
+        xcstringsSourceLanguageMismatchError(
+          sourceLanguageMismatches,
+          settings.defaultLocale
+        )
+      );
+    }
     files.push(...xcstringsFiles);
   }
 

--- a/packages/cli/src/formats/files/aggregateFiles.ts
+++ b/packages/cli/src/formats/files/aggregateFiles.ts
@@ -35,6 +35,7 @@ import type { JSONObject } from '../../types/data/json.js';
 import YAML from 'yaml';
 import { determineLibrary } from '../../fs/determineFramework/index.js';
 import { hashStringSync, hashVersionId } from '../../utils/hash.js';
+import { gt } from '../../utils/gt.js';
 import { preprocessContent } from './preprocessContent.js';
 import {
   parseKeyedMetadata,
@@ -480,8 +481,12 @@ export async function aggregateFiles(
         // Slicing follows the catalog's own sourceLanguage while the upload is
         // labeled settings.defaultLocale; a mismatch would upload mislabeled
         // source content, so it is a configuration error that stops the run
-        // rather than a skipped file.
-        if (catalog.sourceLanguage !== settings.defaultLocale) {
+        // rather than a skipped file. The configured locale may be a custom
+        // alias, so canonical forms are compared.
+        if (
+          gt.resolveCanonicalLocale(catalog.sourceLanguage) !==
+          gt.resolveCanonicalLocale(settings.defaultLocale)
+        ) {
           sourceLanguageMismatches.push({
             file: relativePath,
             sourceLanguage: catalog.sourceLanguage,

--- a/packages/cli/src/formats/xcstrings/__mocks__/implicit_entries.xcstrings
+++ b/packages/cli/src/formats/xcstrings/__mocks__/implicit_entries.xcstrings
@@ -1,0 +1,29 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "Save" : {
+
+    },
+    "Cancel" : {
+      "comment" : "Toolbar button",
+      "extractionState" : "manual"
+    },
+    "Welcome to %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Welcome to %@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Willkommen bei %@"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/formats/xcstrings/__mocks__/multi_locale.xcstrings
+++ b/packages/cli/src/formats/xcstrings/__mocks__/multi_locale.xcstrings
@@ -1,0 +1,88 @@
+{
+  "sourceLanguage" : "en",
+  "version" : "1.0",
+  "strings" : {
+    "greeting" : {
+      "comment" : "Home screen greeting",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hola"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bonjour"
+          }
+        }
+      }
+    },
+    "account.plan.pro" : {
+      "comment" : "Product name. Do not translate.",
+      "shouldTranslate" : false,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cascade Pro"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cascade Pro"
+          }
+        }
+      }
+    },
+    "items.count" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d item"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d items"
+                }
+              }
+            }
+          }
+        },
+        "fr" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d élément"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "%d éléments"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { parseXcstrings, type XcstringsCatalog } from '../parseXcstrings.js';
+
+const multiLocaleContent = readFileSync(
+  path.join(__dirname, '../__mocks__', 'multi_locale.xcstrings'),
+  'utf8'
+);
+const implicitEntriesContent = readFileSync(
+  path.join(__dirname, '../__mocks__', 'implicit_entries.xcstrings'),
+  'utf8'
+);
+
+const parseCatalog = (content: string): XcstringsCatalog =>
+  JSON.parse(content) as XcstringsCatalog;
+
+describe('parseXcstrings - source slice', () => {
+  it('keeps every entry but only the source-language localization', () => {
+    const input = parseCatalog(multiLocaleContent);
+    const slice = parseCatalog(parseXcstrings(multiLocaleContent));
+
+    expect(slice.sourceLanguage).toBe('en');
+    // Entry set and order are preserved
+    expect(Object.keys(slice.strings)).toEqual(Object.keys(input.strings));
+
+    for (const entry of Object.values(slice.strings)) {
+      const locales = Object.keys(entry.localizations ?? {});
+      expect(locales).toEqual(['en']);
+    }
+    // The foreign-locale content is gone, the source content is untouched
+    expect(slice.strings.greeting.localizations).toEqual({
+      en: { stringUnit: { state: 'translated', value: 'Hello' } },
+    });
+  });
+
+  it('slices shouldTranslate:false entries to source but keeps the flag', () => {
+    const slice = parseCatalog(parseXcstrings(multiLocaleContent));
+    const entry = slice.strings['account.plan.pro'];
+
+    expect(entry.shouldTranslate).toBe(false);
+    expect(entry.comment).toBe('Product name. Do not translate.');
+    expect(Object.keys(entry.localizations ?? {})).toEqual(['en']);
+  });
+
+  it('handles implicit entries where the key is the source', () => {
+    const input = parseCatalog(implicitEntriesContent);
+    const slice = parseCatalog(parseXcstrings(implicitEntriesContent));
+
+    expect(Object.keys(slice.strings)).toEqual(Object.keys(input.strings));
+    // Entries with no localizations are kept verbatim (the key is the source)
+    expect(slice.strings.Save).toEqual({});
+    expect(slice.strings.Cancel).toEqual({
+      comment: 'Toolbar button',
+      extractionState: 'manual',
+    });
+    // Entries with localizations still slice down to the source locale
+    expect(slice.strings['Welcome to %@'].localizations).toEqual({
+      en: { stringUnit: { state: 'translated', value: 'Welcome to %@' } },
+    });
+  });
+
+  it('preserves unknown and nested fields at every level', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      unknownRoot: { nested: true },
+      strings: {
+        items: {
+          comment: 'Home screen',
+          unknownEntryField: [1, 2, 3],
+          localizations: {
+            en: {
+              variations: {
+                plural: {
+                  other: {
+                    stringUnit: { state: 'translated', value: '%d items' },
+                  },
+                },
+              },
+              unknownLocalizationField: { deep: 'value' },
+            },
+            es: { stringUnit: { state: 'translated', value: '%d elementos' } },
+          },
+        },
+      },
+      version: '1.0',
+    });
+
+    const slice = parseCatalog(parseXcstrings(content));
+
+    expect(slice.unknownRoot).toEqual({ nested: true });
+    expect(slice.strings.items).toEqual({
+      comment: 'Home screen',
+      unknownEntryField: [1, 2, 3],
+      localizations: {
+        en: {
+          variations: {
+            plural: {
+              other: { stringUnit: { state: 'translated', value: '%d items' } },
+            },
+          },
+          unknownLocalizationField: { deep: 'value' },
+        },
+      },
+    });
+    // Top-level key order survives the clone
+    expect(Object.keys(slice)).toEqual([
+      'sourceLanguage',
+      'unknownRoot',
+      'strings',
+      'version',
+    ]);
+  });
+
+  it('slices by the catalog sourceLanguage, not a hardcoded locale', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'fr',
+      strings: {
+        greeting: {
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+            fr: { stringUnit: { state: 'translated', value: 'Bonjour' } },
+          },
+        },
+      },
+    });
+
+    const slice = parseCatalog(parseXcstrings(content));
+
+    expect(Object.keys(slice.strings.greeting.localizations!)).toEqual(['fr']);
+  });
+
+  describe('serialization contract (versionId hashes this output)', () => {
+    it('re-slices an unchanged catalog byte-identically', () => {
+      expect(parseXcstrings(multiLocaleContent)).toBe(
+        parseXcstrings(multiLocaleContent)
+      );
+    });
+
+    // DO NOT update these bytes to make a failing test pass: the slice is
+    // hashed into versionId, so a serialization change re-versions every
+    // customer .xcstrings file and re-triggers translation fleet-wide.
+    it('produces the pinned byte-exact output and versionId', () => {
+      const content = JSON.stringify({
+        sourceLanguage: 'en',
+        version: '1.0',
+        strings: {
+          Save: {},
+          greeting: {
+            comment: 'Home screen',
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Hello' } },
+              es: { stringUnit: { state: 'translated', value: 'Hola' } },
+            },
+          },
+        },
+      });
+      const expected = `{
+  "sourceLanguage": "en",
+  "version": "1.0",
+  "strings": {
+    "Save": {},
+    "greeting": {
+      "comment": "Home screen",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hello"
+          }
+        }
+      }
+    }
+  }
+}
+`;
+      const slice = parseXcstrings(content);
+      expect(slice).toBe(expected);
+      expect(createHash('sha256').update(slice).digest('hex')).toBe(
+        'aad579f973ef23dea4b7750203b6001e1fbe1a739791f2d784265b254e5d8ed6'
+      );
+    });
+  });
+
+  describe('validation and reserved-key safety', () => {
+    it.each([
+      ['not JSON', 'not valid', /not valid JSON/],
+      ['a root array', '[]', /document root must be an object/],
+      ['a root string', '"catalog"', /document root must be an object/],
+      [
+        'a missing sourceLanguage',
+        '{"strings":{}}',
+        /sourceLanguage must be a non-empty string/,
+      ],
+      [
+        'an empty sourceLanguage',
+        '{"sourceLanguage":"","strings":{}}',
+        /sourceLanguage must be a non-empty string/,
+      ],
+      [
+        'missing strings',
+        '{"sourceLanguage":"en"}',
+        /strings must be an object/,
+      ],
+      [
+        'an array strings value',
+        '{"sourceLanguage":"en","strings":[]}',
+        /strings must be an object/,
+      ],
+      [
+        'a non-object entry',
+        '{"sourceLanguage":"en","strings":{"key":"value"}}',
+        /strings\["key"\] must be an object/,
+      ],
+      [
+        'a non-object localizations value',
+        '{"sourceLanguage":"en","strings":{"key":{"localizations":[]}}}',
+        /localizations must be an object/,
+      ],
+      [
+        'a reserved entry key',
+        '{"sourceLanguage":"en","strings":{"__proto__":{}}}',
+        /reserved name "__proto__"/,
+      ],
+      [
+        'a reserved locale key',
+        '{"sourceLanguage":"en","strings":{"key":{"localizations":{"constructor":{}}}}}',
+        /reserved name "constructor"/,
+      ],
+      [
+        'a reserved sourceLanguage',
+        '{"sourceLanguage":"__proto__","strings":{}}',
+        /reserved name "__proto__"/,
+      ],
+    ])('rejects %s', (_name, content, message) => {
+      expect(() => parseXcstrings(content)).toThrow(message);
+    });
+
+    it('does not pollute Object.prototype when slicing reserved-key content', () => {
+      expect(() =>
+        parseXcstrings('{"sourceLanguage":"en","strings":{"__proto__":{}}}')
+      ).toThrow();
+      expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+  });
+});

--- a/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect } from 'vitest';
 import { createHash } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import path from 'node:path';
-import { parseXcstrings, type XcstringsCatalog } from '../parseXcstrings.js';
+import {
+  parseXcstrings,
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+  type XcstringsCatalog,
+} from '../parseXcstrings.js';
 
 const multiLocaleContent = readFileSync(
   path.join(__dirname, '../__mocks__', 'multi_locale.xcstrings'),
@@ -129,6 +135,92 @@ describe('parseXcstrings - source slice', () => {
     const slice = parseCatalog(parseXcstrings(content));
 
     expect(Object.keys(slice.strings.greeting.localizations!)).toEqual(['fr']);
+  });
+
+  describe('translation slices', () => {
+    const sliceLocale = (content: string, locale: string) => {
+      const slice = sliceTranslationCatalog(
+        parseXcstringsCatalog(content),
+        locale
+      );
+      return slice && serializeXcstringsSlice(slice);
+    };
+
+    it('keeps only the entries carrying the locale, each with only that localization', () => {
+      const es = parseCatalog(sliceLocale(multiLocaleContent, 'es')!);
+      const fr = parseCatalog(sliceLocale(multiLocaleContent, 'fr')!);
+
+      expect(es.sourceLanguage).toBe('en');
+      // items.count has no es localization; account.plan.pro has no fr one
+      expect(Object.keys(es.strings)).toEqual(['greeting', 'account.plan.pro']);
+      expect(Object.keys(fr.strings)).toEqual(['greeting', 'items.count']);
+      for (const entry of Object.values(es.strings)) {
+        expect(Object.keys(entry.localizations!)).toEqual(['es']);
+      }
+      for (const entry of Object.values(fr.strings)) {
+        expect(Object.keys(entry.localizations!)).toEqual(['fr']);
+      }
+      expect(es.strings.greeting.localizations).toEqual({
+        es: { stringUnit: { state: 'translated', value: 'Hola' } },
+      });
+      // Entry-level fields travel with the slice
+      expect(es.strings['account.plan.pro'].shouldTranslate).toBe(false);
+      expect(es.strings['account.plan.pro'].comment).toBe(
+        'Product name. Do not translate.'
+      );
+    });
+
+    it('returns undefined for a locale the catalog does not carry', () => {
+      expect(sliceLocale(multiLocaleContent, 'ja')).toBeUndefined();
+      expect(sliceLocale(implicitEntriesContent, 'es')).toBeUndefined();
+    });
+
+    it('preserves unknown fields at every level', () => {
+      const content = JSON.stringify({
+        sourceLanguage: 'en',
+        unknownRoot: { nested: true },
+        strings: {
+          items: {
+            unknownEntryField: [1, 2, 3],
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Items' } },
+              es: {
+                stringUnit: { state: 'translated', value: 'Elementos' },
+                unknownLocalizationField: { deep: 'value' },
+              },
+            },
+          },
+        },
+        version: '1.0',
+      });
+
+      const slice = parseCatalog(sliceLocale(content, 'es')!);
+
+      expect(Object.keys(slice)).toEqual([
+        'sourceLanguage',
+        'unknownRoot',
+        'strings',
+        'version',
+      ]);
+      expect(slice.unknownRoot).toEqual({ nested: true });
+      expect(slice.strings.items).toEqual({
+        unknownEntryField: [1, 2, 3],
+        localizations: {
+          es: {
+            stringUnit: { state: 'translated', value: 'Elementos' },
+            unknownLocalizationField: { deep: 'value' },
+          },
+        },
+      });
+    });
+
+    it('serializes byte-stably and slicing a slice is a fixed point', () => {
+      const first = sliceLocale(multiLocaleContent, 'fr')!;
+      expect(sliceLocale(multiLocaleContent, 'fr')).toBe(first);
+      expect(sliceLocale(first, 'fr')).toBe(first);
+      // Same pinned layout as the source slice
+      expect(first).toBe(JSON.stringify(JSON.parse(first), null, 2) + '\n');
+    });
   });
 
   describe('serialization contract (versionId hashes this output)', () => {

--- a/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
@@ -67,6 +67,74 @@ describe('parseXcstrings - source slice', () => {
     });
   });
 
+  it('slices an entry holding only target locales like one with no localizations', () => {
+    // A key-is-source entry has no source unit even once it carries
+    // translations, so it must slice like an implicit entry.
+    const withTargets = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        Save: {
+          comment: 'Toolbar button',
+          localizations: {
+            de: { stringUnit: { state: 'translated', value: 'Sichern' } },
+          },
+        },
+      },
+    });
+    const withoutLocalizations = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { Save: { comment: 'Toolbar button' } },
+    });
+
+    expect(parseCatalog(parseXcstrings(withTargets)).strings.Save).toEqual({
+      comment: 'Toolbar button',
+    });
+    expect(parseXcstrings(withTargets)).toBe(
+      parseXcstrings(withoutLocalizations)
+    );
+  });
+
+  it('slices a catalog with target locales identically to one without them', () => {
+    const withTargets = JSON.stringify({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        greeting: {
+          comment: 'Home screen',
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+            de: { stringUnit: { state: 'translated', value: 'Hallo' } },
+          },
+        },
+        Save: {
+          localizations: {
+            de: { stringUnit: { state: 'translated', value: 'Sichern' } },
+            fr: { stringUnit: { state: 'translated', value: 'Enregistrer' } },
+          },
+        },
+        Cancel: { comment: 'Toolbar button', localizations: {} },
+        Done: {},
+      },
+    });
+    const withoutTargets = JSON.stringify({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        greeting: {
+          comment: 'Home screen',
+          localizations: {
+            en: { stringUnit: { state: 'translated', value: 'Hello' } },
+          },
+        },
+        Save: {},
+        Cancel: { comment: 'Toolbar button' },
+        Done: {},
+      },
+    });
+
+    expect(parseXcstrings(withTargets)).toBe(parseXcstrings(withoutTargets));
+  });
+
   it('preserves unknown and nested fields at every level', () => {
     const content = JSON.stringify({
       sourceLanguage: 'en',

--- a/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts
@@ -225,8 +225,8 @@ describe('parseXcstrings - source slice', () => {
       ],
       [
         'a reserved locale key',
-        '{"sourceLanguage":"en","strings":{"key":{"localizations":{"constructor":{}}}}}',
-        /reserved name "constructor"/,
+        '{"sourceLanguage":"en","strings":{"key":{"localizations":{"__proto__":{}}}}}',
+        /reserved name "__proto__"/,
       ],
       [
         'a reserved sourceLanguage',
@@ -242,6 +242,48 @@ describe('parseXcstrings - source slice', () => {
         parseXcstrings('{"sourceLanguage":"en","strings":{"__proto__":{}}}')
       ).toThrow();
       expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    });
+
+    // Only __proto__ is reserved, matching the server's validator: a catalog
+    // whose UI literally shows "constructor" or "prototype" stays uploadable.
+    it('slices and round-trips catalogs keyed by constructor and prototype', () => {
+      const content = JSON.stringify({
+        sourceLanguage: 'en',
+        strings: {
+          constructor: {
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Constructor' } },
+              es: { stringUnit: { state: 'translated', value: 'Constructor' } },
+            },
+          },
+          prototype: {
+            comment: 'Lab feature name',
+            localizations: {
+              en: { stringUnit: { state: 'translated', value: 'Prototype' } },
+              prototype: { stringUnit: { state: 'translated', value: 'x' } },
+            },
+          },
+        },
+      });
+
+      const slice = parseCatalog(parseXcstrings(content));
+
+      expect(Object.keys(slice.strings)).toEqual(['constructor', 'prototype']);
+      expect(slice.strings.constructor).toEqual({
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: 'Constructor' } },
+        },
+      });
+      expect(slice.strings.prototype).toEqual({
+        comment: 'Lab feature name',
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: 'Prototype' } },
+        },
+      });
+      // Re-slicing the slice is a fixed point
+      expect(parseXcstrings(parseXcstrings(content))).toBe(
+        parseXcstrings(content)
+      );
     });
   });
 });

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -94,9 +94,12 @@ export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
 
 /**
  * Clones a validated catalog keeping, per entry, only `localizations[locale]`.
- * An entry without that localization is kept with its other fields when
- * `keepEntriesWithoutLocale` is set and dropped otherwise. Nodes are cloned,
- * never rebuilt, so unknown fields and key order survive at every level.
+ * An entry without that localization is dropped, or kept without a
+ * `localizations` key when `keepEntriesWithoutLocale` is set: an entry whose
+ * localizations hold only other locales then slices to the same shape as one
+ * with none, so translations added to the catalog leave the source slice,
+ * and with it versionId, unchanged. Nodes are cloned, never rebuilt, so
+ * unknown fields and key order survive at every level.
  */
 function sliceCatalog(
   catalog: XcstringsCatalog,
@@ -105,16 +108,17 @@ function sliceCatalog(
 ): XcstringsCatalog {
   const strings: Record<string, XcstringsEntry> = Object.create(null);
   for (const [key, entry] of Object.entries(catalog.strings)) {
-    if (entry.localizations === undefined) {
-      if (keepEntriesWithoutLocale) strings[key] = entry;
+    if (
+      entry.localizations === undefined ||
+      !Object.hasOwn(entry.localizations, locale)
+    ) {
+      if (!keepEntriesWithoutLocale) continue;
+      const { localizations: _otherLocales, ...withoutLocalizations } = entry;
+      strings[key] = withoutLocalizations;
       continue;
     }
     const localizations: Record<string, unknown> = Object.create(null);
-    if (Object.hasOwn(entry.localizations, locale)) {
-      localizations[locale] = entry.localizations[locale];
-    } else if (!keepEntriesWithoutLocale) {
-      continue;
-    }
+    localizations[locale] = entry.localizations[locale];
     strings[key] = { ...entry, localizations };
   }
   return { ...catalog, strings };
@@ -123,7 +127,8 @@ function sliceCatalog(
 /**
  * Produces the source-language slice of a validated catalog: a single-locale
  * catalog holding, per entry, only the source-language localization. Entries
- * without localizations (the key itself is the source) are kept verbatim.
+ * without a source localization (the key itself is the source) keep their
+ * other fields and carry no `localizations`.
  */
 export function sliceSourceCatalog(
   catalog: XcstringsCatalog

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -1,0 +1,112 @@
+// Slicing for Apple .xcstrings catalogs. One on-disk catalog holds every
+// locale; the upload carries only the source-language slice as the source
+// document. Slices clone nodes and remove foreign locale keys, so unknown
+// fields survive verbatim at every level and a later download-merge can fold
+// per-locale translations back into the same on-disk catalog.
+
+export type XcstringsEntry = {
+  localizations?: Record<string, unknown>;
+  [key: string]: unknown;
+};
+
+export type XcstringsCatalog = {
+  sourceLanguage: string;
+  strings: Record<string, XcstringsEntry>;
+  [key: string]: unknown;
+};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalid(path: string, expected: string): Error {
+  return new Error(`Invalid .xcstrings content: ${path} must be ${expected}`);
+}
+
+// Catalogs are untrusted input; these names resolve to inherited properties on
+// plain objects, so writing them back could escape into the prototype. No real
+// catalog uses them, so reject them loudly rather than silently mangling data.
+const RESERVED_KEY_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
+
+function assertSafeKey(name: string, path: string): void {
+  if (RESERVED_KEY_NAMES.has(name)) {
+    throw new Error(
+      `Invalid .xcstrings content: ${path} uses the reserved name "${name}"`
+    );
+  }
+}
+
+/**
+ * Parses a raw .xcstrings document and validates the structure the slicer
+ * traverses. Throws on invalid content.
+ */
+export function parseXcstringsCatalog(content: string): XcstringsCatalog {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error('Invalid .xcstrings content: not valid JSON');
+  }
+  if (!isPlainObject(parsed)) throw invalid('document root', 'an object');
+  if (typeof parsed.sourceLanguage !== 'string' || !parsed.sourceLanguage) {
+    throw invalid('sourceLanguage', 'a non-empty string');
+  }
+  assertSafeKey(parsed.sourceLanguage, 'sourceLanguage');
+  if (!isPlainObject(parsed.strings)) throw invalid('strings', 'an object');
+  for (const [key, entry] of Object.entries(parsed.strings)) {
+    const path = `strings[${JSON.stringify(key)}]`;
+    assertSafeKey(key, path);
+    if (!isPlainObject(entry)) throw invalid(path, 'an object');
+    if (entry.localizations === undefined) continue;
+    if (!isPlainObject(entry.localizations)) {
+      throw invalid(`${path}.localizations`, 'an object');
+    }
+    for (const locale of Object.keys(entry.localizations)) {
+      assertSafeKey(locale, `${path}.localizations[${JSON.stringify(locale)}]`);
+    }
+  }
+  return parsed as XcstringsCatalog;
+}
+
+/**
+ * PINNED SERIALIZATION — DO NOT CHANGE.
+ *
+ * The slice is hashed into versionId (see aggregateFiles), so any change to
+ * these bytes re-versions every customer .xcstrings file and re-triggers
+ * translation fleet-wide. The byte-exact tests on this format are the contract.
+ */
+export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
+  return JSON.stringify(catalog, null, 2) + '\n';
+}
+
+/**
+ * Produces the source-language slice of a validated catalog: a single-locale
+ * catalog holding, per entry, only the source-language localization.
+ *
+ * Nodes are cloned and foreign locale keys removed (never rebuilt), so unknown
+ * fields and key order survive at every level. Entries without localizations
+ * (the key itself is the source) are kept verbatim.
+ */
+export function sliceSourceCatalog(
+  catalog: XcstringsCatalog
+): XcstringsCatalog {
+  const strings: Record<string, XcstringsEntry> = { ...catalog.strings };
+  for (const [key, entry] of Object.entries(strings)) {
+    if (entry.localizations === undefined) continue;
+    const localizations = { ...entry.localizations };
+    for (const locale of Object.keys(localizations)) {
+      if (locale !== catalog.sourceLanguage) delete localizations[locale];
+    }
+    strings[key] = { ...entry, localizations };
+  }
+  return { ...catalog, strings };
+}
+
+/**
+ * Parses, slices to the catalog's source language, and serializes with the
+ * pinned byte layout. Throws on invalid content.
+ */
+export function parseXcstrings(content: string): string {
+  const catalog = parseXcstringsCatalog(content);
+  return serializeXcstringsSlice(sliceSourceCatalog(catalog));
+}

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -1,8 +1,9 @@
 // Slicing for Apple .xcstrings catalogs. One on-disk catalog holds every
-// locale; the upload carries only the source-language slice as the source
-// document. Slices clone nodes and keep only the source locale key, so unknown
-// fields survive verbatim at every level and a later download-merge can fold
-// per-locale translations back into the same on-disk catalog.
+// locale; the upload carries the source-language slice as the source document
+// and one single-locale slice per translated locale. Slices clone nodes and
+// keep only the wanted locale key, so unknown fields survive verbatim at every
+// level and a later download-merge can fold per-locale translations back into
+// the same on-disk catalog.
 
 export type XcstringsEntry = {
   localizations?: Record<string, unknown>;
@@ -92,30 +93,55 @@ export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
 }
 
 /**
- * Produces the source-language slice of a validated catalog: a single-locale
- * catalog holding, per entry, only the source-language localization.
- *
- * Nodes are cloned and foreign locale keys dropped (never rebuilt), so unknown
- * fields and key order survive at every level. Entries without localizations
- * (the key itself is the source) are kept verbatim.
+ * Clones a validated catalog keeping, per entry, only `localizations[locale]`.
+ * An entry without that localization is kept with its other fields when
+ * `keepEntriesWithoutLocale` is set and dropped otherwise. Nodes are cloned,
+ * never rebuilt, so unknown fields and key order survive at every level.
  */
-export function sliceSourceCatalog(
-  catalog: XcstringsCatalog
+function sliceCatalog(
+  catalog: XcstringsCatalog,
+  locale: string,
+  keepEntriesWithoutLocale: boolean
 ): XcstringsCatalog {
   const strings: Record<string, XcstringsEntry> = Object.create(null);
   for (const [key, entry] of Object.entries(catalog.strings)) {
     if (entry.localizations === undefined) {
-      strings[key] = entry;
+      if (keepEntriesWithoutLocale) strings[key] = entry;
       continue;
     }
     const localizations: Record<string, unknown> = Object.create(null);
-    if (Object.hasOwn(entry.localizations, catalog.sourceLanguage)) {
-      localizations[catalog.sourceLanguage] =
-        entry.localizations[catalog.sourceLanguage];
+    if (Object.hasOwn(entry.localizations, locale)) {
+      localizations[locale] = entry.localizations[locale];
+    } else if (!keepEntriesWithoutLocale) {
+      continue;
     }
     strings[key] = { ...entry, localizations };
   }
   return { ...catalog, strings };
+}
+
+/**
+ * Produces the source-language slice of a validated catalog: a single-locale
+ * catalog holding, per entry, only the source-language localization. Entries
+ * without localizations (the key itself is the source) are kept verbatim.
+ */
+export function sliceSourceCatalog(
+  catalog: XcstringsCatalog
+): XcstringsCatalog {
+  return sliceCatalog(catalog, catalog.sourceLanguage, true);
+}
+
+/**
+ * Produces one locale's translation slice: the entries that carry
+ * `localizations[locale]`, each holding only that localization. Returns
+ * undefined when the catalog carries no translation for the locale.
+ */
+export function sliceTranslationCatalog(
+  catalog: XcstringsCatalog,
+  locale: string
+): XcstringsCatalog | undefined {
+  const slice = sliceCatalog(catalog, locale, false);
+  return Object.keys(slice.strings).length > 0 ? slice : undefined;
 }
 
 /**

--- a/packages/cli/src/formats/xcstrings/parseXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/parseXcstrings.ts
@@ -1,6 +1,6 @@
 // Slicing for Apple .xcstrings catalogs. One on-disk catalog holds every
 // locale; the upload carries only the source-language slice as the source
-// document. Slices clone nodes and remove foreign locale keys, so unknown
+// document. Slices clone nodes and keep only the source locale key, so unknown
 // fields survive verbatim at every level and a later download-merge can fold
 // per-locale translations back into the same on-disk catalog.
 
@@ -23,13 +23,15 @@ function invalid(path: string, expected: string): Error {
   return new Error(`Invalid .xcstrings content: ${path} must be ${expected}`);
 }
 
-// Catalogs are untrusted input; these names resolve to inherited properties on
-// plain objects, so writing them back could escape into the prototype. No real
-// catalog uses them, so reject them loudly rather than silently mangling data.
-const RESERVED_KEY_NAMES = new Set(['__proto__', 'constructor', 'prototype']);
+// Catalogs are untrusted input. Every container keyed by catalog-chosen names
+// (string keys, locales) is built without a prototype, so `constructor` and
+// `prototype` are ordinary properties and stay uploadable, matching the
+// server's validator. `__proto__` is still rejected: assigning it on a plain
+// object reassigns the prototype instead of creating a property.
+const RESERVED_KEY_NAME = '__proto__';
 
 function assertSafeKey(name: string, path: string): void {
-  if (RESERVED_KEY_NAMES.has(name)) {
+  if (name === RESERVED_KEY_NAME) {
     throw new Error(
       `Invalid .xcstrings content: ${path} uses the reserved name "${name}"`
     );
@@ -38,7 +40,9 @@ function assertSafeKey(name: string, path: string): void {
 
 /**
  * Parses a raw .xcstrings document and validates the structure the slicer
- * traverses. Throws on invalid content.
+ * traverses. The `strings` and `localizations` containers are re-keyed onto
+ * prototype-less records so lookups by catalog-chosen names cannot resolve to
+ * inherited properties. Throws on invalid content.
  */
 export function parseXcstringsCatalog(content: string): XcstringsCatalog {
   let parsed: unknown;
@@ -53,27 +57,35 @@ export function parseXcstringsCatalog(content: string): XcstringsCatalog {
   }
   assertSafeKey(parsed.sourceLanguage, 'sourceLanguage');
   if (!isPlainObject(parsed.strings)) throw invalid('strings', 'an object');
+  const strings: Record<string, XcstringsEntry> = Object.create(null);
   for (const [key, entry] of Object.entries(parsed.strings)) {
     const path = `strings[${JSON.stringify(key)}]`;
     assertSafeKey(key, path);
     if (!isPlainObject(entry)) throw invalid(path, 'an object');
-    if (entry.localizations === undefined) continue;
+    if (entry.localizations === undefined) {
+      strings[key] = entry;
+      continue;
+    }
     if (!isPlainObject(entry.localizations)) {
       throw invalid(`${path}.localizations`, 'an object');
     }
-    for (const locale of Object.keys(entry.localizations)) {
+    const localizations: Record<string, unknown> = Object.create(null);
+    for (const [locale, localization] of Object.entries(entry.localizations)) {
       assertSafeKey(locale, `${path}.localizations[${JSON.stringify(locale)}]`);
+      localizations[locale] = localization;
     }
+    strings[key] = { ...entry, localizations };
   }
-  return parsed as XcstringsCatalog;
+  return { ...parsed, strings } as XcstringsCatalog;
 }
 
 /**
  * PINNED SERIALIZATION — DO NOT CHANGE.
  *
- * The slice is hashed into versionId (see aggregateFiles), so any change to
- * these bytes re-versions every customer .xcstrings file and re-triggers
- * translation fleet-wide. The byte-exact tests on this format are the contract.
+ * The source slice is hashed into versionId (see aggregateFiles), so any
+ * change to these bytes re-versions every customer .xcstrings file and
+ * re-triggers translation fleet-wide. The byte-exact tests on this format are
+ * the contract.
  */
 export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
   return JSON.stringify(catalog, null, 2) + '\n';
@@ -83,19 +95,23 @@ export function serializeXcstringsSlice(catalog: XcstringsCatalog): string {
  * Produces the source-language slice of a validated catalog: a single-locale
  * catalog holding, per entry, only the source-language localization.
  *
- * Nodes are cloned and foreign locale keys removed (never rebuilt), so unknown
+ * Nodes are cloned and foreign locale keys dropped (never rebuilt), so unknown
  * fields and key order survive at every level. Entries without localizations
  * (the key itself is the source) are kept verbatim.
  */
 export function sliceSourceCatalog(
   catalog: XcstringsCatalog
 ): XcstringsCatalog {
-  const strings: Record<string, XcstringsEntry> = { ...catalog.strings };
-  for (const [key, entry] of Object.entries(strings)) {
-    if (entry.localizations === undefined) continue;
-    const localizations = { ...entry.localizations };
-    for (const locale of Object.keys(localizations)) {
-      if (locale !== catalog.sourceLanguage) delete localizations[locale];
+  const strings: Record<string, XcstringsEntry> = Object.create(null);
+  for (const [key, entry] of Object.entries(catalog.strings)) {
+    if (entry.localizations === undefined) {
+      strings[key] = entry;
+      continue;
+    }
+    const localizations: Record<string, unknown> = Object.create(null);
+    if (Object.hasOwn(entry.localizations, catalog.sourceLanguage)) {
+      localizations[catalog.sourceLanguage] =
+        entry.localizations[catalog.sourceLanguage];
     }
     strings[key] = { ...entry, localizations };
   }


### PR DESCRIPTION
## Summary

The slicing/upload layer for Apple `.xcstrings` catalog support in the CLI. **Stacked on #2254** (the registration PR); this PR contains only the upload behavior. The download merge follows in the next PR of the stack.

An `.xcstrings` catalog holds every locale in one JSON file. On upload the CLI validates the catalog and uploads two kinds of slice of it:

- **Source:** every entry, holding only the `sourceLanguage` localization. Uploaded as the source document. The slice is serialized with a pinned byte layout and hashed into its `versionId`, so an unchanged catalog re-slices byte-identically and does not re-upload.
- **Per-locale translations:** for each configured target locale, the entries that carry `localizations[<locale>]`, each holding only that localization. A locale the catalog does not carry uploads nothing. This replaces the previous behavior of resolving the shared catalog path per locale and uploading the whole multi-locale file as every locale's translation.

Both slices come from one slicer. Nodes are cloned and other locale keys dropped (never rebuilt), so unknown fields and key order survive verbatim at every level and the later download merge can fold translations back into the same on-disk catalog. Entries whose key is the source (no `localizations`) are kept as-is in the source slice.

Only `__proto__` is a reserved name, matching the server's validator; `constructor` and `prototype` are legal catalog keys, and every container keyed by catalog-chosen names is built without a prototype so they are ordinary properties.

## What this contains

- `parseXcstrings.ts` — parser/validator, the shared slicer (`sliceSourceCatalog`, `sliceTranslationCatalog`), and the pinned serializer, with tests and two `.xcstrings` fixtures.
- `aggregateFiles.ts` — slices catalogs to their source-language document on upload; a `sourceLanguage` vs configured `defaultLocale` mismatch is a config error.
- `upload.ts` — builds one translation slice per locale from the same catalog instead of reading a per-locale file, with tests.
- The source slice omits a `localizations` key from any entry without a source-language localization, rather than writing `"localizations": {}`. An entry carrying only target locales then slices byte-identically to one with none, so adding translations to the catalog does not change its `versionId`. Covered by a standalone slice-stability test.

No changeset: a CLI that uploads `.xcstrings` before the server accepts the format is a hard user-facing failure, so the release is gated. The changeset lands in a final PR at the top of the stack.

## Verification

- Stacked on #2254; build, typecheck, and the full CLI + core test suites are green on top of it.











<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

Adds Apple `.xcstrings` upload support by validating each catalog and producing deterministic source and per-locale translation slices.
- Preserves unknown catalog fields and stable serialization while removing unrelated locale data from each slice.
- Uses source-slice hashing for version identity and retains configured locale aliases in upload metadata.
- Stops uploads when the catalog source language and configured default locale differ after canonicalization.
- Adds focused parser, serializer, aggregation, alias, failure, and upload-flow coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the latest canonicalization change fixes the remaining alias mismatch without introducing a new actionable failure.

All previous findings are resolved, withdrawn, or fully addressed in the current code, and no new merge-blocking or non-blocking issue was established.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/xcstrings/parseXcstrings.ts | Introduces validated, prototype-safe catalog parsing and deterministic source and translation slicing. |
| packages/cli/src/formats/files/aggregateFiles.ts | Aggregates source slices, hashes their stable serialization, and rejects canonical source-locale mismatches. |
| packages/cli/src/cli/commands/upload.ts | Uploads one catalog translation slice for each configured locale represented in the catalog. |
| packages/cli/src/formats/xcstrings/__tests__/parseXcstrings.test.ts | Covers slicing semantics, structural preservation, reserved keys, stable bytes, and version hashing. |
| packages/cli/src/formats/files/__tests__/aggregateFiles.test.ts | Covers source aggregation, malformed catalogs, mismatches, and default-locale aliases. |
| packages/cli/src/cli/commands/__tests__/upload.test.ts | Covers per-locale catalog uploads, alias resolution, metadata, and absent target locales. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[".xcstrings catalog"] --> B["Parse and validate"]
    B --> C["Source-language slice"]
    B --> D["Resolve configured locale aliases"]
    D --> E["Per-locale translation slices"]
    C --> F["Stable serialization and version hash"]
    E --> G["Translation uploads"]
    F --> H["Source upload"]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(cli): compare an .xcstrings sourceLa..."](https://github.com/generaltranslation/gt/commit/1afa000a1f82901d2019a9e9d07fe35b99fab9f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61695492)</sub>

<!-- /greptile_comment -->