### PR TITLE
fix(cli): flip defautl save-local behavior

### DIFF
--- a/.changeset/quiet-local-edits.md
+++ b/.changeset/quiet-local-edits.md
@@ -1,0 +1,5 @@
+---
+"gt": minor
+---
+
+`gt translate` no longer saves local edits to translated output by default. Saving local edits is now opt-in via `--save-local` or `options.saveLocal: true` in `gt.config.json`, so running the CLI locally does not overwrite production translations.

--- a/.changeset/quiet-local-edits.md
+++ b/.changeset/quiet-local-edits.md
@@ -1,5 +1,5 @@
 ---
-"gt": minor
+"gt": patch
 ---
 
 `gt translate` no longer saves local edits to translated output by default. Saving local edits is now opt-in via `--save-local` or `options.saveLocal: true` in `gt.config.json`, so running the CLI locally does not overwrite production translations.

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -784,8 +784,8 @@
         },
         "saveLocal": {
           "type": "boolean",
-          "description": "Detect and save local edits to translated output before enqueuing translations. Can be overridden per run with --save-local / --no-save-local.",
-          "default": true
+          "description": "Detect and save local edits to translated output before enqueuing translations. Off by default so local runs do not overwrite remote translations. Can be overridden per run with --save-local / --no-save-local.",
+          "default": false
         },
         "baseDomain": {
           "type": "string",

--- a/assets/config-schema.json
+++ b/assets/config-schema.json
@@ -784,7 +784,7 @@
         },
         "saveLocal": {
           "type": "boolean",
-          "description": "Detect and save local edits to translated output before enqueuing translations. Off by default so local runs do not overwrite remote translations. Can be overridden per run with --save-local / --no-save-local.",
+          "description": "Detect and save local edits to translated output before enqueuing translations.",
           "default": false
         },
         "baseDomain": {

--- a/packages/cli/src/cli/flags.ts
+++ b/packages/cli/src/cli/flags.ts
@@ -49,7 +49,7 @@ export function attachTranslateFlags(command: Command) {
     )
     .option(
       '--save-local',
-      'Detect and save local edits before enqueuing translations (default: true; configurable via options.saveLocal in gt.config.json)'
+      'Detect and save local edits before enqueuing translations (default: false; configurable via options.saveLocal in gt.config.json)'
     )
     .option(
       '--no-save-local',

--- a/packages/cli/src/config/__tests__/generateSettings.test.ts
+++ b/packages/cli/src/config/__tests__/generateSettings.test.ts
@@ -263,9 +263,9 @@ describe('generateSettings - composite patterns', () => {
   });
 
   describe('options.saveLocal', () => {
-    it('defaults to true when neither flag nor config sets it', async () => {
+    it('defaults to false when neither flag nor config sets it', async () => {
       const settings = await generateSettings({}, '/test/cwd');
-      expect(settings.options?.saveLocal).toBe(true);
+      expect(settings.options?.saveLocal).toBe(false);
     });
 
     it('reads options.saveLocal from gt.config.json', async () => {

--- a/packages/cli/src/config/generateSettings.ts
+++ b/packages/cli/src/config/generateSettings.ts
@@ -323,7 +323,7 @@ export async function generateSettings(
       flags.experimentalClearLocaleDirs,
     clearLocaleDirsExclude:
       gtConfig.options?.clearLocaleDirsExclude || flags.clearLocaleDirsExclude,
-    saveLocal: flags.saveLocal ?? gtConfig.options?.saveLocal ?? true,
+    saveLocal: flags.saveLocal ?? gtConfig.options?.saveLocal ?? false,
   };
 
   if (

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -337,7 +337,7 @@ export type AdditionalOptions = {
     replace: string; // replacement prefix, can include [locale] or [defaultLocale]
   }>;
   experimentalCanonicalLocaleKeys?: boolean; // For composite JSON schemas with locale keys, force canonical locale even when alias provided
-  saveLocal?: boolean; // if true, detect and save local edits to translated output before enqueuing translations (default: true)
+  saveLocal?: boolean; // if true, detect and save local edits to translated output before enqueuing translations (default: false)
 };
 
 export type SharedStaticAssetsConfig = {

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -152,10 +152,11 @@ describe('runStageFilesWorkflow save-local gate', () => {
     expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
   });
 
-  it('saves local edits when options.saveLocal is not set', async () => {
-    await runStageFilesWorkflow({ files, options, settings });
+  it('skips saving local edits when options.saveLocal is not set', async () => {
+    const result = await runStageFilesWorkflow({ files, options, settings });
 
-    expect(userEditDiffsRun).toHaveBeenCalledTimes(1);
+    expect(userEditDiffsRun).not.toHaveBeenCalled();
+    expect(result.enqueueResult).toEqual({ message: 'enqueued', jobData: {} });
   });
 
   it('ignores the raw flag and uses the resolved setting', async () => {

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -64,8 +64,8 @@ export async function runStageFilesWorkflow({
     // then run the upload step
     const uploadedFiles = await uploadStep.run({ files, branchData });
 
-    // optionally run the user edit diffs step
-    if (settings.options?.saveLocal !== false) {
+    // optionally run the user edit diffs step (opt-in via --save-local or options.saveLocal)
+    if (settings.options?.saveLocal === true) {
       await userEditDiffsStep.run(uploadedFiles);
     }
 


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR changes saving local translation edits from opt-out to opt-in.
- Defaults `options.saveLocal` to `false` while preserving explicit CLI and configuration overrides.
- Runs the user-edit-diff step only when the resolved setting is `true`.
- Updates the configuration schema, CLI help, type documentation, tests, and release changeset consistently.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the default change is consistently implemented, documented, and tested.

No actionable failures remain: explicit positive and negative overrides retain the expected precedence, production callers receive resolved settings, and the workflow gate matches the documented opt-in behavior.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/config/generateSettings.ts | Changes the resolved `saveLocal` fallback to `false` while preserving CLI-over-config precedence. |
| packages/cli/src/workflows/stage.ts | Makes submission of local user-edit diffs explicitly opt-in through the resolved setting. |
| packages/cli/src/config/__tests__/generateSettings.test.ts | Updates the default-setting assertion while retaining coverage for configuration and flag precedence. |
| packages/cli/src/workflows/__tests__/stage.test.ts | Verifies that omitted or false settings skip local-edit submission and true settings enable it. |
| assets/config-schema.json | Aligns the published configuration schema and description with the new runtime default. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): flip defautl save-local behavi..."](https://github.com/generaltranslation/gt/commit/2ba588a9b2f9006ca6cbbd9833f1f9bded7b44c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61743737)</sub>

<!-- /greptile_comment -->