### PR TITLE
fix(cli) 4/5: compare catalog edits slice to slice

### DIFF
--- a/.changeset/download-bookkeeping-per-locale.md
+++ b/.changeset/download-bookkeeping-per-locale.md
@@ -1,0 +1,5 @@
+---
+"gt": patch
+---
+
+Record download bookkeeping per locale for translation files that hold every locale, so every locale keeps its post-process hash and unchanged in-place files are no longer resubmitted as user edits by save-local.

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -471,9 +471,11 @@ describe('collectAndSendUserEditDiffs', () => {
       ).toEqual([expect.stringContaining('"Hallo!"')]);
     });
 
-    it('treats a server payload with nothing for the locale as no baseline', async () => {
+    it('submits the locale slice against a baseline of nothing when the server payload carries nothing for the locale', async () => {
       const settings = buildCatalogSettings();
-      writeCatalog(pinned(catalog('Hallo')));
+      // de written by hand into a catalog the server holds no de for
+      const local = pinned(catalog('Hallo'));
+      writeCatalog(local);
       writeLockHashes({ de: hashStringSync('stale') });
 
       vi.mocked(api.queryFileData).mockResolvedValue({
@@ -503,11 +505,25 @@ describe('collectAndSendUserEditDiffs', () => {
         ],
         count: 1,
       });
+      const { getGitUnifiedDiff: realGitUnifiedDiff } = await vi.importActual<
+        typeof import('../../utils/gitDiff.js')
+      >('../../utils/gitDiff.js');
+      vi.mocked(getGitUnifiedDiff).mockImplementation(realGitUnifiedDiff);
 
       await collectAndSendUserEditDiffs([reference], settings);
 
-      expect(getGitUnifiedDiff).not.toHaveBeenCalled();
-      expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+      expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+      const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+      expect(diffs.map((diff) => diff.locale)).toEqual(['de']);
+      expect(diffs[0].localContent).toBe(slice(local, 'de'));
+      // The diff adds the hand-written slice to a catalog with no entries
+      const lines = diffs[0].diff.split('\n');
+      expect(
+        lines.filter((line) => line.startsWith('-') && !line.startsWith('---'))
+      ).toEqual(['-  "strings": {}']);
+      expect(
+        lines.filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+      ).toContainEqual(expect.stringContaining('"Hallo"'));
     });
 
     it('reports a payload that is not a catalog and still checks the other locales', async () => {

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -12,6 +12,11 @@ import {
   DownloadedVersionsV1,
 } from '../../fs/config/downloadedVersions.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+} from '../../formats/xcstrings/parseXcstrings.js';
 import type { FileReference } from 'generaltranslation/types';
 
 vi.mock('../../utils/api.js', () => ({
@@ -258,5 +263,249 @@ describe('collectAndSendUserEditDiffs', () => {
     ).toBe('version1');
     expect(api.downloadFileBatch).toHaveBeenCalledTimes(1);
     expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+  });
+
+  describe('Apple .xcstrings catalogs', () => {
+    const CATALOG = 'App/Localizable.xcstrings';
+    const unit = (value: string) => ({
+      stringUnit: { state: 'translated', value },
+    });
+    const catalog = (deGreeting: string) => ({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        Save: {},
+        greeting: {
+          comment: 'Home screen',
+          localizations: {
+            de: unit(deGreeting),
+            en: unit('Hello'),
+            fr: unit('Bonjour'),
+          },
+        },
+        farewell: {
+          localizations: { en: unit('Bye'), fr: unit('Au revoir') },
+        },
+      },
+    });
+    const pinned = (content: object) => JSON.stringify(content, null, 2) + '\n';
+    const slice = (content: string, locale: string) =>
+      serializeXcstringsSlice(
+        sliceTranslationCatalog(parseXcstringsCatalog(content), locale)!
+      );
+    /** A download as the server returns it: the source slice plus the locale. */
+    const served = (locale: string, values: Record<string, string>) =>
+      JSON.stringify({
+        sourceLanguage: 'en',
+        version: '1.0',
+        strings: {
+          Save: {},
+          greeting: {
+            comment: 'Home screen',
+            localizations: {
+              en: unit('Hello'),
+              ...(values.greeting && { [locale]: unit(values.greeting) }),
+            },
+          },
+          farewell: {
+            localizations: {
+              en: unit('Bye'),
+              ...(values.farewell && { [locale]: unit(values.farewell) }),
+            },
+          },
+        },
+      });
+    const reference: FileReference = {
+      fileName: CATALOG,
+      fileFormat: 'XCSTRINGS',
+      branchId: 'branch1',
+      fileId: 'file1',
+      versionId: 'version1',
+    };
+
+    const buildCatalogSettings = () => {
+      const catalogPath = path.join(tempDir, CATALOG);
+      return createMockSettings({
+        configDirectory: tempDir,
+        config: path.join(tempDir, 'gt.config.json'),
+        defaultLocale: 'en',
+        locales: ['de', 'fr'],
+        _branchId: 'branch1',
+        files: {
+          resolvedPaths: { xcstrings: [catalogPath] },
+          placeholderPaths: { xcstrings: [catalogPath] },
+          transformPaths: {},
+        },
+      });
+    };
+    const writeCatalog = (content: string) => {
+      fs.mkdirSync(path.join(tempDir, 'App'), { recursive: true });
+      fs.writeFileSync(path.join(tempDir, CATALOG), content);
+    };
+    /** The lockfile as translate leaves it: one file hash under each locale. */
+    const writeLockHashes = (hashes: Record<string, string>) => {
+      writeLockFile({
+        version: 1,
+        entries: {
+          branch1: {
+            file1: {
+              version1: Object.fromEntries(
+                Object.entries(hashes).map(([locale, postProcessHash]) => [
+                  locale,
+                  { updatedAt: new Date().toISOString(), postProcessHash },
+                ])
+              ),
+            },
+          },
+        },
+      });
+    };
+    /** The server holds the catalog's translations as they were downloaded. */
+    const serveTranslations = () => {
+      vi.mocked(api.queryFileData).mockImplementation(async (body) => ({
+        translatedFiles: (body.translatedFiles ?? []).map((file) => ({
+          ...file,
+          completedAt: new Date().toISOString(),
+        })),
+      }));
+      vi.mocked(api.downloadFileBatch).mockImplementation(async (files) => ({
+        files: files.map((file) => ({
+          id: `translation-${file.locale}`,
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: file.locale,
+          fileFormat: 'XCSTRINGS' as const,
+          data:
+            file.locale === 'de'
+              ? served('de', { greeting: 'Hallo' })
+              : served('fr', { greeting: 'Bonjour', farewell: 'Au revoir' }),
+          metadata: {},
+        })),
+        count: files.length,
+      }));
+    };
+    const queriedLocales = () =>
+      vi
+        .mocked(api.queryFileData)
+        .mock.calls[0][0].translatedFiles?.map((file) => file.locale);
+
+    it('skips every locale while the catalog still hashes to the recorded post-process hash', async () => {
+      const settings = buildCatalogSettings();
+      const content = pinned(catalog('Hallo'));
+      writeCatalog(content);
+      writeLockHashes({
+        de: hashStringSync(content),
+        fr: hashStringSync(content),
+      });
+
+      await collectAndSendUserEditDiffs([reference], settings);
+
+      expect(api.queryFileData).not.toHaveBeenCalled();
+      expect(api.downloadFileBatch).not.toHaveBeenCalled();
+      expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
+
+    it('submits nothing when the catalog was only re-saved in another layout', async () => {
+      const settings = buildCatalogSettings();
+      const pristine = pinned(catalog('Hallo'));
+      writeLockHashes({
+        de: hashStringSync(pristine),
+        fr: hashStringSync(pristine),
+      });
+      // The same content as Xcode lays it out
+      writeCatalog(JSON.stringify(catalog('Hallo'), null, 4));
+      serveTranslations();
+
+      await collectAndSendUserEditDiffs([reference], settings);
+
+      // The file hash no longer matches, so every locale is checked against
+      // the server — slice against slice, where nothing differs
+      expect(queriedLocales()).toEqual(['de', 'fr']);
+      expect(getGitUnifiedDiff).not.toHaveBeenCalled();
+      expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
+
+    it('submits one slice diff for the edited locale and nothing for the others', async () => {
+      const settings = buildCatalogSettings();
+      const pristine = pinned(catalog('Hallo'));
+      writeLockHashes({
+        de: hashStringSync(pristine),
+        fr: hashStringSync(pristine),
+      });
+      // One de string edited by hand
+      const edited = JSON.stringify(catalog('Hallo!'));
+      writeCatalog(edited);
+      serveTranslations();
+      const { getGitUnifiedDiff: realGitUnifiedDiff } = await vi.importActual<
+        typeof import('../../utils/gitDiff.js')
+      >('../../utils/gitDiff.js');
+      vi.mocked(getGitUnifiedDiff).mockImplementation(realGitUnifiedDiff);
+
+      await collectAndSendUserEditDiffs([reference], settings);
+
+      // Both locales share the changed file, so both are checked; only de
+      // differs from the server
+      expect(queriedLocales()).toEqual(['de', 'fr']);
+      expect(getGitUnifiedDiff).toHaveBeenCalledTimes(1);
+      expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+      const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+      expect(diffs).toHaveLength(1);
+      expect(diffs[0]).toMatchObject({
+        fileName: CATALOG,
+        locale: 'de',
+        fileId: 'file1',
+        versionId: 'version1',
+      });
+      // The submitted content is the de slice, not the whole catalog
+      expect(diffs[0].localContent).toBe(slice(edited, 'de'));
+      // The diff is slice against slice: the one edited value and nothing else
+      const lines = diffs[0].diff.split('\n');
+      expect(
+        lines.filter((line) => line.startsWith('-') && !line.startsWith('---'))
+      ).toEqual([expect.stringContaining('"Hallo"')]);
+      expect(
+        lines.filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+      ).toEqual([expect.stringContaining('"Hallo!"')]);
+    });
+
+    it('treats a server payload with nothing for the locale as no baseline', async () => {
+      const settings = buildCatalogSettings();
+      writeCatalog(pinned(catalog('Hallo')));
+      writeLockHashes({ de: hashStringSync('stale') });
+
+      vi.mocked(api.queryFileData).mockResolvedValue({
+        translatedFiles: [
+          {
+            branchId: 'branch1',
+            fileId: 'file1',
+            versionId: 'version1',
+            locale: 'de',
+            completedAt: new Date().toISOString(),
+          },
+        ],
+      });
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          {
+            id: 'translation-de',
+            branchId: 'branch1',
+            fileId: 'file1',
+            versionId: 'version1',
+            locale: 'de',
+            fileFormat: 'XCSTRINGS',
+            // The source slice with no de in it
+            data: served('de', {}),
+            metadata: {},
+          },
+        ],
+        count: 1,
+      });
+
+      await collectAndSendUserEditDiffs([reference], settings);
+
+      expect(getGitUnifiedDiff).not.toHaveBeenCalled();
+      expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -344,7 +344,7 @@ describe('collectAndSendUserEditDiffs', () => {
       fs.mkdirSync(path.join(tempDir, 'App'), { recursive: true });
       fs.writeFileSync(path.join(tempDir, CATALOG), content);
     };
-    /** The lockfile as translate leaves it: one file hash under each locale. */
+    /** The lockfile as translate leaves it: each locale's slice hash under it. */
     const writeLockHashes = (hashes: Record<string, string>) => {
       writeLockFile({
         version: 1,
@@ -392,13 +392,13 @@ describe('collectAndSendUserEditDiffs', () => {
         .mocked(api.queryFileData)
         .mock.calls[0][0].translatedFiles?.map((file) => file.locale);
 
-    it('skips every locale while the catalog still hashes to the recorded post-process hash', async () => {
+    it('skips every locale while each slice still hashes to its recorded post-process hash', async () => {
       const settings = buildCatalogSettings();
       const content = pinned(catalog('Hallo'));
       writeCatalog(content);
       writeLockHashes({
-        de: hashStringSync(content),
-        fr: hashStringSync(content),
+        de: hashStringSync(slice(content, 'de')),
+        fr: hashStringSync(slice(content, 'fr')),
       });
 
       await collectAndSendUserEditDiffs([reference], settings);
@@ -412,18 +412,16 @@ describe('collectAndSendUserEditDiffs', () => {
       const settings = buildCatalogSettings();
       const pristine = pinned(catalog('Hallo'));
       writeLockHashes({
-        de: hashStringSync(pristine),
-        fr: hashStringSync(pristine),
+        de: hashStringSync(slice(pristine, 'de')),
+        fr: hashStringSync(slice(pristine, 'fr')),
       });
       // The same content as Xcode lays it out
       writeCatalog(JSON.stringify(catalog('Hallo'), null, 4));
-      serveTranslations();
 
       await collectAndSendUserEditDiffs([reference], settings);
 
-      // The file hash no longer matches, so every locale is checked against
-      // the server — slice against slice, where nothing differs
-      expect(queriedLocales()).toEqual(['de', 'fr']);
+      // Each slice still hashes to its recorded hash, so no locale is checked
+      expect(api.queryFileData).not.toHaveBeenCalled();
       expect(getGitUnifiedDiff).not.toHaveBeenCalled();
       expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
     });
@@ -432,8 +430,8 @@ describe('collectAndSendUserEditDiffs', () => {
       const settings = buildCatalogSettings();
       const pristine = pinned(catalog('Hallo'));
       writeLockHashes({
-        de: hashStringSync(pristine),
-        fr: hashStringSync(pristine),
+        de: hashStringSync(slice(pristine, 'de')),
+        fr: hashStringSync(slice(pristine, 'fr')),
       });
       // One de string edited by hand
       const edited = JSON.stringify(catalog('Hallo!'));
@@ -446,9 +444,8 @@ describe('collectAndSendUserEditDiffs', () => {
 
       await collectAndSendUserEditDiffs([reference], settings);
 
-      // Both locales share the changed file, so both are checked; only de
-      // differs from the server
-      expect(queriedLocales()).toEqual(['de', 'fr']);
+      // Only the de slice changed, so only de is checked against the server
+      expect(queriedLocales()).toEqual(['de']);
       expect(getGitUnifiedDiff).toHaveBeenCalledTimes(1);
       expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
       const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];

--- a/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
+++ b/packages/cli/src/api/__tests__/collectUserEditDiffs.test.ts
@@ -12,6 +12,7 @@ import {
   DownloadedVersionsV1,
 } from '../../fs/config/downloadedVersions.js';
 import { createFileMapping } from '../../formats/files/fileMapping.js';
+import { clearWarnings, getWarnings } from '../../state/translateWarnings.js';
 import {
   parseXcstringsCatalog,
   serializeXcstringsSlice,
@@ -41,6 +42,7 @@ describe('collectAndSendUserEditDiffs', () => {
     );
     process.chdir(tempDir);
     vi.clearAllMocks();
+    clearWarnings();
   });
 
   afterEach(() => {
@@ -506,6 +508,55 @@ describe('collectAndSendUserEditDiffs', () => {
 
       expect(getGitUnifiedDiff).not.toHaveBeenCalled();
       expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    });
+
+    it('reports a payload that is not a catalog and still checks the other locales', async () => {
+      const settings = buildCatalogSettings();
+      writeLockHashes({
+        de: hashStringSync('stale'),
+        fr: hashStringSync('stale'),
+      });
+      // One fr string edited by hand
+      const edited = catalog('Hallo');
+      edited.strings.farewell.localizations.fr = unit('Adieu');
+      writeCatalog(JSON.stringify(edited));
+      serveTranslations();
+      // de, checked first, comes back as something other than a catalog
+      vi.mocked(api.downloadFileBatch).mockImplementation(async (files) => ({
+        files: files.map((file) => ({
+          id: `translation-${file.locale}`,
+          branchId: 'branch1',
+          fileId: 'file1',
+          versionId: 'version1',
+          locale: file.locale,
+          fileFormat: 'XCSTRINGS' as const,
+          data:
+            file.locale === 'de'
+              ? 'not a catalog'
+              : served('fr', { greeting: 'Bonjour', farewell: 'Au revoir' }),
+          metadata: {},
+        })),
+        count: files.length,
+      }));
+      const { getGitUnifiedDiff: realGitUnifiedDiff } = await vi.importActual<
+        typeof import('../../utils/gitDiff.js')
+      >('../../utils/gitDiff.js');
+      vi.mocked(getGitUnifiedDiff).mockImplementation(realGitUnifiedDiff);
+
+      await collectAndSendUserEditDiffs([reference], settings);
+
+      expect(queriedLocales()).toEqual(['de', 'fr']);
+      expect(getWarnings()).toEqual([
+        {
+          category: 'skipped_file',
+          fileName: CATALOG,
+          reason: expect.stringContaining('Invalid .xcstrings content'),
+        },
+      ]);
+      expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+      const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+      expect(diffs.map((diff) => diff.locale)).toEqual(['fr']);
+      expect(diffs[0].localContent).toBe(slice(JSON.stringify(edited), 'fr'));
     });
   });
 });

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -17,6 +17,10 @@ import {
 import type { DownloadedVersionEntry } from '../../fs/config/downloadedVersions.js';
 import type { FileStatusTracker } from '../../workflows/steps/PollJobsStep.js';
 import { clearWarnings, getWarnings } from '../../state/translateWarnings.js';
+import {
+  clearDownloaded,
+  getDownloadedMeta,
+} from '../../state/recentDownloads.js';
 
 // Mock dependencies
 vi.mock('../../utils/api.js', () => ({
@@ -172,6 +176,7 @@ describe('downloadFileBatch', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     clearWarnings();
+    clearDownloaded();
   });
 
   afterEach(() => {
@@ -997,6 +1002,192 @@ describe('downloadFileBatch', () => {
         es: unit('Hola'),
         fr: unit('Bonjour'),
       });
+    });
+
+    it('merges every locale even when the lockfile already records all of them', async () => {
+      const files: BatchedFiles = [batched('de'), batched('es')];
+      const fileTracker = createMockFileTracker(files);
+      vi.mocked(readLockfile).mockReturnValue({
+        data: { version: 2, branchId: 'branch-1', entries: [] },
+        entryMap: new Map<string, DownloadedVersionEntry>([
+          [
+            'file-1',
+            {
+              fileId: 'file-1',
+              versionId: 'version-1',
+              fileName: CATALOG,
+              translations: {
+                de: {
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                  fileName: CATALOG,
+                  postProcessHash: 'hash-of-catalog',
+                },
+                es: {
+                  updatedAt: '2026-01-01T00:00:00.000Z',
+                  fileName: CATALOG,
+                  postProcessHash: 'hash-of-catalog',
+                },
+              },
+            },
+          ],
+        ]),
+        originalV1: false,
+      });
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          served('de', downloadFor('de', { greeting: unit('Hallo') })),
+          served('es', downloadFor('es', { greeting: unit('Hola') })),
+        ],
+        count: 2,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      const disk = mockDisk(catalogContent);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'es'] })
+      );
+
+      // The catalog always reflects what the server stores: the lockfile only
+      // exists to detect local edits, never to skip a download
+      expect(result.skipped).toHaveLength(0);
+      expect(result.successful).toHaveLength(2);
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(2);
+      expect(JSON.parse(disk.content).strings.greeting.localizations).toEqual({
+        de: unit('Hallo'),
+        en: unit('Hello'),
+        es: unit('Hola'),
+        fr: unit('Bonjour'),
+      });
+    });
+
+    it('records download metadata for every locale merged into the shared catalog', async () => {
+      const files: BatchedFiles = [batched('de'), batched('es')];
+      const fileTracker = createMockFileTracker(files);
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          served('de', downloadFor('de', { greeting: unit('Hallo') })),
+          served('es', downloadFor('es', { greeting: unit('Hola') })),
+        ],
+        count: 2,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      mockDisk(catalogContent);
+
+      await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'es'] })
+      );
+
+      // One catalog path, one entry per locale: the post-process hash step
+      // must be able to record a hash for de as well as es.
+      const metas = getDownloadedMeta().get(CATALOG);
+      expect(metas?.map((meta) => meta.locale)).toEqual(['de', 'es']);
+      expect(metas?.every((meta) => meta.fileFormat === 'XCSTRINGS')).toBe(
+        true
+      );
+    });
+
+    it('keeps the hash upload recorded when it writes the lock entry', async () => {
+      const files: BatchedFiles = [batched('de')];
+      const fileTracker = createMockFileTracker(files);
+      const lockEntry: DownloadedVersionEntry = {
+        fileId: 'file-1',
+        versionId: 'version-1',
+        translations: {
+          de: {
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            postProcessHash: 'upload-hash',
+          },
+        },
+      };
+      vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [served('de', downloadFor('de', { greeting: unit('Hallo') }))],
+        count: 1,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      mockDisk(catalogContent);
+
+      await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de'] })
+      );
+
+      expect(lockEntry.translations.de.postProcessHash).toBe('upload-hash');
+      expect(lockEntry.translations.de.fileName).toBe(CATALOG);
+      expect(lockEntry.translations.de.updatedAt).not.toBe(
+        '2026-01-01T00:00:00.000Z'
+      );
+    });
+
+    it('fails the locale, records nothing for it, and leaves the catalog untouched when the payload carries nothing for it', async () => {
+      const files: BatchedFiles = [batched('de'), batched('es')];
+      const fileTracker = createMockFileTracker(files);
+      const lockEntry: DownloadedVersionEntry = {
+        fileId: 'file-1',
+        versionId: 'version-1',
+        translations: {},
+      };
+      vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+      vi.mocked(api.downloadFileBatch).mockResolvedValue({
+        files: [
+          // The source slice handed back untranslated: no de anywhere in it
+          served(
+            'de',
+            JSON.stringify({
+              sourceLanguage: 'en',
+              version: '1.0',
+              strings: {
+                Save: {},
+                greeting: {
+                  comment: 'Home screen',
+                  localizations: { en: unit('Hello') },
+                },
+              },
+            })
+          ),
+          served('es', downloadFor('es', { greeting: unit('Hola') })),
+        ],
+        count: 2,
+      });
+      setupFileSystemMocks({ dirExists: true });
+      vi.mocked(path.relative).mockReturnValue(CATALOG);
+      const disk = mockDisk(catalogContent);
+
+      const result = await downloadFileBatch(
+        fileTracker,
+        files,
+        createMockSettings({ locales: ['de', 'es'] })
+      );
+
+      expect(result.failed).toEqual([files[0]]);
+      expect(result.successful).toEqual([files[1]]);
+      expect(result.skipped).toHaveLength(0);
+      expect(logger.error).toHaveBeenCalledWith(
+        expect.stringContaining('no de content')
+      );
+      // Only es was written; de is nowhere in the catalog, the lockfile, or
+      // the download metadata
+      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      expect(JSON.parse(disk.content).strings.greeting.localizations).toEqual({
+        en: unit('Hello'),
+        es: unit('Hola'),
+        fr: unit('Bonjour'),
+      });
+      expect(lockEntry.translations.de).toBeUndefined();
+      expect(lockEntry.translations.es).toBeDefined();
+      expect(
+        getDownloadedMeta()
+          .get(CATALOG)
+          ?.map((meta) => meta.locale)
+      ).toEqual(['es']);
     });
   });
 });

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -1127,7 +1127,7 @@ describe('downloadFileBatch', () => {
       );
     });
 
-    it('fails the locale, records nothing for it, and leaves the catalog untouched when the payload carries nothing for it', async () => {
+    it('records the locale and leaves the catalog as it was when the payload carries nothing for it', async () => {
       const files: BatchedFiles = [batched('de'), batched('es')];
       const fileTracker = createMockFileTracker(files);
       const lockEntry: DownloadedVersionEntry = {
@@ -1138,16 +1138,18 @@ describe('downloadFileBatch', () => {
       vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
       vi.mocked(api.downloadFileBatch).mockResolvedValue({
         files: [
-          // The source slice handed back untranslated: no de anywhere in it
+          // A catalog with nothing to translate comes back as its source
+          // slice: no de anywhere in it
           served(
             'de',
             JSON.stringify({
               sourceLanguage: 'en',
               version: '1.0',
               strings: {
-                Save: {},
+                Save: { shouldTranslate: false },
                 greeting: {
                   comment: 'Home screen',
+                  shouldTranslate: false,
                   localizations: { en: unit('Hello') },
                 },
               },
@@ -1167,27 +1169,26 @@ describe('downloadFileBatch', () => {
         createMockSettings({ locales: ['de', 'es'] })
       );
 
-      expect(result.failed).toEqual([files[0]]);
-      expect(result.successful).toEqual([files[1]]);
-      expect(result.skipped).toHaveLength(0);
-      expect(logger.error).toHaveBeenCalledWith(
-        expect.stringContaining('no de content')
-      );
-      // Only es was written; de is nowhere in the catalog, the lockfile, or
-      // the download metadata
-      expect(fs.promises.writeFile).toHaveBeenCalledTimes(1);
+      // Not a failure: the catalog is re-downloaded every run, so the record
+      // only says the locale was handled
+      expect(result.failed).toEqual([]);
+      expect(result.successful).toEqual(files);
+      expect(logger.error).not.toHaveBeenCalled();
+      // The de merge rewrote the catalog with the same content
+      const deWrite = vi.mocked(fs.promises.writeFile).mock.calls[0][1];
+      expect(JSON.parse(String(deWrite))).toEqual(JSON.parse(catalogContent));
       expect(JSON.parse(disk.content).strings.greeting.localizations).toEqual({
         en: unit('Hello'),
         es: unit('Hola'),
         fr: unit('Bonjour'),
       });
-      expect(lockEntry.translations.de).toBeUndefined();
-      expect(lockEntry.translations.es).toBeDefined();
+      expect(lockEntry.translations.de).toMatchObject({ fileName: CATALOG });
+      expect(lockEntry.translations.es).toMatchObject({ fileName: CATALOG });
       expect(
         getDownloadedMeta()
           .get(CATALOG)
           ?.map((meta) => meta.locale)
-      ).toEqual(['es']);
+      ).toEqual(['de', 'es']);
     });
   });
 });

--- a/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
+++ b/packages/cli/src/api/__tests__/downloadFileBatch.test.ts
@@ -546,6 +546,50 @@ describe('downloadFileBatch', () => {
     expect(lockEntry.translations.es.fileName).toBe('public/gt/es.json');
   });
 
+  it('keeps a previously recorded postProcessHash when it re-downloads a locale', async () => {
+    const files = createBatchedFiles(1, { locale: 'es' });
+    const fileTracker = createMockFileTracker(files);
+    const lockEntry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {
+        es: {
+          updatedAt: '2026-01-01T00:00:00.000Z',
+          fileName: 'file1.json',
+          postProcessHash: 'upload-hash',
+        },
+      },
+    };
+
+    vi.mocked(findOrCreateEntry).mockReturnValue(lockEntry);
+    vi.mocked(api.downloadFileBatch).mockResolvedValue({
+      files: [
+        {
+          id: 'translation-1',
+          branchId: 'branch-1',
+          fileId: 'file-1',
+          versionId: 'version-1',
+          locale: 'es',
+          fileFormat: 'GTJSON' as FileFormat,
+          data: '{"hello":"Hola"}',
+          fileName: 'es.json',
+          metadata: {},
+        },
+      ],
+      count: 1,
+    });
+    setupFileSystemMocks();
+
+    await downloadFileBatch(fileTracker, files, createMockSettings());
+
+    // The hash is what user-edit detection compares against; dropping it here
+    // would make an unchanged file look edited until postprocessing re-hashes it
+    expect(lockEntry.translations.es.postProcessHash).toBe('upload-hash');
+    expect(lockEntry.translations.es.updatedAt).not.toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
+  });
+
   it.each([
     ['gt-vue', '<Vue Elements>'],
     ['gt-react', '<React Elements>'],

--- a/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
+++ b/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
@@ -1,0 +1,411 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import os from 'node:os';
+import type { FileReference } from 'generaltranslation/types';
+import { api } from '../../utils/api.js';
+import { logger } from '../../console/logger.js';
+import { collectAndSendUserEditDiffs } from '../collectUserEditDiffs.js';
+import { downloadFileBatch, type BatchedFiles } from '../downloadFileBatch.js';
+import { persistPostProcessHashes } from '../../utils/persistPostprocessHashes.js';
+import {
+  clearDownloaded,
+  getDownloadedMeta,
+  getNeedsPostprocessing,
+} from '../../state/recentDownloads.js';
+import { clearWarnings } from '../../state/translateWarnings.js';
+import { readLockfile } from '../../fs/config/downloadedVersions.js';
+import { hashStringSync } from '../../utils/hash.js';
+import { localeContent } from '../../formats/files/localeContent.js';
+import {
+  parseXcstrings,
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  type XcstringsCatalog,
+} from '../../formats/xcstrings/parseXcstrings.js';
+import { createMockSettings } from '../__mocks__/settings.js';
+import type { FileStatusTracker } from '../../workflows/steps/PollJobsStep.js';
+import type { Settings } from '../../types/index.js';
+
+vi.mock('../../utils/api.js', () => ({
+  api: {
+    queryFileData: vi.fn(),
+    downloadFileBatch: vi.fn(),
+    submitUserEditDiffs: vi.fn(),
+    resolveAliasLocale: vi.fn((locale: string) => locale),
+    resolveCanonicalLocale: vi.fn((locale: string) => locale),
+  },
+}));
+
+const spinner = vi.hoisted(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  message: vi.fn(),
+  advance: vi.fn(),
+}));
+vi.mock('../../console/logger.js', () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    message: vi.fn(),
+    step: vi.fn(),
+    createSpinner: () => spinner,
+    createProgressBar: () => spinner,
+  },
+}));
+vi.mock('../../console/logging.js', () => ({
+  displayHeader: vi.fn(),
+  exitSync: vi.fn((code: number) => {
+    throw new Error(`exit ${code}`);
+  }),
+  logErrorAndExit: vi.fn((message: string) => {
+    throw new Error(message);
+  }),
+}));
+
+/**
+ * The lifecycle of one .xcstrings catalog across `translate` runs, driven
+ * through the real modules that own the lockfile, the download metadata, the
+ * post-process hashes, and the user-edit diffs. Only the API client is
+ * mocked; files, lockfile, slicing, merging, and git diff are real.
+ */
+describe('.xcstrings catalog bookkeeping across translate runs', () => {
+  const CATALOG = 'App/Localizable.xcstrings';
+  const BRANCH = 'branch-1';
+  const LOCALES = ['de', 'fr', 'ja'];
+  const unit = (value: string) => ({
+    stringUnit: { state: 'translated', value },
+  });
+  const TRANSLATIONS: Record<string, Record<string, string>> = {
+    de: { Save: 'Sichern', greeting: 'Hallo', 'items.count': '%d Elemente' },
+    fr: {
+      Save: 'Enregistrer',
+      greeting: 'Bonjour',
+      'items.count': '%d éléments',
+    },
+    ja: { Save: '保存', greeting: 'こんにちは', 'items.count': '%d 件' },
+  };
+  const sourceCatalog: XcstringsCatalog = {
+    sourceLanguage: 'en',
+    version: '1.0',
+    strings: {
+      Save: {},
+      greeting: {
+        comment: 'Home screen',
+        localizations: { en: unit('Hello') },
+      },
+      'items.count': {
+        extractionState: 'manual',
+        localizations: { en: unit('%d items') },
+      },
+    },
+  };
+  /** The catalog after every locale has been merged in (sorted locale keys). */
+  const translatedCatalog: XcstringsCatalog = {
+    sourceLanguage: 'en',
+    version: '1.0',
+    strings: {
+      Save: {
+        localizations: {
+          de: unit(TRANSLATIONS.de.Save),
+          fr: unit(TRANSLATIONS.fr.Save),
+          ja: unit(TRANSLATIONS.ja.Save),
+        },
+      },
+      greeting: {
+        comment: 'Home screen',
+        localizations: {
+          de: unit(TRANSLATIONS.de.greeting),
+          en: unit('Hello'),
+          fr: unit(TRANSLATIONS.fr.greeting),
+          ja: unit(TRANSLATIONS.ja.greeting),
+        },
+      },
+      'items.count': {
+        extractionState: 'manual',
+        localizations: {
+          de: unit(TRANSLATIONS.de['items.count']),
+          en: unit('%d items'),
+          fr: unit(TRANSLATIONS.fr['items.count']),
+          ja: unit(TRANSLATIONS.ja['items.count']),
+        },
+      },
+    },
+  };
+
+  const originalCwd = process.cwd();
+  let tempDir: string;
+  let settings: Settings;
+  /** What the server serves per locale on the next download. */
+  const server = new Map<string, string>();
+
+  beforeEach(() => {
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(os.tmpdir(), 'gt-xcstrings-'))
+    );
+    process.chdir(tempDir);
+    fs.mkdirSync(path.join(tempDir, 'App'), { recursive: true });
+    vi.clearAllMocks();
+    clearDownloaded();
+    clearWarnings();
+    server.clear();
+
+    const catalogPath = path.join(tempDir, CATALOG);
+    settings = {
+      ...createMockSettings({
+        configDirectory: path.join(tempDir, '.gt'),
+        config: path.join(tempDir, 'gt.config.json'),
+        apiKey: 'gtx-api-key',
+        projectId: 'project-1',
+        defaultLocale: 'en',
+        locales: [...LOCALES],
+        _branchId: BRANCH,
+      }),
+      files: {
+        resolvedPaths: { xcstrings: [catalogPath] },
+        placeholderPaths: { xcstrings: [catalogPath] },
+        transformPaths: {},
+        transformFormats: {},
+        publishPaths: new Set<string>(),
+        unpublishPaths: new Set<string>(),
+        requiresReviewPaths: new Set<string>(),
+        parsingFlags: {},
+        gtJson: { parsingFlags: {} },
+      },
+    };
+
+    vi.mocked(api.queryFileData).mockImplementation(async (body) => ({
+      translatedFiles: (body.translatedFiles ?? []).map((file) => ({
+        ...file,
+        completedAt: new Date().toISOString(),
+      })),
+    }));
+    vi.mocked(api.downloadFileBatch).mockImplementation(async (requests) => {
+      const { fileId, versionId } = ids();
+      const files = requests.flatMap((request) => {
+        const data = server.get(request.locale ?? '');
+        if (data === undefined) return [];
+        return [
+          {
+            id: `translation-${request.locale}`,
+            branchId: BRANCH,
+            fileId,
+            versionId,
+            locale: request.locale,
+            fileFormat: 'XCSTRINGS' as const,
+            data,
+            metadata: {},
+          },
+        ];
+      });
+      return { files, count: files.length };
+    });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const readCatalog = () => fs.readFileSync(CATALOG, 'utf8');
+  const writeCatalog = (content: string) => fs.writeFileSync(CATALOG, content);
+  /** fileId and versionId exactly as aggregateFiles derives them. */
+  const ids = () => ({
+    fileId: hashStringSync(CATALOG),
+    versionId: hashStringSync(parseXcstrings(readCatalog())),
+  });
+  const lockTranslations = () =>
+    readLockfile(settings).entryMap.get(ids().fileId)?.translations ?? {};
+
+  /**
+   * A download as the server returns it: the source slice of the current
+   * catalog with the locale's units added, in a compact layout.
+   */
+  const served = (locale: string, values: Record<string, string>) => {
+    const slice = parseXcstringsCatalog(parseXcstrings(readCatalog()));
+    for (const [key, value] of Object.entries(values)) {
+      slice.strings[key] = {
+        ...slice.strings[key],
+        localizations: {
+          ...slice.strings[key].localizations,
+          [locale]: unit(value),
+        },
+      };
+    }
+    return JSON.stringify(slice);
+  };
+  const serveTranslations = (locales: string[] = LOCALES) => {
+    for (const locale of locales) {
+      server.set(locale, served(locale, TRANSLATIONS[locale]));
+    }
+  };
+
+  /**
+   * What `gt translate` does with a catalog once its jobs are complete: save
+   * local edits, download every locale into the catalog, record the hashes.
+   */
+  const translateRun = async () => {
+    const { fileId, versionId } = ids();
+    const reference: FileReference = {
+      fileName: CATALOG,
+      fileFormat: 'XCSTRINGS',
+      branchId: BRANCH,
+      fileId,
+      versionId,
+    };
+    await collectAndSendUserEditDiffs([reference], settings);
+
+    const fileTracker: FileStatusTracker = {
+      completed: new Map(
+        LOCALES.map((locale) => [
+          `${BRANCH}:${fileId}:${versionId}:${locale}`,
+          { fileId, versionId, locale, branchId: BRANCH, fileName: CATALOG },
+        ])
+      ),
+      inProgress: new Map(),
+      failed: new Map(),
+      skipped: new Map(),
+    };
+    const batched: BatchedFiles = LOCALES.map((locale) => ({
+      branchId: BRANCH,
+      fileId,
+      versionId,
+      locale,
+      outputPath: CATALOG,
+      inputPath: CATALOG,
+    }));
+    const result = await downloadFileBatch(fileTracker, batched, settings);
+    persistPostProcessHashes(
+      settings,
+      getNeedsPostprocessing(),
+      getDownloadedMeta()
+    );
+    clearDownloaded();
+    return result;
+  };
+
+  it('gives every locale of a fresh translate the merged file hash, with each slice equal to what the server sent', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations();
+
+    const result = await translateRun();
+
+    expect(result.failed).toEqual([]);
+    expect(result.successful).toHaveLength(3);
+    expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(readCatalog()).toBe(serializeXcstringsSlice(translatedCatalog));
+
+    // One file holds every locale, so every locale carries the same hash of
+    // that file — not only the last locale merged
+    const translations = lockTranslations();
+    expect(Object.keys(translations).sort()).toEqual(LOCALES);
+    const disk = readCatalog();
+    for (const locale of LOCALES) {
+      expect(translations[locale].postProcessHash, locale).toBe(
+        hashStringSync(disk)
+      );
+      // The slice of the merged catalog is byte-identical to the locale's
+      // share of what the server sent: that is what save-local compares
+      expect(localeContent(disk, 'XCSTRINGS', locale), locale).toBe(
+        localeContent(server.get(locale)!, 'XCSTRINGS', locale)
+      );
+    }
+  });
+
+  it('submits no user edits on a second translate when nothing changed', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations();
+    await translateRun();
+    const before = readCatalog();
+    const lockBefore = fs.readFileSync('gt-lock.json', 'utf8');
+    vi.clearAllMocks();
+
+    const result = await translateRun();
+
+    expect(api.queryFileData).not.toHaveBeenCalled();
+    expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    // The lockfile records every locale, yet the catalog is downloaded and
+    // merged again: it always reflects what the server stores
+    expect(api.downloadFileBatch).toHaveBeenCalledTimes(1);
+    expect(result.skipped).toEqual([]);
+    expect(result.successful).toHaveLength(3);
+    expect(readCatalog()).toBe(before);
+    expect(
+      JSON.parse(fs.readFileSync('gt-lock.json', 'utf8')).entries[0]
+        .translations
+    ).toMatchObject(
+      Object.fromEntries(
+        LOCALES.map((locale) => [
+          locale,
+          {
+            postProcessHash:
+              JSON.parse(lockBefore).entries[0].translations[locale]
+                .postProcessHash,
+          },
+        ])
+      )
+    );
+  });
+
+  it('submits exactly one diff, for the edited locale, after one de string changes', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations();
+    await translateRun();
+    vi.clearAllMocks();
+
+    // Edited by hand, saved in a layout of the editor's choosing
+    const edited = parseXcstringsCatalog(readCatalog());
+    edited.strings.greeting.localizations!.de = unit('Hallo!');
+    writeCatalog(JSON.stringify(edited));
+    const editedContent = readCatalog();
+
+    await translateRun();
+
+    // The shared file changed, so every locale is checked against the server;
+    // slice against slice, only de differs
+    expect(api.queryFileData).toHaveBeenCalledTimes(1);
+    expect(
+      vi
+        .mocked(api.queryFileData)
+        .mock.calls[0][0].translatedFiles?.map((file) => file.locale)
+    ).toEqual(LOCALES);
+    expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+    const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+    expect(diffs).toHaveLength(1);
+    expect(diffs[0]).toMatchObject({ fileName: CATALOG, locale: 'de' });
+    expect(diffs[0].localContent).toBe(
+      localeContent(editedContent, 'XCSTRINGS', 'de')
+    );
+    const lines = diffs[0].diff.split('\n');
+    expect(
+      lines.filter((line) => line.startsWith('-') && !line.startsWith('---'))
+    ).toEqual([expect.stringContaining('"Hallo"')]);
+    expect(
+      lines.filter((line) => line.startsWith('+') && !line.startsWith('+++'))
+    ).toEqual([expect.stringContaining('"Hallo!"')]);
+  });
+
+  it('fails a locale whose payload carries nothing for it and records nothing for that locale', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations(['de', 'ja']);
+    // fr comes back as the untouched source slice
+    server.set('fr', served('fr', {}));
+
+    const result = await translateRun();
+
+    expect(result.failed.map((file) => file.locale)).toEqual(['fr']);
+    expect(result.successful.map((file) => file.locale)).toEqual(['de', 'ja']);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('no fr content')
+    );
+    const disk = readCatalog();
+    expect(localeContent(disk, 'XCSTRINGS', 'fr')).toBeUndefined();
+    expect(localeContent(disk, 'XCSTRINGS', 'de')).toBe(
+      localeContent(server.get('de')!, 'XCSTRINGS', 'de')
+    );
+    expect(Object.keys(lockTranslations()).sort()).toEqual(['de', 'ja']);
+  });
+});

--- a/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
+++ b/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
@@ -417,4 +417,35 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
     expect(readCatalog()).toBe(disk);
   });
+
+  it('submits a slice written by hand for a locale whose download carried nothing for it', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations(['de', 'ja']);
+    server.set('fr', served('fr', {}));
+    await translateRun();
+    vi.clearAllMocks();
+
+    // The user writes the fr greeting by hand
+    const edited = parseXcstringsCatalog(readCatalog());
+    edited.strings.greeting.localizations!.fr = unit('Salut');
+    writeCatalog(serializeXcstringsSlice(edited));
+    const editedContent = readCatalog();
+
+    const result = await translateRun();
+
+    // Every locale is checked; de and ja match the server, fr is compared
+    // against a baseline of nothing and submitted
+    expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+    const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+    expect(diffs.map((diff) => diff.locale)).toEqual(['fr']);
+    expect(diffs[0].localContent).toBe(
+      localeContent(editedContent, 'XCSTRINGS', 'fr')
+    );
+    // The download still carries nothing for fr, so the hand-written slice
+    // stays in the catalog
+    expect(result.failed).toEqual([]);
+    expect(localeContent(readCatalog(), 'XCSTRINGS', 'fr')).toBe(
+      localeContent(editedContent, 'XCSTRINGS', 'fr')
+    );
+  });
 });

--- a/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
+++ b/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
@@ -388,24 +388,33 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     ).toEqual([expect.stringContaining('"Hallo!"')]);
   });
 
