### PR TITLE
feat(cli): use new mint native anchor syntax

### DIFF
--- a/.changeset/mintlify-native-anchors.md
+++ b/.changeset/mintlify-native-anchors.md
@@ -2,4 +2,4 @@
 'gt': patch
 ---
 
-fix(cli): with `experimentalAddHeaderAnchorIds: 'mintlify'`, write Mintlify's native `{#id}` on every translated heading, using the source heading's ID so anchors match across locales and the heading hover link points at the same target. Mintlify only reads `{#id}` on headings indented up to three spaces, and the MDX serializer indents JSX children two spaces per level, so headings nested in JSX are moved back to the margin. The `<div id>` wrappers written by 2.20.3 are unwrapped. Default mode is unchanged.
+fix(cli): with `experimentalAddHeaderAnchorIds: 'mintlify'`, write Mintlify's native `{#id}` on every translated heading, using the source heading's ID so anchors match across locales and the heading hover link points at the same target. Mintlify only reads `{#id}` on headings indented up to three spaces, and the MDX serializer indents JSX children two spaces per level, so headings nested in JSX are moved back to the margin. Default mode is unchanged.

--- a/.changeset/mintlify-native-anchors.md
+++ b/.changeset/mintlify-native-anchors.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix(cli): with `experimentalAddHeaderAnchorIds: 'mintlify'`, write Mintlify's native `{#id}` on every translated heading, using the source heading's ID so anchors match across locales and the heading hover link points at the same target. Mintlify only reads `{#id}` on headings indented up to three spaces, and the MDX serializer indents JSX children two spaces per level, so headings nested in JSX are moved back to the margin. The `<div id>` wrappers written by 2.20.3 are unwrapped. Default mode is unchanged.

--- a/packages/cli/src/cli/commands/translate.ts
+++ b/packages/cli/src/cli/commands/translate.ts
@@ -131,7 +131,8 @@ export async function postProcessTranslations(
     settings.options?.experimentalAddHeaderAnchorIds;
 
   // Add explicit anchor IDs to translated MDX/MD files to preserve navigation.
-  // Uses inline {#id} format by default, or div wrapping if experimentalAddHeaderAnchorIds is 'mintlify'.
+  // Uses escaped inline \{#id\} by default, or Mintlify's native {#id} if
+  // experimentalAddHeaderAnchorIds is 'mintlify'.
   //
   // Runs last of the md/mdx passes: the others re-stringify the document, which
   // re-indents headings nested in JSX and would otherwise move them out from

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -328,7 +328,7 @@ export type AdditionalOptions = {
   experimentalLocalizeStaticImports?: boolean; // Inserts locale in static import paths in md/mdx files
   experimentalLocalizeStaticUrls?: boolean; // Inserts locale in static url paths in md/mdx files and adds anchor IDs to preserve navigation
   experimentalLocalizeRelativeAssets?: boolean; // Rewrites relative asset URLs in translated md/mdx files to valid paths
-  experimentalAddHeaderAnchorIds?: 'mintlify' | 'default'; // Format for anchor IDs: 'mintlify' for div wrapping, 'default' or undefined for inline {#id}. Can run independently of static url localization
+  experimentalAddHeaderAnchorIds?: 'mintlify' | 'default'; // Format for anchor IDs: 'mintlify' for Mintlify's native {#id} on every heading, 'default' or undefined for escaped inline \{#id\}. Can run independently of static url localization
   experimentalHideDefaultLocale?: boolean; // Hides the default locale in the import path
   experimentalFlattenJsonFiles?: boolean; // Flattens JSON files into a single file
   baseDomain?: string; // The base http:// url where the project is hosted

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -416,7 +416,7 @@ Another section here.
       expect(result.content).not.toContain('<div id="getting-started">');
     });
 
-    it('should add div wrapping in Mintlify mode', () => {
+    it('should add native {#id} anchors in Mintlify mode', () => {
       const sourceHeadingMap = extractHeadingInfo(basicInput);
       const result = addExplicitAnchorIds(
         basicInput,
@@ -427,18 +427,17 @@ Another section here.
       expect(result.hasChanges).toBe(true);
       expect(result.addedIds).toHaveLength(3);
 
+      expect(result.content).toContain('# Getting Started {#getting-started}');
       expect(result.content).toContain(
-        '<div id="getting-started">\n  # Getting Started\n</div>'
+        '## Code-based workflow {#code-based-workflow}'
       );
       expect(result.content).toContain(
-        '<div id="code-based-workflow">\n  ## Code-based workflow\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="web-editor-workflow">\n  ## Web editor workflow\n</div>'
+        '## Web editor workflow {#web-editor-workflow}'
       );
 
-      // Should NOT contain \\{#id} format
+      // Native anchors, never the escaped form or a wrapper
       expect(result.content).not.toContain('\\{#getting-started\\}');
+      expect(result.content).not.toContain('<div id=');
     });
   });
 
@@ -484,13 +483,13 @@ Another section here.
       expect(result.addedIds).toHaveLength(3);
 
       expect(result.content).toContain(
-        '<div id="bold-heading-with-formatting">\n  ## **Bold Heading** with formatting\n</div>'
+        '## **Bold Heading** with formatting {#bold-heading-with-formatting}'
       );
       expect(result.content).toContain(
-        '<div id="code-heading-example">\n  ## `Code Heading` example\n</div>'
+        '## `Code Heading` example {#code-heading-example}'
       );
       expect(result.content).toContain(
-        '<div id="italic-and-mixed-formatting">\n  ## *Italic* and **mixed** formatting\n</div>'
+        '## *Italic* and **mixed** formatting {#italic-and-mixed-formatting}'
       );
     });
   });
@@ -548,15 +547,11 @@ More content.
       expect(result.hasChanges).toBe(true);
       expect(result.addedIds).toHaveLength(2);
 
