### PR TITLE
fix(next): [3/7] support trailing slash middleware paths

### DIFF
--- a/.changeset/support-trailing-slash-paths.md
+++ b/.changeset/support-trailing-slash-paths.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Match middleware paths with trailing slashes and preserve them in rewrites.

--- a/packages/next/src/middleware-dir/__tests__/trailingRouteRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/trailingRouteRegression.edge.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+import type { PathConfig } from '../utils';
+
+const origin = 'http://localhost:3000';
+const query = '?tag=a&tag=b';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+describe.each(['', '/'])('route ownership with trailing slash %j', (slash) => {
+  it('does not treat the locale root as a locale-named shared page', () => {
+    const middleware = createNextMiddleware({
+      prefixDefaultLocale: true,
+      pathConfig: { '/fr': { en: '/fr', fr: '/other' } },
+    });
+    const response = middleware(
+      new NextRequest(`${origin}/fr${slash}${query}`)
+    );
+    expect(response.headers.get('location')).toBeNull();
+    expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    expect(response.headers.get('x-generaltranslation-locale')).toBe('fr');
+  });
+
+  it.each([false, true])(
+    'keeps dynamic route ownership in reverse order %s',
+    (reverse) => {
+      const entries: [string, Record<string, string>][] = [
+        ['/[id]', { en: '/[id]', fr: '/[id]' }],
+        ['/fr/[id]', { en: '/fr/[id]', fr: '/other/[id]' }],
+      ];
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: Object.fromEntries(reverse ? entries.reverse() : entries),
+      });
+      const response = middleware(
+        new NextRequest(`${origin}/fr/hello${slash}${query}`)
+      );
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+    }
+  );
+
+  it.each([false, true])(
+    'keeps an explicit localized root alias in reverse order %s',
+    (reverse) => {
+      const entries: [string, Record<string, string>][] = [
+        ['/landing', { en: '/home', fr: '/' }],
+        ['/fr', { en: '/fr', fr: '/other' }],
+      ];
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: Object.fromEntries(reverse ? entries.reverse() : entries),
+      });
+      const response = middleware(
+        new NextRequest(`${origin}/fr${slash}${query}`)
+      );
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        `${origin}/fr/landing${slash}${query}`
+      );
+    }
+  );
+});
+
+const depthCases: [
+  string,
+  PathConfig,
+  string,
+  string,
+  'location' | 'x-middleware-rewrite',
+][] = [
+  [
+    'shared to deeper alias',
+    {
+      '/short/[a]/[b]': {
+        en: '/short/[a]/[b]',
+        fr: '/long/static/[first]/[second]',
+      },
+    },
+    '/fr/short/alpha/beta',
+    '/fr/long/static/alpha/beta',
+    'location',
+  ],
+  [
+    'deeper alias to shared',
+    {
+      '/short/[a]/[b]': {
+        en: '/short/[a]/[b]',
+        fr: '/long/static/[first]/[second]',
+      },
+    },
+    '/fr/long/static/alpha/beta',
+    '/fr/short/alpha/beta',
+    'x-middleware-rewrite',
+  ],
+  [
+    'shared to shallower alias',
+    {
+      '/long/static/[a]/[b]': {
+        en: '/long/static/[a]/[b]',
+        fr: '/short/[first]/[second]',
+      },
+    },
+    '/fr/long/static/alpha/beta',
+    '/fr/short/alpha/beta',
+    'location',
+  ],
+  [
+    'shallower alias to shared',
+    {
+      '/long/static/[a]/[b]': {
+        en: '/long/static/[a]/[b]',
+        fr: '/short/[first]/[second]',
+      },
+    },
+    '/fr/short/alpha/beta',
+    '/fr/long/static/alpha/beta',
+    'x-middleware-rewrite',
+  ],
+  [
+    'same-depth reordered names remain positional',
+    { '/pair/[first]/[second]': { fr: '/paire/[second]/[first]' } },
+    '/fr/paire/alpha/beta',
+    '/fr/pair/alpha/beta',
+    'x-middleware-rewrite',
+  ],
+];
+
+describe.each(['', '/'])(
+  'source-template parameters with trailing slash %j',
+  (slash) => {
+    it.each(depthCases)(
+      '%s',
+      (_name, pathConfig, path, destination, header) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: true,
+          pathConfig,
+        });
+        const response = middleware(
+          new NextRequest(origin + path + slash + query)
+        );
+        expect(response.headers.get(header)).toBe(
+          origin + destination + slash + query
+        );
+        expect(
+          response.headers.get(
+            header === 'location' ? 'x-middleware-rewrite' : 'location'
+          )
+        ).toBeNull();
+        expect(response.headers.get('x-generaltranslation-locale')).toBe('fr');
+      }
+    );
+
+    it.each(['a%2Fb', 'a%25b', 'a%252Fb'])(
+      'preserves raw parameter %s across different depths',
+      (value) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: true,
+          pathConfig: {
+            '/short/[a]/[b]': { fr: '/long/static/[first]/[second]' },
+          },
+        });
+        const response = middleware(
+          new NextRequest(`${origin}/fr/short/${value}/beta${slash}${query}`)
+        );
+        expect(response.headers.get('location')).toBe(
+          `${origin}/fr/long/static/${value}/beta${slash}${query}`
+        );
+        const localized = middleware(
+          new NextRequest(
+            `${origin}/fr/long/static/${value}/beta${slash}${query}`
+          )
+        );
+        expect(localized.headers.get('location')).toBeNull();
+        expect(localized.headers.get('x-middleware-rewrite')).toBe(
+          `${origin}/fr/short/${value}/beta${slash}${query}`
+        );
+      }
+    );
+
+    it('uses the source locale template during a cookie locale switch', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/short/[a]/[b]': {
+            en: '/short/[a]/[b]',
+            fr: '/long/static/[first]/[second]',
+          },
+        },
+      });
+      const response = middleware(
+        new NextRequest(`${origin}/fr/long/static/alpha/beta${slash}${query}`, {
+          headers: {
+            cookie:
+              'generaltranslation.locale=en; generaltranslation.locale-reset=true',
+          },
+        })
+      );
+      expect(response.headers.get('location')).toBe(
+        `${origin}/en/short/alpha/beta${slash}${query}`
+      );
+    });
+
+    it('uses the actual unprefixed default alias template', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: false,
+        pathConfig: {
+          '/short/[a]/[b]': {
+            en: '/long/static/[first]/[second]',
+            fr: '/autre/[first]/[second]',
+          },
+        },
+      });
+      const response = middleware(
+        new NextRequest(`${origin}/long/static/alpha/beta${slash}${query}`)
+      );
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        `${origin}/en/short/alpha/beta${slash}${query}`
+      );
+    });
+  }
+);

