### PR TITLE
feat(cli) 3/5: merge downloaded locales back into the catalog

### DIFF
--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -743,4 +743,216 @@ describe('downloadFileBatch', () => {
     expect(esEntry).toBeDefined();
     expect(esEntry!.tabs[0].tab).toBe('Guías');
   });
+
+  describe('XCSTRINGS catalogs', () => {
+    const CATALOG = 'App/Localizable.xcstrings';
+    const unit = (value: string) => ({
+      stringUnit: { state: 'translated', value },
+    });
+    const catalogContent = JSON.stringify(
+      {
+        sourceLanguage: 'en',
+        version: '1.0',
+        strings: {
+          Save: {},
+          greeting: {
+            comment: 'Home screen',
+            localizations: { en: unit('Hello'), fr: unit('Bonjour') },
+          },
+        },
+      },
+      null,
+      2
+    );
+    const downloadFor = (locale: string, values: Record<string, unknown>) =>
+      JSON.stringify({
+        sourceLanguage: 'en',
+        version: '1.0',
+        strings: Object.fromEntries(
+          Object.entries(values).map(([key, localization]) => [
+            key,
+            { localizations: { [locale]: localization } },
+          ])
+        ),
+      });
+    const batched = (locale: string) => ({
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      outputPath: CATALOG,
+      inputPath: CATALOG,
+      locale,
+    });
+    const served = (locale: string, data: string) => ({
+      id: `translation-${locale}`,
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      locale,
+      fileFormat: 'XCSTRINGS' as FileFormat,
+      data,
+      fileName: CATALOG,
+      metadata: {},
+    });
+    // The lockfile already records de for this version: the condition that
+    // skips every other format because "the file is already downloaded"
+    const lockfileWithDe = () => ({
+      data: { version: 2, branchId: 'branch-1', entries: [] },
+      entryMap: new Map<string, DownloadedVersionEntry>([
+        [
+          'file-1',
+          {
+            fileId: 'file-1',
+            versionId: 'version-1',
+            fileName: CATALOG,
+            translations: {
+              de: { updatedAt: '2026-01-01T00:00:00.000Z', fileName: CATALOG },
+            },
+          },
+        ],
+      ]),
+      originalV1: false,
+    });
+
+    /** Backs the fs mocks with one string so sequential merges accumulate. */
+    const mockDisk = (initial: string) => {
+      const disk = { content: initial };
+      vi.mocked(fs.readFileSync).mockImplementation(() => disk.content);
+      vi.mocked(fs.promises.writeFile).mockImplementation(
+        async (_path, content) => {
+          disk.content = String(content);
+        }
+      );
+      return disk;
+    };
+
+    it('merges the locale into the catalog itself, bypassing the lockfile skip and the JSON key sorter', async () => {
+      const files: BatchedFiles = [batched('de')];
+      const fileTracker = createMockFileTracker(files);
+      const lockEntry: DownloadedVersionEntry = {
+        fileId: 'file-1',
+        versionId: 'version-1',
+        translations: {},
+      };
+      vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+      vi.mocked(readLockfile).mockReturnValue(lockfileWithDe());
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          served(
+            'de',
+            downloadFor('de', {
+              Save: unit('Sichern'),
+              greeting: unit('Hallo'),
+            })
+          ),
+        ],
+        count: 1,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      const disk = mockDisk(catalogContent);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'fr'] })
+      );
+
+      expect(result.skipped).toHaveLength(0);
+      expect(result.failed).toHaveLength(0);
+      expect(result.successful).toHaveLength(1);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(fs.promises.writeFile).mock.calls[0][0]).toBe(CATALOG);
+      // Byte-exact: the pinned layout, root keys in the catalog's own order
+      // (a key sorter would move "version" after "strings"), the source unit
+      // and fr untouched, de inserted at its sorted position
+      expect(disk.content).toBe(
+        JSON.stringify(
+          {
+            sourceLanguage: 'en',
+            version: '1.0',
+            strings: {
+              Save: { localizations: { de: unit('Sichern') } },
+              greeting: {
+                comment: 'Home screen',
+                localizations: {
+                  de: unit('Hallo'),
+                  en: unit('Hello'),
+                  fr: unit('Bonjour'),
+                },
+              },
+            },
+          },
+          null,
+          2
+        ) + '\n'
+      );
+      expect(lockEntry.translations.de.fileName).toBe(CATALOG);
+    });
+
+    it('accumulates every locale of one batch in the shared catalog', async () => {
+      const files: BatchedFiles = [batched('de'), batched('es')];
+      const fileTracker = createMockFileTracker(files);
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          served('de', downloadFor('de', { greeting: unit('Hallo') })),
+          served('es', downloadFor('es', { greeting: unit('Hola') })),
+        ],
+        count: 2,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      const disk = mockDisk(catalogContent);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'es'] })
+      );
+
+      expect(result.successful).toHaveLength(2);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(2);
+      const written = JSON.parse(disk.content) as {
+        strings: Record<string, { localizations: Record<string, unknown> }>;
+      };
+      expect(written.strings.greeting.localizations).toEqual({
+        de: unit('Hallo'),
+        en: unit('Hello'),
+        es: unit('Hola'),
+        fr: unit('Bonjour'),
+      });
+    });
+
+    it('fails the locale, not the batch, when the download is not a catalog', async () => {
+      const files: BatchedFiles = [batched('de'), batched('es')];
+      const fileTracker = createMockFileTracker(files);
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          served('de', 'not json'),
+          served('es', downloadFor('es', { greeting: unit('Hola') })),
+        ],
+        count: 2,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      const disk = mockDisk(catalogContent);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'es'] })
+      );
+
+      expect(result.failed).toEqual([files[0]]);
+      expect(result.successful).toEqual([files[1]]);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('Invalid .xcstrings content')
+      );
+      expect(JSON.parse(disk.content).strings.greeting.localizations).toEqual({
+        en: unit('Hello'),
+        es: unit('Hola'),
+        fr: unit('Bonjour'),
+      });
+    });
+  });
 });

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -8,6 +8,7 @@ import { validateJsonSchema } from '../formats/json/utils.js';
 import { validateYamlSchema } from '../formats/yaml/utils.js';
 import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