+      expect(result.content).toContain('## Real Heading {#real-heading}');
       expect(result.content).toContain(
-        '<div id="real-heading">\n  ## Real Heading\n</div>'
+        '## Another Real Heading {#another-real-heading}'
       );
-      expect(result.content).toContain(
-        '<div id="another-real-heading">\n  ## Another Real Heading\n</div>'
-      );
-      expect(result.content).not.toContain(
-        '<div id="fake-heading-in-code-block">'
-      );
+      expect(result.content).not.toContain('{#fake-heading-in-code-block}');
 
       // Code block should remain unchanged
       expect(result.content).toContain(
@@ -657,17 +652,15 @@ This is just an example
       expect(result.addedIds).toHaveLength(4);
 
       expect(result.content).toContain(
-        '<div id="code-design-workflow">\n  ## Code & Design Workflow!\n</div>'
+        '## Code & Design Workflow! {#code-design-workflow}'
       );
       expect(result.content).toContain(
-        '<div id="api-reference-v20">\n  ## API Reference (v2.0)\n</div>'
+        '## API Reference (v2.0) {#api-reference-v20}'
       );
       expect(result.content).toContain(
-        '<div id="getting-started-step-1">\n  ## Getting Started: Step 1\n</div>'
+        '## Getting Started: Step 1 {#getting-started-step-1}'
       );
-      expect(result.content).toContain(
-        '<div id="whats-new">\n  ## What\'s New?\n</div>'
-      );
+      expect(result.content).toContain("## What's New? {#whats-new}");
     });
   });
 
@@ -715,24 +708,12 @@ This is just an example
       expect(result.hasChanges).toBe(true);
       expect(result.addedIds).toHaveLength(6);
 
-      expect(result.content).toContain(
-        '<div id="h1-heading">\n  # H1 Heading\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="h2-heading">\n  ## H2 Heading\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="h3-heading">\n  ### H3 Heading\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="h4-heading">\n  #### H4 Heading\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="h5-heading">\n  ##### H5 Heading\n</div>'
-      );
-      expect(result.content).toContain(
-        '<div id="h6-heading">\n  ###### H6 Heading\n</div>'
-      );
+      expect(result.content).toContain('# H1 Heading {#h1-heading}');
+      expect(result.content).toContain('## H2 Heading {#h2-heading}');
+      expect(result.content).toContain('### H3 Heading {#h3-heading}');
+      expect(result.content).toContain('#### H4 Heading {#h4-heading}');
+      expect(result.content).toContain('##### H5 Heading {#h5-heading}');
+      expect(result.content).toContain('###### H6 Heading {#h6-heading}');
     });
   });
 
@@ -745,7 +726,7 @@ This is just an example
       expect(result.content).toContain('## Sub Heading \\{#sub-heading\\}');
     });
 
-    it('Mintlify wrapping remains stable on repeated runs', () => {
+    it('Mintlify anchors remain stable on repeated runs', () => {
       const input = `## Real Heading`;
       const sourceHeadingMap = extractHeadingInfo(input);
       const settings = {
@@ -763,7 +744,7 @@ This is just an example
       expect(second.content).toBe(first.content);
     });
 
-    it('wraps headings containing HTML entities in Mintlify mode', () => {
+    it('anchors headings containing HTML entities in Mintlify mode', () => {
       const sourceContent = `## Register the app`;
       const translatedContent = `## Configurer l&#39;application`;
       const sourceHeadingMap = extractHeadingInfo(sourceContent);
@@ -779,7 +760,7 @@ This is just an example
 
       expect(result.hasChanges).toBe(true);
       expect(result.content).toContain(
-        '<div id="register-the-app">\n  ## Configurer l&#39;application\n</div>'
+        '## Configurer l&#39;application {#register-the-app}'
       );
     });
   });
@@ -849,7 +830,7 @@ Más contenido.`;
       });
     });
 
-    it('wraps an author-written ID like any other heading', () => {
+    it('restores an author-written ID in native syntax', () => {
       const source = '## CSS variables reference {#css-variables}\n';
       const translated = '## Référence des variables CSS\n';
 
@@ -863,12 +844,15 @@ Más contenido.`;
       );
 
       expect(result.content).toBe(
-        '<div id="css-variables">\n  ## Référence des variables CSS\n</div>\n'
+        '## Référence des variables CSS {#css-variables}\n'
       );
-      expect(result.content).not.toContain('{#');
+      expect(result.content).not.toContain('<div id=');
+      expect(result.content).not.toContain('\\{#');
     });
 