--- a/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
@@ -1,0 +1,73 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+
+const origin = 'http://localhost:3000';
+describe.each([true, false])(
+  'prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    describe.each(['', '/'])('configured slash="%s"', (configuredSlash) => {
+      it.each(['', '/'])('preserves request slash="%s"', (slash) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: {
+            ['/about' + configuredSlash]: {
+              en: '/company' + configuredSlash,
+              fr: '/a-propos' + configuredSlash,
+            },
+            ['/posts/[id]' + configuredSlash]: {
+              en: '/entries/[id]' + configuredSlash,
+              fr: '/articles/[id]' + configuredSlash,
+            },
+          },
+        });
+        for (const locale of ['en', 'fr']) {
+          const prefix =
+            locale === 'en' && !prefixDefaultLocale ? '' : '/' + locale;
+          const aliases =
+            locale === 'en'
+              ? ['/company', '/entries/123']
+              : ['/a-propos', '/articles/123'];
+          for (const [index, shared] of ['/about', '/posts/123'].entries()) {
+            const publicPath = prefix + aliases[index] + slash;
+            const response = middleware(
+              new NextRequest(origin + publicPath + '?tag=a&tag=b')
+            );
+            expect(response.headers.get('location')).toBeNull();
+            expect(response.headers.get('x-middleware-rewrite')).toBe(
+              origin + '/' + locale + shared + slash + '?tag=a&tag=b'
+            );
+            const redirect = middleware(
+              new NextRequest(origin + prefix + shared + slash)
+            );
+            expect(redirect.headers.get('location')).toBe(origin + publicPath);
+          }
+        }
+      });
+    });
+  }
+);
+
+it('keeps the locale landing slash when matching the shared root', () => {
+  const middleware = createNextMiddleware({
+    prefixDefaultLocale: true,
+    pathConfig: { '/': { fr: '/home' } },
+  });
+  const response = middleware(new NextRequest(origin + '/fr/'));
+  expect(response.headers.get('location')).toBe(origin + '/fr/home/');
+});

--- a/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts
@@ -71,3 +71,73 @@ it('keeps the locale landing slash when matching the shared root', () => {
   const response = middleware(new NextRequest(origin + '/fr/'));
   expect(response.headers.get('location')).toBe(origin + '/fr/home/');
 });