+import { mergeXcstringsLocale } from '../formats/xcstrings/mergeXcstrings.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import {
@@ -334,20 +335,25 @@ export async function downloadFileBatch(
           continue;
         }
 
-        // Composite schema files merge translations into the source file itself,
-        // so outputPath always exists and the lock can't tell whether derived
-        // split outputs (e.g. {locale}/docs.json) are still on disk. Always
-        // merge fresh API data so derived files are regenerated every run;
-        // local edits to translated output are preserved via `gt save-local`.
+        // In-place translation files (composite schema JSON, .xcstrings
+        // catalogs) merge translations into the source file itself, so
+        // outputPath always exists and the lock can't tell whether this
+        // locale's content or derived split outputs (e.g. {locale}/docs.json)
+        // are still on disk. Always merge fresh API data so they are
+        // regenerated every run; local edits to translated output are
+        // preserved via `gt save-local`.
+        const isXcstringsCatalog = file.fileFormat === 'XCSTRINGS';
         const isInPlaceComposite = options.options?.jsonSchema
           ? !!validateJsonSchema(options.options, inputPath)?.composite
           : false;
+        const isInPlaceTranslationFile =
+          isXcstringsCatalog || isInPlaceComposite;
 
         if (
           !forceDownload &&
           fileExists &&
           downloadedTranslation &&
-          !isInPlaceComposite
+          !isInPlaceTranslationFile
         ) {
           // For schema-based files, re-merge with current source in case
           // non-translatable fields changed (skip the API download, not the merge)
@@ -418,14 +424,24 @@ export async function downloadFileBatch(
           result.skipped.push(requestedFile);
           continue;
         }
-        let data = mergeWithSource(file.data, locale, inputPath, options);
+        let data: string;
+        if (isXcstringsCatalog) {
+          // The pinned serializer owns the bytes and the JSON key sorter below
+          // must never see them. JSON.parse hoists integer-like keys ("404")
+          // first; versionId is unaffected (slices come from the parsed object)
+          // and Xcode re-sorts on its next save, so the only effect is a
+          // one-time reorder.
+          data = mergeXcstringsLocale(file.data, locale, inputPath);
+        } else {
+          data = mergeWithSource(file.data, locale, inputPath, options);
 
-        // Stable sort JSON keys for deterministic output
-        if (file.fileFormat === 'GTJSON' || outputPath.endsWith('.json')) {
-          try {
-            data = sortJsonString(data);
-          } catch (error) {
-            logger.warn(`Failed to sort JSON file: ${file.id}: ` + error);
+          // Stable sort JSON keys for deterministic output
+          if (file.fileFormat === 'GTJSON' || outputPath.endsWith('.json')) {
+            try {
+              data = sortJsonString(data);
+            } catch (error) {
+              logger.warn(`Failed to sort JSON file: ${file.id}: ` + error);
+            }
           }
         }
 

--- a/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/mergeXcstrings.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { mergeXcstringsLocale } from '../mergeXcstrings.js';
+import {
+  parseXcstrings,
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+  type XcstringsCatalog,
+} from '../parseXcstrings.js';
+import { logger } from '../../../console/logger.js';
+import { gt } from '../../../utils/gt.js';
+
+vi.mock('../../../console/logger.js');
+
+const multiLocaleContent = readFileSync(
+  path.join(__dirname, '../__mocks__', 'multi_locale.xcstrings'),
+  'utf8'
+);
+
+const parseCatalog = (content: string): XcstringsCatalog =>
+  JSON.parse(content) as XcstringsCatalog;
+
+const unit = (value: string) => ({
+  stringUnit: { state: 'translated', value },
+});
+
+/**
+ * A download as the server returns it: the source slice with `locale` units
+ * added for the given keys. Serialized compactly, not with the pinned layout,
+ * so the merge cannot depend on the download's formatting.
+ */
+function download(
+  content: string,
+  locale: string,
+  values: Record<string, unknown>
+): string {
+  const slice = parseCatalog(parseXcstrings(content));
+  for (const [key, localization] of Object.entries(values)) {
+    slice.strings[key] = {
+      ...slice.strings[key],
+      localizations: {
+        ...slice.strings[key].localizations,
+        [locale]: localization,
+      },
+    };
+  }
+  return JSON.stringify(slice);
+}
+
+describe('mergeXcstringsLocale', () => {
+  let tmpDir: string;
+  let catalogPath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'gt-merge-xcstrings-'));
+    catalogPath = path.join(tmpDir, 'Localizable.xcstrings');
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    gt.setConfig({ customMapping: {} });
+  });
+
+  /** Writes `catalogContent` to the temp catalog and merges `downloaded` into it. */
+  const merge = (
+    catalogContent: string,
+    downloaded: string,
+    locale: string
+  ): string => {
+    writeFileSync(catalogPath, catalogContent);
+    return mergeXcstringsLocale(downloaded, locale, catalogPath);
+  };
+
+  it('copies only localizations[locale] into each matching entry', () => {
+    const input = parseCatalog(multiLocaleContent);
+    const merged = merge(
+      multiLocaleContent,
+      download(multiLocaleContent, 'es', {
+        greeting: unit('Hola (rev)'),
+        'items.count': unit('%d elementos'),
+      }),
+      'es'
+    );
+    const catalog = parseCatalog(merged);
+
+    // Document shape, entry set, and entry order are the catalog's
+    expect(Object.keys(catalog)).toEqual(Object.keys(input));
+    expect(catalog.version).toBe(input.version);
+    expect(Object.keys(catalog.strings)).toEqual(Object.keys(input.strings));
+
+    for (const [key, inputEntry] of Object.entries(input.strings)) {
+      const { localizations: inputLocalizations, ...inputFields } = inputEntry;
+      const { localizations, ...fields } = catalog.strings[key];
+      // Entry-level fields are untouched
+      expect(fields).toEqual(inputFields);
+      // Every other locale is untouched, serialization included
+      for (const [locale, localization] of Object.entries(
+        inputLocalizations!
+      )) {
+        if (locale === 'es') continue;
+        expect(JSON.stringify(localizations![locale])).toBe(
+          JSON.stringify(localization)
+        );
+      }
+    }
+    // An existing es unit is replaced in place; a missing one is added
+    expect(Object.keys(catalog.strings.greeting.localizations!)).toEqual(
+      Object.keys(input.strings.greeting.localizations!)
+    );
+    expect(catalog.strings.greeting.localizations!.es).toEqual(
+      unit('Hola (rev)')
+    );
+    expect(catalog.strings['items.count'].localizations!.es).toEqual(
+      unit('%d elementos')
+    );
+    // The entry the download did not translate keeps its es unit as it was
+    expect(catalog.strings['account.plan.pro'].localizations!.es).toEqual(
+      input.strings['account.plan.pro'].localizations!.es
+    );
+  });
+
+  it('merges the same download twice to identical bytes', () => {
+    const esDownload = download(multiLocaleContent, 'es', {
+      greeting: unit('Hola'),
+    });
+    const once = merge(multiLocaleContent, esDownload, 'es');
+    expect(merge(once, esDownload, 'es')).toBe(once);
+    // The pinned layout is the write format
+    expect(once).toBe(JSON.stringify(JSON.parse(once), null, 2) + '\n');
+  });
+
+  it('inserts a new locale at its sorted position and never moves existing keys', () => {
+    // fr before en: the developer's order is not sorted and must survive
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: {
+          localizations: { fr: unit('Salut'), en: unit('Hello') },
+        },
+      },
+    });
+    const de = download(content, 'de', { greeting: unit('Hallo') });
+    const it_ = download(content, 'it', { greeting: unit('Ciao') });
+    const es = download(content, 'es', { greeting: unit('Hola') });
+
+    const deItEs = merge(merge(merge(content, de, 'de'), it_, 'it'), es, 'es');
+    const esItDe = merge(merge(merge(content, es, 'es'), it_, 'it'), de, 'de');
+
+    expect(deItEs).toBe(esItDe);
+    expect(
+      Object.keys(parseCatalog(deItEs).strings.greeting.localizations!)
+    ).toEqual(['de', 'es', 'fr', 'en', 'it']);
+  });
+
+  it('adds localizations to an implicit entry and leaves the source slice unchanged', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        Save: {},
+        Cancel: { comment: 'Toolbar button', extractionState: 'manual' },
+        greeting: { localizations: { en: unit('Hello') } },
+      },
+    });
+
+    let merged = merge(
+      content,
+      download(content, 'es', {
+        Save: unit('Guardar'),
+        Cancel: unit('Cancelar'),
+        greeting: unit('Hola'),
+      }),
+      'es'
+    );
+    merged = merge(
+      merged,
+      download(content, 'fr', { Save: unit('Enregistrer') }),
+      'fr'
+    );
+    const catalog = parseCatalog(merged);
+
+    expect(catalog.strings.Save).toEqual({
+      localizations: { es: unit('Guardar'), fr: unit('Enregistrer') },
+    });
+    expect(catalog.strings.Cancel).toEqual({
+      comment: 'Toolbar button',
+      extractionState: 'manual',
+      localizations: { es: unit('Cancelar') },
+    });
+    // Re-slicing the merged catalog reproduces the uploaded source slice, so
+    // versionId does not change because translations were downloaded
+    expect(parseXcstrings(merged)).toBe(parseXcstrings(content));
+    // And the per-locale upload slice is what was merged in
+    expect(
+      serializeXcstringsSlice(
+        sliceTranslationCatalog(parseXcstringsCatalog(merged), 'fr')!
+      )
+    ).toBe(
+      serializeXcstringsSlice({
+        sourceLanguage: 'en',
+        strings: { Save: { localizations: { fr: unit('Enregistrer') } } },
+      })
+    );
+  });
+
+  it('never replaces an entry or its localizations object wholesale', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      unknownRoot: { keep: ['me'] },
+      strings: {
+        'task.count': {
+          comment: 'Badge',
+          unknownEntryField: 7,
+          localizations: {
+            en: unit('Tasks'),
+            es: {
+              variations: {
+                plural: {
+                  one: { stringUnit: { state: 'new', value: 'Tarea' } },
+                  other: { stringUnit: { state: 'new', value: 'Tareas' } },
+                },
+              },
+            },
+            fr: {
+              stringUnit: {
+                state: 'translated',
+                value: 'Tâches',
+                unknownUnitField: true,
+              },
+            },
+          },
+        },
+      },
+    });
+    // The download carries only the es unit and drops every other field
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        'task.count': {
+          localizations: {
+            es: {
+              variations: {
+                plural: {
+                  one: unit('Tarea'),
+                  many: unit('Tareas'),
+                  other: unit('Tareas'),
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const catalog = parseCatalog(merge(content, downloaded, 'es'));
+
+    expect(catalog.unknownRoot).toEqual({ keep: ['me'] });
+    const entry = catalog.strings['task.count'];
+    expect(entry.comment).toBe('Badge');
+    expect(entry.unknownEntryField).toBe(7);
+    expect(Object.keys(entry.localizations!)).toEqual(['en', 'es', 'fr']);
+    expect(entry.localizations!.en).toEqual(unit('Tasks'));
+    expect(entry.localizations!.fr).toEqual({
+      stringUnit: {
+        state: 'translated',
+        value: 'Tâches',
+        unknownUnitField: true,
+      },
+    });
+    // The target unit itself is replaced wholesale: target plural categories
+    // legitimately differ from the source's
+    expect(entry.localizations!.es).toEqual({
+      variations: {
+        plural: {
+          one: unit('Tarea'),
+          many: unit('Tareas'),
+          other: unit('Tareas'),
+        },
+      },
+    });
+  });
+
+  it('leaves entries the download did not translate alone', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: { localizations: { en: unit('Hello'), es: unit('Hola') } },
+        farewell: { localizations: { en: unit('Bye') } },
+        Save: {},
+      },
+    });
+    // Untranslated entries come back as the source slice had them
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: { localizations: { en: unit('Hello') } },
+        farewell: { localizations: { en: unit('Bye'), es: unit('Adiós') } },
+        Save: {},
+      },
+    });
+
+    const merged = merge(content, downloaded, 'es');
+    const catalog = parseCatalog(merged);
+
+    expect(catalog.strings.greeting.localizations!.es).toEqual(unit('Hola'));
+    expect(catalog.strings.farewell.localizations!.es).toEqual(unit('Adiós'));
+    expect(catalog.strings.Save).toEqual({});
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('skips downloaded keys the catalog no longer has and warns', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { greeting: { localizations: { en: unit('Hello') } } },
+    });
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        greeting: { localizations: { es: unit('Hola') } },
+        'deleted.key': { localizations: { es: unit('Huérfano') } },
+        // Absent from the catalog: must not resolve to Object.prototype's
+        constructor: { localizations: { es: unit('Constructor') } },
+      },
+    });
+
+    const catalog = parseCatalog(merge(content, downloaded, 'es'));
+
+    expect(Object.keys(catalog.strings)).toEqual(['greeting']);
+    expect(catalog.strings.greeting.localizations!.es).toEqual(unit('Hola'));
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('"deleted.key", "constructor"')
+    );
+  });
+
+  it('merges into entries keyed by constructor and prototype', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        constructor: { localizations: { en: unit('Constructor') } },
+        prototype: { localizations: { en: unit('Prototype') } },
+      },
+    });
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        constructor: { localizations: { es: unit('Constructor (es)') } },
+        prototype: { localizations: { es: unit('Prototipo') } },
+      },
+    });
+
+    const catalog = parseCatalog(merge(content, downloaded, 'es'));
+
+    expect(catalog.strings.constructor.localizations).toEqual({
+      en: unit('Constructor'),
+      es: unit('Constructor (es)'),
+    });
+    expect(catalog.strings.prototype.localizations).toEqual({
+      en: unit('Prototype'),
+      es: unit('Prototipo'),
+    });
+  });
+
+  // JSON.parse hoists integer-like keys ahead of the others, so the merge
+  // writes them first. Pinned here so the reorder is a known, one-time effect.
+  it('lists integer-like keys first and stays idempotent', () => {
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: {
+        About: { localizations: { en: unit('About') } },
+        '404': { localizations: { en: unit('Not found') } },
+      },
+    });
+    const downloaded = download(content, 'es', {
+      About: unit('Acerca de'),
+      '404': unit('No encontrado'),
+    });
+
+    const once = merge(content, downloaded, 'es');
+
+    expect(Object.keys(parseCatalog(once).strings)).toEqual(['404', 'About']);
+    expect(merge(once, downloaded, 'es')).toBe(once);
+  });
+
+  it('keys the catalog by the canonical tag a custom mapping gives a differently cased locale', () => {
+    gt.setConfig({ customMapping: { 'pt-br': { code: 'pt-BR' } } });
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { greeting: { localizations: { en: unit('Hello') } } },
+    });
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { greeting: { localizations: { 'pt-BR': unit('Olá') } } },
+    });
+
+    const once = merge(content, downloaded, 'pt-br');
+    const catalog = parseCatalog(once);
+
+    expect(Object.keys(catalog.strings.greeting.localizations!)).toEqual([
+      'en',
+      'pt-BR',
+    ]);
+    expect(catalog.strings.greeting.localizations!['pt-BR']).toEqual(
+      unit('Olá')
+    );
+    // A second merge replaces pt-BR in place rather than adding pt-br
+    expect(merge(once, downloaded, 'pt-br')).toBe(once);
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('keys the catalog by the canonical tag a custom mapping aliases the locale to', () => {
+    gt.setConfig({ customMapping: { 'brand-french': { code: 'fr-CA' } } });
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { greeting: { localizations: { en: unit('Hello') } } },
+    });
+    const downloaded = JSON.stringify({
+      sourceLanguage: 'en',
+      strings: { greeting: { localizations: { 'fr-CA': unit('Salut') } } },
+    });
+
+    const catalog = parseCatalog(merge(content, downloaded, 'brand-french'));
+
+    expect(catalog.strings.greeting.localizations).toEqual({
+      en: unit('Hello'),
+      'fr-CA': unit('Salut'),
+    });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('throws on invalid catalog or download content', () => {
+    const valid = JSON.stringify({ sourceLanguage: 'en', strings: {} });
+    expect(() => merge('not json', valid, 'es')).toThrow(
+      'Invalid .xcstrings content'
+    );
+    expect(() => merge(valid, '{"strings":{}}', 'es')).toThrow(
+      'Invalid .xcstrings content'
+    );
+  });
+});