-  it('fails a locale whose payload carries nothing for it and records nothing for that locale', async () => {
+  it('records a locale whose payload carries nothing for it, leaves the catalog alone, and submits nothing for it later', async () => {
     writeCatalog(serializeXcstringsSlice(sourceCatalog));
     serveTranslations(['de', 'ja']);
-    // fr comes back as the untouched source slice
+    // fr comes back as the untouched source slice: nothing to translate
     server.set('fr', served('fr', {}));
 
     const result = await translateRun();
 
-    expect(result.failed.map((file) => file.locale)).toEqual(['fr']);
-    expect(result.successful.map((file) => file.locale)).toEqual(['de', 'ja']);
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('no fr content')
-    );
+    expect(result.failed).toEqual([]);
+    expect(result.successful.map((file) => file.locale)).toEqual(LOCALES);
+    expect(logger.error).not.toHaveBeenCalled();
     const disk = readCatalog();
     expect(localeContent(disk, 'XCSTRINGS', 'fr')).toBeUndefined();
     expect(localeContent(disk, 'XCSTRINGS', 'de')).toBe(
       localeContent(server.get('de')!, 'XCSTRINGS', 'de')
     );
-    expect(Object.keys(lockTranslations()).sort()).toEqual(['de', 'ja']);
+    // fr carries the file hash like every other locale, so the next run does
+    // not read the catalog as edited
+    const translations = lockTranslations();
+    expect(Object.keys(translations).sort()).toEqual(LOCALES);
+    expect(translations.fr.postProcessHash).toBe(hashStringSync(disk));
+    vi.clearAllMocks();
+
+    await translateRun();
+
+    expect(api.queryFileData).not.toHaveBeenCalled();
+    expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
+    expect(readCatalog()).toBe(disk);
   });
 });

