### PR TITLE
fix(next): [4/7] preserve middleware base paths

### DIFF
--- a/.changeset/preserve-middleware-base-path.md
+++ b/.changeset/preserve-middleware-base-path.md
@@ -1,0 +1,7 @@
+---
+'gt-next': patch
+---
+
+Preserve the configured Next.js base path in middleware rewrites and redirects.
+
+Handle app routes and locale prefixes that repeat the base path without dropping a segment or redirecting to themselves.

--- a/.changeset/preserve-middleware-base-path.md
+++ b/.changeset/preserve-middleware-base-path.md
@@ -5,3 +5,5 @@
 Preserve the configured Next.js base path in middleware rewrites and redirects.
 
 Handle app routes and locale prefixes that repeat the base path without dropping a segment or redirecting to themselves.
+
+Preserve the request's trailing-slash style when redirecting to the base-path root, avoiding an extra slash-normalization redirect.

--- a/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { createNextMiddleware } from '../createNextMiddleware';
+beforeEach(() => {
+  vi.stubEnv(
+    '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+    JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+  );
+  vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', 'false');
+  vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', 'true');
+  vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', '');
+});
+afterEach(() => vi.unstubAllEnvs());
+const origin = 'http://localhost:3000';
+
+describe.each(['/docs', '/fr', '/en', '/corp/nested'])(
+  'basePath=%s',
+  (basePath) => {
+    it.each(['', '/'])(
+      'retains a same-named app route (trailing slash "%s")',
+      (slash) => {
+        const middleware = createNextMiddleware({
+          prefixDefaultLocale: false,
+          pathConfig: {
+            '/about': { en: basePath + '/about', fr: '/a-propos' },
+          },
+        });
+        const request = (path: string) =>
+          new NextRequest(origin + basePath + path, {
+            nextConfig: { basePath },
+          });
+        const response = middleware(request('/about' + slash + '?tag=a&tag=b'));
+        expect(response.headers.get('location')).toBe(
+          origin + basePath + basePath + '/about' + slash + '?tag=a&tag=b'
+        );
+      }
+    );
+    it('retains a locale prefix identical to the base path', () => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: { '/posts/[id]': { fr: '/articles/[id]' } },
+      });
+      const response = middleware(
+        new NextRequest(origin + basePath + '/fr/articles/123', {
+          nextConfig: { basePath },
+        })
+      );
+      expect(response.headers.get('location')).toBeNull();
+      expect(response.headers.get('x-middleware-rewrite')).toBe(
+        origin + basePath + '/fr/posts/123'
+      );
+    });
+  }
+);

--- a/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment edge-runtime
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { NextRequest } from 'next/server';
+import {
+  defaultLocaleCookieName,
+  defaultResetLocaleCookieName,
+} from '@generaltranslation/react-core/pure';
 import { createNextMiddleware } from '../createNextMiddleware';
