### PR TITLE
fix(next): [1/7] escape literal route pattern text

### DIFF
--- a/.changeset/escape-dynamic-route-literals.md
+++ b/.changeset/escape-dynamic-route-literals.md
@@ -1,0 +1,5 @@
+---
+'gt-next': patch
+---
+
+Treat static text in configured dynamic routes literally when matching shared paths and localized aliases. Escape regex metacharacters such as `.`, `+`, parentheses, `|`, and `$` so valid routes match and lookalike paths do not, including unprefixed default-locale aliases used for locale selection.

--- a/packages/next/src/middleware-dir/__tests__/pathPatternRegression.edge.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/pathPatternRegression.edge.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment edge-runtime
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { defaultLocaleCookieName } from 'gt-i18n/internal/cookies';
+import { defaultLocaleHeaderName } from '../../utils/headers';
+import { createNextMiddleware } from '../createNextMiddleware';
+
+describe('literal default-locale dynamic aliases', () => {
+  beforeEach(() => {
+    vi.stubEnv(
+      '_GENERALTRANSLATION_I18N_CONFIG_PARAMS',
+      JSON.stringify({ defaultLocale: 'en', locales: ['en', 'fr'] })
+    );
+    vi.stubEnv('_GENERALTRANSLATION_GT_SERVICES_ENABLED', undefined);
+    vi.stubEnv('_GENERALTRANSLATION_IGNORE_BROWSER_LOCALES', undefined);
+    vi.stubEnv('_GENERALTRANSLATION_PATH_REGEX', undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    ['v1.0', 'v1X0'],
+    ['a+b', 'aaab'],
+    ['docs(v2)', 'docsv2'],
+    ['left|right', 'left'],
+    ['cost$', 'cost'],
+  ])(
+    'recognizes %s before the locale cookie, but not %s',
+    (literal, lookalike) => {
+      const middleware = createNextMiddleware({
+        prefixDefaultLocale: false,
+        pathConfig: {
+          '/shared/articles/[id]': {
+            en: `/english/${literal}/[id]`,
+            fr: '/french/articles/[id]',
+          },
+        },
+      });
+      const request = (segment: string) => {
+        const req = new NextRequest(
+          `http://localhost:3000/english/${segment}/one`
+        );
+        req.cookies.set(defaultLocaleCookieName, 'fr');
+        return req;
+      };
+
+      const matched = middleware(request(literal));
+      expect(matched.headers.get(defaultLocaleHeaderName)).toBe('en');
+      expect(matched.headers.get('location')).toBeNull();
+      expect(
+        new URL(matched.headers.get('x-middleware-rewrite')!).pathname
+      ).toBe('/en/shared/articles/one');
+
+      const unmatched = middleware(request(lookalike));
+      expect(unmatched.headers.get(defaultLocaleHeaderName)).toBe('fr');
+      expect(unmatched.headers.get('x-middleware-rewrite')).toBeNull();
+      expect(new URL(unmatched.headers.get('location')!).pathname).toBe(
+        `/fr/english/${lookalike}/one`
+      );
+    }
+  );
+});

--- a/packages/next/src/middleware-dir/__tests__/utils.test.ts
+++ b/packages/next/src/middleware-dir/__tests__/utils.test.ts
@@ -421,3 +421,90 @@ describe('getSharedPath', () => {
     expect(getSharedPath('/en/', pathToSharedPath, 'en')).toBe(undefined);
   });
 });
