### PR TITLE
fix(next): [2/7] normalize middleware pathnames

### DIFF
--- a/.changeset/normalize-middleware-paths.md
+++ b/.changeset/normalize-middleware-paths.md
@@ -1,0 +1,9 @@
+---
+'gt-next': patch
+---
+
+Match encoded request paths against normalized Unicode middleware paths.
+
+Preserve encoded dynamic parameter values during redirects and rewrites, decode static lookup keys only once, and avoid redirect loops for encoded or decomposed Unicode path templates.
+
+Keep percent-encoded bracket literals distinct from dynamic route syntax.

--- a/packages/next/src/middleware-dir/__tests__/encodedLocaleRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/encodedLocaleRegression.edge.test.ts
@@ -51,6 +51,47 @@ describe.each([false, true])(
       }
     });
 
+    it.each(['%66r', 'f%72', 'fr'])(
+      'preserves category %s after an actual locale prefix',
+      (category) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: {
+            '/posts/[id]': { en: '/entries/[id]', fr: '/articles/[id]' },
+            '/[category]/articles/[id]': { en: '/[category]/articles/[id]' },
+          },
+        });
+        const response = middleware(
+          new NextRequest(`${origin}/fr/${category}/articles/a${query}`)
+        );
+
+        expect(response.headers.get('location')).toBeNull();
+        expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+        expect(response.headers.get('x-generaltranslation-locale')).toBe('fr');
+        expect(
+          response.cookies.get('generaltranslation.locale-routing-enabled')
+            ?.value
+        ).toBe('true');
+      }
+    );
+
+    it('does not match an exact localized alias after removing the locale prefix', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: {
+          '/posts': { en: '/entries', fr: '/articles' },
+          '/[category]/articles': { en: '/[category]/articles' },
+        },
+      });
+      const response = middleware(
+        new NextRequest(`${origin}/fr/%66r/articles${query}`)
+      );
+
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+      expect(response.headers.get('x-generaltranslation-locale')).toBe('fr');
+    });
+
     it.each(['en', 'fr'])(
       'still recognizes the literal %s prefix',
       (locale) => {

--- a/packages/next/src/middleware-dir/__tests__/encodedLocaleRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/encodedLocaleRegression.edge.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+const origin = 'http://localhost:3000';
+const query = '?tag=a&tag=b';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe.each([false, true])(
+  'encoded locale-like route segments, prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    it.each([
+      ['%66r', 'articles'],
+      ['f%72', 'articles'],
+      ['%65n', 'entries'],
+      ['e%6E', 'entries'],
+      ['%2566r', 'articles'],
+      ['bad%escape', 'articles'],
+      ['%E0%A4%A', 'articles'],
+    ])('preserves category %s and the ID in /%s routes', (category, alias) => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: {
+          '/posts/[id]': { en: '/entries/[id]', fr: '/articles/[id]' },
+          [`/[category]/${alias}/[id]`]: {
+            en: `/[category]/${alias}/[id]`,
+          },
+        },
+      });
+      for (const id of ['one', 'value%252Fpart', 'bad%escape']) {
+        const path = `/${category}/${alias}/${id}`;
+        const response = middleware(new NextRequest(origin + path + query));
+        const destination = origin + '/en' + path + query;
+        expect(response.headers.get('location')).toBe(
+          prefixDefaultLocale ? destination : null
+        );
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+          prefixDefaultLocale ? null : destination
+        );
+      }
+    });
+
+    it.each(['en', 'fr'])(
+      'still recognizes the literal %s prefix',
+      (locale) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: {
+            '/posts/[id]': { en: '/entries/[id]', fr: '/articles/[id]' },
+            '/[category]/articles/[id]': { en: '/[category]/articles/[id]' },
+          },
+        });
+        const alias = locale === 'en' ? 'entries' : 'articles';
+        const response = middleware(
+          new NextRequest(`${origin}/${locale}/${alias}/one${query}`)
+        );
+        expect(response.headers.get('location')).toBeNull();
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+          `${origin}/${locale}/posts/one${query}`
+        );
+      }
+    );
+
+    it('does not consume an encoded locale when no unprefixed route matches', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: { '/posts/[id]': { fr: '/articles/[id]' } },
+      });
+      const response = middleware(
+        new NextRequest(origin + '/%66r/articles/one' + query)
+      );
+      const destination = origin + '/en/%66r/articles/one' + query;
+      expect(response.headers.get('location')).toBe(
+        prefixDefaultLocale ? destination : null
+      );
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        prefixDefaultLocale ? null : destination
+      );
+    });
+
+    it('still normalizes a shared static path beginning with an encoded locale', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: {
+          '/posts': { fr: '/café' },
+          '/fr/café': { en: '/category' },
+        },
+      });
+      const response = middleware(
+        new NextRequest(origin + '/%66r/cafe%CC%81' + query)
+      );
+      expect(response.headers.get('location')).toBe(
+        origin + (prefixDefaultLocale ? '/en' : '') + '/category' + query
+      );
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    });
+  }
+);
+
+it('still normalizes unprefixed default aliases and gives them locale precedence', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: false,
+    pathConfig: {
+      '/posts/[id]': { fr: '/café/[id]' },
+      '/categories/[id]/article': {
+        en: '/fr/[id]/article',
+        fr: '/catégories/[id]/article',
+      },
+    },
+  });
+  const response = middleware(
+    new NextRequest(origin + '/%66r/cafe%CC%81/article' + query, {
+      headers: { cookie: 'generaltranslation.locale=fr' },
+    })
+  );
+  expect(response.headers.get('location')).toBeNull();
+  expect(response.headers.get('x-middleware-rewrite')).toBe(
+    origin + '/en/categories/cafe%CC%81/article' + query
+  );
+});