--- a/packages/cli/src/formats/xcstrings/mergeXcstrings.ts
+++ b/packages/cli/src/formats/xcstrings/mergeXcstrings.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import { logger } from '../../console/logger.js';
+import { gt } from '../../utils/gt.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  type XcstringsEntry,
+} from './parseXcstrings.js';
+
+/**
+ * Folds one locale's downloaded translations into the catalog at `inputPath`.
+ *
+ * Catalog keys are canonical tags and the configured `locale` may be a custom
+ * alias, so the alias is resolved before it is used as the key on either side.
+ * The catalog is read fresh so a batch of locales accumulates. It is truth for
+ * everything except that key: for each entry the download carries that
+ * localization for, only it is copied into the catalog's entry. Entries,
+ * entry-level fields, other locales, and unknown fields at every level are
+ * untouched. Keys the download did not translate are left alone; keys the
+ * catalog no longer has are skipped with a warning. Throws on invalid content.
+ */
+export function mergeXcstringsLocale(
+  downloadedContent: string,
+  locale: string,
+  inputPath: string
+): string {
+  const canonicalLocale = gt.resolveCanonicalLocale(locale);
+  const catalog = parseXcstringsCatalog(fs.readFileSync(inputPath, 'utf8'));
+  const downloaded = parseXcstringsCatalog(downloadedContent);
+
+  const strings: Record<string, XcstringsEntry> = Object.create(null);
+  for (const [key, entry] of Object.entries(catalog.strings)) {
+    strings[key] = entry;
+  }
+
+  const unmatchedKeys: string[] = [];
+  for (const [key, downloadedEntry] of Object.entries(downloaded.strings)) {
+    const localization = downloadedEntry.localizations?.[canonicalLocale];
+    if (localization === undefined) continue;
+    const entry = strings[key];
+    if (entry === undefined) {
+      unmatchedKeys.push(key);
+      continue;
+    }
+    strings[key] = {
+      ...entry,
+      localizations: withLocalization(
+        entry.localizations,
+        canonicalLocale,
+        localization
+      ),
+    };
+  }
+
+  if (unmatchedKeys.length > 0) {
+    logger.warn(
+      `Skipped ${unmatchedKeys.length} downloaded ${locale} translation(s) with no matching entry in the local catalog: ${unmatchedKeys
+        .map((key) => JSON.stringify(key))
+        .join(', ')}`
+    );
+  }
+
+  return serializeXcstringsSlice({ ...catalog, strings });
+}
+
+/**
+ * Clones `localizations` with `locale` set. An existing locale keeps its
+ * position; a new one is inserted before the first existing key that sorts
+ * after it, so the bytes do not depend on the order locales were downloaded
+ * and keys already present never move.
+ */
+function withLocalization(
+  localizations: Record<string, unknown> | undefined,
+  locale: string,
+  localization: unknown
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = Object.create(null);
+  let inserted = false;
+  for (const [existing, value] of Object.entries(localizations ?? {})) {
+    if (existing === locale) {
+      merged[locale] = localization;
+      inserted = true;
+      continue;
+    }
+    if (!inserted && locale < existing) {
+      merged[locale] = localization;
+      inserted = true;
+    }
+    merged[existing] = value;
+  }
+  if (!inserted) merged[locale] = localization;
+  return merged;
+}