+
+describe('configured dynamic route literals', () => {
+  const literals = [
+    ['v1.0', 'v1X0'],
+    ['a+b', 'aaab'],
+    ['docs(v2)', 'docsv2'],
+    ['left|right', 'left'],
+    ['cost$', 'cost'],
+  ];
+
+  it.each(literals)(
+    'matches shared and localized %s literally and rejects %s',
+    (literal, lookalike) => {
+      const sharedPath = `/shared/${literal}/[id]`;
+      const { pathToSharedPath } = createPathToSharedPathMap(
+        {
+          [sharedPath]: {
+            en: `/english/${literal}/[id]`,
+            fr: `/french/${literal}/[id]`,
+          },
+        },
+        false,
+        'en'
+      );
+
+      for (const [prefix, locale] of [
+        ['/shared', undefined],
+        ['/english', undefined],
+        ['/fr/french', 'fr'],
+      ] as const) {
+        expect(
+          getSharedPath(`${prefix}/${literal}/one`, pathToSharedPath, locale)
+        ).toBe(sharedPath);
+        expect(
+          getSharedPath(`${prefix}/${lookalike}/one`, pathToSharedPath, locale)
+        ).toBeUndefined();
+        expect(
+          getSharedPath(
+            `${prefix}/${literal}/one/two`,
+            pathToSharedPath,
+            locale
+          )
+        ).toBeUndefined();
+      }
+    }
+  );
+
+  it('prefers exact static routes over earlier dynamic routes', () => {
+    const { pathToSharedPath } = createPathToSharedPathMap(
+      {
+        '/v1.0/[id]': { fr: '/version.1/[id]' },
+        '/v1.0/new': { fr: '/version.1/new' },
+      },
+      false,
+      'en'
+    );
+
+    expect(getSharedPath('/v1.0/new', pathToSharedPath, undefined)).toBe(
+      '/v1.0/new'
+    );
+    expect(getSharedPath('/fr/version.1/new', pathToSharedPath, 'fr')).toBe(
+      '/v1.0/new'
+    );
+  });
+
+  it('keeps encoded brackets literal beside a real placeholder', () => {
+    const sharedPath = '/%5Bid%5D/[slug]';
+    const { pathToSharedPath } = createPathToSharedPathMap(
+      { [sharedPath]: { fr: '/%5Barticle%5D/[slug]' } },
+      false,
+      'en'
+    );
+
+    expect(getSharedPath('/%5Bid%5D/one', pathToSharedPath, undefined)).toBe(
+      sharedPath
+    );
+    expect(getSharedPath('/fr/%5Barticle%5D/one', pathToSharedPath, 'fr')).toBe(
+      sharedPath
+    );
+    expect(
+      getSharedPath('/anything/one', pathToSharedPath, undefined)
+    ).toBeUndefined();
+    expect(
+      getSharedPath('/fr/anything/one', pathToSharedPath, 'fr')
+    ).toBeUndefined();
+  });
+});

--- a/packages/next/src/middleware-dir/utils.ts
+++ b/packages/next/src/middleware-dir/utils.ts
@@ -22,10 +22,17 @@ export type ResponseConfig = {
 };
 
 const DYNAMIC_PATH_SEGMENT_PATTERN = '/[^/]+';
