### PR TITLE
chore(release) 5/5: publish .xcstrings catalog support

### DIFF
--- a/.changeset/xcstrings-slice-upload.md
+++ b/.changeset/xcstrings-slice-upload.md
@@ -1,0 +1,7 @@
+---
+'@generaltranslation/api': minor
+'generaltranslation': minor
+'gt': minor
+---
+
+Add Apple `.xcstrings` catalog upload support to the CLI. An `.xcstrings` catalog holds every locale in one file; on upload the CLI extracts a source-only slice (only the catalog's `sourceLanguage` localization per entry) and uploads that as the source document. The slice is serialized with a pinned byte layout and hashed into its `versionId`, so an unchanged catalog re-slices byte-identically and does not re-upload. Configure it under `files.xcstrings` in `gt.config.json`; patterns without `[locale]` are expected because the catalog is shared across locales.


### PR DESCRIPTION
## Summary

This PR carries only the changeset for Apple `.xcstrings` catalog support in the CLI; it adds no code. The feature changeset was lifted out of #2251 (`chore(cli): hold the .xcstrings changeset until the stack is complete`) so the code PRs in this stack can merge without publishing, and the `gtx-cli` release becomes the explicit last step of the stack. The changeset bumps `@generaltranslation/api`, `generaltranslation`, and `gt` (minor); `gtx-cli` follows `gt` through the fixed group in `.changeset/config.json`, so it needs no separate changeset.

## Merge order

1. 1/4 #2254 `e/cli/register-xcstrings-format` - register the `.xcstrings` file format
2. 2/4 #2251 `e/cli/xcstrings-slice-upload` - slice catalogs to a source-only upload
3. 3/4 `e/cli/xcstrings-download-merge` - merge downloaded translations back into the catalog (PR not yet open)
4. 4/4 this PR - changeset only

## Base

The base is temporarily `e/cli/xcstrings-slice-upload` (#2251) because the download-merge branch does not exist yet. Once the 3/4 PR opens, this PR's base must be moved to `e/cli/xcstrings-download-merge` and the branch rebased onto it, so the release cannot land before the download merge.

## Gate

Do not merge until generaltranslation/gt-cloud#4732 (server ingress and egress for `.xcstrings`) is deployed. Merging this PR releases a CLI that uploads `.xcstrings` slices, so the server must accept them first.