--- a/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
+++ b/packages/cli/src/fs/__tests__/parseFilesConfig.test.ts
@@ -1305,4 +1305,60 @@ describe('parseFilesConfig', () => {
       ).toThrow(/files\.json\.requiresReview must be a boolean/);
     });
   });
+
+  describe('resolveFiles - xcstrings catalogs', () => {
+    const defaultLocales = ['en', 'fr', 'es'];
+
+    beforeEach(() => {
+      vi.mocked(fg.sync).mockReturnValue([
+        '/project/App/Localizable.xcstrings',
+      ]);
+    });
+
+    it('resolves a catalog that is updated in place', () => {
+      const result = resolveFiles(
+        { xcstrings: { include: ['App/Localizable.xcstrings'] } },
+        'en',
+        defaultLocales,
+        '/project'
+      );
+
+      expect(result.resolvedPaths.xcstrings).toEqual([
+        '/project/App/Localizable.xcstrings',
+      ]);
+      expect(result.placeholderPaths.xcstrings).toEqual([
+        '/project/App/Localizable.xcstrings',
+      ]);
+      expect(result.transformPaths.xcstrings).toBeUndefined();
+    });
+
+    it('rejects a path transform, which would write each locale to a separate catalog', () => {
+      expect(() =>
+        resolveFiles(
+          {
+            xcstrings: {
+              include: ['App/Localizable.xcstrings'],
+              transform: 'Localized/[locale]/*.xcstrings',
+            },
+          },
+          'en',
+          defaultLocales,
+          '/project'
+        )
+      ).toThrow(/files\.xcstrings\.transform is not supported/);
+    });
+
+    it('rejects [locale] in an include pattern, which would map each locale to a separate catalog', () => {
+      expect(() =>
+        resolveFiles(
+          { xcstrings: { include: [{ pattern: 'App/[locale].xcstrings' }] } },
+          'en',
+          defaultLocales,
+          '/project'
+        )
+      ).toThrow(
+        /files\.xcstrings\.include must not contain \[locale\]: "App\/\[locale\]\.xcstrings"/
+      );
+    });
+  });
 });