--- a/packages/next/src/middleware-dir/__tests__/encodingRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/encodingRegression.edge.test.ts
@@ -169,3 +169,108 @@ it('keeps encoded shared literals ahead of localized dynamic aliases', () => {
   expect(response.headers.get('location')).toBeNull();
   expect(response.headers.get('x-middleware-rewrite')).toBeNull();
 });
+
+describe.each([true, false])(
+  'route identity, prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    const reservedEscapes = [
+      '2F',
+      '3F',
+      '23',
+      '26',
+      '3A',
+      '3B',
+      '2B',
+      '3D',
+      '24',
+      '2C',
+      '40',
+    ];
+
+    it.each(reservedEscapes)(
+      'keeps aliases containing %s distinct from double-encoded aliases',
+      (escape) => {
+        for (const suffix of ['', '/[id]']) {
+          const firstAlias = '/a%' + escape + 'b';
+          const secondAlias = '/a%25' + escape + 'b';
+          const middleware = createNextMiddleware({
+            prefixDefaultLocale,
+            pathConfig: {
+              ['/one' + suffix]: {
+                en: firstAlias + suffix,
+                fr: firstAlias + suffix,
+              },
+              ['/two' + suffix]: {
+                en: secondAlias + suffix,
+                fr: secondAlias + suffix,
+              },
+            },
+          });
+          const parameter = suffix ? '/value%252Fpart' : '';
+          for (const locale of ['en', 'fr']) {
+            const prefix =
+              locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+            for (const [alias, shared] of [
+              [firstAlias, '/one'],
+              [secondAlias, '/two'],
+            ]) {
+              const response = middleware(
+                request(prefix + alias + parameter + '?tag=a&tag=b')
+              );
+              expect(response.headers.get('location')).toBeNull();
+              expect(response.headers.get('x-middleware-rewrite')).toBe(
+                origin + '/' + locale + shared + parameter + '?tag=a&tag=b'
+              );
+            }
+          }
+        }
+      }
+    );
+
+    it.each(reservedEscapes)(
+      'does not match a double-encoded request against a static %s alias',
+      (escape) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: { '/docs': { fr: '/a%' + escape + 'b' } },
+        });
+        const response = middleware(request('/fr/a%25' + escape + 'b'));
+        expect(response.headers.get('location')).toBeNull();
+        expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+      }
+    );
+
+    it('rewrites a decomposed alias to the shared route spelling', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: { '/café': { en: '/cafe%CC%81', fr: '/cafe%CC%81' } },
+      });
+      for (const locale of ['en', 'fr']) {
+        const prefix =
+          locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+        const response = middleware(request(prefix + '/cafe%CC%81'));
+        expect(response.headers.get('location')).toBeNull();
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+          origin + '/' + locale + '/caf%C3%A9'
+        );
+      }
+    });
+
+    it('keeps encoded regex-looking static segments literal', () => {
+      const alias = '/literal/%5B%5E/%5D+';
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: { '/docs': { fr: alias } },
+      });
+      const unrelated = middleware(request('/fr/literal/unrelated'));
+      expect(unrelated.headers.get('location')).toBeNull();
+      expect(unrelated.headers.get('x-middleware-rewrite')).toBeNull();
+
+      const matched = middleware(request('/fr' + alias));
+      expect(matched.headers.get('location')).toBeNull();
+      expect(matched.headers.get('x-middleware-rewrite')).toBe(
+        origin + '/fr/docs'
+      );
+    });
+  }
+);

