### PR TITLE
fix(cli): upload dry run + customMapping reupload

### DIFF
--- a/.changeset/upload-dry-run-lock-aliases.md
+++ b/.changeset/upload-dry-run-lock-aliases.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+fix(cli): make `gt upload --dry-run` a true no-op and stop re-uploading unchanged translations for `customMapping` locales. The upload command accepted `--dry-run` but ignored it; it now lists what would be sent (honoring the `gt-lock.json` skip check), requires no credentials, and never calls the API or publishes. Separately, the server confirms translation uploads under GT's canonical locale code while local files carry the configured alias (for example `he-IL` -> `he`), so aliased locales never got a `gt-lock.json` hash and re-uploaded on every run. Confirmations are now matched in canonical locale space and the API wrapper maps confirmed locales back to their configured alias, consistent with download.

--- a/packages/cli/src/cli/base.ts
+++ b/packages/cli/src/cli/base.ts
@@ -142,6 +142,7 @@ export type UploadOptions = {
   apiKey?: string;
   projectId?: string;
   defaultLocale?: string;
+  dryRun?: boolean;
 };
 
 export type LoginOptions = {

--- a/packages/cli/src/cli/commands/__tests__/upload.test.ts
+++ b/packages/cli/src/cli/commands/__tests__/upload.test.ts
@@ -43,7 +43,7 @@ vi.mock('../../../utils/hash.js', () => ({
       `hash_${requiresReview ? 'rr_' : ''}${s.slice(0, 16)}`
   ),
 }));