--- a/packages/cli/src/fs/config/parseFilesConfig.ts
+++ b/packages/cli/src/fs/config/parseFilesConfig.ts
@@ -112,6 +112,7 @@ export function resolveFiles(
   }
 
   for (const fileType of SUPPORTED_FILE_EXTENSIONS) {
+    if (fileType === 'xcstrings') validateXcstringsInPlace(files.xcstrings);
     // ==== TRANSFORMS ==== //
     const transform = files[fileType]?.transform;
     if (
@@ -391,6 +392,34 @@ function classifyPublishPaths(
         unpublishPaths.add(resolvedPaths[i]);
       }
     }
+  }
+}
+
+/**
+ * An .xcstrings catalog holds every locale in one file and is updated in
+ * place: each locale's download is merged into the source catalog. A path
+ * transform or a `[locale]` placeholder would map each locale to a separate
+ * output, and every write would start from the source catalog and discard the
+ * locales written before it.
+ */
+function validateXcstringsInPlace(config: FilesOptions['xcstrings']): void {
+  if (!config) return;
+  if (config.transform) {
+    logErrorAndExit(
+      'files.xcstrings.transform is not supported. An .xcstrings catalog holds every locale in one file and is updated in place, so remove the transform.'
+    );
+  }
+  const localePatterns = normalizeIncludePatterns(
+    config.include ?? []
+  ).paths.filter((pattern) => pattern.includes('[locale]'));
+  if (localePatterns.length > 0) {
+    logErrorAndExit(
+      `files.xcstrings.include must not contain [locale]: ${localePatterns
+        .map((pattern) => `"${pattern}"`)
+        .join(
+          ', '
+        )}. An .xcstrings catalog holds every locale in one file and is updated in place, so point the pattern at the catalog itself.`
+    );
   }
 }
 