-const PATH_REGEX_SLASHES = /[\\/]/g;
-
-function escapePathRegexSlashes(pathPattern: string): string {
-  return pathPattern.replace(PATH_REGEX_SLASHES, '\\$&');
+/** Compiles placeholders while treating the surrounding static text literally. */
+function createPathPattern(pathname: string): string {
+  if (!/\[([^\]]+)\]/.test(pathname)) {
+    return pathname;
+  }
+  return pathname
+    .split(/(\[[^\]]+\])/)
+    .map((part, index) =>
+      index % 2 ? '[^/]+' : part.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    )
+    .join('');
 }
 
 export function getResponse({
@@ -164,18 +171,13 @@ export function createPathToSharedPathMap(
     (acc, [sharedPath, localizedPaths]) => {
       const { pathToSharedPath, defaultLocalePaths } = acc;
       // Add the shared path itself, converting to regex pattern if it has dynamic segments
-      if (sharedPath.includes('[')) {
-        const pattern = sharedPath.replace(/\[([^\]]+)\]/g, '[^/]+');
-        pathToSharedPath[pattern] = sharedPath;
-      } else {
-        pathToSharedPath[sharedPath] = sharedPath;
-      }
+      pathToSharedPath[createPathPattern(sharedPath)] = sharedPath;
 
       if (typeof localizedPaths === 'object') {
         Object.entries(localizedPaths).forEach(([locale, localizedPath]) => {
           // Convert the localized path to a regex pattern
           // Replace [param] with [^/]+ to match any non-slash characters
-          const pattern = localizedPath.replace(/\[([^\]]+)\]/g, '[^/]+');
+          const pattern = createPathPattern(localizedPath);
           pathToSharedPath[`/${locale}${pattern}`] = sharedPath;
           if (!prefixDefaultLocale && locale === defaultLocale) {
             pathToSharedPath[pattern] = sharedPath;
@@ -217,7 +219,7 @@ export function getSharedPath(
   for (const [pattern, sharedPath] of Object.entries(pathToSharedPath)) {
     if (pattern.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
       // Convert the pattern to a strict regex that matches the exact path structure
-      const regex = new RegExp(`^${escapePathRegexSlashes(pattern)}$`);
+      const regex = new RegExp(`^${pattern}$`);
       // Exact match
       if (regex.test(standardizedPathname)) {
         return sharedPath;
@@ -254,7 +256,7 @@ function inDefaultLocalePaths(
   // Try regex pattern match
   for (const path of defaultLocalePaths) {
     if (path.includes(DYNAMIC_PATH_SEGMENT_PATTERN)) {
-      const regex = new RegExp(`^${escapePathRegexSlashes(path)}$`);
+      const regex = new RegExp(`^${path}$`);
       if (regex.test(pathname)) {
         return true;
       }


### PR DESCRIPTION
configured routes with a bracket placeholder compiled to a regex with their static text left raw. `/v1.0/[id]` also matched `/v1X0/one`, templates spelled with `+`, parentheses or `$` failed to match their own spelling, and a `|` split the pattern into two alternatives, so `/shared/left|right/[id]` also matched `/shared/left/one`. a template without a placeholder is stored raw and found by exact key before the regex loop runs, so static routes were unaffected.

**why.** `createPathToSharedPathMap` replaced each `[param]` with `[^/]+` and stored the result as the map key. `getSharedPath` and `inDefaultLocalePaths` anchored that key as `^...$` and escaped only `/` and `\` (`escapePathRegexSlashes`), so every other metacharacter in the template was still interpreted as regex.

**fix.** `createPathPattern` splits the template on its placeholders, replaces each placeholder with `[^/]+`, escapes the regex metacharacters in the static text between them, and returns a template with no placeholder unchanged. shared paths and localized aliases both go through it. `getSharedPath` and `inDefaultLocalePaths` consume the compiled pattern directly and the slash-escaping pass is gone. encoded brackets such as `%5Bid%5D` are not placeholders and stay literal. an exact static route still wins over an earlier dynamic route.

with `prefixDefaultLocale: false` this also fixes locale selection on unprefixed default-locale aliases. the alias has to match literally to take precedence over the locale cookie:

```
pathConfig { '/shared/articles/[id]': { en: '/english/cost$/[id]', fr: '/french/articles/[id]' } }, cookie fr
/english/cost$/one   rewrite -> /en/shared/articles/one   locale header en
/english/cost/one    307 -> /fr/english/cost/one          locale header fr
```

**verified.** 12 new cases: the five literal and lookalike pairs (`v1.0`/`v1X0`, `a+b`/`aaab`, `docs(v2)`/`docsv2`, `left|right`/`left`, `cost$`/`cost`) against `getSharedPath` in shared, localized and unprefixed form, the same five through `createNextMiddleware` with a fr cookie, exact-static precedence, and encoded brackets beside a real placeholder. all 12 pass at the stack head (6d4f27811), where #2243's trie has replaced this regex code and the middleware-dir suite is 1,192 tests in 19 files. this pr stays its own commit so the stack bisects.

the changeset is a patch for gt-next.

base is main; #2265 follows.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR corrects dynamic route matching by compiling bracket placeholders separately from escaped literal path text.
- Escapes regular-expression metacharacters in shared routes and localized aliases.
- Uses compiled patterns directly for shared-path and default-locale alias matching.
- Adds unit and edge-runtime coverage for literal metacharacters, false positives, locale precedence, exact-static precedence, encoded brackets, and segment boundaries.
- Adds a patch changeset for `gt-next`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with the route-pattern correction narrowly scoped and backed by focused unit and edge-runtime regression tests.

The compiler escapes all regular-expression metacharacters in static portions while retaining a simple single-segment placeholder expression, and no newly introduced correctness, security, or repository-rule violation remains.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/next/src/middleware-dir/utils.ts | Introduces literal-safe route-pattern compilation and consumes compiled patterns directly during dynamic route matching. |
| packages/next/src/middleware-dir/__tests__/utils.test.ts | Adds focused coverage for regex metacharacters, false positives, segment boundaries, static precedence, and encoded bracket literals. |
| packages/next/src/middleware-dir/__tests__/pathPatternRegression.edge.test.ts | Verifies unprefixed default-locale aliases are recognized literally without breaking locale-cookie precedence. |
| .changeset/escape-dynamic-route-literals.md | Accurately documents the patch-level route-matching correction. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Configured route] --> B[Split bracket placeholders]
  B --> C[Escape static text]
  B --> D[Compile placeholders as non-slash segments]
  C --> E[Compiled route pattern]
  D --> E
  E --> F[Shared-path lookup]
  E --> G[Default-locale alias recognition]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(next): escape literal text in dynami..."](https://github.com/generaltranslation/gt/commit/804eb640edb8237fcd617bc7a03b014e393529e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61925624)</sub>

<!-- /greptile_comment -->