+
+describe.each([true, false])(
+  'locale root routing, prefixDefaultLocale=%s',
+  (prefixDefaultLocale) => {
+    it('resolves a localized root alias and preserves repeated query values', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: { '/landing/': { en: '/home/', fr: '/' } },
+      });
+      const response = middleware(new NextRequest(origin + '/fr/?tag=a&tag=b'));
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        origin + '/fr/landing/?tag=a&tag=b'
+      );
+    });
+
+    it('prefers the localized root alias over an unrelated shared root', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: {
+          '/': { fr: '/accueil/' },
+          '/landing/': { fr: '/' },
+        },
+      });
+      const response = middleware(new NextRequest(origin + '/fr/'));
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        origin + '/fr/landing/'
+      );
+    });
+
+    it('does not use the locale as a missing root slug', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale,
+        pathConfig: { '/[slug]': { en: '/[slug]', fr: '/[slug]' } },
+      });
+      const response = middleware(new NextRequest(origin + '/fr/?tag=a&tag=b'));
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBeNull();
+      expect(response.headers.get('x-middleware-next')).toBe('1');
+    });
+
+    it.each(['', '/'])(
+      'still resolves a real root slug, slash="%s"',
+      (slash) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale,
+          pathConfig: { '/[slug]/edit': { fr: '/[slug]/modifier' } },
+        });
+        const response = middleware(
+          new NextRequest(
+            origin + '/fr/hello%2Fworld/edit' + slash + '?tag=a&tag=b'
+          )
+        );
+        expect(response.headers.get('location')).toBe(
+          origin + '/fr/hello%2Fworld/modifier' + slash + '?tag=a&tag=b'
+        );
+        const localizedResponse = middleware(
+          new NextRequest(
+            origin + '/fr/hello%2Fworld/modifier' + slash + '?tag=a&tag=b'
+          )
+        );
+        expect(localizedResponse.headers.get('location')).toBeNull();
+        expect(localizedResponse.headers.get('x-middleware-rewrite')).toBe(
+          origin + '/fr/hello%2Fworld/edit' + slash + '?tag=a&tag=b'
+        );
+      }
+    );
+  }
+);

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -11,11 +11,22 @@ import {
 
 function getSharedPath(
   pathname: string,
-  paths: Record<string, string>,
+  paths: Record<
+    string,
+    string | { sharedPath: string; sourceTemplate: string }
+  >,
   pathnameLocale: string | undefined
 ): string | undefined {
+  const mappings = Object.fromEntries(
+    Object.entries(paths).map(([pattern, value]) => [
+      pattern,
+      typeof value === 'string'
+        ? { sharedPath: value, sourceTemplate: value }
+        : value,
+    ])
+  );
   const sharedPaths = Object.fromEntries(
-    Object.values(paths).map((sharedPath) => [sharedPath, sharedPath])
+    Object.values(mappings).map(({ sharedPath }) => [sharedPath, sharedPath])
   );
   const { sharedOnlyPathToSharedPath } = createPathToSharedPathMap(
     sharedPaths,
@@ -24,10 +35,10 @@ function getSharedPath(
   );
   return getSharedPathWithMaps(
     pathname,
-    paths,
+    mappings,
     pathnameLocale,
     sharedOnlyPathToSharedPath
-  );
+  )?.sharedPath;
 }
 
 describe('extractLocale', () => {
@@ -270,9 +281,15 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/about']).toBe('/about');
-    expect(result.pathToSharedPath['/contact']).toBe('/contact');
-    expect(result.pathToSharedPath['/services']).toBe('/services');
+    expect(result.unprefixedPathToSharedPath['/about']?.sharedPath).toBe(
+      '/about'
+    );
+    expect(result.unprefixedPathToSharedPath['/contact']?.sharedPath).toBe(
+      '/contact'
+    );
+    expect(result.unprefixedPathToSharedPath['/services']?.sharedPath).toBe(
+      '/services'
+    );
     expect(result.defaultLocalePaths).toEqual([]);
   });
 
@@ -287,10 +304,12 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/about']).toBe('/about');
-    expect(result.pathToSharedPath['/en/about-us']).toBe('/about');
-    expect(result.pathToSharedPath['/fr/a-propos']).toBe('/about');
-    expect(result.pathToSharedPath['/es/acerca-de']).toBe('/about');
+    expect(result.unprefixedPathToSharedPath['/about']?.sharedPath).toBe(
+      '/about'
+    );
+    expect(result.pathToSharedPath['/en/about-us']?.sharedPath).toBe('/about');
+    expect(result.pathToSharedPath['/fr/a-propos']?.sharedPath).toBe('/about');
+    expect(result.pathToSharedPath['/es/acerca-de']?.sharedPath).toBe('/about');
   });
 
   it('should handle default locale without prefix', () => {
@@ -307,10 +326,16 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, false, 'en');
 
-    expect(result.pathToSharedPath['/about-us']).toBe('/about');
-    expect(result.pathToSharedPath['/contact-us']).toBe('/contact');
-    expect(result.pathToSharedPath['/fr/a-propos']).toBe('/about');
-    expect(result.pathToSharedPath['/fr/contactez-nous']).toBe('/contact');
+    expect(result.unprefixedPathToSharedPath['/about-us']?.sharedPath).toBe(
+      '/about'
+    );
+    expect(result.unprefixedPathToSharedPath['/contact-us']?.sharedPath).toBe(
+      '/contact'
+    );
+    expect(result.pathToSharedPath['/fr/a-propos']?.sharedPath).toBe('/about');
+    expect(result.pathToSharedPath['/fr/contactez-nous']?.sharedPath).toBe(
+      '/contact'
+    );
     expect(result.defaultLocalePaths).toContain('/about-us');
     expect(result.defaultLocalePaths).toContain('/contact-us');
   });