-    it('uses one wrapper form for explicit and derived IDs alike', () => {
+    it('writes native anchors for explicit and derived IDs alike', () => {
+      // A wrapper keeps old links working, but Mintlify's hover link on the
+      // heading would then point at a slug of the translated text instead.
       const source = '## Setup {#custom}\n\n## Other heading\n';
       const translated = '## Configuration\n\n## Autre titre\n';
 
@@ -882,12 +866,11 @@ Más contenido.`;
       );
 
       expect(result.content).toBe(
-        '<div id="custom">\n  ## Configuration\n</div>\n\n' +
-          '<div id="other-heading">\n  ## Autre titre\n</div>\n'
+        '## Configuration {#custom}\n\n## Autre titre {#other-heading}\n'
       );
     });
 
-    it('drops an inline ID the translation carried over when wrapping', () => {
+    it('does not double-apply an ID the translation already carried over', () => {
       const source = '## Setup {#custom}\n';
       const translated = '## Configuration {#custom}\n';
 
@@ -900,34 +883,13 @@ Más contenido.`;
         'mdx'
       );
 
-      expect(result.content).toBe(
-        '<div id="custom">\n  ## Configuration\n</div>\n'
-      );
-      expect(result.hasChanges).toBe(true);
+      expect(result.content).toBe('## Configuration {#custom}\n');
+      expect(result.hasChanges).toBe(false);
     });
 
-    it('wraps an explicit-ID heading the serializer indented inside nested JSX', () => {
-      // Mintlify only recognizes `{#id}` on headings indented at most three
-      // spaces. The MDX serializer indents JSX children two spaces per level,
-      // so re-attaching the inline ID here produced an acorn parse error.
-      const source = `<Tabs>
-  <Tab title="Plain CSS">
-
-## CSS variables reference {#css-variables}
-
-Body text.
-
-  </Tab>
-</Tabs>
-`;
-      const translated = `<Tabs>
-  <Tab title="CSS simple">
-    ## Référence des variables CSS
-
-    Corps du texte.
-  </Tab>
-</Tabs>
-`;
+    it('unescapes an anchor the translation carried over in escaped form', () => {
+      const source = '## Setup {#custom}\n';
+      const translated = '## Configuration \\{#custom\\}\n';
 
       const result = addExplicitAnchorIds(
         translated,
@@ -938,10 +900,110 @@ Body text.
         'mdx'
       );
 
-      expect(result.content).toContain(
-        '    <div id="css-variables">\n      ## Référence des variables CSS\n    </div>'
+      expect(result.content).toBe('## Configuration {#custom}\n');
+    });
+  });
+
+  describe('Mintlify only reads {#id} on headings indented up to three spaces', () => {
+    // Verified with `mint validate`: `{#id}` on a heading at four or more
+    // spaces fails with "Could not parse expression with acorn". The MDX
+    // serializer indents JSX children two spaces per level, so a heading
+    // inside <Tabs><Tab> lands at four.
+    const mintlify = {
+      options: { experimentalAddHeaderAnchorIds: 'mintlify' as const },
+    };
+    const run = (source: string, translated: string) =>
+      addExplicitAnchorIds(
+        translated,
+        extractHeadingInfo(source),
+        mintlify,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      ).content;
+
+    const source = `<Tabs>
+  <Tab title="Plain CSS">
+
+## CSS variables reference {#css-variables}
+
+Body text.
+
+  </Tab>
+</Tabs>
+`;
+
+    it('moves a heading the serializer indented too deep back to the margin', () => {
+      const translated = `<Tabs>
+  <Tab title="CSS simple">
+    ## Référence des variables CSS
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`;
+
+      expect(run(source, translated)).toBe(`<Tabs>
+  <Tab title="CSS simple">
+## Référence des variables CSS {#css-variables}
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`);
+    });
+
+    it('leaves a heading within reach where it is', () => {
+      const translated = `<Tabs>
+  <Tab title="CSS simple">
+   ## Référence des variables CSS
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`;
+
+      expect(run(source, translated)).toContain(
+        '\n   ## Référence des variables CSS {#css-variables}\n'
       );
-      expect(result.content).not.toContain('{#');
+    });
+
+    it('unwraps the <div id> an earlier version placed around a nested heading', () => {
+      const translated = `<Tabs>
+  <Tab title="CSS simple">
+    <div id="css-variables">
+      ## Référence des variables CSS
+    </div>
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`;
+
+      expect(run(source, translated)).toBe(`<Tabs>
+  <Tab title="CSS simple">
+## Référence des variables CSS {#css-variables}
+
+    Corps du texte.
+  </Tab>
+</Tabs>
+`);
+    });
+
+    it('unwraps a top-level <div id> and rewrites a stale ID', () => {
+      const out = run(
+        '## Setup {#setup}\n',
+        '<div id="stale">\n  ## Configuration\n</div>\n'
+      );
+      expect(out).toBe('## Configuration {#setup}\n');
+    });
+
+    it('still wraps a setext heading, which has no line to hold an anchor', () => {
+      const doc = 'Setup\n=====\n';
+      expect(run(doc, doc)).toBe(
+        '<div id="setup">\n  Setup\n  =====\n</div>\n'
+      );
+      expect(run(doc, run(doc, doc))).toBe(run(doc, doc));
     });
   });
 
@@ -973,7 +1035,7 @@ Body text.
 `;
       const out = wrap(doc, doc);
 
-      expect(out).toContain('    <div id="setup">\n      ## Setup\n    </div>');
+      expect(out).toContain('\n## Setup {#setup}\n');
     });
 
     it('anchors headings containing JSX elements', () => {
@@ -981,16 +1043,14 @@ Body text.
         '### <Badge color="yellow">Early Access</Badge> Use your own database\n';
       const out = wrap(doc, doc);
 
-      expect(out).toContain('<div id="early-access-use-your-own-database">');
+      expect(out).toContain('{#early-access-use-your-own-database}');
     });
 
     it('anchors headings containing escaped characters', () => {
       const doc = '### country\\_code\n';
       const out = wrap(doc, doc);
 
-      expect(out).toContain(
-        '<div id="country_code">\n  ### country\\_code\n</div>'
-      );
+      expect(out).toContain('### country\\_code {#country_code}');
     });
 
     it('gives every repeated heading its own Mintlify-compatible ID', () => {
@@ -1008,9 +1068,15 @@ Body text.
       ]);
 
       const out = wrap(doc, doc);
-      expect(out).toContain('<div id="response-status-codes">');
-      expect(out).toContain('<div id="response-status-codes-2">');
-      expect(out).toContain('<div id="response-status-codes-3">');
+      expect(out).toContain(
+        '### Response status codes {#response-status-codes}\n'
+      );
+      expect(out).toContain(
+        '### Response status codes {#response-status-codes-2}\n'
+      );
+      expect(out).toContain(
+        '### Response status codes {#response-status-codes-3}\n'
+      );
     });
 
     it('does not let a generated slug claim a later explicit ID', () => {
@@ -1024,8 +1090,8 @@ Body text.
       ]);
 
       const out = wrap(doc, doc);
-      expect(out).toContain('<div id="setup-2">\n  ## Setup\n</div>');
-      expect(out).toContain('<div id="setup">\n  ## Configuration\n</div>');
+      expect(out).toContain('## Setup {#setup-2}');
+      expect(out).toContain('## Configuration {#setup}');
     });
 
     it('does not renumber author-written IDs', () => {
@@ -1079,13 +1145,9 @@ Body text.
         'mdx'
       );
 
-      expect(result.content).toContain(
-        '<div id="alpha">\n  ## Alpha-fr\n</div>'
-      );
-      expect(result.content).toContain(
-        '  <div id="nested">\n    ## Imbriqué-fr\n  </div>'
-      );
-      expect(result.content).toContain('<div id="beta">\n  ## Beta-fr\n</div>');
+      expect(result.content).toContain('## Alpha-fr {#alpha}');
+      expect(result.content).toContain('  ## Imbriqué-fr {#nested}');
+      expect(result.content).toContain('## Beta-fr {#beta}');
     });
   });
   describe('Heading location is taken from the parser, not matched by shape', () => {
@@ -1108,32 +1170,42 @@ Body text.
       expect(run('## Foo ##\n')).toBe('## Foo \\{#foo\\} ##\n');
     });
 
-    it('recognizes an existing wrapper whatever shape its tag takes', () => {
+    it('unwraps a wrapper of ours whichever quotes its tag uses', () => {
       const variants = [
         '<div id="stale">\n  ## Foo\n</div>\n',
-        '<div className="x" id="stale">\n  ## Foo\n</div>\n',
         "<div id='stale'>\n  ## Foo\n</div>\n",
+      ];
+
+      for (const variant of variants) {
+        expect(run(variant, mintlify)).toBe('## Foo {#foo}\n');
+      }
+    });
+
+    it('leaves an element that is not a wrapper of ours in place', () => {
+      // Extra attributes, another tag name, or a multi-line tag were never
+      // produced by the anchor pass, so the element belongs to the author.
+      const variants = [
+        '<div className="x" id="stale">\n  ## Foo\n</div>\n',
         '<div\n  id="stale"\n>\n  ## Foo\n</div>\n',
         '<section id="stale">\n  ## Foo\n</section>\n',
       ];
 
       for (const variant of variants) {
         const out = run(variant, mintlify);
-        // The stale ID is corrected in place; no second wrapper is nested.
-        expect(out).not.toContain('stale');
-        expect(out.match(/id=/g)).toHaveLength(1);
-        expect(out).toContain('id="foo"');
+        expect(out).toContain('id="stale"');
+        expect(out).toContain('  ## Foo {#foo}\n');
       }
     });
 
     it('does not mistake an ordinary container for an anchor wrapper', () => {
       // <Tab> carries an id-less title and holds the heading among other
-      // content, so the heading still needs its own wrapper.
+      // content, so the heading gets its own anchor, within Mintlify's reach.
       const out = run(
         '<Tabs>\n  <Tab title="x">\n\n    ## Foo\n\n    Body.\n\n  </Tab>\n</Tabs>\n',
         mintlify
       );
-      expect(out).toContain('    <div id="foo">\n      ## Foo\n    </div>');
+      expect(out).toContain('\n## Foo {#foo}\n');
+      expect(out).toContain('  <Tab title="x">');
     });
 
     it('does not treat a container holding more than the heading as a wrapper', () => {
@@ -1141,8 +1213,7 @@ Body text.
         '<div id="card">\n  ## Foo\n\n  Body.\n</div>\n',
         mintlify
       );
-      expect(out).toContain('<div id="foo">');
-      expect(out).toContain('id="card"');
+      expect(out).toBe('<div id="card">\n  ## Foo {#foo}\n\n  Body.\n</div>\n');
     });
   });
 });

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -968,9 +968,22 @@ Body text.
       );
     });
 
-    it('leaves a setext heading alone, as it has no line to hold an anchor', () => {
+    it('leaves a setext heading alone, since Mintlify reads {#id} on ATX headings only', () => {
       const doc = 'Setup\n=====\n';
       expect(run(doc, doc)).toBe(doc);
+    });
+
+    it('still anchors a setext heading in default mode, as before', () => {
+      const doc = 'Setup\n=====\n';
+      const out = addExplicitAnchorIds(
+        doc,
+        extractHeadingInfo(doc),
+        undefined,
+        'a.mdx',
+        'fr/a.mdx',
+        'mdx'
+      ).content;
+      expect(out).toBe('Setup \\{#setup\\}\n=====\n');
     });
 
     it('anchors a heading inside an existing element without touching the element', () => {

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -968,11 +968,20 @@ Body text.
       );
     });
 
-    it('still wraps a setext heading, which has no line to hold an anchor', () => {
+    it('leaves a setext heading alone, as it has no line to hold an anchor', () => {
       const doc = 'Setup\n=====\n';
-      expect(run(doc, doc)).toBe(
-        '<div id="setup">\n  Setup\n  =====\n</div>\n'
+      expect(run(doc, doc)).toBe(doc);
+    });
+
+    it('anchors a heading inside an existing element without touching the element', () => {
+      const out = run(
+        '## Setup {#setup}\n',
+        '<div id="setup">\n  ## Configuration\n</div>\n'
       );
+      expect(out).toBe(
+        '<div id="setup">\n  ## Configuration {#setup}\n</div>\n'
+      );
+      expect(run('## Setup {#setup}\n', out)).toBe(out);
     });
   });
 

--- a/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
+++ b/packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts
@@ -968,42 +968,11 @@ Body text.
       );
     });
 
-    it('unwraps the <div id> an earlier version placed around a nested heading', () => {
-      const translated = `<Tabs>
-  <Tab title="CSS simple">
-    <div id="css-variables">
-      ## Référence des variables CSS
-    </div>
-
-    Corps du texte.
-  </Tab>
-</Tabs>
-`;
-
-      expect(run(source, translated)).toBe(`<Tabs>
-  <Tab title="CSS simple">
-## Référence des variables CSS {#css-variables}
-
-    Corps du texte.
-  </Tab>
-</Tabs>
-`);
-    });
-
-    it('unwraps a top-level <div id> and rewrites a stale ID', () => {
-      const out = run(
-        '## Setup {#setup}\n',
-        '<div id="stale">\n  ## Configuration\n</div>\n'
-      );
-      expect(out).toBe('## Configuration {#setup}\n');
-    });
-
     it('still wraps a setext heading, which has no line to hold an anchor', () => {
       const doc = 'Setup\n=====\n';
       expect(run(doc, doc)).toBe(
         '<div id="setup">\n  Setup\n  =====\n</div>\n'
       );
-      expect(run(doc, run(doc, doc))).toBe(run(doc, doc));
     });
   });
 
@@ -1168,33 +1137,6 @@ Body text.
       // Appending after the closing `##` would stop it being a closing
       // sequence, turning it into visible heading text.
       expect(run('## Foo ##\n')).toBe('## Foo \\{#foo\\} ##\n');
-    });
-
-    it('unwraps a wrapper of ours whichever quotes its tag uses', () => {
-      const variants = [
-        '<div id="stale">\n  ## Foo\n</div>\n',
-        "<div id='stale'>\n  ## Foo\n</div>\n",
-      ];
-
-      for (const variant of variants) {
-        expect(run(variant, mintlify)).toBe('## Foo {#foo}\n');
-      }
-    });
-
-    it('leaves an element that is not a wrapper of ours in place', () => {
-      // Extra attributes, another tag name, or a multi-line tag were never
-      // produced by the anchor pass, so the element belongs to the author.
-      const variants = [
-        '<div className="x" id="stale">\n  ## Foo\n</div>\n',
-        '<div\n  id="stale"\n>\n  ## Foo\n</div>\n',
-        '<section id="stale">\n  ## Foo\n</section>\n',
-      ];
-
-      for (const variant of variants) {
-        const out = run(variant, mintlify);
-        expect(out).toContain('id="stale"');
-        expect(out).toContain('  ## Foo {#foo}\n');
-      }
     });
 
     it('does not mistake an ordinary container for an anchor wrapper', () => {

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -317,25 +317,8 @@ function applyAnchorIds(
 
     const index = heading.startLine - 1;
 
+    // Setext headings have no heading line to append an anchor to.
     if (heading.textEndColumn < 1 || heading.endLine > heading.startLine) {
-      // Setext headings have no heading line to append an anchor to. Mintlify
-      // can still anchor one through a wrapper.
-      if (mintlifyMode) {
-        const indent = lines[index].slice(
-          0,
-          Math.max(0, heading.startColumn - 1)
-        );
-        const body = lines
-          .slice(index, heading.endLine)
-          .map((line) => `  ${line}`);
-        lines.splice(
-          index,
-          heading.endLine - heading.startLine + 1,
-          `${indent}<div id="${mapping.id}">`,
-          ...body,
-          `${indent}</div>`
-        );
-      }
       continue;
     }
 

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -20,6 +20,13 @@ const ATX_HEADING = /^([ \t]*)(#{1,6}[ \t]+)(.*)$/;
 const TRAILING_ANCHOR = /\s*(?:\\\{#[^}]+\\\}|\{#[^}]+\})\s*$/;
 
 /**
+ * Deepest indentation at which Mintlify still reads `## Heading {#id}`. It is
+ * the CommonMark limit for a heading; MDX itself accepts deeper headings, so
+ * past it the `{#id}` reaches the expression parser and fails to compile.
+ */
+const MAX_MINTLIFY_HEADING_INDENT = 3;
+
+/**
  * Generates a slug from heading text
  */
 function generateSlug(text: string): string {
@@ -72,7 +79,7 @@ function extractHeadingsWithFallback(mdxContent: string): HeadingInfo[] {
       startColumn: indent.length + 1,
       // Without a parser there is nothing finer to go on than end of line.
       textEndColumn: line.length + 1,
-      wrapperId: null,
+      wrapper: null,
       explicit: explicitId !== undefined,
     });
   });
@@ -128,11 +135,12 @@ function assignUniqueSlugs(headings: HeadingInfo[]): void {
   }
 }
 
-/** A source range on a single line, as 1-based inclusive/exclusive columns. */
-interface ColumnRange {
-  line: number;
-  startColumn: number;
-  endColumn: number;
+/** Lines of a `<div id>` an earlier anchor pass wrapped around a heading. */
+interface WrapperLines {
+  /** 1-based line of the opening tag. */
+  startLine: number;
+  /** 1-based line of the closing tag. */
+  endLine: number;
 }
 
 /**
@@ -151,39 +159,49 @@ export interface HeadingInfo {
   startColumn: number;
   /** 1-based column just past the text, before any closing `##`; -1 if unknown. */
   textEndColumn: number;
-  /** `id` attribute of a wrapper element already anchoring this heading. */
-  wrapperId: ColumnRange | null;
+  /** Wrapper an earlier anchor pass placed around this heading. */
+  wrapper: WrapperLines | null;
   /** Whether the author wrote an explicit `{#id}`. */
   explicit: boolean;
 }
 
 /**
- * Finds the `id` of a wrapper element already anchoring this heading. Requiring
- * the heading to be its only child rules out containers like `<Tab>`.
+ * Recognizes a `<div id="...">` an earlier anchor pass wrapped around this
+ * heading: a div whose only attribute is `id`, whose only child is the
+ * heading, with its tags on the lines directly around it. Requiring the
+ * heading to be the only child rules out containers like `<Tab>`.
  */
-function findWrapperId(
+function findWrapper(
   heading: Heading,
   parent: Node | undefined
-): ColumnRange | null {
+): WrapperLines | null {
   if (!parent || parent.type !== 'mdxJsxFlowElement') return null;
 
   const element = parent as MdxJsxFlowElement;
+  if (element.name !== 'div') return null;
   if (element.children.length !== 1 || element.children[0] !== heading) {
     return null;
   }
+  const [attribute] = element.attributes;
+  if (
+    element.attributes.length !== 1 ||
+    attribute.type !== 'mdxJsxAttribute' ||
+    attribute.name !== 'id'
+  ) {
+    return null;
+  }
 
-  const id = element.attributes.find(
-    (attribute) =>
-      attribute.type === 'mdxJsxAttribute' && attribute.name === 'id'
-  );
-  const position = id?.position;
-  if (!position || position.start.line !== position.end.line) return null;
+  const outer = element.position;
+  const inner = heading.position;
+  if (!outer || !inner) return null;
+  if (
+    outer.start.line !== inner.start.line - 1 ||
+    outer.end.line !== inner.end.line + 1
+  ) {
+    return null;
+  }
 
-  return {
-    line: position.start.line,
-    startColumn: position.start.column,
-    endColumn: position.end.column,
-  };
+  return { startLine: outer.start.line, endLine: outer.end.line };
 }
 
 /**
@@ -220,7 +238,7 @@ export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
       startColumn: heading.position?.start.column ?? 1,
       textEndColumn:
         lastChild?.position?.end.column ?? heading.position?.end.column ?? -1,
-      wrapperId: findWrapperId(heading, parent),
+      wrapper: findWrapper(heading, parent ?? undefined),
       explicit: explicitId !== undefined,
     });
   });
@@ -245,7 +263,8 @@ export function addExplicitAnchorIds(
   addedIds: Array<{ heading: string; id: string }>;
 } {
   const addedIds: Array<{ heading: string; id: string }> = [];
-  const useDivWrapping =
+  // Mintlify mode writes Mintlify's native `{#id}` on every heading.
+  const mintlifyMode =
     settings?.options?.experimentalAddHeaderAnchorIds === 'mintlify';
 
   // Extract headings from translated content
@@ -287,8 +306,9 @@ export function addExplicitAnchorIds(
   const translatedIsMdx = translatedPath
     ? translatedPath.toLowerCase().endsWith('.mdx')
     : true; // default to mdx-style escaping when unknown
-  const shouldEscapeAnchors =
-    fileTypeHint === 'mdx'
+  const shouldEscapeAnchors = mintlifyMode
+    ? false
+    : fileTypeHint === 'mdx'
       ? true
       : fileTypeHint === 'md'
         ? false
@@ -296,9 +316,10 @@ export function addExplicitAnchorIds(
 
   if (idMappings.size === 0) {
     // Normalize anchors the translation carried over.
-    const content = useDivWrapping
-      ? translatedContent
-      : normalizeInlineAnchors(translatedContent, shouldEscapeAnchors);
+    const content = normalizeInlineAnchors(
+      translatedContent,
+      shouldEscapeAnchors
+    );
     return {
       content,
       hasChanges: content !== translatedContent,
@@ -306,17 +327,16 @@ export function addExplicitAnchorIds(
     };
   }
 
-  let content = applyAnchorIds(
-    translatedContent,
-    translatedHeadings,
-    idMappings,
-    useDivWrapping,
+  const content = normalizeInlineAnchors(
+    applyAnchorIds(
+      translatedContent,
+      translatedHeadings,
+      idMappings,
+      mintlifyMode,
+      shouldEscapeAnchors
+    ),
     shouldEscapeAnchors
   );
-
-  if (!useDivWrapping) {
-    content = normalizeInlineAnchors(content, shouldEscapeAnchors);
-  }
 
   return {
     content,
@@ -333,7 +353,7 @@ function applyAnchorIds(
   translatedContent: string,
   translatedHeadings: HeadingInfo[],
   idMappings: Map<number, { id: string; explicit: boolean }>,
-  useDivWrapping: boolean,
+  mintlifyMode: boolean,
   escapeAnchors: boolean
 ): string {
   const lines = translatedContent.split('\n');
@@ -349,53 +369,62 @@ function applyAnchorIds(
 
     const index = heading.startLine - 1;
 
-    if (!useDivWrapping) {
-      // Setext headings have no column to append to.
-      if (heading.textEndColumn < 1) continue;
-
-      const escape = escapeAnchors && !mapping.explicit;
-      const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;
-      const { text, trailer } = splitHeadingLine(lines[index], heading);
-
-      lines[index] = `${text} ${anchor}${trailer}`;
+    if (heading.textEndColumn < 1 || heading.endLine > heading.startLine) {
+      // Setext headings have no heading line to append an anchor to. Mintlify
+      // can still anchor one through a wrapper.
+      if (mintlifyMode && !heading.wrapper) {
+        const indent = lines[index].slice(
+          0,
+          Math.max(0, heading.startColumn - 1)
+        );
+        const body = lines
+          .slice(index, heading.endLine)
+          .map((line) => `  ${line}`);
+        lines.splice(
+          index,
+          heading.endLine - heading.startLine + 1,
+          `${indent}<div id="${mapping.id}">`,
+          ...body,
+          `${indent}</div>`
+        );
+      }
       continue;
     }
 
-    // In wrapper mode every heading gets a wrapper, including ones whose ID
-    // the author wrote inline. Mintlify's `{#id}` pre-pass does not recognize
-    // headings indented four or more spaces, which the MDX serializer produces
-    // for headings nested in JSX, so a re-attached inline ID fails to compile.
-    // A wrapper anchors the heading at any indentation. Drop any inline ID the
-    // translation carried over so the two forms never appear together.
-    if (heading.textEndColumn >= 1) {
-      const { text, trailer } = splitHeadingLine(lines[index], heading);
-      lines[index] = `${text}${trailer}`;
-    }
+    const escape = escapeAnchors && !mapping.explicit;
+    const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;
+    const { text, trailer } = splitHeadingLine(lines[index], heading);
+    let line = `${text} ${anchor}${trailer}`;
 
-    if (heading.wrapperId) {
-      // Already wrapped: fix the ID in place rather than nesting another.
-      const { line, startColumn, endColumn } = heading.wrapperId;
-      const wrapper = lines[line - 1];
-      lines[line - 1] =
-        wrapper.slice(0, startColumn - 1) +
-        `id="${mapping.id}"` +
-        wrapper.slice(endColumn - 1);
+    if (!mintlifyMode) {
+      lines[index] = line;
       continue;
     }
 
-    const indent = lines[index].slice(0, Math.max(0, heading.startColumn - 1));
-    const body = lines.slice(index, heading.endLine).map((line) => `  ${line}`);
+    if (heading.wrapper) {
+      // Unwrap the `<div id>` an earlier version placed here; the heading goes
+      // back to the wrapper's own indentation.
+      const { startLine, endLine } = heading.wrapper;
+      line = leadingWhitespace(lines[startLine - 1]) + line.trimStart();
+      lines.splice(startLine - 1, endLine - startLine + 1, line);
+    } else {
+      lines[index] = line;
+    }
 
-    lines.splice(
-      index,
-      heading.endLine - heading.startLine + 1,
-      `${indent}<div id="${mapping.id}">`,
-      ...body,
-      `${indent}</div>`
-    );
+    // The MDX serializer indents JSX children two spaces per level, so a
+    // heading nested in JSX can sit deeper than Mintlify reads `{#id}`. Move it
+    // to the margin; mixed indentation inside a JSX element is valid MDX.
+    const target = heading.wrapper ? heading.wrapper.startLine - 1 : index;
+    if (leadingWhitespace(lines[target]).length > MAX_MINTLIFY_HEADING_INDENT) {
+      lines[target] = lines[target].trimStart();
+    }
   }
 
   return lines.join('\n');
+}
+
+function leadingWhitespace(line: string): string {
+  return line.match(/^[ \t]*/)?.[0] ?? '';
 }
 
 /**

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -317,10 +317,11 @@ function applyAnchorIds(
 
     const index = heading.startLine - 1;
 
-    // Setext headings have no heading line to append an anchor to.
-    if (heading.textEndColumn < 1 || heading.endLine > heading.startLine) {
-      continue;
-    }
+    if (heading.textEndColumn < 1) continue;
+
+    // Mintlify reads `{#id}` on ATX headings only, so a setext heading is left
+    // alone. Other modes keep the anchor on its text line as before.
+    if (mintlifyMode && heading.endLine > heading.startLine) continue;
 
     const escape = escapeAnchors && !mapping.explicit;
     const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;

--- a/packages/cli/src/utils/addExplicitAnchorIds.ts
+++ b/packages/cli/src/utils/addExplicitAnchorIds.ts
@@ -1,6 +1,5 @@
 import { visit } from 'unist-util-visit';
 import type { Heading, Node } from 'mdast';
-import type { MdxJsxFlowElement } from 'mdast-util-mdx-jsx';
 import { logger } from '../console/logger.js';
 import type { AdditionalOptions } from '../types/index.js';
 import {
@@ -79,7 +78,6 @@ function extractHeadingsWithFallback(mdxContent: string): HeadingInfo[] {
       startColumn: indent.length + 1,
       // Without a parser there is nothing finer to go on than end of line.
       textEndColumn: line.length + 1,
-      wrapper: null,
       explicit: explicitId !== undefined,
     });
   });
@@ -135,14 +133,6 @@ function assignUniqueSlugs(headings: HeadingInfo[]): void {
   }
 }
 
-/** Lines of a `<div id>` an earlier anchor pass wrapped around a heading. */
-interface WrapperLines {
-  /** 1-based line of the opening tag. */
-  startLine: number;
-  /** 1-based line of the closing tag. */
-  endLine: number;
-}
-
 /**
  * Represents a heading with its position and metadata
  */
@@ -159,49 +149,8 @@ export interface HeadingInfo {
   startColumn: number;
   /** 1-based column just past the text, before any closing `##`; -1 if unknown. */
   textEndColumn: number;
-  /** Wrapper an earlier anchor pass placed around this heading. */
-  wrapper: WrapperLines | null;
   /** Whether the author wrote an explicit `{#id}`. */
   explicit: boolean;
-}
-
-/**
- * Recognizes a `<div id="...">` an earlier anchor pass wrapped around this
- * heading: a div whose only attribute is `id`, whose only child is the
- * heading, with its tags on the lines directly around it. Requiring the
- * heading to be the only child rules out containers like `<Tab>`.
- */
-function findWrapper(
-  heading: Heading,
-  parent: Node | undefined
-): WrapperLines | null {
-  if (!parent || parent.type !== 'mdxJsxFlowElement') return null;
-
-  const element = parent as MdxJsxFlowElement;
-  if (element.name !== 'div') return null;
-  if (element.children.length !== 1 || element.children[0] !== heading) {
-    return null;
-  }
-  const [attribute] = element.attributes;
-  if (
-    element.attributes.length !== 1 ||
-    attribute.type !== 'mdxJsxAttribute' ||
-    attribute.name !== 'id'
-  ) {
-    return null;
-  }
-
-  const outer = element.position;
-  const inner = heading.position;
-  if (!outer || !inner) return null;
-  if (
-    outer.start.line !== inner.start.line - 1 ||
-    outer.end.line !== inner.end.line + 1
-  ) {
-    return null;
-  }
-
-  return { startLine: outer.start.line, endLine: outer.end.line };
 }
 
 /**
@@ -221,7 +170,7 @@ export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
   const headings: HeadingInfo[] = [];
   let position = 0;
 
-  visit(ast, 'heading', (heading: Heading, _index, parent) => {
+  visit(ast, 'heading', (heading: Heading) => {
     const headingText = extractHeadingText(heading);
     const { cleanedText, explicitId } = parseHeadingContent(headingText);
     if (!cleanedText && !explicitId) return;
@@ -238,7 +187,6 @@ export function extractHeadingInfo(mdxContent: string): HeadingInfo[] {
       startColumn: heading.position?.start.column ?? 1,
       textEndColumn:
         lastChild?.position?.end.column ?? heading.position?.end.column ?? -1,
-      wrapper: findWrapper(heading, parent ?? undefined),
       explicit: explicitId !== undefined,
     });
   });
@@ -372,7 +320,7 @@ function applyAnchorIds(
     if (heading.textEndColumn < 1 || heading.endLine > heading.startLine) {
       // Setext headings have no heading line to append an anchor to. Mintlify
       // can still anchor one through a wrapper.
-      if (mintlifyMode && !heading.wrapper) {
+      if (mintlifyMode) {
         const indent = lines[index].slice(
           0,
           Math.max(0, heading.startColumn - 1)
@@ -394,37 +342,19 @@ function applyAnchorIds(
     const escape = escapeAnchors && !mapping.explicit;
     const anchor = escape ? `\\{#${mapping.id}\\}` : `{#${mapping.id}}`;
     const { text, trailer } = splitHeadingLine(lines[index], heading);
-    let line = `${text} ${anchor}${trailer}`;
-
-    if (!mintlifyMode) {
-      lines[index] = line;
-      continue;
-    }
-
-    if (heading.wrapper) {
-      // Unwrap the `<div id>` an earlier version placed here; the heading goes
-      // back to the wrapper's own indentation.
-      const { startLine, endLine } = heading.wrapper;
-      line = leadingWhitespace(lines[startLine - 1]) + line.trimStart();
-      lines.splice(startLine - 1, endLine - startLine + 1, line);
-    } else {
-      lines[index] = line;
-    }
+    const line = `${text} ${anchor}${trailer}`;
 
     // The MDX serializer indents JSX children two spaces per level, so a
     // heading nested in JSX can sit deeper than Mintlify reads `{#id}`. Move it
     // to the margin; mixed indentation inside a JSX element is valid MDX.
-    const target = heading.wrapper ? heading.wrapper.startLine - 1 : index;
-    if (leadingWhitespace(lines[target]).length > MAX_MINTLIFY_HEADING_INDENT) {
-      lines[target] = lines[target].trimStart();
-    }
+    const indent = line.match(/^[ \t]*/)?.[0].length ?? 0;
+    lines[index] =
+      mintlifyMode && indent > MAX_MINTLIFY_HEADING_INDENT
+        ? line.trimStart()
+        : line;
   }
 
   return lines.join('\n');