--- a/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
+++ b/packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts
@@ -16,7 +16,10 @@ import {
 import { clearWarnings } from '../../state/translateWarnings.js';
 import { readLockfile } from '../../fs/config/downloadedVersions.js';
 import { hashStringSync } from '../../utils/hash.js';
-import { localeContent } from '../../formats/files/localeContent.js';
+import {
+  emptyLocaleContent,
+  localeContent,
+} from '../../formats/files/localeContent.js';
 import {
   parseXcstrings,
   parseXcstringsCatalog,
@@ -219,6 +222,11 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
   });
   const lockTranslations = () =>
     readLockfile(settings).entryMap.get(ids().fileId)?.translations ?? {};
+  /** The locales save-local asked the server about, in order. */
+  const queriedLocales = () =>
+    vi
+      .mocked(api.queryFileData)
+      .mock.calls[0][0].translatedFiles?.map((file) => file.locale);
 
   /**
    * A download as the server returns it: the source slice of the current
@@ -287,7 +295,7 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     return result;
   };
 
-  it('gives every locale of a fresh translate the merged file hash, with each slice equal to what the server sent', async () => {
+  it('gives every locale of a fresh translate the hash of its own slice, each equal to what the server sent', async () => {
     writeCatalog(serializeXcstringsSlice(sourceCatalog));
     serveTranslations();
 
@@ -298,14 +306,14 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     expect(api.submitUserEditDiffs).not.toHaveBeenCalled();
     expect(readCatalog()).toBe(serializeXcstringsSlice(translatedCatalog));
 
-    // One file holds every locale, so every locale carries the same hash of
-    // that file — not only the last locale merged
+    // One file holds every locale, and each locale is fingerprinted by its
+    // own slice of it, so an edit to one locale leaves the others matching
     const translations = lockTranslations();
     expect(Object.keys(translations).sort()).toEqual(LOCALES);
     const disk = readCatalog();
     for (const locale of LOCALES) {
       expect(translations[locale].postProcessHash, locale).toBe(
-        hashStringSync(disk)
+        hashStringSync(localeContent(disk, 'XCSTRINGS', locale)!)
       );
       // The slice of the merged catalog is byte-identical to the locale's
       // share of what the server sent: that is what save-local compares
@@ -364,14 +372,9 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
 
     await translateRun();
 
-    // The shared file changed, so every locale is checked against the server;
-    // slice against slice, only de differs
+    // Only the de slice changed, so only de is checked against the server
     expect(api.queryFileData).toHaveBeenCalledTimes(1);
-    expect(
-      vi
-        .mocked(api.queryFileData)
-        .mock.calls[0][0].translatedFiles?.map((file) => file.locale)
-    ).toEqual(LOCALES);
+    expect(queriedLocales()).toEqual(['de']);
     expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
     const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
     expect(diffs).toHaveLength(1);
@@ -386,6 +389,51 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     expect(
       lines.filter((line) => line.startsWith('+') && !line.startsWith('+++'))
     ).toEqual([expect.stringContaining('"Hallo!"')]);
+  });
+
+  it('submits only the locale edited on disk when another locale changed on the server since the download', async () => {
+    writeCatalog(serializeXcstringsSlice(sourceCatalog));
+    serveTranslations();
+    await translateRun();
+    vi.clearAllMocks();
+
+    // de edited in the dashboard: the server now holds a newer de slice
+    server.set('de', served('de', { ...TRANSLATIONS.de, Save: 'Speichern' }));
+    // The server applies a submitted edit before it is downloaded again
+    vi.mocked(api.submitUserEditDiffs).mockImplementation(async ({ diffs }) => {
+      for (const diff of diffs) server.set(diff.locale, diff.localContent);
+      return { success: true };
+    });
+    // fr edited by hand
+    const edited = parseXcstringsCatalog(readCatalog());
+    edited.strings.Save.localizations!.fr = unit('Sauvegarder');
+    writeCatalog(serializeXcstringsSlice(edited));
+    const editedContent = readCatalog();
+
+    const result = await translateRun();
+
+    // The local de slice is stale, not edited: only fr is submitted
+    expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
+    const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
+    expect(diffs.map((diff) => diff.locale)).toEqual(['fr']);
+    expect(diffs[0].localContent).toBe(
+      localeContent(editedContent, 'XCSTRINGS', 'fr')
+    );
+    // Only the fr slice changed on disk, so only fr is checked at all
+    expect(queriedLocales()).toEqual(['fr']);
+    // The download brings the dashboard edit down, keeps the fr edit, and
+    // leaves ja as it was
+    expect(result.failed).toEqual([]);
+    const disk = readCatalog();
+    expect(localeContent(disk, 'XCSTRINGS', 'de')).toBe(
+      localeContent(server.get('de')!, 'XCSTRINGS', 'de')
+    );
+    expect(localeContent(disk, 'XCSTRINGS', 'fr')).toBe(
+      localeContent(editedContent, 'XCSTRINGS', 'fr')
+    );
+    expect(localeContent(disk, 'XCSTRINGS', 'ja')).toBe(
+      localeContent(server.get('ja')!, 'XCSTRINGS', 'ja')
+    );
   });
 
   it('records a locale whose payload carries nothing for it, leaves the catalog alone, and submits nothing for it later', async () => {
@@ -404,11 +452,13 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
     expect(localeContent(disk, 'XCSTRINGS', 'de')).toBe(
       localeContent(server.get('de')!, 'XCSTRINGS', 'de')
     );
-    // fr carries the file hash like every other locale, so the next run does
-    // not read the catalog as edited
+    // fr is fingerprinted by the empty slice it stands for, so the next run
+    // does not read it as edited
     const translations = lockTranslations();
     expect(Object.keys(translations).sort()).toEqual(LOCALES);
-    expect(translations.fr.postProcessHash).toBe(hashStringSync(disk));
+    expect(translations.fr.postProcessHash).toBe(
+      hashStringSync(emptyLocaleContent(disk, 'XCSTRINGS'))
+    );
     vi.clearAllMocks();
 
     await translateRun();
@@ -433,8 +483,9 @@ describe('.xcstrings catalog bookkeeping across translate runs', () => {
 
     const result = await translateRun();
 
-    // Every locale is checked; de and ja match the server, fr is compared
-    // against a baseline of nothing and submitted
+    // Only fr changed on disk; it is compared against a baseline of nothing
+    // and submitted
+    expect(queriedLocales()).toEqual(['fr']);
     expect(api.submitUserEditDiffs).toHaveBeenCalledTimes(1);
     const { diffs } = vi.mocked(api.submitUserEditDiffs).mock.calls[0][0];
     expect(diffs.map((diff) => diff.locale)).toEqual(['fr']);

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -159,7 +159,9 @@ export async function collectAndSendUserEditDiffs(
     const translatedFiles =
       checkResponse.translatedFiles?.filter((t) => t.completedAt) ?? [];
 
-    const serverContentByKey = new Map<string, Buffer>();
+    // The server's copy of each candidate, keyed like the candidates
+    type ServerPayload = { data: string; fileFormat: FileFormat };
+    const serverPayloadByKey = new Map<string, ServerPayload>();
     try {
       const resp = await api.downloadFileBatch(
         translatedFiles.map((file) => ({
@@ -169,16 +171,11 @@ export async function collectAndSendUserEditDiffs(
           versionId: file.versionId,
         }))
       );
-      const files = resp?.files || [];
-      for (const f of files) {
+      for (const f of resp?.files || []) {
         if (!f.locale) continue;
-        // The locale's share of the payload; a catalog payload that carries
-        // nothing for the locale is no baseline at all.
-        const content = localeContent(f.data, f.fileFormat, f.locale);
-        if (content === undefined) continue;
-        serverContentByKey.set(
+        serverPayloadByKey.set(
           `${f.branchId}:${f.fileId}:${f.versionId}:${f.locale}`,
-          contentBytes(content, f.fileFormat)
+          { data: f.data, fileFormat: f.fileFormat }
         );
       }
     } catch {
@@ -188,11 +185,34 @@ export async function collectAndSendUserEditDiffs(
     // Compute diffs using fetched server contents
     for (const c of candidates) {
       const key = `${c.branchId}:${c.fileId}:${c.versionId}:${c.locale}`;
-      const serverBytes = serverContentByKey.get(key);
+      const payload = serverPayloadByKey.get(key);
       // Absent means the batch did not return this file, so there is no
       // baseline. An empty payload is a baseline of nothing, which the user
       // may well have written against.
-      if (!serverBytes) continue;
+      if (!payload) continue;
+
+      // The locale's share of the payload, read on its own so a payload the
+      // server sent malformed costs only its own locale.
+      let serverContent: string | undefined;
+      try {
+        serverContent = localeContent(
+          payload.data,
+          payload.fileFormat,
+          c.locale
+        );
+      } catch (error) {
+        const relativePath = getRelative(c.outputPath);
+        const reason = `The downloaded ${c.locale} translation could not be read (${
+          error instanceof Error ? error.message : String(error)
+        })`;
+        logger.warn(`Skipping local edits to ${relativePath}: ${reason}`);
+        recordWarning('skipped_file', relativePath, reason);
+        continue;
+      }
+      // A catalog payload that carries nothing for the locale is no baseline
+      // at all.
+      if (serverContent === undefined) continue;
+      const serverBytes = contentBytes(serverContent, payload.fileFormat);
 
       try {
         // Read the local file the same way the pipeline read it originally, so

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -20,7 +20,10 @@ import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { hashStringSync } from '../utils/hash.js';
 import { extractJson } from '../formats/json/extractJson.js';
-import { localeContent } from '../formats/files/localeContent.js';
+import {
+  emptyLocaleContent,
+  localeContent,
+} from '../formats/files/localeContent.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import { logger } from '../console/logger.js';
 import { recordWarning } from '../state/translateWarnings.js';
@@ -192,14 +195,14 @@ export async function collectAndSendUserEditDiffs(
       if (!payload) continue;
 
       // The locale's share of the payload, read on its own so a payload the
-      // server sent malformed costs only its own locale.
-      let serverContent: string | undefined;
+      // server sent malformed costs only its own locale. A catalog payload
+      // that carries nothing for the locale is that file's empty payload, and
+      // a baseline of nothing like any other.
+      let serverContent: string;
       try {
-        serverContent = localeContent(
-          payload.data,
-          payload.fileFormat,
-          c.locale
-        );
+        serverContent =
+          localeContent(payload.data, payload.fileFormat, c.locale) ??
+          emptyLocaleContent(payload.data, payload.fileFormat);
       } catch (error) {
         const relativePath = getRelative(c.outputPath);
         const reason = `The downloaded ${c.locale} translation could not be read (${
@@ -209,9 +212,6 @@ export async function collectAndSendUserEditDiffs(
         recordWarning('skipped_file', relativePath, reason);
         continue;
       }
-      // A catalog payload that carries nothing for the locale is no baseline
-      // at all.
-      if (serverContent === undefined) continue;
       const serverBytes = contentBytes(serverContent, payload.fileFormat);
 
       try {

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -115,16 +115,20 @@ export async function collectAndSendUserEditDiffs(
       if (!latestDownloaded) continue;
       const downloadedVersion = latestDownloaded.entry;
 
-      // Skip if local file matches the last postprocessed content hash
+      // Skip if the locale's local content matches the last recorded hash
       if (downloadedVersion.postProcessHash) {
         try {
-          // Hashed from the same pipeline content the hash was recorded from,
-          // so a file stored in UTF-16 still matches when it is untouched.
-          const localContent = readFileContent(
+          // Hashed from the locale's share of the pipeline content, which is
+          // what was recorded, so an untouched locale matches regardless of
+          // the file's encoding or of edits to its other locales.
+          const localFile = readFileContent(
             outputPath,
             uploadedFile.fileFormat
           );
-          const localHash = hashStringSync(localContent);
+          const localHash = hashStringSync(
+            localeContent(localFile, uploadedFile.fileFormat, locale) ??
+              emptyLocaleContent(localFile, uploadedFile.fileFormat)
+          );
           if (localHash === downloadedVersion.postProcessHash) {
             continue;
           }

--- a/packages/cli/src/api/collectUserEditDiffs.ts
+++ b/packages/cli/src/api/collectUserEditDiffs.ts
@@ -20,6 +20,7 @@ import os from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { hashStringSync } from '../utils/hash.js';
 import { extractJson } from '../formats/json/extractJson.js';
+import { localeContent } from '../formats/files/localeContent.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import { logger } from '../console/logger.js';
 import { recordWarning } from '../state/translateWarnings.js';
@@ -57,6 +58,8 @@ const findLatestDownloadedVersion = (
 /**
  * Collects local user edits by diffing the latest downloaded server translation version
  * against the current local translation file, and submits the diffs upstream.
+ * A file that holds every locale is compared one locale slice at a time, so an
+ * edit to one locale is submitted under that locale alone.
  *
  * Must run before enqueueing new translations so rules are available to the generator.
  */