### PR DESCRIPTION
## Summary

3/4 of the `.xcstrings` CLI stack. The missing download step: merging each translated locale back into the developer's single catalog. Without it, `gt translate` wrote the server's one-locale catalog over the whole file.

- `mergeXcstringsLocale(downloaded, locale, inputPath)`: reads the catalog at `inputPath` fresh so a batch of locales accumulates. Catalog keys are canonical tags and the configured `locale` may be a custom alias, so the alias is resolved (as the upload slice does in #2251) and the canonical tag is the key on both the download and the catalog side, while the lockfile and metadata keep the configured locale. For every downloaded key that carries `localizations[<canonical>]`, set only that key on a clone of the entry's `localizations`. The source-language unit, every other locale, entry-level fields, and unknown fields are untouched. A new locale key is inserted before the first existing key that sorts after it and existing keys never move, so `de` then `fr` and `fr` then `de` produce identical bytes. Downloaded keys the catalog no longer has are skipped with one warning.
- `downloadFileBatch`: catalogs take their own branch. The merge result is written with the pinned serializer, and the `.json` key sorter cannot see it. The already-downloaded skip is generalised from composite JSON to any in-place translation file, so a shared catalog is never skipped once the lockfile records one locale.

Integer-like keys (`"0"`, `"404"`) are hoisted to the front by `JSON.parse`; the merged file keeps that order. Version ids are unaffected because slices are built from the parsed object, and Xcode restores its own ordering on its next save. Accepted as a one-time diff; comment at the write path.

## Stack

1/4 #2254 register the format → 2/4 #2251 slice and per-locale uploads → **3/4 this** → 4/4 #2257 changesets. No `gtx-cli` release before gt-cloud#4732 (server ingress) is deployed.

## Tests

`mergeXcstrings.test.ts` (12, two of them for custom-mapping aliases) and three `XCSTRINGS` cases in `downloadFileBatch.test.ts`. Slice stability across merges is covered by the standalone test in #2251. Full CLI suite 2607 tests, typecheck and lint clean.













<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR adds in-place merging of downloaded XCSTRINGS locales while preserving the rest of each catalog, bypasses inappropriate lockfile and JSON-sorting behavior for shared catalogs, and rejects XCSTRINGS configurations that would produce separate locale outputs.

- Adds deterministic, locale-scoped catalog merging with custom alias support.
- Accumulates sequential locale downloads in the shared catalog.
- Adds focused merge, failure, idempotency, configuration, and batch-download tests.
- Extends source-language validation to support configured aliases, but currently remaps the catalog’s literal language as well.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until XCSTRINGS source-language validation stops remapping the catalog’s literal canonical tag, which can otherwise produce mislabeled source uploads.

The merge and in-place path handling are well covered, and the previous divergent-path finding was manually resolved after validation was added. However, resolving both sides of the source-language comparison allows a valid catalog tag that is also a custom alias key to compare equal to a different configured locale, defeating the guard against mislabeled uploads.

**Files Needing Attention:** packages/cli/src/formats/files/aggregateFiles.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/xcstrings/mergeXcstrings.ts | Adds structure-preserving, deterministic merging of one downloaded locale into an existing catalog. |
| packages/cli/src/api/downloadFileBatch.ts | Routes XCSTRINGS downloads through the catalog merger and prevents inappropriate lockfile skips and JSON key sorting. |
| packages/cli/src/fs/config/parseFilesConfig.ts | Enforces in-place XCSTRINGS paths by rejecting transforms and locale placeholders. |
| packages/cli/src/formats/files/aggregateFiles.ts | Adds alias-aware source-language validation, but can incorrectly accept mismatched source languages when a valid catalog tag is also a custom-mapping key. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Local XCSTRINGS catalog] --> M[Merge downloaded locale]
  D[Downloaded one-locale slice] --> M
  A[Configured locale alias] --> R[Resolve canonical locale]
  R --> M
  M --> W[Write shared catalog in place]
  W --> C
```
</details>

<sub>Reviews (5): Last reviewed commit: [206bb19](https://github.com/generaltranslation/gt/commit/206bb19d30c90674cbfc3239219cbdf8d8e4fe3b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61743121)</sub>

<!-- /greptile_comment -->