+import { getResponse } from '../utils';
 beforeEach(() => {
   vi.stubEnv(
     '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
@@ -17,6 +22,75 @@ const origin = 'http://localhost:3000';
 describe.each(['/docs', '/fr', '/en', '/corp/nested'])(
   'basePath=%s',
   (basePath) => {
+    describe.each([false, true])('trailingSlash=%s', (trailingSlash) => {
+      const slash = trailingSlash ? '/' : '';
+      const query = '?tag=a&tag=b&raw=%2F';
+      const request = (path: string) =>
+        new NextRequest(origin + basePath + path + query, {
+          nextConfig: { basePath, trailingSlash },
+        });
+
+      it('redirects a locale reset directly to the base-path root', () => {
+        const middleware = createNextMiddleware({ prefixDefaultLocale: false });
+        const req = request('/fr' + slash);
+        req.cookies.set(defaultLocaleCookieName, 'en');
+        req.cookies.set(defaultResetLocaleCookieName, 'true');
+
+        const response = middleware(req);
+
+        expect(response.status).toBe(307);
+        expect(response.headers.get('location')).toBe(
+          origin + basePath + slash + query
+        );
+        const followed = middleware(
+          new NextRequest(response.headers.get('location')!, {
+            headers: req.headers,
+            nextConfig: { basePath, trailingSlash },
+          })
+        );
+        expect(followed.headers.get('location')).toBeNull();
+        expect(followed.headers.get('x-middleware-rewrite')).toBe(
+          origin + basePath + '/en/' + query
+        );
+      });
+
+      it('handles a request for the base-path root', () => {
+        const middleware = createNextMiddleware({ prefixDefaultLocale: false });
+        const response = middleware(request(slash));
+
+        expect(response.headers.get('location')).toBeNull();
+        expect(response.headers.get('x-middleware-rewrite')).toBe(
+          origin + basePath + '/en/' + query
+        );
+      });
+
+      it.each(['redirect', 'rewrite'] as const)(
+        'preserves the incoming base-path root slash for a %s',
+        (type) => {
+          const req = request(slash);
+          const response = getResponse({
+            type,
+            originalUrl: req.nextUrl,
+            responsePath: '/',
+            userLocale: 'en',
+            clearResetCookie: false,
+            headerList: new Headers(),
+            localeRouting: true,
+            localeRoutingEnabledCookieName: 'locale-routing',
+            resetLocaleCookieName: defaultResetLocaleCookieName,
+            localeHeaderName: 'x-locale',
+          });
+
+          expect(response.status).toBe(type === 'redirect' ? 307 : 200);
+          expect(
+            response.headers.get(
+              type === 'redirect' ? 'location' : 'x-middleware-rewrite'
+            )
+          ).toBe(origin + basePath + slash + query);
+        }
+      );
+    });
+
     it.each(['', '/'])(
       'retains a same-named app route (trailing slash "%s")',
       (slash) => {

--- a/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts
@@ -35,6 +35,7 @@ function createRequest(
     cookies?: Record<string, string>;
     acceptLanguage?: string;
     search?: string;
+    basePath?: string;
   } = {}
 ): NextRequest {
   const url = new URL(pathname, 'http://localhost:3000');
@@ -45,7 +46,10 @@ function createRequest(
     headers.set('accept-language', opts.acceptLanguage);
   }
 
-  const req = new NextRequest(url, { headers });
+  const req = new NextRequest(url, {
+    headers,
+    nextConfig: opts.basePath ? { basePath: opts.basePath } : undefined,
+  });
   if (opts.cookies) {
     for (const [name, value] of Object.entries(opts.cookies)) {
       req.cookies.set(name, value);
@@ -405,6 +409,32 @@ describe('Middleware Integration Tests', () => {
 
       expect(getResponseType(res)).toBe('redirect');
       expect(getResponseSearch(res)).toBe('?page=2');
+    });
+
+    it('preserves basePath on rewrites and redirects', () => {
+      setEnvConfig();
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: true,
+        pathConfig: {
+          '/about': { fr: '/a-propos' },
+        },
+      });
+
+      const rewriteResponse = middleware(
+        createRequest('/corp/fr/a-propos', {
+          basePath: '/corp',
+          search: 'preview=true',
+        })
+      );
+      const redirectResponse = middleware(
+        createRequest('/corp/fr/about', { basePath: '/corp' })
+      );
+
+      expect(getResponseType(rewriteResponse)).toBe('rewrite');
+      expect(getResponsePath(rewriteResponse)).toBe('/corp/fr/about');
+      expect(getResponseSearch(rewriteResponse)).toBe('?preview=true');
+      expect(getResponseType(redirectResponse)).toBe('redirect');
+      expect(getResponsePath(redirectResponse)).toBe('/corp/fr/a-propos');
     });
 
     it('sets locale header on rewrite responses', () => {

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -56,7 +56,11 @@ function applyBasePath(responseUrl: URL, originalUrl: NextURL) {
     return;
   }
   // Middleware targets are app-relative, even when a route repeats the base path.
-  responseUrl.pathname = `${basePath}${responseUrl.pathname}`;
+  // Preserve the request's slash style when targeting the app root.
+  responseUrl.pathname =
+    responseUrl.pathname === '/'
+      ? applyTrailingSlash(new URL(originalUrl).pathname, basePath)
+      : `${basePath}${responseUrl.pathname}`;
 }
 
 export function getResponse({

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -46,6 +46,15 @@ function createPathPattern(pathname: string): string {
     .join('');
 }
 
+function applyBasePath(responseUrl: URL, originalUrl: NextURL) {
+  const { basePath } = originalUrl;
+  if (!basePath || responseUrl.origin !== originalUrl.origin) {
+    return;
+  }
+  // Middleware targets are app-relative, even when a route repeats the base path.
+  responseUrl.pathname = `${basePath}${responseUrl.pathname}`;
+}
+
 /** Applies the request pathname's trailing-slash style to a target path. */
 function applyTrailingSlash(pathname: string, targetPathname: string): string {
   const sourceHasTrailingSlash = pathname.length > 1 && pathname.endsWith('/');
@@ -79,6 +88,7 @@ export function getResponse({
     });
   } else {
     const responseUrl = new URL(responsePath, originalUrl);
+    applyBasePath(responseUrl, originalUrl);
     responseUrl.search = originalUrl.search;
     response =
       type === 'rewrite'


### PR DESCRIPTION
middleware redirects and rewrites leave the next `basePath` out of the destination. under `basePath: '/docs'`, 25 of 25 live redirects on main lost the prefix.

**why.** `req.nextUrl.pathname` arrives with the base path stripped, so every path the router computes is app-relative. `getResponse` then builds the destination with `new URL(responsePath, originalUrl)`, which resolves that app-relative path against the origin and never puts the base path back.

**fix.** `applyBasePath` (`packages/next/src/middleware-dir/utils.ts:53`) prefixes `originalUrl.basePath` onto the destination pathname for same-origin rewrites and redirects, before the query is copied over. when the destination is `/`, it emits the base path alone in the request's slash style (d5474593a), so `GET /docs/fr` with the reset cookie 307s to `/docs` and `GET /docs/fr/` 307s to `/docs/`. the prefix comes from next's request metadata, so a route or locale prefix that repeats the base path keeps both occurrences: under `basePath: '/fr'`, `/fr/fr/articles/123` rewrites to `/fr/fr/posts/123`, and a route configured as `/docs/about` under `basePath: '/docs'` redirects to `/docs/docs/about`. nothing here depends on the trie or catch-all work in #2243.

**verified.** 44 cases in `basePathRegression.edge.test.ts` across the base paths `/docs`, `/fr`, `/en` and `/corp/nested`: a same-named route redirect with and without a trailing slash and a repeated query key, a locale prefix equal to the base path, the reset redirect to the base-path root, a request for the bare base path, and both slash styles on a redirect and a rewrite, plus one rewrite and redirect case under `/corp` in `middleware.edge.test.ts`. live against a consumer app with `basePath: '/docs'`, 136 probes kept `/docs` exactly once on every rewrite and redirect.

```
basePath /corp   /corp/fr/a-propos?preview=true   rewrite -> /corp/fr/about?preview=true
basePath /corp   /corp/fr/about                   307     -> /corp/fr/a-propos
basePath /fr     /fr/fr/articles/123              rewrite -> /fr/fr/posts/123
basePath /docs   /docs/about?tag=a&tag=b          307     -> /docs/docs/about?tag=a&tag=b    ('/about' configured as en '/docs/about')
```

stacked on #2266; #2271 follows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR preserves the configured Next.js `basePath` when locale middleware constructs same-origin rewrite and redirect destinations, while retaining the request query string.
- Adds a centralized base-path application step for middleware destinations.
- Covers rewrites, redirects, trailing-slash variants, repeated route/base-path names, nested base paths, locale/base-path collisions, and repeated query parameters.
- Adds a patch changeset for `gt-next`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the centralized change matches the middleware routing model and is covered by focused rewrite and redirect regressions.

No actionable failures remain: rewrite and redirect destinations consistently pass through the new same-origin base-path handling, continuation responses are unaffected, and tests exercise the important base-path, locale, trailing-slash, and query-string cases.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Prefixes same-origin middleware rewrite and redirect destinations with `NextURL.basePath` before preserving the original query string. |
| packages/next/src/middleware-dir/__tests__/basePathRegression.edge.test.ts | Adds focused edge-runtime regressions for repeated and nested base paths, locale collisions, trailing slashes, and repeated query parameters. |
| packages/next/src/middleware-dir/__tests__/middleware.edge.test.ts | Extends the request helper with Next.js base-path metadata and verifies base-path preservation for both rewrites and redirects. |
| .changeset/preserve-middleware-base-path.md | Records the middleware base-path correction as a patch release for `gt-next`. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Incoming NextRequest] --> B[Read app-relative pathname and basePath metadata]
  B --> C[Locale and pathConfig routing decision]
  C -->|Continue| D[NextResponse.next]
  C -->|Rewrite or redirect| E[Construct app-relative destination]
  E --> F{Same origin and basePath configured?}
  F -->|Yes| G[Prefix configured basePath]
  F -->|No| H[Keep destination unchanged]
  G --> I[Restore original query string]
  H --> I
  I --> J[NextResponse.rewrite or redirect]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(next): carry locale root fixes int..."](https://github.com/generaltranslation/gt/commit/1ef23e0fb53cf1b429fc0fb0e6b8221dd74080b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61863786)</sub>

**Context used:**

- Knowledge Base — [Next.js integration](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/nextjs-integration.md)

<!-- /greptile_comment -->