-}
-
-function leadingWhitespace(line: string): string {
-  return line.match(/^[ \t]*/)?.[0] ?? '';
 }
 
 /**


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR replaces Mintlify-mode `<div id>` heading wrappers with Mintlify’s native `{#id}` syntax while retaining the source heading ID across translated locales.
- Writes native, unescaped anchors for Mintlify ATX headings.
- Moves headings indented beyond Mintlify’s supported limit back to the margin.
- Preserves existing surrounding MDX elements rather than inferring wrapper ownership.
- Keeps default-mode setext anchoring unchanged and adds regression coverage.
- Updates CLI option documentation and release notes to describe the new behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the final change preserves default-mode setext behavior and introduces no new actionable failures.

The latest revision restores and tests default-mode setext anchoring, while the Mintlify-specific setext omission, container preservation, and targeted heading-line edits are intentional constraints documented by the reviewer. The author-container finding was resolved, and the remaining prior concerns were addressed by the clarified reachable input and accepted transformation contract.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/utils/addExplicitAnchorIds.ts | Replaces Mintlify wrapper generation with idempotent native-anchor insertion, preserves containers, and retains default setext behavior. |
| packages/cli/src/utils/__tests__/addExplicitAnchorIds.test.ts | Updates wrapper-oriented expectations and adds coverage for native anchors, indentation limits, container preservation, idempotency, and default-mode setext headings. |
| packages/cli/src/cli/commands/translate.ts | Updates orchestration comments to accurately describe the two anchor formats and processing order. |
| packages/cli/src/types/index.ts | Updates the option documentation to reflect Mintlify native-anchor behavior. |
| .changeset/mintlify-native-anchors.md | Adds an accurate patch-level release note for the changed Mintlify behavior. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse translated MDX headings] --> B[Match each heading to source ID]
    B --> C{Mintlify mode?}
    C -->|No| D[Write default escaped or plain anchor]
    C -->|Yes| E{ATX heading?}
    E -->|No| F[Leave setext heading unchanged]
    E -->|Yes| G[Write native source-derived anchor]
    G --> H{Indentation exceeds 3 spaces?}
    H -->|Yes| I[Move heading to margin]
    H -->|No| J[Retain indentation]
    D --> K[Normalize trailing anchors]
    F --> K
    I --> K
    J --> K
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix: skip setext"](https://github.com/generaltranslation/gt/commit/eecd9631f7a612f6305fbf1c34eb29bb79ea6edc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61813332)</sub>

<!-- /greptile_comment -->