@@ -329,12 +354,18 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/blog/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/en/blog/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/fr/article/[^/]+']).toBe('/blog/[id]');
-    expect(result.pathToSharedPath['/user/[^/]+/post/[^/]+']).toBe(
-      '/user/[userId]/post/[postId]'
+    expect(result.unprefixedPathToSharedPath['/blog/[^/]+']?.sharedPath).toBe(
+      '/blog/[id]'
     );
+    expect(result.pathToSharedPath['/en/blog/[^/]+']?.sharedPath).toBe(
+      '/blog/[id]'
+    );
+    expect(result.pathToSharedPath['/fr/article/[^/]+']?.sharedPath).toBe(
+      '/blog/[id]'
+    );
+    expect(
+      result.unprefixedPathToSharedPath['/user/[^/]+/post/[^/]+']?.sharedPath
+    ).toBe('/user/[userId]/post/[postId]');
   });
 
   it('should handle mixed static and dynamic configurations', () => {
@@ -348,10 +379,16 @@ describe('createPathToSharedPathMap', () => {
 
     const result = createPathToSharedPathMap(pathConfig, true, 'en');
 
-    expect(result.pathToSharedPath['/static-page']).toBe('/static-page');
-    expect(result.pathToSharedPath['/dynamic/[^/]+']).toBe('/dynamic/[id]');
-    expect(result.pathToSharedPath['/en/dynamic/[^/]+']).toBe('/dynamic/[id]');
-    expect(result.pathToSharedPath['/fr/dynamique/[^/]+']).toBe(
+    expect(result.unprefixedPathToSharedPath['/static-page']?.sharedPath).toBe(
+      '/static-page'
+    );
+    expect(
+      result.unprefixedPathToSharedPath['/dynamic/[^/]+']?.sharedPath
+    ).toBe('/dynamic/[id]');
+    expect(result.pathToSharedPath['/en/dynamic/[^/]+']?.sharedPath).toBe(
+      '/dynamic/[id]'
+    );
+    expect(result.pathToSharedPath['/fr/dynamique/[^/]+']?.sharedPath).toBe(
       '/dynamic/[id]'
     );
   });
@@ -456,16 +493,17 @@ describe('configured dynamic route literals', () => {
     'matches shared and localized %s literally and rejects %s',
     (literal, lookalike) => {
       const sharedPath = `/shared/${literal}/[id]`;
-      const { pathToSharedPath } = createPathToSharedPathMap(
-        {
-          [sharedPath]: {
-            en: `/english/${literal}/[id]`,
-            fr: `/french/${literal}/[id]`,
+      const { pathToSharedPath, unprefixedPathToSharedPath } =
+        createPathToSharedPathMap(
+          {
+            [sharedPath]: {
+              en: `/english/${literal}/[id]`,
+              fr: `/french/${literal}/[id]`,
+            },
           },
-        },
-        false,
-        'en'
-      );
+          false,
+          'en'
+        );
 
       for (const [prefix, locale] of [
         ['/shared', undefined],
@@ -473,15 +511,23 @@ describe('configured dynamic route literals', () => {
         ['/fr/french', 'fr'],
       ] as const) {
         expect(
-          getSharedPath(`${prefix}/${literal}/one`, pathToSharedPath, locale)
+          getSharedPath(
+            `${prefix}/${literal}/one`,
+            locale ? pathToSharedPath : unprefixedPathToSharedPath,
+            locale
+          )
         ).toBe(sharedPath);
         expect(
-          getSharedPath(`${prefix}/${lookalike}/one`, pathToSharedPath, locale)
+          getSharedPath(
+            `${prefix}/${lookalike}/one`,
+            locale ? pathToSharedPath : unprefixedPathToSharedPath,
+            locale
+          )
         ).toBeUndefined();
         expect(
           getSharedPath(
             `${prefix}/${literal}/one/two`,
-            pathToSharedPath,
+            locale ? pathToSharedPath : unprefixedPathToSharedPath,
             locale
           )
         ).toBeUndefined();
@@ -490,18 +536,19 @@ describe('configured dynamic route literals', () => {
   );
 
   it('prefers exact static routes over earlier dynamic routes', () => {
-    const { pathToSharedPath } = createPathToSharedPathMap(
-      {
-        '/v1.0/[id]': { fr: '/version.1/[id]' },
-        '/v1.0/new': { fr: '/version.1/new' },
-      },
-      false,
-      'en'
-    );
+    const { pathToSharedPath, unprefixedPathToSharedPath } =
+      createPathToSharedPathMap(
+        {
+          '/v1.0/[id]': { fr: '/version.1/[id]' },
+          '/v1.0/new': { fr: '/version.1/new' },
+        },
+        false,
+        'en'
+      );
 
-    expect(getSharedPath('/v1.0/new', pathToSharedPath, undefined)).toBe(
-      '/v1.0/new'
-    );
+    expect(
+      getSharedPath('/v1.0/new', unprefixedPathToSharedPath, undefined)
+    ).toBe('/v1.0/new');
     expect(getSharedPath('/fr/version.1/new', pathToSharedPath, 'fr')).toBe(
       '/v1.0/new'
     );
@@ -509,20 +556,21 @@ describe('configured dynamic route literals', () => {
 
   it('keeps encoded brackets literal beside a real placeholder', () => {
     const sharedPath = '/%5Bid%5D/[slug]';
-    const { pathToSharedPath } = createPathToSharedPathMap(
-      { [sharedPath]: { fr: '/%5Barticle%5D/[slug]' } },
-      false,
-      'en'
-    );
+    const { pathToSharedPath, unprefixedPathToSharedPath } =
+      createPathToSharedPathMap(
+        { [sharedPath]: { fr: '/%5Barticle%5D/[slug]' } },
+        false,
+        'en'
+      );
 
-    expect(getSharedPath('/%5Bid%5D/one', pathToSharedPath, undefined)).toBe(
-      sharedPath
-    );
+    expect(
+      getSharedPath('/%5Bid%5D/one', unprefixedPathToSharedPath, undefined)
+    ).toBe(sharedPath);
     expect(getSharedPath('/fr/%5Barticle%5D/one', pathToSharedPath, 'fr')).toBe(
       sharedPath
     );
     expect(
-      getSharedPath('/anything/one', pathToSharedPath, undefined)
+      getSharedPath('/anything/one', unprefixedPathToSharedPath, undefined)
     ).toBeUndefined();
     expect(
       getSharedPath('/fr/anything/one', pathToSharedPath, 'fr')

--- a/packages/next/src/middleware-dir/createNextMiddleware.ts
+++ b/packages/next/src/middleware-dir/createNextMiddleware.ts
@@ -244,12 +244,13 @@ export function createNextMiddleware({
       // Get the shared path for the unprefixed pathname
       // Normalization must not turn an unrecognized prefix (such as %66r)
       // into a locale: it may be a static route segment or a dynamic value.
-      const sharedPath = getSharedPath(
+      const sharedMatch = getSharedPath(
         standardizedPathname,
         pathnameLocale ? pathToSharedPath : unprefixedPathToSharedPath,
         pathnameLocale,
         sharedOnlyPathToSharedPath
       );
+      const sharedPath = sharedMatch?.sharedPath;
 
       // Get shared path with parameters (/en/dashboard/1/custom), for rewriting localized paths
       const sharedPathWithParameters =
@@ -258,7 +259,8 @@ export function createNextMiddleware({
               pathnameLocale
                 ? standardizedPathname
                 : `/${userLocale}${standardizedPathname}`,
-              `/${userLocale}${sharedPath}`
+              `/${userLocale}${sharedPath}`,
+              sharedMatch?.params
             )
           : undefined;
 
@@ -275,7 +277,8 @@ export function createNextMiddleware({
               pathnameLocale
                 ? standardizedPathname
                 : `/${userLocale}${standardizedPathname}`,
-              localizedPath
+              localizedPath,
+              sharedMatch?.params
             )
           : undefined;
 

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -18,3 +18,17 @@ export function normalizePathname(pathname: string): string {
 export function stripTrailingSlashes(pathname: string): string {
   return pathname.length > 1 ? pathname.replace(/\/+$/, '') || '/' : pathname;
 }
+
+/** Applies the request pathname's trailing-slash style to a target path. */
+export function applyTrailingSlash(
+  pathname: string,
+  targetPathname: string
+): string {
+  const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
+  if (sourceHasTrailingSlash) {
+    return targetPathname === '/' || targetPathname.endsWith('/')
+      ? targetPathname
+      : `${targetPathname}/`;
+  }
+  return stripTrailingSlashes(targetPathname);
+}

--- a/packages/next/src/middleware-dir/pathname.ts
+++ b/packages/next/src/middleware-dir/pathname.ts
@@ -13,3 +13,8 @@ export function normalizePathname(pathname: string): string {
     })
     .join('/');
 }
+
+/** Removes trailing slashes while keeping the root pathname distinct. */
+export function stripTrailingSlashes(pathname: string): string {
+  return pathname.length > 1 ? pathname.replace(/\/+$/, '') || '/' : pathname;
+}

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -134,16 +134,17 @@ export function extractDynamicParams(
  */
 export function replaceDynamicSegments(
   path: string,
-  templatePath: string
+  templatePath: string,
+  params?: string[]
 ): string {
   if (!templatePath.includes('[')) {
     return applyTrailingSlash(path, templatePath);
   }
 
-  const params = extractDynamicParams(templatePath, path);
+  const pathParams = params ?? extractDynamicParams(templatePath, path);
   let paramIndex = 0;
   const result = templatePath.replace(/\[([^\]]+)\]/g, (match: string) => {
-    return params[paramIndex++] || match;
+    return pathParams[paramIndex++] || match;
   });
   return applyTrailingSlash(path, result);
 }
@@ -170,6 +171,8 @@ export function getLocalizedPath(
   return path;
 }
 
+type PathMapping = { sharedPath: string; sourceTemplate: string };
+
 /**
  * Creates a map of localized paths to shared paths using regex patterns
  */
@@ -178,15 +181,15 @@ export function createPathToSharedPathMap(
   prefixDefaultLocale: boolean,
   defaultLocale: string
 ): {
-  pathToSharedPath: { [key: string]: string };
-  unprefixedPathToSharedPath: { [key: string]: string };
-  sharedOnlyPathToSharedPath: { [key: string]: string };
+  pathToSharedPath: Record<string, PathMapping>;
+  unprefixedPathToSharedPath: Record<string, PathMapping>;
+  sharedOnlyPathToSharedPath: Record<string, PathMapping>;
   defaultLocalePaths: string[];
 } {
   return Object.entries(pathConfig).reduce<{
-    pathToSharedPath: { [key: string]: string };
-    unprefixedPathToSharedPath: { [key: string]: string };
-    sharedOnlyPathToSharedPath: { [key: string]: string };
+    pathToSharedPath: Record<string, PathMapping>;
+    unprefixedPathToSharedPath: Record<string, PathMapping>;
+    sharedOnlyPathToSharedPath: Record<string, PathMapping>;
     defaultLocalePaths: string[];
   }>(
     (acc, [sharedPath, localizedPaths]) => {
@@ -198,20 +201,24 @@ export function createPathToSharedPathMap(
       } = acc;
       // Preserve raw templates for parameter substitution and output URLs.
       const sharedPattern = createPathPattern(sharedPath);
-      pathToSharedPath[sharedPattern] = sharedPath;
-      unprefixedPathToSharedPath[sharedPattern] = sharedPath;
-      sharedOnlyPathToSharedPath[sharedPattern] = sharedPath;
+      const sharedMapping = { sharedPath, sourceTemplate: sharedPath };
+      unprefixedPathToSharedPath[sharedPattern] = sharedMapping;
+      sharedOnlyPathToSharedPath[sharedPattern] = sharedMapping;
 
       if (typeof localizedPaths === 'object') {
         Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
           // Convert the localized path to a regex pattern
           // Replace [param] with [^/]+ to match any non-slash characters
           const pattern = createPathPattern(localizedPath);
-          pathToSharedPath[stripTrailingSlashes(`/${locale}${pattern}`)] =
-            sharedPath;
+          pathToSharedPath[stripTrailingSlashes(`/${locale}${pattern}`)] = {
+            sharedPath,
+            sourceTemplate: `/${locale}${localizedPath}`,
+          };
           if (!prefixDefaultLocale && locale === defaultLocale) {
-            pathToSharedPath[pattern] = sharedPath;
-            unprefixedPathToSharedPath[pattern] = sharedPath;
+            unprefixedPathToSharedPath[pattern] = {
+              sharedPath,
+              sourceTemplate: localizedPath,
+            };
             defaultLocalePaths.push(pattern);
           }
         });
@@ -232,16 +239,21 @@ export function createPathToSharedPathMap(
  */
 export function getSharedPath(
   standardizedPathname: string,
-  pathToSharedPath: { [key: string]: string },
+  pathToSharedPath: Record<string, PathMapping>,
   pathnameLocale: string | undefined,
-  sharedOnlyPathToSharedPath: { [key: string]: string }
-): string | undefined {
+  sharedOnlyPathToSharedPath: Record<string, PathMapping>
+): { sharedPath: string; params: string[] } | undefined {
+  const rawPathname = standardizedPathname;
+  const match = (mapping: PathMapping, pathname: string) => ({
+    sharedPath: mapping.sharedPath,
+    params: extractDynamicParams(mapping.sourceTemplate, pathname),
+  });
   standardizedPathname = normalizePathForMatching(standardizedPathname);
   const pathnameWithoutTrailingSlash =
     stripTrailingSlashes(standardizedPathname);
   // Try exact match first
   if (pathToSharedPath[pathnameWithoutTrailingSlash]) {
-    return pathToSharedPath[pathnameWithoutTrailingSlash];
+    return match(pathToSharedPath[pathnameWithoutTrailingSlash], rawPathname);
   }
 
   // Without locale prefix
@@ -252,22 +264,23 @@ export function getSharedPath(
       standardizedPathname.replace(/^\/[^/]+/, '')
     );
     if (sharedOnlyPathToSharedPath[pathnameWithoutLocale]) {
-      return sharedOnlyPathToSharedPath[pathnameWithoutLocale];
+      return match(
+        sharedOnlyPathToSharedPath[pathnameWithoutLocale],
+        rawPathname.replace(/^\/[^/]+/, '') || '/'
+      );
     }
   }
 
   // Try regex pattern match
-  for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
+  for (const [pattern, mapping] of Object.entries(pathToSharedPath)) {
     if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
       // Convert the pattern to a strict regex that matches the exact path structure
       const regex = new RegExp(`^${pattern}$`);
       // Exact match
       // Shared patterns must not consume a recognized locale as a parameter.
-      if (
-        (!pathnameLocale || pattern.startsWith(`/${pathnameLocale}/`)) &&
-        regex.test(pathnameWithoutTrailingSlash)
-      ) {
-        return sharedPath;
+      // The full-path map contains only aliases when a locale is recognized.
+      if (regex.test(pathnameWithoutTrailingSlash)) {
+        return match(mapping, rawPathname);
       }
     }
   }
@@ -275,14 +288,14 @@ export function getSharedPath(
   // Without locale prefix
   // Once the locale is removed, the remaining segments are shared route data.
   if (pathnameWithoutLocale !== undefined) {
-    for (const [pattern, sharedPath] of Object.entries(
+    for (const [pattern, mapping] of Object.entries(
       sharedOnlyPathToSharedPath
     )) {
       if (
         pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN) &&
         new RegExp(`^${pattern}$`).test(pathnameWithoutLocale)
       ) {
-        return sharedPath;
+        return match(mapping, rawPathname.replace(/^\/[^/]+/, '') || '/');
       }
     }
   }

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -210,7 +210,8 @@ export function createPathToSharedPathMap(
           // Convert the localized path to a regex pattern
           // Replace [param] with [^/]+ to match any non-slash characters
           const pattern = createPathPattern(localizedPath);
-          pathToSharedPath[`/${locale}${pattern}`] = sharedPath;
+          pathToSharedPath[stripTrailingSlashes(`/${locale}${pattern}`)] =
+            sharedPath;
           if (!prefixDefaultLocale && locale === defaultLocale) {
             pathToSharedPath[pattern] = sharedPath;
             unprefixedPathToSharedPath[pattern] = sharedPath;
@@ -263,7 +264,11 @@ export function getSharedPath(
       // Convert the pattern to a strict regex that matches the exact path structure
       const regex = new RegExp(`^${pattern}$`);
       // Exact match
-      if (regex.test(pathnameWithoutTrailingSlash)) {
+      // Shared patterns must not consume a recognized locale as a parameter.
+      if (
+        (!pathnameLocale || pattern.startsWith(`/${pathnameLocale}/`)) &&
+        regex.test(pathnameWithoutTrailingSlash)
+      ) {
         return sharedPath;
       }
       // Without locale prefix

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -3,7 +3,7 @@ import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
-import { normalizePathname } from './pathname';
+import { normalizePathname, stripTrailingSlashes } from './pathname';
 
 export { normalizePathname };
 
@@ -32,6 +32,7 @@ function normalizePathForMatching(pathname: string): string {
 
 /** Classifies placeholders before decoding static path content. */
 function createPathPattern(pathname: string): string {
+  pathname = stripTrailingSlashes(pathname);
   if (!/\[([^\]]+)\]/.test(pathname)) {
     return normalizePathForMatching(pathname);
   }
@@ -43,6 +44,17 @@ function createPathPattern(pathname: string): string {
         : normalizePathForMatching(part).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     )
     .join('');
+}
+
+/** Applies the request pathname's trailing-slash style to a target path. */
+function applyTrailingSlash(pathname: string, targetPathname: string): string {
+  const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
+  if (sourceHasTrailingSlash) {
+    return targetPathname === '/' || targetPathname.endsWith('/')
+      ? targetPathname
+      : `${targetPathname}/`;
+  }
+  return stripTrailingSlashes(targetPathname);
 }
 
 export function getResponse({
@@ -131,14 +143,16 @@ export function replaceDynamicSegments(
   path: string,
   templatePath: string
 ): string {
-  if (!templatePath.includes('[')) return templatePath;
+  if (!templatePath.includes('[')) {
+    return applyTrailingSlash(path, templatePath);
+  }
 
   const params = extractDynamicParams(templatePath, path);
   let paramIndex = 0;
   const result = templatePath.replace(/\[([^\]]+)\]/g, (match: string) => {
     return params[paramIndex++] || match;
   });
-  return result;
+  return applyTrailingSlash(path, result);
 }
 
 /**
@@ -210,16 +224,20 @@ export function getSharedPath(
   pathnameLocale: string | undefined
 ): string | undefined {
   standardizedPathname = normalizePathForMatching(standardizedPathname);
+  const pathnameWithoutTrailingSlash =
+    stripTrailingSlashes(standardizedPathname);
   // Try exact match first
-  if (pathToSharedPath[standardizedPathname]) {
-    return pathToSharedPath[standardizedPathname];
+  if (pathToSharedPath[pathnameWithoutTrailingSlash]) {
+    return pathToSharedPath[pathnameWithoutTrailingSlash];
   }
 
   // Without locale prefix
   let pathnameWithoutLocale = undefined;
   // Only remove locale prefix if the locale prefix is valid
   if (pathnameLocale) {
-    pathnameWithoutLocale = standardizedPathname.replace(/^\/[^/]+/, '');
+    pathnameWithoutLocale = stripTrailingSlashes(
+      standardizedPathname.replace(/^\/[^/]+/, '')
+    );
     if (pathToSharedPath[pathnameWithoutLocale]) {
       return pathToSharedPath[pathnameWithoutLocale];
     }
@@ -232,7 +250,7 @@ export function getSharedPath(
       // Convert the pattern to a strict regex that matches the exact path structure
       const regex = new RegExp(`^${pattern}$`);
       // Exact match
-      if (regex.test(standardizedPathname)) {
+      if (regex.test(pathnameWithoutTrailingSlash)) {
         return sharedPath;
       }
       // Without locale prefix
@@ -259,7 +277,7 @@ function inDefaultLocalePaths(
   pathname: string,
   defaultLocalePaths: string[]
 ): boolean {
-  pathname = normalizePathForMatching(pathname);
+  pathname = stripTrailingSlashes(normalizePathForMatching(pathname));
   // Try exact match first
   if (defaultLocalePaths.includes(pathname)) {
     return true;

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -3,7 +3,11 @@ import { standardizeLocale } from '@generaltranslation/format';
 import { GTRuntime } from 'generaltranslation/runtime';
 import { NextURL } from 'next/dist/server/web/next-url';
 import { parseAcceptLanguage } from 'gt-i18n/internal';
-import { normalizePathname, stripTrailingSlashes } from './pathname';
+import {
+  applyTrailingSlash,
+  normalizePathname,
+  stripTrailingSlashes,
+} from './pathname';
 
 export { normalizePathname };
 
@@ -44,17 +48,6 @@ function createPathPattern(pathname: string): string {
         : normalizePathForMatching(part).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     )
     .join('');
-}
-
-/** Applies the request pathname's trailing-slash style to a target path. */
-function applyTrailingSlash(pathname: string, targetPathname: string): string {
-  const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
-  if (sourceHasTrailingSlash) {
-    return targetPathname === '/' || targetPathname.endsWith('/')
-      ? targetPathname
-      : `${targetPathname}/`;
-  }
-  return stripTrailingSlashes(targetPathname);
 }
 
 export function getResponse({


### PR DESCRIPTION
configured middleware paths match with or without a trailing slash, and every redirect and rewrite keeps the request's slash style.

**why.** the lookup kept the request's trailing slash when comparing against keys compiled from the templates as written, so `/fr/a-propos/` never hit the `/fr/a-propos` key, and `replaceDynamicSegments` returned the template as written, so a slashed request got an unslashed target. parameters were also re-extracted positionally from the destination template against the request path, which gives wrong values when alias and shared path differ in depth (`/short/[a]/[b]` against `/long/static/[first]/[second]`).

**fix.** `pathname.ts` adds `stripTrailingSlashes` (`pathname.ts:18`) and `applyTrailingSlash` (`pathname.ts:23`). templates are stripped before compiling, requests before lookup, and both reconstructed paths take the request's slash style. the path maps now carry `{ sharedPath, sourceTemplate }`, `getSharedPath` returns the parameters captured from the matched template, and `createNextMiddleware` reuses them for the rewrite and redirect. shared patterns are removed from the full-path map, which now holds locale-prefixed aliases only, so a prefixed request matches a shared pattern only after its prefix is stripped. a shared `/fr` route no longer matches the french homepage and a shared `/[slug]` no longer takes `fr` as a slug. the locale-prefixed root-alias key is stripped too, so `{ '/landing/': { fr: '/' } }` still resolves `/fr/` once requests are stripped.

```
/fr/a-propos/?tag=a&tag=b     ->  rewrite /fr/about/?tag=a&tag=b       {'/about': {fr: '/a-propos'}}
/fr/about/                    ->  307 /fr/a-propos/
/fr/long/static/alpha/beta/   ->  rewrite /fr/short/alpha/beta/        {'/short/[a]/[b]': {fr: '/long/static/[first]/[second]'}}
/fr/short/a%2Fb/beta          ->  307 /fr/long/static/a%2Fb/beta
/fr/?tag=a&tag=b              ->  rewrite /fr/landing/?tag=a&tag=b     {'/landing/': {fr: '/'}}
/fr/                          ->  passes through                       {'/[slug]': {en: '/[slug]', fr: '/[slug]'}}
/fr                           ->  passes through, locale fr            {'/fr': {en: '/fr', fr: '/other'}}
```

**verified.** two new edge-runtime test files hold 49 cases: 30 for route ownership and source-template parameters, including `%2F`, `%25` and `%252F` values, and 19 for slash style across both prefix modes, both configured styles and both request styles. both files assert repeated query values (`?tag=a&tag=b`). 203 live redirect chains ran on the full stack under `trailingSlash: true`: every 307 keeps the slash, no `//`, no loop.

not touched: the app-root redirect targets `/fr/` (`createNextMiddleware.ts:362` at the stack head 6d4f27811), so next 308s to `/fr` under the default `trailingSlash: false`.

stacked on #2265; #2267 follows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates Next.js middleware route matching to accept configured static and single-parameter paths with or without a trailing slash while preserving the request’s slash style.
- Separates locale-prefixed aliases from unprefixed and shared-only lookup maps to preserve route ownership.
- Captures raw dynamic parameters from the matched source template and reuses them when constructing redirects and rewrites.
- Preserves locale roots and localized root aliases during locale-prefix removal.
- Adds focused edge-runtime regressions for slash handling, root ownership, encoded parameters, route depth changes, and locale switching.
- Adds a patch changeset for `gt-next`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; no actionable correctness, security, or repository-rule issue remains.

The updated lookup flow preserves locale route ownership, captures parameters from the actual matched source template, and consistently reapplies request slash style, with focused tests covering the affected redirect and rewrite paths.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Separates route lookup domains, normalizes trailing-slash matching, and carries source-template parameters into destination reconstruction. |
| packages/next/src/middleware-dir/createNextMiddleware.ts | Consumes structured route matches and reuses their raw positional parameters for localized redirects and shared rewrites. |
| packages/next/src/middleware-dir/pathname.ts | Adds focused helpers for stripping trailing slashes during matching and applying the request’s slash style to destinations. |
| packages/next/src/middleware-dir/__tests__/trailingRouteRegression.edge.test.ts | Covers locale-root ownership and raw parameter preservation across aliases with different static depths. |
| packages/next/src/middleware-dir/__tests__/trailingSlashRegression.edge.test.ts | Covers slash-insensitive matching and slash-preserving routing across locale-prefix configurations. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Incoming pathname] --> B[Normalize path for matching]
  B --> C{Recognized locale prefix?}
  C -- Yes --> D[Check locale-prefixed alias map]
  C -- No --> E[Check unprefixed shared/default-alias map]
  D --> F{Alias matched?}
  F -- No --> G[Strip locale prefix and check shared-only map]
  F -- Yes --> H[Capture raw parameters from source template]
  G --> H
  E --> H
  H --> I[Build shared and localized destinations]
  I --> J[Apply incoming trailing-slash style]
  J --> K{Public path canonical?}
  K -- No --> L[Redirect]
  K -- Yes, internal path differs --> M[Rewrite]
  K -- Yes, same path --> N[Continue]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): preserve route ownership and ..."](https://github.com/generaltranslation/gt/commit/e02000964d3808e65feec6637ec70611b1d67509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62236905)</sub>

<!-- /greptile_comment -->