### PR TITLE
fix(cli): use div wrapping on all anchors

### DIFF
--- a/.changeset/wrap-explicit-anchor-ids.md
+++ b/.changeset/wrap-explicit-anchor-ids.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix(cli): wrap headings with author-written `{#id}` anchors in a `<div id>` like every other heading when `experimentalAddHeaderAnchorIds` is `mintlify`. Re-attaching the inline `{#id}` broke Mintlify builds when the heading sat inside nested JSX, because the MDX serializer indents it four spaces and Mintlify no longer recognizes the anchor there.

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -849,7 +849,7 @@ Más contenido.`;
       });
     });
 
-    it('restores an author-written ID in native syntax rather than a wrapper', () => {
+    it('wraps an author-written ID like any other heading', () => {
       const source = '## CSS variables reference {#css-variables}\n';
       const translated = '## Référence des variables CSS\n';
 
@@ -863,15 +863,12 @@ Más contenido.`;
       );
 
       expect(result.content).toBe(
-        '## Référence des variables CSS {#css-variables}\n'
+        '<div id="css-variables">\n  ## Référence des variables CSS\n</div>\n'
       );
-      // The author chose this ID; it needs no wrapper element, and the escaped
-      // form would render as literal text in Mintlify.
-      expect(result.content).not.toContain('<div id=');
-      expect(result.content).not.toContain('\\{#');
+      expect(result.content).not.toContain('{#');
     });
 
-    it('still wraps headings whose ID had to be derived', () => {
+    it('uses one wrapper form for explicit and derived IDs alike', () => {
       const source = '## Setup {#custom}\n\n## Other heading\n';
       const translated = '## Configuration\n\n## Autre titre\n';
 
@@ -884,13 +881,13 @@ Más contenido.`;
         'mdx'
       );
 
-      expect(result.content).toContain('## Configuration {#custom}');
-      expect(result.content).toContain(
-        '<div id="other-heading">\n  ## Autre titre\n</div>'
+      expect(result.content).toBe(
+        '<div id="custom">\n  ## Configuration\n</div>\n\n' +
+          '<div id="other-heading">\n  ## Autre titre\n</div>\n'
       );
     });
 
-    it('does not double-apply an ID the translation already carried over', () => {
+    it('drops an inline ID the translation carried over when wrapping', () => {
       const source = '## Setup {#custom}\n';
       const translated = '## Configuration {#custom}\n';
 
@@ -903,8 +900,48 @@ Más contenido.`;
         'mdx'
       );
 
-      expect(result.content).toBe('## Configuration {#custom}\n');
-      expect(result.hasChanges).toBe(false);
+      expect(result.content).toBe(
+        '<div id="custom">\n  ## Configuration\n</div>\n'
+      );
+      expect(result.hasChanges).toBe(true);
+    });
+
+    it('wraps an explicit-ID heading the serializer indented inside nested JSX', () => {
+      // Mintlify only recognizes `{#id}` on headings indented at most three
+      // spaces. The MDX serializer indents JSX children two spaces per level,
+      // so re-attaching the inline ID here produced an acorn parse error.
+      const source = `<Tabs>
+  <Tab title="Plain CSS">
+
+## CSS variables reference {#css-variables}
+
+Body text.
+
+  </Tab>
+</Tabs>
+`;
+      const translated = `<Tabs>
+  <Tab title="CSS simple">
+    ## Référence des variables CSS
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`;
+
+      const result = addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      );
+
+      expect(result.content).toContain(
+        '    <div id="css-variables">\n      ## Référence des variables CSS\n    </div>'
+      );
+      expect(result.content).not.toContain('{#');
     });
   });
 
@@ -987,8 +1024,8 @@ Más contenido.`;
       ]);
 
       const out = wrap(doc, doc);
-      expect(out).toContain('<div id="setup-2">');
-      expect(out).toContain('## Configuration {#setup}');
+      expect(out).toContain('<div id="setup-2">\n  ## Setup\n</div>');
+      expect(out).toContain('<div id="setup">\n  ## Configuration\n</div>');
     });
 
     it('does not renumber author-written IDs', () => {
@@ -1042,9 +1079,13 @@ Más contenido.`;
         'mdx'
       );
 