@@ -168,9 +171,14 @@ export async function collectAndSendUserEditDiffs(
       );
       const files = resp?.files || [];
       for (const f of files) {
+        if (!f.locale) continue;
+        // The locale's share of the payload; a catalog payload that carries
+        // nothing for the locale is no baseline at all.
+        const content = localeContent(f.data, f.fileFormat, f.locale);
+        if (content === undefined) continue;
         serverContentByKey.set(
           `${f.branchId}:${f.fileId}:${f.versionId}:${f.locale}`,
-          contentBytes(f.data, f.fileFormat)
+          contentBytes(content, f.fileFormat)
         );
       }
     } catch {
@@ -190,11 +198,16 @@ export async function collectAndSendUserEditDiffs(
         // Read the local file the same way the pipeline read it originally, so
         // a file stored differently on disk than the server's copy is compared
         // as content rather than as bytes. Otherwise every such file would read
-        // as edited on every run.
-        const localBytes = contentBytes(
+        // as edited on every run. Then cut to this locale's share, so a file
+        // that holds every locale is compared slice to slice.
+        const local = localeContent(
           readFileContent(c.outputPath, c.fileFormat),
-          c.fileFormat
+          c.fileFormat,
+          c.locale
         );
+        // A catalog that no longer carries the locale has nothing to submit
+        if (local === undefined) continue;
+        const localBytes = contentBytes(local, c.fileFormat);
 
         // Nothing was edited, so there is no diff to compute or report.
         if (localBytes.equals(serverBytes)) continue;

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -9,7 +9,6 @@ import { validateYamlSchema } from '../formats/yaml/utils.js';
 import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import { mergeXcstringsLocale } from '../formats/xcstrings/mergeXcstrings.js';
-import { localeContent } from '../formats/files/localeContent.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import {
@@ -427,13 +426,6 @@ export async function downloadFileBatch(
         }
         let data: string;
         if (isXcstringsCatalog) {
-          // A payload with nothing for this locale would merge as a no-op yet
-          // be recorded as downloaded; it is a failed download instead.
-          if (localeContent(file.data, 'XCSTRINGS', locale) === undefined) {
-            throw new Error(
-              `The server returned no ${locale} content for this catalog`
-            );
-          }
           // The pinned serializer owns the bytes and the JSON key sorter below
           // must never see them. JSON.parse hoists integer-like keys ("404")
           // first; versionId is unaffected (slices come from the parsed object)

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -9,6 +9,7 @@ import { validateYamlSchema } from '../formats/yaml/utils.js';
 import { mergeJson } from '../formats/json/mergeJson.js';
 import { extractJson } from '../formats/json/extractJson.js';
 import { mergeXcstringsLocale } from '../formats/xcstrings/mergeXcstrings.js';
+import { localeContent } from '../formats/files/localeContent.js';
 import mergeYaml from '../formats/yaml/mergeYaml.js';
 import { extractYaml } from '../formats/yaml/extractYaml.js';
 import {
@@ -426,6 +427,13 @@ export async function downloadFileBatch(
         }
         let data: string;
         if (isXcstringsCatalog) {
+          // A payload with nothing for this locale would merge as a no-op yet
+          // be recorded as downloaded; it is a failed download instead.
+          if (localeContent(file.data, 'XCSTRINGS', locale) === undefined) {
+            throw new Error(
+              `The server returned no ${locale} content for this catalog`
+            );
+          }
           // The pinned serializer owns the bytes and the JSON key sorter below
           // must never see them. JSON.parse hoists integer-like keys ("404")
           // first; versionId is unaffected (slices come from the parsed object)

--- a/packages/cli/src/api/downloadFileBatch.ts
+++ b/packages/cli/src/api/downloadFileBatch.ts
@@ -477,7 +477,9 @@ export async function downloadFileBatch(
             versionId
           );
           entry.fileName = inputPath;
+          // Keep the hash upload recorded until postprocessing re-hashes the file
           entry.translations[locale] = {
+            ...entry.translations[locale],
             updatedAt: new Date().toISOString(),
             fileName: getRelative(outputPath),
           };

--- a/packages/cli/src/formats/files/__tests__/localeContent.test.ts
+++ b/packages/cli/src/formats/files/__tests__/localeContent.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+import { gt } from '../../../utils/gt.js';
 import { localeContent } from '../localeContent.js';
 
 const unit = (value: string) => ({
@@ -41,6 +42,10 @@ const deSlice =
   ) + '\n';
 
 describe('localeContent', () => {
+  afterEach(() => {
+    gt.setConfig({ customMapping: {} });
+  });
+
   it('is the content itself for a file that holds one locale', () => {
     expect(localeContent('# heading\n', 'MD', 'de')).toBe('# heading\n');
     expect(localeContent('{"a":1}', 'JSON', 'de')).toBe('{"a":1}');
@@ -67,6 +72,19 @@ describe('localeContent', () => {
     });
 
     expect(localeContent(download, 'XCSTRINGS', 'de')).toBe(deSlice);
+  });
+
+  it('slices by the canonical tag a custom mapping gives an alias locale', () => {
+    gt.setConfig({ customMapping: { french: { code: 'fr' } } });
+    const slice = localeContent(catalog, 'XCSTRINGS', 'french');
+    expect(slice).toBeDefined();
+    const strings = (
+      JSON.parse(slice!) as {
+        strings: Record<string, { localizations?: Record<string, unknown> }>;
+      }
+    ).strings;
+    expect(Object.keys(strings.greeting.localizations!)).toEqual(['fr']);
+    expect(Object.keys(strings.farewell.localizations!)).toEqual(['fr']);
   });
 
   it('is undefined when the catalog carries nothing for the locale', () => {

--- a/packages/cli/src/formats/files/__tests__/localeContent.test.ts
+++ b/packages/cli/src/formats/files/__tests__/localeContent.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { gt } from '../../../utils/gt.js';
-import { localeContent } from '../localeContent.js';
+import { emptyLocaleContent, localeContent } from '../localeContent.js';
 
 const unit = (value: string) => ({
   stringUnit: { state: 'translated', value },
@@ -93,6 +93,29 @@ describe('localeContent', () => {
 
   it('throws on content that is not a catalog', () => {
     expect(() => localeContent('not json', 'XCSTRINGS', 'de')).toThrow(
+      'Invalid .xcstrings content'
+    );
+  });
+});
+
+describe('emptyLocaleContent', () => {
+  it('is empty content for a file that holds one locale', () => {
+    expect(emptyLocaleContent('# heading\n', 'MD')).toBe('');
+    expect(emptyLocaleContent('{"a":1}', 'JSON')).toBe('');
+  });
+
+  it('is the catalog with no entries and its other fields intact', () => {
+    expect(emptyLocaleContent(catalog, 'XCSTRINGS')).toBe(
+      JSON.stringify(
+        { sourceLanguage: 'en', version: '1.0', strings: {} },
+        null,
+        2
+      ) + '\n'
+    );
+  });
+
+  it('throws on content that is not a catalog', () => {
+    expect(() => emptyLocaleContent('not json', 'XCSTRINGS')).toThrow(
       'Invalid .xcstrings content'
     );
   });

--- a/packages/cli/src/formats/files/__tests__/localeContent.test.ts
+++ b/packages/cli/src/formats/files/__tests__/localeContent.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { localeContent } from '../localeContent.js';
+
+const unit = (value: string) => ({
+  stringUnit: { state: 'translated', value },
+});
+
+const catalog = JSON.stringify({
+  sourceLanguage: 'en',
+  version: '1.0',
+  strings: {
+    Save: {},
+    greeting: {
+      comment: 'Home screen',
+      localizations: {
+        de: unit('Hallo'),
+        en: unit('Hello'),
+        fr: unit('Bonjour'),
+      },
+    },
+    farewell: {
+      localizations: { en: unit('Bye'), fr: unit('Au revoir') },
+    },
+  },
+});
+
+const deSlice =
+  JSON.stringify(
+    {
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        greeting: {
+          comment: 'Home screen',
+          localizations: { de: unit('Hallo') },
+        },
+      },
+    },
+    null,
+    2
+  ) + '\n';
+
+describe('localeContent', () => {
+  it('is the content itself for a file that holds one locale', () => {
+    expect(localeContent('# heading\n', 'MD', 'de')).toBe('# heading\n');
+    expect(localeContent('{"a":1}', 'JSON', 'de')).toBe('{"a":1}');
+  });
+
+  it('is the pinned single-locale slice of an .xcstrings catalog', () => {
+    expect(localeContent(catalog, 'XCSTRINGS', 'de')).toBe(deSlice);
+  });
+
+  it('normalizes a download shaped as the source slice plus the locale to the same bytes as the catalog slice', () => {
+    // The server returns the source slice with the locale's units added, in
+    // whatever layout it likes; only the locale's share of it is the baseline.
+    const download = JSON.stringify({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        Save: {},
+        greeting: {
+          comment: 'Home screen',
+          localizations: { en: unit('Hello'), de: unit('Hallo') },
+        },
+        farewell: { localizations: { en: unit('Bye') } },
+      },
+    });
+
+    expect(localeContent(download, 'XCSTRINGS', 'de')).toBe(deSlice);
+  });
+
+  it('is undefined when the catalog carries nothing for the locale', () => {
+    expect(localeContent(catalog, 'XCSTRINGS', 'ja')).toBeUndefined();
+  });
+
+  it('throws on content that is not a catalog', () => {
+    expect(() => localeContent('not json', 'XCSTRINGS', 'de')).toThrow(
+      'Invalid .xcstrings content'
+    );
+  });
+});

--- a/packages/cli/src/formats/files/localeContent.ts
+++ b/packages/cli/src/formats/files/localeContent.ts
@@ -1,0 +1,29 @@
+import type { FileFormat } from 'generaltranslation/types';
+import { gt } from '../../utils/gt.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+} from '../xcstrings/parseXcstrings.js';
+
+/**
+ * The content one locale of a translation file stands for on the platform.
+ * A file that holds every locale (an .xcstrings catalog) stands for its
+ * single-locale slice — what upload sends and download merges back — so the
+ * on-disk file and a download compare slice to slice. Every other format
+ * stands for the whole file. The catalog is keyed by canonical tags, so a
+ * configured alias is resolved first. Undefined when the content carries
+ * nothing for the locale. Throws on invalid content.
+ */
+export function localeContent(
+  content: string,
+  fileFormat: FileFormat,
+  locale: string
+): string | undefined {
+  if (fileFormat !== 'XCSTRINGS') return content;
+  const slice = sliceTranslationCatalog(
+    parseXcstringsCatalog(content),
+    gt.resolveCanonicalLocale(locale)
+  );
+  return slice === undefined ? undefined : serializeXcstringsSlice(slice);
+}

--- a/packages/cli/src/formats/files/localeContent.ts
+++ b/packages/cli/src/formats/files/localeContent.ts
@@ -27,3 +27,20 @@ export function localeContent(
   );
   return slice === undefined ? undefined : serializeXcstringsSlice(slice);
 }
+
+/**
+ * The content a file stands for when it carries nothing for a locale: for a
+ * file that holds every locale, the catalog with no entries and its other
+ * fields intact; for every other format, empty content. Throws on invalid
+ * content.
+ */
+export function emptyLocaleContent(
+  content: string,
+  fileFormat: FileFormat
+): string {
+  if (fileFormat !== 'XCSTRINGS') return '';
+  return serializeXcstringsSlice({
+    ...parseXcstringsCatalog(content),
+    strings: {},
+  });
+}

--- a/packages/cli/src/state/__tests__/recentDownloads.test.ts
+++ b/packages/cli/src/state/__tests__/recentDownloads.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearDownloaded,
+  getDownloadedMeta,
+  getNeedsPostprocessing,
+  recordDownloaded,
+  type DownloadMeta,
+} from '../recentDownloads.js';
+
+const IN_PLACE_FILE = 'docs.json';
+
+const meta = (locale: string): DownloadMeta => ({
+  branchId: 'branch-1',
+  fileId: 'file-1',
+  versionId: 'version-1',
+  locale,
+  fileFormat: 'JSON',
+});
+
+describe('recordDownloaded', () => {
+  afterEach(() => {
+    clearDownloaded();
+  });
+
+  it('keeps one entry per path and locale, so an in-place file keeps every locale written into it', () => {
+    recordDownloaded(IN_PLACE_FILE, meta('de'));
+    recordDownloaded(IN_PLACE_FILE, meta('fr'));
+    // A locale downloaded twice in one run is still one entry
+    recordDownloaded(IN_PLACE_FILE, meta('de'));
+
+    expect(getNeedsPostprocessing()).toEqual(new Set([IN_PLACE_FILE]));
+    const locales = getDownloadedMeta()
+      .get(IN_PLACE_FILE)
+      ?.map((entry) => entry.locale)
+      .sort();
+    expect(locales).toEqual(['de', 'fr']);
+  });
+
+  it('records a path without metadata as needing postprocessing only', () => {
+    recordDownloaded('docs/fr/guide.md');
+
+    expect(getNeedsPostprocessing()).toEqual(new Set(['docs/fr/guide.md']));
+    expect(getDownloadedMeta().has('docs/fr/guide.md')).toBe(false);
+  });
+});

--- a/packages/cli/src/state/recentDownloads.ts
+++ b/packages/cli/src/state/recentDownloads.ts
@@ -11,14 +11,19 @@ export type DownloadMeta = {
 };
 
 const recent = new Set<string>();
-const recentMeta = new Map<string, DownloadMeta>();
+// A file that holds every locale (a Mintlify composite docs.json) is written once per
+// locale, so a path keeps one entry per locale rather than the last one.
+const recentMeta = new Map<string, DownloadMeta[]>();
 const remerged = new Set<string>();
 
 export function recordDownloaded(filePath: string, meta?: DownloadMeta) {
   recent.add(filePath);
-  if (meta) {
-    recentMeta.set(filePath, meta);
-  }
+  if (!meta) return;
+  const metas = recentMeta.get(filePath) ?? [];
+  recentMeta.set(filePath, [
+    ...metas.filter((existing) => existing.locale !== meta.locale),
+    meta,
+  ]);
 }
 
 /**
@@ -38,7 +43,7 @@ export function getNeedsPostprocessing(): Set<string> {
   return new Set([...recent, ...remerged]);
 }
 
-export function getDownloadedMeta(): Map<string, DownloadMeta> {
+export function getDownloadedMeta(): Map<string, DownloadMeta[]> {
   return recentMeta;
 }
 

--- a/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
+++ b/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
@@ -4,7 +4,12 @@ import {
   findOrCreateEntry,
   readLockfile,
   writeLockfile,
+  type DownloadedVersionEntry,
 } from '../../fs/config/downloadedVersions.js';
+import {
+  emptyLocaleContent,
+  localeContent,
+} from '../../formats/files/localeContent.js';
 import type { Settings } from '../../types/index.js';
 import { hashStringSync } from '../hash.js';
 import { persistPostProcessHashes } from '../persistPostprocessHashes.js';
@@ -29,6 +34,7 @@ vi.mock('../hash.js', () => ({
 describe('persistPostProcessHashes', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(hashStringSync).mockImplementation(() => 'translated-hash');
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue('translated content');
     vi.mocked(readLockfile).mockReturnValue({
@@ -134,6 +140,67 @@ describe('persistPostProcessHashes', () => {
       },
       fr: { postProcessHash: 'translated-hash' },
     });
+    expect(writeLockfile).toHaveBeenCalledTimes(1);
+  });
+
+  it('records the hash of each locale slice under its own locale for a file that holds every locale', () => {
+    const filePath = 'App/Localizable.xcstrings';
+    const unit = (value: string) => ({
+      stringUnit: { state: 'translated', value },
+    });
+    const content = JSON.stringify({
+      sourceLanguage: 'en',
+      version: '1.0',
+      strings: {
+        greeting: {
+          localizations: {
+            de: unit('Hallo'),
+            en: unit('Hello'),
+            fr: unit('Bonjour'),
+          },
+        },
+      },
+    });
+    vi.mocked(fs.readFileSync).mockReturnValue(content);
+    vi.mocked(hashStringSync).mockImplementation((value) => `hash:${value}`);
+    const entry: DownloadedVersionEntry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: {},
+    };
+    vi.mocked(findOrCreateEntry).mockReturnValue(entry);
+    const meta = (locale: string) => ({
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      locale,
+      fileFormat: 'XCSTRINGS' as const,
+    });
+
+    persistPostProcessHashes(
+      {} as Settings,
+      new Set([filePath]),
+      new Map([[filePath, [meta('de'), meta('fr'), meta('ja')]]])
+    );
+
+    // Each locale stands for its own slice, so an edit to one locale leaves
+    // the others matching; a locale the catalog carries nothing for stands
+    // for the catalog with no entries
+    expect(entry.translations).toEqual({
+      de: {
+        postProcessHash: `hash:${localeContent(content, 'XCSTRINGS', 'de')}`,
+      },
+      fr: {
+        postProcessHash: `hash:${localeContent(content, 'XCSTRINGS', 'fr')}`,
+      },
+      ja: {
+        postProcessHash: `hash:${emptyLocaleContent(content, 'XCSTRINGS')}`,
+      },
+    });
+    expect(entry.translations.de.postProcessHash).not.toBe(
+      entry.translations.fr.postProcessHash
+    );
+    expect(hashStringSync).not.toHaveBeenCalledWith(content);
     expect(writeLockfile).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
+++ b/packages/cli/src/utils/__tests__/persistPostprocessHashes.test.ts
@@ -50,13 +50,15 @@ describe('persistPostProcessHashes', () => {
       new Map([
         [
           'out/es/messages.json',
-          {
-            branchId: 'branch-1',
-            fileId: 'file-1',
-            versionId: 'version-1',
-            locale: 'es',
-            fileFormat: 'JSON' as const,
-          },
+          [
+            {
+              branchId: 'branch-1',
+              fileId: 'file-1',
+              versionId: 'version-1',
+              locale: 'es',
+              fileFormat: 'JSON' as const,
+            },
+          ],
         ],
       ])
     );
@@ -80,13 +82,15 @@ describe('persistPostProcessHashes', () => {
       new Map([
         [
           filePath,
-          {
-            branchId: 'branch-1',
-            fileId: 'file-1',
-            versionId: 'version-1',
-            locale: 'es',
-            fileFormat: 'DOT_STRINGS' as const,
-          },
+          [
+            {
+              branchId: 'branch-1',
+              fileId: 'file-1',
+              versionId: 'version-1',
+              locale: 'es',
+              fileFormat: 'DOT_STRINGS' as const,
+            },
+          ],
         ],
       ])
     );
@@ -94,5 +98,42 @@ describe('persistPostProcessHashes', () => {
     // The recorded hash has to stand for the same content every other producer
     // and consumer of it uses, not for the file's UTF-16 bytes read as UTF-8.
     expect(hashStringSync).toHaveBeenCalledWith(text);
+  });
+
+  it('records the shared file hash under every locale written into a file that holds every locale', () => {
+    const filePath = 'docs.json';
+    const content = '{"navigation":{"languages":[]}}\n';
+    vi.mocked(fs.readFileSync).mockReturnValue(content);
+    const entry = {
+      fileId: 'file-1',
+      versionId: 'version-1',
+      translations: { de: { updatedAt: '2026-01-01T00:00:00.000Z' } },
+    };
+    vi.mocked(findOrCreateEntry).mockReturnValue(entry);
+    const meta = (locale: string) => ({
+      branchId: 'branch-1',
+      fileId: 'file-1',
+      versionId: 'version-1',
+      locale,
+      fileFormat: 'JSON' as const,
+    });
+
+    persistPostProcessHashes(
+      {} as Settings,
+      new Set([filePath]),
+      new Map([[filePath, [meta('de'), meta('fr')]]])
+    );
+
+    // One file holds every locale, so its hash is recorded for each locale
+    // merged into it this run, not only the last one written.
+    expect(hashStringSync).toHaveBeenCalledWith(content);
+    expect(entry.translations).toEqual({
+      de: {
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        postProcessHash: 'translated-hash',
+      },
+      fr: { postProcessHash: 'translated-hash' },
+    });
+    expect(writeLockfile).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/cli/src/utils/persistPostprocessHashes.ts
+++ b/packages/cli/src/utils/persistPostprocessHashes.ts
@@ -10,6 +10,10 @@ import { logger } from '../console/logger.js';
 import { getRelative } from '../fs/findFilepath.js';
 import { recordWarning } from '../state/translateWarnings.js';
 import { readFileContent } from '../fs/fileContent.js';
+import {
+  emptyLocaleContent,
+  localeContent,
+} from '../formats/files/localeContent.js';
 import type { DownloadMeta } from '../state/recentDownloads.js';
 import type { Settings } from '../types/index.js';
 
@@ -39,11 +43,20 @@ export function persistPostProcessHashes(
     if (!metas) continue;
     if (!fs.existsSync(filePath)) continue;
 
-    // The hash stands for the file's pipeline content, which is what every
-    // other producer and consumer of it compares against.
-    let hash: string;
+    // Each hash stands for the locale's share of the file's pipeline content,
+    // which is what upload records and user-edit detection compares against.
+    const hashes: [DownloadMeta, string][] = [];
     try {
-      hash = hashStringSync(readFileContent(filePath, metas[0].fileFormat));
+      const content = readFileContent(filePath, metas[0].fileFormat);
+      for (const meta of metas) {
+        hashes.push([
+          meta,
+          hashStringSync(
+            localeContent(content, meta.fileFormat, meta.locale) ??
+              emptyLocaleContent(content, meta.fileFormat)
+          ),
+        ]);
+      }
     } catch (error) {
       // The translation is already written; failing here would lose the whole
       // run's lockfile update over one unreadable file. Skip it and report it
@@ -54,9 +67,7 @@ export function persistPostProcessHashes(
       continue;
     }
 
-    // A file that holds every locale carries the same hash under each locale
-    // merged into it this run, so a local edit invalidates all of them.
-    for (const meta of metas) {
+    for (const [meta, hash] of hashes) {
       const entry = findOrCreateEntry(
         entryMap,
         data.entries,

--- a/packages/cli/src/utils/persistPostprocessHashes.ts
+++ b/packages/cli/src/utils/persistPostprocessHashes.ts
@@ -19,7 +19,7 @@ import type { Settings } from '../types/index.js';
 export function persistPostProcessHashes(
   settings: Settings,
   includeFiles: Set<string> | undefined,
-  downloadedMeta: Map<string, DownloadMeta>
+  downloadedMeta: Map<string, DownloadMeta[]>
 ): void {
   if (!includeFiles || includeFiles.size === 0 || downloadedMeta.size === 0) {
     return;
@@ -35,15 +35,15 @@ export function persistPostProcessHashes(
   let lockUpdated = false;
 
   for (const filePath of includeFiles) {
-    const meta = downloadedMeta.get(filePath);
-    if (!meta) continue;
+    const metas = downloadedMeta.get(filePath);
+    if (!metas) continue;
     if (!fs.existsSync(filePath)) continue;
 
     // The hash stands for the file's pipeline content, which is what every
     // other producer and consumer of it compares against.
     let hash: string;
     try {
-      hash = hashStringSync(readFileContent(filePath, meta.fileFormat));
+      hash = hashStringSync(readFileContent(filePath, metas[0].fileFormat));
     } catch (error) {
       // The translation is already written; failing here would lose the whole
       // run's lockfile update over one unreadable file. Skip it and report it
@@ -54,21 +54,25 @@ export function persistPostProcessHashes(
       continue;
     }
 
-    const entry = findOrCreateEntry(
-      entryMap,
-      data.entries,
-      meta.fileId,
-      meta.versionId
-    );
+    // A file that holds every locale carries the same hash under each locale
+    // merged into it this run, so a local edit invalidates all of them.
+    for (const meta of metas) {
+      const entry = findOrCreateEntry(
+        entryMap,
+        data.entries,
+        meta.fileId,
+        meta.versionId
+      );
 
-    const existing = entry.translations[meta.locale] || {};
+      const existing = entry.translations[meta.locale] || {};
 
-    if (existing.postProcessHash !== hash) {
-      entry.translations[meta.locale] = {
-        ...existing,
-        postProcessHash: hash,
-      };
-      lockUpdated = true;
+      if (existing.postProcessHash !== hash) {
+        entry.translations[meta.locale] = {
+          ...existing,
+          postProcessHash: hash,
+        };
+        lockUpdated = true;
+      }
     }
   }
 
@@ -79,11 +83,11 @@ export function persistPostProcessHashes(
 
 function findDownloadedBranchId(
   includeFiles: Set<string>,
-  downloadedMeta: Map<string, DownloadMeta>
+  downloadedMeta: Map<string, DownloadMeta[]>
 ): string | undefined {
   for (const filePath of includeFiles) {
-    const meta = downloadedMeta.get(filePath);
-    if (meta) return meta.branchId;
+    const branchId = downloadedMeta.get(filePath)?.[0]?.branchId;
+    if (branchId) return branchId;
   }
   return undefined;
 }


### PR DESCRIPTION
Stacked on #2259 (3/5). The changesets PR #2257 (5/5) sits on top of this branch.

The first two commits here are #2270 (the format-agnostic per-locale download bookkeeping fix against main) carried into the stack so this PR builds on it. They drop out on rebase once #2270 merges. Review only the last five commits.

## Problem

A `.xcstrings` catalog is one file that stands for one locale at a time on the platform. User-edit detection (`gt save-local`, `--save-local`, `options.saveLocal: true`) read the entire local catalog and byte-compared it to the server's single-locale slice. Those never match, so every locale without a matching post-process hash was submitted as a human edit, and the local catalog replaced whatever the server held for that locale.

Reproduced live in the local E2E environment: edit a German string in the dashboard, run `translate` (with the diff step on) on an unmodified catalog, and the German and Spanish slices were re-submitted from the local file, superseding the dashboard edit. With #2270 in place the hashes exist for every locale, so an unmodified catalog is skipped; this PR fixes what happens when a locale is a real candidate.

## Fix

- `formats/files/localeContent.ts` returns the locale's share of a file: the pinned single-locale slice for a catalog, the whole content for everything else. A configured alias is resolved to its canonical tag first, matching `mergeXcstringsLocale` and the upload slicer.
- `collectUserEditDiffs` runs both the local file and the server payload through it, so the compare is slice to slice and an edit is submitted under its own locale only.
- Each candidate slices its own downloaded payload. A payload that cannot be read is reported (a warning and a `skipped_file` entry in the run summary) and costs only its locale; the other locales are still checked.
- A catalog payload that carries nothing for the locale is a baseline of nothing (`emptyLocaleContent`: the catalog with no entries), the rule the loop already applied to an empty payload of any other format, so a slice written by hand into a catalog the server holds nothing for is diffed against it and submitted. A local catalog that carries nothing for a locale still has nothing to submit, as a translated file missing from disk has for every other format.
- The post-process hash is per locale. `persistPostProcessHashes` records, under each locale of a downloaded file, the hash of the content that locale stands for (`localeContent`, or `emptyLocaleContent` when the file carries nothing for it), and the skip gate in `collectUserEditDiffs` hashes the local file the same way. An edit to one locale of a catalog therefore leaves the other locales skipped, and the recorded hash is the one upload already records for a slice. For every other format `localeContent` is the whole file, so their hashes do not change.

## Notes

- #2270 records one whole-file hash under every locale of a shared file. With the slice compare alone, an edit to one locale still made every locale a candidate, and a candidate is compared against the server's current slice rather than the downloaded one, so a locale edited in the dashboard since the download was resubmitted from the stale local slice as a human edit and the dashboard edit was lost (reproduced in the final E2E run: fr edited on disk, es edited in the dashboard, `translate --save-local --force-download` pushed both). The last commit fixes this by fingerprinting each locale by its own slice. Its two hunks (`persistPostprocessHashes.ts` and the skip gate in `collectUserEditDiffs.ts`) are a no-op on main today, where `localeContent` is the whole file for every format, and can move into #2270 if that is the preferred home.
- Lockfiles written by the pre-fix CLI carry a hash for one locale only. The first run against such a lockfile still treats the other locales as candidates. Delete the stale entry in the local test apps before re-running.
- No changeset here; the feature ships in #2257 at the top of the stack, and #2270 carries its own patch changeset.

## Tests

`pnpm vitest run` over the xcstrings, files, download, user-edit, bookkeeping, state and upload suites: 20 files, 336 tests passing. `tsc --noEmit`, `oxfmt --check` and `oxlint` clean. The bookkeeping suite includes a regression test for the E2E scenario (one locale changed on the server, another edited on disk) that fails on the previous head and passes now.










<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `.xcstrings` local-edit detection and download bookkeeping locale-aware.
- Extracts canonical, pinned locale slices for comparisons and hashes.
- Persists post-process hashes independently for each locale in shared catalogs.
- Isolates malformed downloaded payloads so one locale does not abort the batch.
- Preserves existing download hashes until post-processing records replacements.
- Adds focused unit and lifecycle coverage for local edits, empty slices, aliases, malformed payloads, and concurrent server/local changes.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the prior malformed-payload and first-entry findings are fixed, while the deletion and ordering findings were correctly withdrawn.

Locale slices are now hashed and compared consistently, malformed server payloads are handled per candidate, and focused lifecycle tests cover the stale-server-edit scenario that motivated the latest change. The earlier empty-locale concern is addressed for newly added translations, and the no-content deletion state remains intentionally unsupported as previously conceded.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/files/localeContent.ts | Centralizes canonical `.xcstrings` locale slicing and empty-locale serialization while retaining whole-file behavior for other formats. |
| packages/cli/src/api/collectUserEditDiffs.ts | Compares local and server content per locale and isolates malformed payload failures without aborting later candidates. |
| packages/cli/src/utils/persistPostprocessHashes.ts | Records the final post-processed hash of each locale’s logical content under its own lockfile entry. |
| packages/cli/src/state/recentDownloads.ts | Retains download metadata for every locale sharing an output path instead of only the last locale. |
| packages/cli/src/api/downloadFileBatch.ts | Preserves a previously confirmed post-process hash while refreshing download metadata. |
| packages/cli/src/api/__tests__/xcstringsCatalogBookkeeping.test.ts | Exercises the complete shared-catalog lifecycle, including independent disk and server edits. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Downloaded locale payload] --> B[Extract canonical locale slice]
  C[Local shared catalog] --> D[Extract same locale slice]
  B --> E[Slice-to-slice diff]
  D --> E
  E -->|Changed| F[Submit locale-specific user edit]
  E -->|Unchanged| G[Skip submission]
  C --> H[Post-process]
  H --> I[Hash each locale slice]
  I --> J[Persist per-locale lockfile hashes]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(cli): fingerprint each catalog local..."](https://github.com/generaltranslation/gt/commit/e9c41b38e7f7be6e71e3f6e7abf17aeeb2912ce1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61876991)</sub>

**Context used:**

- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)

<!-- /greptile_comment -->