-vi.mock('./utils/validation.js', () => ({
+vi.mock('../utils/validation.js', () => ({
   hasValidCredentials: vi.fn(() => true),
 }));
 
@@ -70,7 +70,8 @@ import { runPublishWorkflow } from '../../../workflows/publish.js';
 import { createFileMapping } from '../../../formats/files/fileMapping.js';
 import { logger } from '../../../console/logger.js';
 import { existsSync, readFileSync } from 'node:fs';
-import { logErrorAndExit } from '../../../console/logging.js';
+import { exitSync, logErrorAndExit } from '../../../console/logging.js';
+import { hasValidCredentials } from '../utils/validation.js';
 
 function setMockFiles(files: Record<string, string>) {
   (vi as unknown).__mockFiles = files;
@@ -164,6 +165,33 @@ describe('upload - Twilio Content JSON', () => {
     expect(call.files[0].source.fileFormat).toBe('TWILIO_CONTENT_JSON');
     expect(runPublishWorkflow).toHaveBeenCalledTimes(1);
     expect(vi.mocked(runPublishWorkflow).mock.calls[0][2]).toBe('branch-id');
+  });
+
+  it('does not upload, publish, or require credentials on a dry run', async () => {
+    const translatedContent = JSON.stringify({ body: 'Hola' });
+    setMockFiles({ 'twilio/content.json': JSON.stringify({ body: 'Hi' }) });
+    vi.mocked(createFileMapping).mockReturnValue({
+      es: { 'twilio/content.json': 'twilio/es/content.json' },
+    });
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(translatedContent);
+    vi.mocked(hasValidCredentials).mockReturnValueOnce(false);
+
+    await uploadWithFiles(
+      { twilioContentJson: ['twilio/content.json'] },
+      makeSettings({ locales: ['es'], options: {}, dryRun: true })
+    );
+
+    expect(runUploadFilesWorkflow).not.toHaveBeenCalled();
+    expect(runPublishWorkflow).not.toHaveBeenCalled();
+    expect(exitSync).not.toHaveBeenCalled();
+    expect(logger.message).toHaveBeenCalledWith(
+      expect.stringContaining('twilio/content.json')
+    );
+    expect(logger.message).toHaveBeenCalledWith(expect.stringContaining('es'));
+    expect(logger.success).toHaveBeenCalledWith(
+      expect.stringContaining('Dry run')
+    );
   });
 
   it('should use fileMapping for Twilio Content JSON files (no composite)', async () => {

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -1,5 +1,6 @@
 import {
   fileEncodingSkipReason,
+  filesToUploadMessage,
   noDefaultLocaleError,
 } from '../../console/index.js';
 import { exitSync, logErrorAndExit } from '../../console/logging.js';
@@ -18,6 +19,8 @@ import { hasValidCredentials } from './utils/validation.js';
 import { runPublishWorkflow } from '../../workflows/publish.js';
 import { aggregateFiles } from '../../formats/files/aggregateFiles.js';
 import { recordWarning } from '../../state/translateWarnings.js';
+import { readLockfile } from '../../fs/config/downloadedVersions.js';
+import { partitionTranslationsByLockfile } from '../../workflows/steps/UploadTranslationsStep.js';
 
 /**
  * Sends multiple files to the API for translation
@@ -73,7 +76,8 @@ export async function upload(
   if (!settings.defaultLocale) {
     return logErrorAndExit(noDefaultLocaleError);
   }
-  if (!hasValidCredentials(settings)) return exitSync(1);
+  // A dry run never reaches the API, so it should not demand credentials
+  if (!settings.dryRun && !hasValidCredentials(settings)) return exitSync(1);
 
   const locales = settings.locales || [];
   // Create file mapping for all file types
@@ -151,6 +155,33 @@ export async function upload(
       translations,
     };
   });
+
+  if (settings.dryRun) {
+    // Mirror the real run's lockfile check so the listing shows what would
+    // actually be sent, then stop before any network or filesystem writes.
+    const { filesToUpload, skippedCount } = partitionTranslationsByLockfile(
+      uploadData,
+      readLockfile(settings).entryMap
+    );
+    const pendingTranslations = new Map(
+      filesToUpload.map((file) => [file.source.fileId, file.translations])
+    );
+    logger.message(
+      filesToUploadMessage(
+        uploadData.map((file) => ({
+          source: file.source,
+          translations: pendingTranslations.get(file.source.fileId) ?? [],
+        }))
+      )
+    );
+    if (skippedCount > 0) {
+      logger.info(
+        `${skippedCount} translation file${skippedCount !== 1 ? 's are' : ' is'} unchanged since the last sync and would be skipped`
+      );
+    }
+    logger.success('Dry run: No files were sent to General Translation.');
+    return;
+  }
 
   try {
     // Send all files in a single API call

--- a/packages/cli/src/console/index.ts
+++ b/packages/cli/src/console/index.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import { createDiagnosticMessage } from 'generaltranslation/internal';
 import { BRANCH_COMPONENT } from '../react/jsx/utils/constants.js';
 import {
@@ -450,3 +451,22 @@ export const fileEncodingSkipReason = (error: unknown): string =>
 
 export const withOriginalError = (message: string, error: unknown): string =>
   error != null ? `${message} Original error: ${String(error)}` : message;
+
+/**
+ * Lists every source file queued for upload and the locales of the
+ * translation files that accompany it.
+ */
+export const filesToUploadMessage = (
+  files: {
+    source: { fileName: string };
+    translations: { locale: string }[];
+  }[]
+): string =>
+  chalk.cyan('Files to upload:') +
+  '\n' +
+  files
+    .map(
+      (file) =>
+        `  - ${chalk.bold(file.source.fileName)}${file.translations.length > 0 ? ` -> ${file.translations.map((t) => t.locale).join(', ')}` : ''}`
+    )
+    .join('\n');

--- a/packages/cli/src/utils/__tests__/api.test.ts
+++ b/packages/cli/src/utils/__tests__/api.test.ts
@@ -314,13 +314,13 @@ describe('CLI API client', () => {
       };
       expect(body.data[0].translations[0].locale).toBe('en-US');
       return Response.json({
-        uploadedFiles: [uploadedFile],
+        uploadedFiles: [{ ...uploadedFile, locale: 'en-US' }],
         count: 1,
         message: 'uploaded',
       });
     });
 
-    await api.uploadTranslations(
+    const result = await api.uploadTranslations(
       [
         {
           source: {
@@ -341,6 +341,10 @@ describe('CLI API client', () => {
       ],
       { sourceLocale: 'en' }
     );
+
+    // The server confirms under its canonical code; callers get the alias
+    // back so confirmations line up with what they uploaded.
+    expect(result.uploadedFiles[0].locale).toBe('brand-english');
   });
 
   it('decodes text downloads and preserves binary downloads', async () => {

--- a/packages/cli/src/utils/api.ts
+++ b/packages/cli/src/utils/api.ts
@@ -427,7 +427,14 @@ export const api = {
           client: getClient(),
         })
       );
-      return response.uploadedFiles;
+      // The server echoes canonical codes; hand callers the configured alias
+      // so results line up with the locale they uploaded under.
+      return response.uploadedFiles.map((uploadedFile) => ({
+        ...uploadedFile,
+        ...(uploadedFile.locale && {
+          locale: resolveAliasLocale(uploadedFile.locale, customMapping),
+        }),
+      }));
     });
 
     return { uploadedFiles: result };

--- a/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
+++ b/packages/cli/src/workflows/steps/UploadTranslationsStep.ts
@@ -10,6 +10,7 @@ import {
 } from '../../fs/config/downloadedVersions.js';
 import { hashStringSync } from '../../utils/hash.js';
 import type { FileReference, FileToUpload } from 'generaltranslation/types';
+import { resolveCanonicalLocale } from '@generaltranslation/format';
 
 type UploadTranslationsInput = {
   files: {
@@ -177,17 +178,28 @@ export class UploadTranslationsStep {
     uploaded: UploadTranslationsInput['files'],
     confirmed: ConfirmedTranslationReference[]
   ): void {
+    // Compare in canonical locale space: the server confirms uploads under
+    // GT's code (e.g. `he`), while local translations carry the configured
+    // key (e.g. a customMapping alias like `he-IL`). Several aliases may
+    // collapse onto one canonical code, so a confirmation for that code
+    // covers every local translation that resolves to it.
+    const confirmedKey = (fileId: string, locale: string) =>
+      `${fileId}:${resolveCanonicalLocale(locale, this.settings.customMapping)}`;
     const confirmedKeys = new Set(
       confirmed
         .filter((file) => file.locale)
-        .map((file) => `${file.fileId}:${file.locale}`)
+        .map((file) => confirmedKey(file.fileId, file.locale!))
     );
     if (confirmedKeys.size === 0) return;
 
     const updatedAt = new Date().toISOString();
     for (const file of uploaded) {
       for (const translation of file.translations) {
-        if (!confirmedKeys.has(`${translation.fileId}:${translation.locale}`)) {
+        if (
+          !confirmedKeys.has(
+            confirmedKey(translation.fileId, translation.locale)
+          )
+        ) {
           continue;
         }
         const entry = findOrCreateEntry(

--- a/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
+++ b/packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
@@ -325,6 +325,45 @@ describe('UploadTranslationsStep', () => {
     expect(entry?.translations.fr).toBeUndefined();
   });
 
+  it('records hashes for customMapping aliases confirmed under their canonical code', async () => {
+    // Android-style config: `he` and `he-IL` both resolve to GT's `he`, and
+    // `in` is an alias for `id`. The server confirms uploads by canonical
+    // code, so without alias-aware matching these would never be recorded
+    // and would re-upload on every run.
+    const settings = {
+      ...mockSettings,
+      customMapping: { 'he-IL': { code: 'he' }, in: { code: 'id' } },
+    } as unknown as Settings;
+    const he = makeTranslation('file-1', 'he');
+    const heIL = makeTranslation('file-1', 'he-IL');
+    const indonesian = makeTranslation('file-1', 'in');
+    mockGt.uploadTranslations.mockResolvedValue({
+      uploadedFiles: [
+        confirmedUpload('file-1', 'he'),
+        confirmedUpload('file-1', 'id'),
+      ],
+    });
+
+    const step = new UploadTranslationsStep(mockGt as unknown as GT, settings);
+    await step.run({
+      files: [
+        { source: makeSource('file-1'), translations: [he, heIL, indonesian] },
+      ],
+    });
+
+    const [written] = vi.mocked(writeLockfile).mock.calls[0]!;
+    const entry = written.entries.find((e) => e.fileId === 'file-1');
+    expect(entry?.translations.he?.postProcessHash).toBe(
+      hashStringSync(he.content)
+    );
+    expect(entry?.translations['he-IL']?.postProcessHash).toBe(
+      hashStringSync(heIL.content)
+    );
+    expect(entry?.translations.in?.postProcessHash).toBe(
+      hashStringSync(indonesian.content)
+    );
+  });
+
   it('reports the server-confirmed number of uploaded translation files', async () => {
     const files = [
       {

--- a/packages/cli/src/workflows/upload.ts
+++ b/packages/cli/src/workflows/upload.ts
@@ -1,5 +1,8 @@
-import chalk from 'chalk';
-import { branchResolutionError, withOriginalError } from '../console/index.js';
+import {
+  branchResolutionError,
+  filesToUploadMessage,
+  withOriginalError,
+} from '../console/index.js';
 import { logger } from '../console/logger.js';
 import { logErrorAndExit } from '../console/logging.js';
 import { Settings } from '../types/index.js';
@@ -28,16 +31,7 @@ export async function runUploadFilesWorkflow({
   options: Settings;
 }): Promise<{ branchData: BranchData }> {
   try {
-    logger.message(
-      chalk.cyan('Files to upload:') +
-        '\n' +
-        files
-          .map(
-            (file) =>
-              `  - ${chalk.bold(file.source.fileName)}${file.translations.length > 0 ? ` -> ${file.translations.map((t) => t.locale).join(', ')}` : ''}`
-          )
-          .join('\n')
-    );
+    logger.message(filesToUploadMessage(files));
 
     // Sync fonts first (locale-invariant) so they're available when
     // translating formats that need them.


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR makes `gt upload --dry-run` bypass credentials and remote workflows while reporting lockfile-filtered uploads, and changes custom-locale confirmation handling to update upload hashes in canonical locale space.

- Extracts shared upload-list formatting for real and dry-run output.
- Maps canonical API confirmations back through configured locale aliases.
- Adds dry-run and custom-mapping regression tests.
- The canonical confirmation matching can incorrectly mark an unconfirmed colliding alias as synchronized.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is not safe to merge until canonical-locale collisions stop marking unconfirmed translations as synchronized and the required idempotency failure paths are tested.

A single canonical server confirmation can currently write lockfile hashes for multiple distinct local translations, causing an unpersisted alias to be skipped indefinitely on later uploads.

**Files Needing Attention:** packages/cli/src/workflows/steps/UploadTranslationsStep.ts, packages/cli/src/cli/commands/__tests__/upload.test.ts, packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/cli/commands/upload.ts | Adds a credential-free dry-run branch that reuses lockfile partitioning and returns before upload or publishing. |
| packages/cli/src/utils/api.ts | Converts canonical translation confirmations back to configured aliases, but alias identity is ambiguous when mappings collide. |
| packages/cli/src/workflows/steps/UploadTranslationsStep.ts | Canonicalizes confirmation matching but can record hashes for multiple distinct aliases from one confirmation. |
| packages/cli/src/cli/commands/__tests__/upload.test.ts | Covers basic dry-run no-op behavior but omits required lockfile and failure-path cases. |
| packages/cli/src/workflows/steps/__tests__/UploadTranslationsStep.test.ts | Adds custom-mapping coverage while encoding the unsafe assumption that one canonical confirmation validates every colliding alias. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Collect source and local translations] --> B{Dry run?}
  B -->|Yes| C[Read gt-lock.json]
  C --> D[Filter unchanged translations]
  D --> E[List pending files and stop]
  B -->|No| F[Upload sources]
  F --> G[Upload changed translations]
  G --> H[Receive canonical confirmations]
  H --> I[Record confirmed hashes]
  I --> J[Publish when configured]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232276%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2276&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fworkflows%2Fsteps%2FUploadTranslationsStep.ts%3A181-200%0A**Canonical%20aliases%20share%20confirmations**%0A%0AWhen%20multiple%20local%20locales%20for%20one%20file%20map%20to%20the%20same%20canonical%20locale%20but%20contain%20different%20translations%2C%20one%20server%20confirmation%20now%20marks%20every%20matching%20locale%20as%20uploaded.%20For%20example%2C%20%60he%60%20and%20%60he-IL%60%20both%20become%20%60he%60%20in%20the%20API%20request.%20If%20only%20one%20translation%20is%20persisted%20and%20confirmed%2C%20this%20loop%20records%20hashes%20for%20both%20local%20translations.%20The%20unpersisted%20translation%20will%20then%20be%20skipped%20on%20later%20uploads%20instead%20of%20retried.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Fcli%2Fcommands%2F__tests__%2Fupload.test.ts%3A170-195%0A**Idempotency%20failures%20remain%20untested**%0A%0AThese%20tests%20cover%20only%20successful%20dry%20runs%20and%20successful%20canonical%20confirmations.%20They%20do%20not%20verify%20lockfile-skipped%20output%2C%20lockfile-read%20failures%2C%20or%20partial%20and%20missing%20server%20confirmations%20in%20%60UploadTranslationsStep.test.ts%60.%20The%20repository%20requires%20cache-coherence%20and%20cross-system-write%20changes%20to%20include%20failure%20and%20retry%2Fidempotency%20tests%2C%20not%20only%20happy%20paths%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fauth0-found-bugs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fauth0-found-bugs%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fworkflows%2Fsteps%2FUploadTranslationsStep.ts%3A181-200%0A**Canonical%20aliases%20share%20confirmations**%0A%0AWhen%20multiple%20local%20locales%20for%20one%20file%20map%20to%20the%20same%20canonical%20locale%20but%20contain%20different%20translations%2C%20one%20server%20confirmation%20now%20marks%20every%20matching%20locale%20as%20uploaded.%20For%20example%2C%20%60he%60%20and%20%60he-IL%60%20both%20become%20%60he%60%20in%20the%20API%20request.%20If%20only%20one%20translation%20is%20persisted%20and%20confirmed%2C%20this%20loop%20records%20hashes%20for%20both%20local%20translations.%20The%20unpersisted%20translation%20will%20then%20be%20skipped%20on%20later%20uploads%20instead%20of%20retried.%0A%0A%23%23%23%20Issue%202%0Apackages%2Fcli%2Fsrc%2Fcli%2Fcommands%2F__tests__%2Fupload.test.ts%3A170-195%0A**Idempotency%20failures%20remain%20untested**%0A%0AThese%20tests%20cover%20only%20successful%20dry%20runs%20and%20successful%20canonical%20confirmations.%20They%20do%20not%20verify%20lockfile-skipped%20output%2C%20lockfile-read%20failures%2C%20or%20partial%20and%20missing%20server%20confirmations%20in%20%60UploadTranslationsStep.test.ts%60.%20The%20repository%20requires%20cache-coherence%20and%20cross-system-write%20changes%20to%20include%20failure%20and%20retry%2Fidempotency%20tests%2C%20not%20only%20happy%20paths%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2276&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/workflows/steps/UploadTranslationsStep.ts:181-200
**Canonical aliases share confirmations**

When multiple local locales for one file map to the same canonical locale but contain different translations, one server confirmation now marks every matching locale as uploaded. For example, `he` and `he-IL` both become `he` in the API request. If only one translation is persisted and confirmed, this loop records hashes for both local translations. The unpersisted translation will then be skipped on later uploads instead of retried.

### Issue 2
packages/cli/src/cli/commands/__tests__/upload.test.ts:170-195
**Idempotency failures remain untested**

These tests cover only successful dry runs and successful canonical confirmations. They do not verify lockfile-skipped output, lockfile-read failures, or partial and missing server confirmations in `UploadTranslationsStep.test.ts`. The repository requires cache-coherence and cross-system-write changes to include failure and retry/idempotency tests, not only happy paths, so this requirement must be satisfied before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): upload dry run + customMapping..."](https://github.com/generaltranslation/gt/commit/3ef8555e55a331999daa87f521d9dd7dfcef3b2d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61873796)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - Require focused tests when changing parsing or ser... ([source](https://app.greptile.com/generaltranslation/-/custom-context?memory=4a600f31-4141-4102-80aa-4a4cd19da101))
- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)

<!-- /greptile_comment -->