--- a/packages/next/src/middleware-dir/__tests__/encodingRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/encodingRegression.edge.test.ts
@@ -1,0 +1,171 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+const origin = 'http://localhost:3000';
+const request = (path: string) => new NextRequest(origin + path);
+
+it.each(['caf%C3%A9-fran%C3%A7ais', 'café-français', 'cafe\u0301-français'])(
+  'matches Unicode pathConfig entries against %s',
+  (alias) => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: true,
+      pathConfig: { '/café/[slug]': { fr: '/café-français/[slug]' } },
+    });
+    const response = middleware(request('/fr/' + alias + '/article'));
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('x-middleware-rewrite')).toBe(
+      origin + '/fr/caf%C3%A9/article'
+    );
+  }
+);
+
+describe.each([true, false])(
+  'encoded paths, prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    it.each(['bad%escape', '%E0%A4%A'])(
+      'normalizes static segments independently of malformed parameter %s',
+      (value) => {
+        for (const alias of ['/café', '/notes%5Bfr%5D']) {
+          const middleware = createNextMiddleware({
+            prefixDefaultLocale,
+            pathConfig: {
+              '/docs/[id]': { en: alias + '/[id]', fr: alias + '/[id]' },
+            },
+          });
+          for (const locale of ['en', 'fr']) {
+            const prefix =
+              locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+            const response = middleware(
+              request(prefix + alias + '/' + value + '?tag=a&tag=b')
+            );
+            expect(response.headers.get('location')).toBeNull();
+            expect(response.headers.get('x-middleware-rewrite')).toBe(
+              origin + '/' + locale + '/docs/' + value + '?tag=a&tag=b'
+            );
+          }
+        }
+      }
+    );
+
+    it.each([
+      'a%252Fb',
+      '100%25',
+      'a%5Cb',
+      'a%0Ab',
+      'a%09b',
+      'a%0Db',
+      'a%2Fb',
+      'a%3Fb',
+      'a%23b',
+      'a%26b',
+      '%C3%A9',
+      'e%CC%81',
+      'a%255Cb',
+      '%252e%252e',
+      '%E0%A4%A',
+      'bad%escape',
+    ])(
+      'preserves parameter bytes for %s through redirects and rewrites',
+      (value) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: {
+            '/posts/[id]': { en: '/entries/[id]', fr: '/articles/[id]' },
+          },
+        });
+        for (const locale of ['en', 'fr']) {
+          const prefix =
+            locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+          const alias = locale === 'en' ? '/entries/' : '/articles/';
+          const publicPath = prefix + alias + value;
+          const response = middleware(request(publicPath + '?tag=a&tag=b'));
+          expect(response.headers.get('location')).toBeNull();
+          expect(response.headers.get('x-middleware-rewrite')).toBe(
+            origin + '/' + locale + '/posts/' + value + '?tag=a&tag=b'
+          );
+          const redirect = middleware(
+            request(prefix + '/posts/' + value + '?tag=a&tag=b')
+          );
+          expect(redirect.headers.get('location')).toBe(
+            origin + publicPath + '?tag=a&tag=b'
+          );
+        }
+      }
+    );
+
+    it.each(['/notes%5Bfr%5D', '/cafe\u0301', '/café', '/c++', '/100%25'])(
+      'terminates for encoded or Unicode static template %s',
+      (alias) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: { '/docs': { en: alias, fr: alias } },
+        });
+        for (const locale of ['en', 'fr']) {
+          const prefix =
+            locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+          const response = middleware(request(prefix + alias));
+          expect(response.headers.get('location')).toBeNull();
+          expect(response.headers.get('x-middleware-rewrite')).toBe(
+            origin + '/' + locale + '/docs'
+          );
+        }
+      }
+    );
+  }
+);
+
+it('does not decode a double-encoded static segment twice', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: true,
+    pathConfig: { '/docs/[id]': { fr: '/café/[id]' } },
+  });
+  const response = middleware(request('/fr/caf%25C3%25A9/123'));
+  expect(response.headers.get('location')).toBeNull();
+  expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+});
+
+it.each(['%5Bid%5D', '%5B...slug%5D', '%5B%5B...slug%5D%5D'])(
+  'does not promote encoded literal %s into a dynamic route',
+  (literal) => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: true,
+      pathConfig: { '/docs': { fr: '/' + literal } },
+    });
+    const unrelated = middleware(request('/fr/unrelated'));
+    expect(unrelated.headers.get('location')).toBeNull();
+    expect(unrelated.headers.get('x-middleware-rewrite')).toBeNull();
+    const matched = middleware(request('/fr/' + literal));
+    expect(matched.headers.get('location')).toBeNull();
+    expect(matched.headers.get('x-middleware-rewrite')).toBe(
+      origin + '/fr/docs'
+    );
+  }
+);
+
+it('keeps encoded shared literals ahead of localized dynamic aliases', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: true,
+    pathConfig: {
+      '/%5Bid%5D': { en: '/%5Bid%5D' },
+      '/docs/[slug]': { fr: '/[slug]' },
+    },
+  });
+  const response = middleware(request('/fr/%5Bid%5D'));
+  expect(response.headers.get('location')).toBeNull();
+  expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+});

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -5,9 +5,30 @@ import {
   replaceDynamicSegments,
   getLocalizedPath,
   createPathToSharedPathMap,
-  getSharedPath,
+  getSharedPath as getSharedPathWithMaps,
   type PathConfig,
 } from '../utils';