-      expect(result.content).toContain('## Alpha-fr {#alpha}');
-      expect(result.content).toContain('## Imbriqué-fr {#nested}');
-      expect(result.content).toContain('## Beta-fr {#beta}');
+      expect(result.content).toContain(
+        '<div id="alpha">\n  ## Alpha-fr\n</div>'
+      );
+      expect(result.content).toContain(
+        '  <div id="nested">\n    ## Imbriqué-fr\n  </div>'
+      );
+      expect(result.content).toContain('<div id="beta">\n  ## Beta-fr\n</div>');
     });
   });
   describe('Heading location is taken from the parser, not matched by shape', () => {

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -349,23 +349,27 @@ function applyAnchorIds(
 
     const index = heading.startLine - 1;
 
-    // Author-written IDs stay inline; derived ones go in a wrapper.
-    const inline = !useDivWrapping || mapping.explicit;
-
-    if (inline) {
+    if (!useDivWrapping) {
       // Setext headings have no column to append to.
       if (heading.textEndColumn < 1) continue;
 
       const escape = escapeAnchors && !mapping.explicit;
       const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;
-      const line = lines[index];
-      const text = line
-        .slice(0, heading.textEndColumn - 1)
-        .replace(TRAILING_ANCHOR, '');
-      const trailer = line.slice(heading.textEndColumn - 1);
+      const { text, trailer } = splitHeadingLine(lines[index], heading);
 
       lines[index] = `${text} ${anchor}${trailer}`;
       continue;
+    }
+
+    // In wrapper mode every heading gets a wrapper, including ones whose ID
+    // the author wrote inline. Mintlify's `{#id}` pre-pass does not recognize
+    // headings indented four or more spaces, which the MDX serializer produces
+    // for headings nested in JSX, so a re-attached inline ID fails to compile.
+    // A wrapper anchors the heading at any indentation. Drop any inline ID the
+    // translation carried over so the two forms never appear together.
+    if (heading.textEndColumn >= 1) {
+      const { text, trailer } = splitHeadingLine(lines[index], heading);
+      lines[index] = `${text}${trailer}`;
     }
 
     if (heading.wrapperId) {
@@ -392,6 +396,20 @@ function applyAnchorIds(
   }
 
   return lines.join('\n');
+}
+
+/**
+ * Splits a heading line into its text, minus any trailing inline anchor, and
+ * whatever follows the text (a closing `##` sequence, for instance).
+ */
+function splitHeadingLine(
+  line: string,
+  heading: HeadingInfo
+): { text: string; trailer: string } {
+  return {
+    text: line.slice(0, heading.textEndColumn - 1).replace(TRAILING_ANCHOR, ''),
+    trailer: line.slice(heading.textEndColumn - 1),
+  };
 }
 
 /**


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes Mintlify heading-anchor post-processing so both author-written and derived IDs use the same `<div id="…">` wrapper, preventing deeply indented inline anchors from breaking nested MDX builds.
- Removes carried-over inline anchor syntax before wrapping translated headings.
- Adds focused tests for explicit IDs, derived IDs, collisions, and headings nested in JSX.
- Adds a patch changeset for the CLI package.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The behavioral fix appears sound, but the explicit repository requirement for format-aware MDX transformation must be satisfied before merging.

The wrapper behavior is well covered and no concrete runtime regression was established, but the production change still edits structured MDX through raw slicing and regex replacement in violation of the repository’s transformation standard.

**Files Needing Attention:** packages/cli/src/utils/addExplicitAnchorIds.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/addExplicitAnchorIds.ts | Unifies explicit and derived anchor handling in Mintlify mode, but the newly applied raw-line regex transformation violates the repository’s format-aware MDX transformation requirement. |
| packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts | Updates expected wrapper output and adds focused regression coverage for explicit anchors inside nested JSX. |
| .changeset/wrap-explicit-anchor-ids.md | Correctly records the nested-MDX anchor fix as a patch release for `gt`. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232256%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2256&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A405-412%0A**Raw%20MDX%20rewriting**%0A%0AThe%20new%20wrapper%20path%20removes%20inline%20anchors%20by%20slicing%20the%20serialized%20MDX%20line%20and%20applying%20a%20regular%20expression.%20This%20violates%20the%20repository%20directive%20that%20MDX%20transformations%20use%20a%20format-aware%20parser%20and%20serializer%20while%20preserving%20unaffected%20structure.%20Parser-derived%20columns%20do%20not%20make%20the%20rewrite%20structure-aware%2C%20so%20the%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fmintlify-consistent-anchors%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fmintlify-consistent-anchors%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Futils%2FaddExplicitAnchorIds.ts%3A405-412%0A**Raw%20MDX%20rewriting**%0A%0AThe%20new%20wrapper%20path%20removes%20inline%20anchors%20by%20slicing%20the%20serialized%20MDX%20line%20and%20applying%20a%20regular%20expression.%20This%20violates%20the%20repository%20directive%20that%20MDX%20transformations%20use%20a%20format-aware%20parser%20and%20serializer%20while%20preserving%20unaffected%20structure.%20Parser-derived%20columns%20do%20not%20make%20the%20rewrite%20structure-aware%2C%20so%20the%20repository%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2256&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/utils/addExplicitAnchorIds.ts:405-412
**Raw MDX rewriting**

The new wrapper path removes inline anchors by slicing the serialized MDX line and applying a regular expression. This violates the repository directive that MDX transformations use a format-aware parser and serializer while preserving unaffected structure. Parser-derived columns do not make the rewrite structure-aware, so the repository requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): use div wrapping on all anchor..."](https://github.com/generaltranslation/gt/commit/27d8481b752e51b32d61b1a11fa299bc2a578624) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61731122)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - For JSON, YAML, HTML, SVG, XML, MDX, source code, ... ([source](https://app.greptile.com/generaltranslation/-/custom-context?memory=498f44d3-3036-4f80-9c20-3c643887e413))
- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)

<!-- /greptile_comment -->