### PR TITLE
feat(cli) 1/5: register the .xcstrings file format

### DIFF
--- a/packages/api/spec/openapi.json
+++ b/packages/api/spec/openapi.json
@@ -74,7 +74,8 @@
           "SVG",
           "DOT_STRINGS",
           "DOT_STRINGSDICT",
-          "ANDROID_STRINGS"
+          "ANDROID_STRINGS",
+          "XCSTRINGS"
         ]
       },
       "ModelProvider": {
@@ -620,7 +621,8 @@
                                 "SVG",
                                 "DOT_STRINGS",
                                 "DOT_STRINGSDICT",
-                                "ANDROID_STRINGS"
+                                "ANDROID_STRINGS",
+                                "XCSTRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -935,7 +937,8 @@
                                 "SVG",
                                 "DOT_STRINGS",
                                 "DOT_STRINGSDICT",
-                                "ANDROID_STRINGS"
+                                "ANDROID_STRINGS",
+                                "XCSTRINGS"
                               ]
                             },
                             "dataFormat": {
@@ -1008,7 +1011,8 @@
                                   "SVG",
                                   "DOT_STRINGS",
                                   "DOT_STRINGSDICT",
-                                  "ANDROID_STRINGS"
+                                  "ANDROID_STRINGS",
+                                  "XCSTRINGS"
                                 ]
                               },
                               "dataFormat": {
@@ -1037,7 +1041,8 @@
                                   "SVG",
                                   "DOT_STRINGS",
                                   "DOT_STRINGSDICT",
-                                  "ANDROID_STRINGS"
+                                  "ANDROID_STRINGS",
+                                  "XCSTRINGS"
                                 ]
                               }
                             },
@@ -2324,7 +2329,8 @@
                             "SVG",
                             "DOT_STRINGS",
                             "DOT_STRINGSDICT",
-                            "ANDROID_STRINGS"
+                            "ANDROID_STRINGS",
+                            "XCSTRINGS"
                           ]
                         }
                       },

--- a/packages/api/src/generated/types.gen.ts
+++ b/packages/api/src/generated/types.gen.ts
@@ -25,7 +25,8 @@ export type FileFormat =
   | 'SVG'
   | 'DOT_STRINGS'
   | 'DOT_STRINGSDICT'
-  | 'ANDROID_STRINGS';
+  | 'ANDROID_STRINGS'
+  | 'XCSTRINGS';
 
 export type ModelProvider = 'ANTHROPIC' | 'OPENAI' | 'XAI' | 'GOOGLE';
 