+
+function getSharedPath(
+  pathname: string,
+  paths: Record<string, string>,
+  pathnameLocale: string | undefined
+): string | undefined {
+  const sharedPaths = Object.fromEntries(
+    Object.values(paths).map((sharedPath) => [sharedPath, sharedPath])
+  );
+  const { sharedOnlyPathToSharedPath } = createPathToSharedPathMap(
+    sharedPaths,
+    true,
+    'en'
+  );
+  return getSharedPathWithMaps(
+    pathname,
+    paths,
+    pathnameLocale,
+    sharedOnlyPathToSharedPath
+  );
+}
 
 describe('extractLocale', () => {
   it('should extract locale from various pathname formats', () => {

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -364,12 +364,13 @@ export function createNextMiddleware({
         return getRedirectResponse(localizedPathWithParameters);
       }
 
-      // REWRITE CASE: displaying correct localized path, which is the same as the shared path (/fil/blog => /fil/blog) (/fr/fr-dashboard/1/fr-custom => /fr/dashboard/1/custom)
-      if (
-        normalizePathname(standardizedPathname) !==
-        normalizePathname(sharedPathWithParameters as string) // no rewrite needed if it's already the shared path
-      ) {
-        // convert to shared path with dynamic parameters
+      // Next.js route identity preserves Unicode spelling, even when lookup
+      // considers the public alias and shared path canonically equivalent.
+      const rewriteUrl = new URL(
+        sharedPathWithParameters as string,
+        req.nextUrl
+      );
+      if (req.nextUrl.pathname !== rewriteUrl.pathname) {
         return getRewriteResponse(sharedPathWithParameters as string);
       }
     }

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -364,13 +364,17 @@ export function createNextMiddleware({
         return getRedirectResponse(localizedPathWithParameters);
       }
 
+      // REWRITE CASE: displaying correct localized path, which is the same as the shared path (/fil/blog => /fil/blog) (/fr/fr-dashboard/1/fr-custom => /fr/dashboard/1/custom)
       // Next.js route identity preserves Unicode spelling, even when lookup
       // considers the public alias and shared path canonically equivalent.
       const rewriteUrl = new URL(
         sharedPathWithParameters as string,
         req.nextUrl
       );
-      if (req.nextUrl.pathname !== rewriteUrl.pathname) {
+      if (
+        req.nextUrl.pathname !== rewriteUrl.pathname // no rewrite needed if it's already the shared path
+      ) {
+        // convert to shared path with dynamic parameters
         return getRewriteResponse(sharedPathWithParameters as string);
       }
     }

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -150,11 +150,8 @@ export function createNextMiddleware({
   );
 
   // Create the path mapping
-  const { pathToSharedPath, defaultLocalePaths } = createPathToSharedPathMap(
-    pathConfig,
-    prefixDefaultLocale,
-    defaultLocale
-  );
+  const { pathToSharedPath, unprefixedPathToSharedPath, defaultLocalePaths } =
+    createPathToSharedPathMap(pathConfig, prefixDefaultLocale, defaultLocale);
 
   /**
    * Processes the incoming request to determine the user's locale and sets a locale cookie.
@@ -241,9 +238,11 @@ export function createNextMiddleware({
           : pathname;
 
       // Get the shared path for the unprefixed pathname
+      // Normalization must not turn an unrecognized prefix (such as %66r)
+      // into a locale: it may be a static route segment or a dynamic value.
       const sharedPath = getSharedPath(
         standardizedPathname,
-        pathToSharedPath,
+        pathnameLocale ? pathToSharedPath : unprefixedPathToSharedPath,
         pathnameLocale
       );
 

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -150,8 +150,12 @@ export function createNextMiddleware({
   );
 
   // Create the path mapping
-  const { pathToSharedPath, unprefixedPathToSharedPath, defaultLocalePaths } =
-    createPathToSharedPathMap(pathConfig, prefixDefaultLocale, defaultLocale);
+  const {
+    pathToSharedPath,
+    unprefixedPathToSharedPath,
+    sharedOnlyPathToSharedPath,
+    defaultLocalePaths,
+  } = createPathToSharedPathMap(pathConfig, prefixDefaultLocale, defaultLocale);
 
   /**
    * Processes the incoming request to determine the user's locale and sets a locale cookie.
@@ -243,7 +247,8 @@ export function createNextMiddleware({
       const sharedPath = getSharedPath(
         standardizedPathname,
         pathnameLocale ? pathToSharedPath : unprefixedPathToSharedPath,
-        pathnameLocale
+        pathnameLocale,
+        sharedOnlyPathToSharedPath
       );
 
       // Get shared path with parameters (/en/dashboard/1/custom), for rewriting localized paths

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -13,6 +13,7 @@ import {
 } from '@generaltranslation/react-core/pure';
 import {
   PathConfig,
+  normalizePathname,
   getSharedPath,
   replaceDynamicSegments,
   getLocalizedPath,
@@ -337,7 +338,8 @@ export function createNextMiddleware({
           // REDIRECT CASE: unprefixed pathname is wrong (/about -> /en-about)
           if (
             !pathnameLocale &&
-            localizedPathWithParameters !== `/${userLocale}${pathname}`
+            normalizePathname(localizedPathWithParameters) !==
+              normalizePathname(`/${userLocale}${pathname}`)
           ) {
             return getRedirectResponse(
               localizedPathWithParameters.replace(
@@ -355,13 +357,17 @@ export function createNextMiddleware({
       // --- CASE: add defaultLocale prefix --- //
 
       // REDIRECT CASE: incorrect pathnameLocale
-      if (pathname !== localizedPathWithParameters) {
+      if (
+        normalizePathname(pathname) !==
+        normalizePathname(localizedPathWithParameters)
+      ) {
         return getRedirectResponse(localizedPathWithParameters);
       }
 
       // REWRITE CASE: displaying correct localized path, which is the same as the shared path (/fil/blog => /fil/blog) (/fr/fr-dashboard/1/fr-custom => /fr/dashboard/1/custom)
       if (
-        standardizedPathname !== sharedPathWithParameters // no rewrite needed if it's already the shared path
+        normalizePathname(standardizedPathname) !==
+        normalizePathname(sharedPathWithParameters as string) // no rewrite needed if it's already the shared path
       ) {
         // convert to shared path with dynamic parameters
         return getRewriteResponse(sharedPathWithParameters as string);

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -1,9 +1,10 @@
-/** Normalizes each segment without conflating escaped separators or encoding levels. */
+/** Normalizes segments independently so malformed params cannot block static normalization. */
 export function normalizePathname(pathname: string): string {
   return pathname
     .split('/')
     .map((segment) => {
       try {
+        // Re-encode each segment so escaped separators and encoding levels stay distinct.
         return encodeURIComponent(decodeURIComponent(segment).normalize('NFC'));
       } catch {
         // Preserve malformed escape sequences without rejecting the request.

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -1,15 +1,14 @@
-/** Normalizes segments independently so malformed params cannot block static normalization. */
+/** Normalizes each segment without conflating escaped separators or encoding levels. */
 export function normalizePathname(pathname: string): string {
   return pathname
     .split('/')
     .map((segment) => {
-      let normalizedSegment = segment;
       try {
-        normalizedSegment = decodeURI(segment);
+        return encodeURIComponent(decodeURIComponent(segment).normalize('NFC'));
       } catch {
         // Preserve malformed escape sequences without rejecting the request.
+        return segment.normalize('NFC');
       }
-      return normalizedSegment.normalize('NFC');
     })
     .join('/');
 }

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -1,0 +1,15 @@
+/** Normalizes segments independently so malformed params cannot block static normalization. */
+export function normalizePathname(pathname: string): string {
+  return pathname
+    .split('/')
+    .map((segment) => {
+      let normalizedSegment = segment;
+      try {
+        normalizedSegment = decodeURI(segment);
+      } catch {
+        // Preserve malformed escape sequences without rejecting the request.
+      }
+      return normalizedSegment.normalize('NFC');
+    })
+    .join('/');
+}

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -172,16 +172,24 @@ export function createPathToSharedPathMap(
   defaultLocale: string
 ): {
   pathToSharedPath: { [key: string]: string };
+  unprefixedPathToSharedPath: { [key: string]: string };
   defaultLocalePaths: string[];
 } {
   return Object.entries(pathConfig).reduce<{
     pathToSharedPath: { [key: string]: string };
+    unprefixedPathToSharedPath: { [key: string]: string };
     defaultLocalePaths: string[];
   }>(
     (acc, [sharedPath, localizedPaths]) => {
-      const { pathToSharedPath, defaultLocalePaths } = acc;
+      const {
+        pathToSharedPath,
+        unprefixedPathToSharedPath,
+        defaultLocalePaths,
+      } = acc;
       // Preserve raw templates for parameter substitution and output URLs.
-      pathToSharedPath[createPathPattern(sharedPath)] = sharedPath;
+      const sharedPattern = createPathPattern(sharedPath);
+      pathToSharedPath[sharedPattern] = sharedPath;
+      unprefixedPathToSharedPath[sharedPattern] = sharedPath;
 
       if (typeof localizedPaths === 'object') {
         Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
@@ -191,13 +199,18 @@ export function createPathToSharedPathMap(
           pathToSharedPath[`/${locale}${pattern}`] = sharedPath;
           if (!prefixDefaultLocale && locale === defaultLocale) {
             pathToSharedPath[pattern] = sharedPath;
+            unprefixedPathToSharedPath[pattern] = sharedPath;
             defaultLocalePaths.push(pattern);
           }
         });
       }
       return acc;
     },
-    { pathToSharedPath: {}, defaultLocalePaths: [] }
+    {
+      pathToSharedPath: {},
+      unprefixedPathToSharedPath: {},
+      defaultLocalePaths: [],
+    }
   );
 }
 

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -3,6 +3,9 @@ import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
+import { normalizePathname } from './pathname';
+
+export { normalizePathname };
 
 export type PathConfig = {
   [key: string]: string | { [key: string]: string };
@@ -22,10 +25,24 @@ export type ResponseConfig = {
 };
 
 const DYNAMIC_PATH_SEGMENT_PATTERN = '/[^/]+';
-const PATH_REGEX_SLASHES = /[\\/]/g;
+/** Normalizes each segment once without decoding encoded separators. */
+function normalizePathForMatching(pathname: string): string {
+  return pathname.split('/').map(normalizePathname).join('/');
+}
 
-function escapePathRegexSlashes(pathPattern: string): string {
-  return pathPattern.replace(PATH_REGEX_SLASHES, '\\$&');
+/** Classifies placeholders before decoding static path content. */
+function createPathPattern(pathname: string): string {
+  if (!/\[([^\]]+)\]/.test(pathname)) {
+    return normalizePathForMatching(pathname);
+  }
+  return pathname
+    .split(/(\[[^\]]+\])/)
+    .map((part, index) =>
+      index % 2
+        ? '[^/]+'
+        : normalizePathForMatching(part).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    )
+    .join('');
 }
 
 export function getResponse({
@@ -163,19 +180,14 @@ export function createPathToSharedPathMap(
   }>(
     (acc, [sharedPath, localizedPaths]) => {
       const { pathToSharedPath, defaultLocalePaths } = acc;
-      // Add the shared path itself, converting to regex pattern if it has dynamic segments
-      if (sharedPath.includes('[')) {
-        const pattern = sharedPath.replace(/\[([^\]]+)\]/g, '[^/]+');
-        pathToSharedPath[pattern] = sharedPath;
-      } else {
-        pathToSharedPath[sharedPath] = sharedPath;
-      }
+      // Preserve raw templates for parameter substitution and output URLs.
+      pathToSharedPath[createPathPattern(sharedPath)] = sharedPath;
 
       if (typeof localizedPaths === 'object') {
         Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
           // Convert the localized path to a regex pattern
           // Replace [param] with [^/]+ to match any non-slash characters
-          const pattern = localizedPath.replace(/\[([^\]]+)\]/g, '[^/]+');
+          const pattern = createPathPattern(localizedPath);
           pathToSharedPath[`/${locale}${pattern}`] = sharedPath;
           if (!prefixDefaultLocale && locale === defaultLocale) {
             pathToSharedPath[pattern] = sharedPath;
@@ -197,6 +209,7 @@ export function getSharedPath(
   pathToSharedPath: { [key: string]: string },
   pathnameLocale: string | undefined
 ): string | undefined {
+  standardizedPathname = normalizePathForMatching(standardizedPathname);
   // Try exact match first
   if (pathToSharedPath[standardizedPathname]) {
     return pathToSharedPath[standardizedPathname];
@@ -217,7 +230,7 @@ export function getSharedPath(
   for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
     if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
       // Convert the pattern to a strict regex that matches the exact path structure
-      const regex = new RegExp(`^${escapePathRegexSlashes(pattern)}$`);
+      const regex = new RegExp(`^${pattern}$`);
       // Exact match
       if (regex.test(standardizedPathname)) {
         return sharedPath;
@@ -246,6 +259,7 @@ function inDefaultLocalePaths(
   pathname: string,
   defaultLocalePaths: string[]
 ): boolean {
+  pathname = normalizePathForMatching(pathname);
   // Try exact match first
   if (defaultLocalePaths.includes(pathname)) {
     return true;
@@ -254,7 +268,7 @@ function inDefaultLocalePaths(
   // Try regex pattern match
   for (const path of defaultLocalePaths) {
     if (path.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
-      const regex = new RegExp(`^${escapePathRegexSlashes(path)}$`);
+      const regex = new RegExp(`^${path}$`);
       if (regex.test(pathname)) {
         return true;
       }

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -173,23 +173,27 @@ export function createPathToSharedPathMap(
 ): {
   pathToSharedPath: { [key: string]: string };
   unprefixedPathToSharedPath: { [key: string]: string };
+  sharedOnlyPathToSharedPath: { [key: string]: string };
   defaultLocalePaths: string[];
 } {
   return Object.entries(pathConfig).reduce<{
     pathToSharedPath: { [key: string]: string };
     unprefixedPathToSharedPath: { [key: string]: string };
+    sharedOnlyPathToSharedPath: { [key: string]: string };
     defaultLocalePaths: string[];
   }>(
     (acc, [sharedPath, localizedPaths]) => {
       const {
         pathToSharedPath,
         unprefixedPathToSharedPath,
+        sharedOnlyPathToSharedPath,
         defaultLocalePaths,
       } = acc;
       // Preserve raw templates for parameter substitution and output URLs.
       const sharedPattern = createPathPattern(sharedPath);
       pathToSharedPath[sharedPattern] = sharedPath;
       unprefixedPathToSharedPath[sharedPattern] = sharedPath;
+      sharedOnlyPathToSharedPath[sharedPattern] = sharedPath;
 
       if (typeof localizedPaths === 'object') {
         Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
@@ -209,6 +213,7 @@ export function createPathToSharedPathMap(
     {
       pathToSharedPath: {},
       unprefixedPathToSharedPath: {},
+      sharedOnlyPathToSharedPath: {},
       defaultLocalePaths: [],
     }
   );
@@ -220,7 +225,8 @@ export function createPathToSharedPathMap(
 export function getSharedPath(
   standardizedPathname: string,
   pathToSharedPath: { [key: string]: string },
-  pathnameLocale: string | undefined
+  pathnameLocale: string | undefined,
+  sharedOnlyPathToSharedPath: { [key: string]: string }
 ): string | undefined {
   standardizedPathname = normalizePathForMatching(standardizedPathname);
   // Try exact match first
@@ -233,13 +239,12 @@ export function getSharedPath(
   // Only remove locale prefix if the locale prefix is valid
   if (pathnameLocale) {
     pathnameWithoutLocale = standardizedPathname.replace(/^\/[^/]+/, '');
-    if (pathToSharedPath[pathnameWithoutLocale]) {
-      return pathToSharedPath[pathnameWithoutLocale];
+    if (sharedOnlyPathToSharedPath[pathnameWithoutLocale]) {
+      return sharedOnlyPathToSharedPath[pathnameWithoutLocale];
     }
   }
 
   // Try regex pattern match
-  let candidateSharedPath = undefined;
   for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
     if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
       // Convert the pattern to a strict regex that matches the exact path structure
@@ -248,17 +253,24 @@ export function getSharedPath(
       if (regex.test(standardizedPathname)) {
         return sharedPath;
       }
-      // Without locale prefix
+    }
+  }
+
+  // Without locale prefix
+  // Once the locale is removed, the remaining segments are shared route data.
+  if (pathnameWithoutLocale !== undefined) {
+    for (const [pattern, sharedPath] of Object.entries(
+      sharedOnlyPathToSharedPath
+    )) {
       if (
-        !candidateSharedPath &&
-        pathnameLocale &&
-        regex.test(pathnameWithoutLocale as string)
+        pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN) &&
+        new RegExp(`^${pattern}$`).test(pathnameWithoutLocale)
       ) {
-        candidateSharedPath = sharedPath;
+        return sharedPath;
       }
     }
   }
-  return candidateSharedPath;
+  return undefined;
 }
 
 /**


### PR DESCRIPTION
request pathnames and configured templates were compared as raw strings, so an alias with unicode or percent-encoded text matched only when the request used the same bytes.

**normalization.** `normalizePathname` (`pathname.ts:8`) normalizes each segment separately with `encodeURIComponent(decodeURIComponent(segment).normalize('NFC'))`. a segment with a malformed escape falls back to `segment.normalize('NFC')` (`pathname.ts:11`), so one bad parameter value no longer blocks the static segments beside it. a template segment is classified as static or dynamic before its text is decoded, so `%5Bid%5D` stays a literal. encoding levels stay distinct: `a%2Fb` and `a%252Fb` differ.

**comparisons.** the two redirect checks compare normalized pathnames (`createNextMiddleware.ts:407` and `:424`), so a decomposed request for a composed template is rewritten instead of redirected into a loop. the rewrite check compares serialized url pathnames (`createNextMiddleware.ts:437` to `:442`), so a decomposed public alias rewrites to the shared route's exact spelling, which next uses as the route identity.

**lookup scope.** normalization decodes `%66r` to `fr`, so lookups are scoped. an unprefixed request is looked up against shared routes and enabled default-locale aliases only, and a locale-stripped lookup uses shared routes only. `/fr/%66r/articles` with `{'/posts': {en: '/entries', fr: '/articles'}}` passes through as a french request instead of hitting the `/articles` alias.

```
/fr/cafe%CC%81-fran%C3%A7ais/article   rewrite -> /fr/caf%C3%A9/article            template /café-français/[slug] for shared /café/[slug]
/fr/cafe%CC%81                         rewrite -> /fr/caf%C3%A9                    template /cafe%CC%81 for shared /café
/caf%C3%A9/bad%escape?tag=a&tag=b      rewrite -> /en/docs/bad%escape?tag=a&tag=b  template /café/[id] for shared /docs/[id]
/%66r/articles/one                     rewrite -> /en/%66r/articles/one            shared /[category]/articles/[id]; %66r is a category
```

**verified.** the two new edge-runtime files are `encodedLocaleRegression.edge.test.ts` and `encodingRegression.edge.test.ts`; 16 parameter encodings run through redirects and rewrites in both prefix modes. at the stack head (6d4f27811) 1,192 middleware-dir tests and 1,413 package tests pass across 42 files and typecheck is clean. live at c9d3ee587, the head i reviewed, 322 hostile probes (encoded slashes and dots, `%00`, 3,000-char segments, decomposed unicode) produced 0 wrong pages, loops, off-origin targets, lost queries or lost encodings. the only 500s are next's own `URIError` on a malformed escape in a dynamic segment, identical on main. composed and decomposed spellings of one alias both serve 200 with no canonical redirect, which is intended.

stacked on #2274; #2266 follows.

line numbers refer to the stack head 6d4f27811.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `gt-next` middleware path matching Unicode- and encoding-aware while retaining the original serialized dynamic values in redirects and rewrites.
- Normalizes configured and requested static pathname segments to encoded NFC for matching.
- Preserves malformed escapes, encoded separators, encoding depth, dynamic parameter bytes, and query strings.
- Separates shared-only, unprefixed, and fully localized route maps to prevent encoded locale-like segments from changing locale interpretation.
- Adds focused Edge Runtime regressions for Unicode spelling, malformed escapes, encoded literals, route identity, and locale-prefix ambiguity.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule violations remain.

Normalization is confined to route matching and comparisons, while substitutions and emitted URLs retain original serialized parameters. The new map selection preserves valid localized routing while preventing encoded path data from being reinterpreted as locale prefixes.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/pathname.ts | Adds segment-wise decode, NFC normalization, and re-encoding while preserving malformed escape sequences. |
| packages/next/src/middleware-dir/utils.ts | Normalizes route patterns for lookup and separates full, unprefixed, and shared-only routing maps. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Selects the appropriate route map and uses normalized comparisons without changing emitted parameter bytes. |
| packages/next/src/middleware-dir/__tests__/encodingRegression.edge.test.ts | Adds extensive coverage for Unicode normalization, malformed escapes, encoded literals, and encoding-level identity. |
| packages/next/src/middleware-dir/__tests__/encodedLocaleRegression.edge.test.ts | Verifies encoded locale-like route segments cannot be misclassified during normalized lookup. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Incoming Next.js pathname] --> B[Extract explicit locale]
    B --> C[Normalize segments for matching]
    C --> D{Locale prefix present?}
    D -->|Yes| E[Search localized and shared route map]
    D -->|No| F[Search shared and enabled default-locale aliases]
    E --> G[Resolve shared route template]
    F --> G
    G --> H[Substitute original serialized parameter bytes]
    H --> I{Public URL canonical?}
    I -->|No| J[Redirect to localized path]
    I -->|Yes| K{Shared route spelling differs?}
    K -->|Yes| L[Rewrite to shared Next.js route]
    K -->|No| M[Continue request]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): restrict locale-stripped look..."](https://github.com/generaltranslation/gt/commit/2ebdbd1f5b9b6e6628aaef869cec2293cd84f2f6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61925639)</sub>

**Context used:**

- Knowledge Base — [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)

<!-- /greptile_comment -->