@@ -214,7 +215,8 @@ export type UploadSourceFilesData = {
           | 'SVG'
           | 'DOT_STRINGS'
           | 'DOT_STRINGSDICT'
-          | 'ANDROID_STRINGS';
+          | 'ANDROID_STRINGS'
+          | 'XCSTRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -331,7 +333,8 @@ export type UploadTranslationsData = {
           | 'SVG'
           | 'DOT_STRINGS'
           | 'DOT_STRINGSDICT'
-          | 'ANDROID_STRINGS';
+          | 'ANDROID_STRINGS'
+          | 'XCSTRINGS';
         dataFormat?: string;
         locale: string;
         fileId?: string;
@@ -363,7 +366,8 @@ export type UploadTranslationsData = {
           | 'SVG'
           | 'DOT_STRINGS'
           | 'DOT_STRINGSDICT'
-          | 'ANDROID_STRINGS';
+          | 'ANDROID_STRINGS'
+          | 'XCSTRINGS';
         dataFormat?: string;
         locale: string;
         transformFormat?:
@@ -383,7 +387,8 @@ export type UploadTranslationsData = {
           | 'SVG'
           | 'DOT_STRINGS'
           | 'DOT_STRINGSDICT'
-          | 'ANDROID_STRINGS';
+          | 'ANDROID_STRINGS'
+          | 'XCSTRINGS';
       }>;
     }>;
     sourceLocale?: string;
@@ -858,7 +863,8 @@ export type EnqueueFileTranslationsData = {
         | 'SVG'
         | 'DOT_STRINGS'
         | 'DOT_STRINGSDICT'
-        | 'ANDROID_STRINGS';
+        | 'ANDROID_STRINGS'
+        | 'XCSTRINGS';
     }>;
     targetLocales?: Array<string>;
     sourceLocale?: string;

--- a/packages/cli/src/formats/files/supportedFiles.ts
+++ b/packages/cli/src/formats/files/supportedFiles.ts
@@ -13,6 +13,7 @@ export const SUPPORTED_FILE_EXTENSIONS = [
   'dotStrings',
   'dotStringsdict',
   'androidStrings',
+  'xcstrings',
 ] as const;
 
 export const FILE_EXT_TO_EXT_LABEL = {
@@ -30,4 +31,5 @@ export const FILE_EXT_TO_EXT_LABEL = {
   dotStrings: '.strings',
   dotStringsdict: '.stringsdict',
   androidStrings: 'Android strings.xml',
+  xcstrings: '.xcstrings',
 };

--- a/packages/cli/src/formats/files/transformFormat.ts
+++ b/packages/cli/src/formats/files/transformFormat.ts
@@ -24,6 +24,7 @@ export const CONFIG_FILE_TYPE_TO_FILE_FORMAT = {
   dotStrings: 'DOT_STRINGS',
   dotStringsdict: 'DOT_STRINGSDICT',
   androidStrings: 'ANDROID_STRINGS',
+  xcstrings: 'XCSTRINGS',
 } as const satisfies Record<SupportedFileExtension, FileFormat>;
 
 /**
@@ -44,6 +45,7 @@ export const FILE_FORMAT_TO_CONFIG_FILE_TYPE = {
   DOT_STRINGS: 'dotStrings',
   DOT_STRINGSDICT: 'dotStringsdict',
   ANDROID_STRINGS: 'androidStrings',
+  XCSTRINGS: 'xcstrings',
 } as const satisfies Partial<Record<FileFormat, SupportedFileExtension>>;
 
 /**
@@ -67,6 +69,7 @@ const FILE_FORMAT_EXTENSIONS = {
   DOT_STRINGS: 'strings',
   DOT_STRINGSDICT: 'stringsdict',
   ANDROID_STRINGS: 'xml',
+  XCSTRINGS: 'xcstrings',
 } as const satisfies Record<FileFormat, string>;
 
 /**

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -550,6 +550,30 @@ describe('parseFilesConfig', () => {
       expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
     });
 
+    it('should not warn when an xcstrings pattern does not include [locale]', () => {
+      // xcstrings catalogs hold every locale in one shared file, so a pattern
+      // without [locale] is the expected layout there
+      const includePatterns = ['Cascade/Localizable.xcstrings'];
+      const excludePatterns = [];
+
+      vi.mocked(fg.sync).mockReturnValue([
+        '/project/Cascade/Localizable.xcstrings',
+      ]);
+
+      expandGlobPatterns(
+        '/project',
+        includePatterns,
+        excludePatterns,
+        'en',
+        defaultLocales,
+        undefined,
+        undefined,
+        'xcstrings'
+      );
+
+      expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+    });
+
     it('should not warn when pattern does not include [locale] but has TransformOption patterns', () => {
       const includePatterns = ['src/static/*.json'];
       const excludePatterns = [];

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -5,6 +5,7 @@ import {
   RequiresReviewConfig,
   ResolvedFiles,
   Settings,
+  SupportedFileExtension,
   TransformFormats,
   TransformFiles,
   TransformOption,
@@ -141,7 +142,8 @@ export function resolveFiles(
         locale,
         locales,
         transformPaths[fileType] || undefined,
-        compositePatterns
+        compositePatterns,
+        fileType
       );
       resolvedPaths[fileType] = filePaths.resolvedPaths;
       placeholderResult[fileType] = filePaths.placeholderPaths;
@@ -209,7 +211,8 @@ export function expandGlobPatterns(
   locale: string,
   locales: string[],
   transformPatterns?: TransformOption | string | TransformOption[],
-  compositePatterns?: string[]
+  compositePatterns?: string[],
+  fileType?: SupportedFileExtension
 ): {
   resolvedPaths: string[];
   placeholderPaths: string[];
@@ -224,10 +227,13 @@ export function expandGlobPatterns(
     // It must be included in the pattern, otherwise the CLI tool will not be able to find the correct output path
     // Warn if it's not included
     // Ignore if is composite pattern
+    // xcstrings catalogs hold every locale in one shared file, so a pattern
+    // without [locale] is the expected layout there, not a misconfiguration
     if (
       !pattern.includes('[locale]') &&
       !transformPatterns &&
-      !compositePatterns?.includes(pattern)
+      !compositePatterns?.includes(pattern) &&
+      fileType !== 'xcstrings'
     ) {
       logger.warn(
         chalk.yellow(

--- a/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
+++ b/packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts
@@ -20,6 +20,7 @@ describe('isSupportedFileFormatTransform', () => {
     'DOT_STRINGS',
     'DOT_STRINGSDICT',
     'ANDROID_STRINGS',
+    'XCSTRINGS',
   ];
 
   it('supports identity transforms by default', () => {

--- a/packages/core/src/utils/isSupportedFileFormatTransform.ts
+++ b/packages/core/src/utils/isSupportedFileFormatTransform.ts
@@ -19,6 +19,7 @@ const SUPPORTED_TRANSFORMATIONS = {
   DOT_STRINGS: ['DOT_STRINGS'],
   DOT_STRINGSDICT: ['DOT_STRINGSDICT'],
   ANDROID_STRINGS: ['ANDROID_STRINGS'],
+  XCSTRINGS: ['XCSTRINGS'],
 } as const satisfies Record<FileFormat, FileFormat[]>;
 
 /**


### PR DESCRIPTION
## Summary

Registration/boilerplate layer for Apple `.xcstrings` catalog support in the CLI. This PR makes the toolchain *aware* the `.xcstrings` format exists, with no slicing or upload logic. The actual slicing/upload behavior lands in the stacked follow-up (#2251), which is now based on this branch.

## What this does

- Adds `XCSTRINGS` to the `FileFormat` enum in the API spec (`openapi.json`) and generated types (`types.gen.ts`).
- Adds the `XCSTRINGS` identity entry to the core transform table (`isSupportedFileFormatTransform`).
- Registers the CLI format tables: supported extension (`.xcstrings`), config-key → format mapping, and format → extension mapping (`supportedFiles.ts`, `transformFormat.ts`).
- Skips the `[locale]` pattern warning for `xcstrings` config includes, since one catalog is shared across every locale (`parseFilesConfig.ts`).

## Why these hunks are grouped here

Several of these are forced together by exhaustive `satisfies Record<FileFormat, ...>` / `Record<SupportedFileExtension, ...>` constraints: once `XCSTRINGS` joins the `FileFormat` union, the core transform table and the CLI `FILE_FORMAT_EXTENSIONS` map must gain the key or the build fails; likewise adding `xcstrings` to `SUPPORTED_FILE_EXTENSIONS` forces the `CONFIG_FILE_TYPE_TO_FILE_FORMAT` entry. None of these files reference the not-yet-existing slicer, so they compile and test green standalone.

## No behavior change

Pointing the CLI at an `.xcstrings` file is recognized as the format but not yet specially processed (no slicing). This transient "registered but not sliced" state is only reachable via the stacked logic PR; build and the full CLI + core test suites are green.

## Coordination note

The CLI hand-edits its own copy of `openapi.json` / `types.gen.ts` (the `FileFormat` enum), which is normally synced from gt-cloud. Once the server registers `XCSTRINGS`, these generated files may want a regen to stay in sync with the canonical source.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR registers Apple `.xcstrings` catalogs throughout the API, core transform, and CLI configuration tables, and suppresses the locale-placeholder warning for their shared-file layout.

- Extends the generated API contract with the `XCSTRINGS` format.
- Adds bidirectional CLI format and extension mappings.
- Marks the identity transform as supported.
- Allows `.xcstrings` include patterns without `[locale]`.
- The registration currently exposes the format before the service rollout and before shared-catalog output mapping is implemented.
</details>


<details open><summary><h3>Confidence Score: 3/5</h3></summary>

The PR is not safe to merge until the XCSTRINGS API rollout is coordinated and shared-catalog paths no longer cause target locales to overwrite one another.

Current CLI callers can send the newly advertised API value before compatible service support is established, while locale-independent xcstrings paths map every target locale to one output file and produce last-writer-wins downloads.

**Files Needing Attention:** packages/api/spec/openapi.json; packages/cli/src/fs/config/parseFilesConfig.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/api/spec/openapi.json | Advertises XCSTRINGS across public API request enums before a coordinated service implementation is established. |
| packages/api/src/generated/types.gen.ts | Updates generated request types consistently with the modified OpenAPI enum. |
| packages/cli/src/formats/files/supportedFiles.ts | Makes xcstrings an accepted CLI configuration type and labels its extension. |
| packages/cli/src/formats/files/transformFormat.ts | Adds complete config/API/extension mappings that allow XCSTRINGS to enter operational workflows. |
| packages/cli/src/fs/config/parseFilesConfig.ts | Accepts shared catalog paths without a locale placeholder even though downstream per-locale mapping writes every result to that same path. |
| packages/cli/src/fs/__tests__/parseFilesConfig.test.ts | Tests warning suppression but does not cover the resulting multi-locale output-path collision. |
| packages/core/src/utils/isSupportedFileFormatTransform.ts | Adds the expected identity-only XCSTRINGS transform entry. |
| packages/core/src/utils/__tests__/isSupportedFileFormatTransform.test.ts | Extends identity-transform coverage to the new format. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[files.xcstrings configuration] --> R[Resolve shared catalog path]
  R --> A[Aggregate as XCSTRINGS]
  A --> API[Upload through generated API contract]
  R --> M[Create mapping for each target locale]
  M --> P[Same output path for every locale]
  P --> W[Sequential download writes]
```
</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/cli/src/fs/config/parseFilesConfig.ts`, line 241 ([link](https://github.com/generaltranslation/gt/blob/9ca7d72502c073338e31c38d14a271621e55cbf8/packages/cli/src/fs/config/parseFilesConfig.ts#L241)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Locales overwrite shared catalog**

   Suppressing the missing-`[locale]` warning makes a shared `.xcstrings` path appear valid, but the existing mapping still resolves an output independently for every target locale. Without a placeholder, every locale resolves to the same file, and the download workflow writes each result to that path in turn. The catalog therefore retains only the last locale instead of merging all locales into the shared file.

   **Knowledge Base Used:**
   - [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
   - [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: packages/cli/src/fs/config/parseFilesConfig.ts
   Line: 241
   
   Comment:
   **Locales overwrite shared catalog**
   
   Suppressing the missing-`[locale]` warning makes a shared `.xcstrings` path appear valid, but the existing mapping still resolves an output independently for every target locale. Without a placeholder, every locale resolves to the same file, and the download workflow writes each result to that path in turn. The catalog therefore retains only the last locale instead of merging all locales into the shared file.
   
   **Knowledge Base Used:**
   - [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
   - [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
   
   ---
   
   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FparseFilesConfig.ts%0ALine%3A%20241%0A%0AComment%3A%0A**Locales%20overwrite%20shared%20catalog**%0A%0ASuppressing%20the%20missing-%60%5Blocale%5D%60%20warning%20makes%20a%20shared%20%60.xcstrings%60%20path%20appear%20valid%2C%20but%20the%20existing%20mapping%20still%20resolves%20an%20output%20independently%20for%20every%20target%20locale.%20Without%20a%20placeholder%2C%20every%20locale%20resolves%20to%20the%20same%20file%2C%20and%20the%20download%20workflow%20writes%20each%20result%20to%20that%20path%20in%20turn.%20The%20catalog%20therefore%20retains%20only%20the%20last%20locale%20instead%20of%20merging%20all%20locales%20into%20the%20shared%20file.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BExtraction%20and%20compilation%20pipeline%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fextraction-and-compilation.md%29%0A-%20%5BCLI%20orchestration%20and%20repository%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fcli-orchestration.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fregister-xcstrings-format%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fregister-xcstrings-format%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FparseFilesConfig.ts%0ALine%3A%20241%0A%0AComment%3A%0A**Locales%20overwrite%20shared%20catalog**%0A%0ASuppressing%20the%20missing-%60%5Blocale%5D%60%20warning%20makes%20a%20shared%20%60.xcstrings%60%20path%20appear%20valid%2C%20but%20the%20existing%20mapping%20still%20resolves%20an%20output%20independently%20for%20every%20target%20locale.%20Without%20a%20placeholder%2C%20every%20locale%20resolves%20to%20the%20same%20file%2C%20and%20the%20download%20workflow%20writes%20each%20result%20to%20that%20path%20in%20turn.%20The%20catalog%20therefore%20retains%20only%20the%20last%20locale%20instead%20of%20merging%20all%20locales%20into%20the%20shared%20file.%0A%0A**Knowledge%20Base%20Used%3A**%0A-%20%5BExtraction%20and%20compilation%20pipeline%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fextraction-and-compilation.md%29%0A-%20%5BCLI%20orchestration%20and%20repository%20workflows%5D%28https%3A%2F%2Fapp.greptile.com%2Fgeneraltranslation%2F-%2Fcustom-context%2Fknowledge-base%2Fgeneraltranslation%2Fgt%2F-%2Fdocs%2Fcli-orchestration.md%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232254%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2254&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fapi%2Fspec%2Fopenapi.json%3A78%0A**Uncoordinated%20API%20contract**%0A%0AAdding%20%60XCSTRINGS%60%20to%20the%20public%20API%20contract%20and%20CLI%20mappings%20allows%20current%20callers%20to%20upload%20%60fileFormat%3A%20%22XCSTRINGS%22%60%2C%20but%20the%20PR%20states%20that%20the%20canonical%20service%20has%20not%20registered%20this%20value%20yet.%20These%20requests%20can%20therefore%20be%20rejected%20until%20gt-cloud%20is%20deployed%20compatibly.%20This%20also%20violates%20the%20repository%20directive%20requiring%20shared%20contract%20changes%20between%20generaltranslation%2Fgt%20and%20generaltranslation%2Fgt-cloud%20to%20be%20verified%20and%20released%20through%20a%20coordinated%20compatible%20rollout.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FparseFilesConfig.ts%3A241%0A**Locales%20overwrite%20shared%20catalog**%0A%0ASuppressing%20the%20missing-%60%5Blocale%5D%60%20warning%20makes%20a%20shared%20%60.xcstrings%60%20path%20appear%20valid%2C%20but%20the%20existing%20mapping%20still%20resolves%20an%20output%20independently%20for%20every%20target%20locale.%20Without%20a%20placeholder%2C%20every%20locale%20resolves%20to%20the%20same%20file%2C%20and%20the%20download%20workflow%20writes%20each%20result%20to%20that%20path%20in%20turn.%20The%20catalog%20therefore%20retains%20only%20the%20last%20locale%20instead%20of%20merging%20all%20locales%20into%20the%20shared%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22e%2Fcli%2Fregister-xcstrings-format%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22e%2Fcli%2Fregister-xcstrings-format%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fapi%2Fspec%2Fopenapi.json%3A78%0A**Uncoordinated%20API%20contract**%0A%0AAdding%20%60XCSTRINGS%60%20to%20the%20public%20API%20contract%20and%20CLI%20mappings%20allows%20current%20callers%20to%20upload%20%60fileFormat%3A%20%22XCSTRINGS%22%60%2C%20but%20the%20PR%20states%20that%20the%20canonical%20service%20has%20not%20registered%20this%20value%20yet.%20These%20requests%20can%20therefore%20be%20rejected%20until%20gt-cloud%20is%20deployed%20compatibly.%20This%20also%20violates%20the%20repository%20directive%20requiring%20shared%20contract%20changes%20between%20generaltranslation%2Fgt%20and%20generaltranslation%2Fgt-cloud%20to%20be%20verified%20and%20released%20through%20a%20coordinated%20compatible%20rollout.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Ffs%2Fconfig%2FparseFilesConfig.ts%3A241%0A**Locales%20overwrite%20shared%20catalog**%0A%0ASuppressing%20the%20missing-%60%5Blocale%5D%60%20warning%20makes%20a%20shared%20%60.xcstrings%60%20path%20appear%20valid%2C%20but%20the%20existing%20mapping%20still%20resolves%20an%20output%20independently%20for%20every%20target%20locale.%20Without%20a%20placeholder%2C%20every%20locale%20resolves%20to%20the%20same%20file%2C%20and%20the%20download%20workflow%20writes%20each%20result%20to%20that%20path%20in%20turn.%20The%20catalog%20therefore%20retains%20only%20the%20last%20locale%20instead%20of%20merging%20all%20locales%20into%20the%20shared%20file.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2254&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/api/spec/openapi.json:78
**Uncoordinated API contract**

Adding `XCSTRINGS` to the public API contract and CLI mappings allows current callers to upload `fileFormat: "XCSTRINGS"`, but the PR states that the canonical service has not registered this value yet. These requests can therefore be rejected until gt-cloud is deployed compatibly. This also violates the repository directive requiring shared contract changes between generaltranslation/gt and generaltranslation/gt-cloud to be verified and released through a coordinated compatible rollout.

### Issue 2
packages/cli/src/fs/config/parseFilesConfig.ts:241
**Locales overwrite shared catalog**

Suppressing the missing-`[locale]` warning makes a shared `.xcstrings` path appear valid, but the existing mapping still resolves an output independently for every target locale. Without a placeholder, every locale resolves to the same file, and the download workflow writes each result to that path in turn. The catalog therefore retains only the last locale instead of merging all locales into the shared file.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(cli): register the .xcstrings file ..."](https://github.com/generaltranslation/gt/commit/9ca7d72502c073338e31c38d14a271621e55cbf8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61383288)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (4)</h4></summary>

- Rule used - When a change modifies a shared contract between g... ([source](https://app.greptile.com/generaltranslation/-/custom-context?memory=7056c402-c174-42b0-b40f-d20897e35951))
- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
- Knowledge Base — [Translation API client and service bindings](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/translation-api-client.md)
</details>


<!-- /greptile_comment -->