### PR TITLE
test(next): add packed middleware regression E2E suite

### DIFF
--- a/tests/apps/next/middleware/package.json
+++ b/tests/apps/next/middleware/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "test:e2e": "node runPlaywright.mjs",
+    "test:e2e:packed": "node packed-regressions/run.mjs",
     "test:e2e:install": "pnpm exec playwright install chromium-headless-shell",
     "bench": "pnpm bench:e2e",
     "bench:e2e": "node runBenchE2E.mjs",

--- a/tests/apps/next/middleware/packed-regressions/README.md
+++ b/tests/apps/next/middleware/packed-regressions/README.md
@@ -1,0 +1,78 @@
+# Packed routing regression tests
+
+Run real App Router pages and Chromium against an explicitly packed `gt-next`.
+The runner never builds GT, changes workspace dependencies, or writes generated
+apps/results into the repository. It creates a fresh external consumer, installs
+the supplied artifact, verifies its SHA256 and installed middleware bytes, builds
+Next, typechecks the fixture/tests, and runs Playwright with **zero retries**.
+
+```sh
+pnpm --filter gt-next-middleware-e2e test:e2e:packed \
+  --manifest /absolute/path/manifest.json --artifact head \
+  --features encoded,ownership,depth --next 16.3.4 \
+  --output /tmp/gt-routing-fixed --port 4631 --repeat 3
+```
+
+`--output` must be a new directory outside Git. Omitting it creates a directory
+under the system temporary directory. The local server uses Next's reported
+`http://localhost:<port>` origin with no hostname override; Playwright refuses to
+reuse an already running server and stops the server it starts.
+
+The manifest selects an exact tarball, with optional packed dependency overrides:
+
+```json
+{
+  "head": {
+    "sha": "source-commit-recorded-by-the-packer",
+    "tarball": "/absolute/path/gt-next-11.1.23.tgz",
+    "sha256": "sha256-of-that-tarball"
+  },
+  "dependencies": {
+    "generaltranslation": "file:/absolute/path/generaltranslation.tgz"
+  }
+}
+```
+
+Paths may also be relative to the manifest. `--artifact base` selects a `base`
+entry with the same shape. Build the desired GT checkout and pack `packages/next`
+with `pnpm pack --pack-destination /absolute/output/path`; record `git rev-parse
+HEAD` and `shasum -a 256 <tarball>`. The runner verifies the bytes, not the packer's
+claim about which Git commit produced them. For controlled parent/head comparisons,
+pack the required GT dependency closure and reuse the same `dependencies` entries
+for both runs. Every override must be a local `file:` tarball; its actual hash is
+recorded. Without overrides, pnpm resolves the tarball's normal dependencies and
+retains the resulting consumer lockfile.
+
+Features are independent positive regression assertions:
+
+| Feature     | Behavior checked                                                                                                                                                |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `encoded`   | `%66r` / `f%72` after a real French locale prefix remain category data, with both default-prefix modes.                                                         |
+| `ownership` | Locale home and dynamic aliases retain ownership when shared paths are locale-named, in both insertion orders.                                                  |
+| `depth`     | Shared/localized templates of different depths preserve parameters, raw encoding, unprefixed aliases, and locale-reset cookies.                                 |
+| `catchall`  | Required catchall aliases with one/two trailing slashes terminate, preserve arrays, and support navigation to a deeper tail; missing required tails return 404. |
+
+Encoded-only consumers use `trailingSlash: false`; other feature sets use `true`.
+All assertions inspect real rendered route/params, repeated queries and locale
+headers. HTTP redirects are limited to five with a visited-URL set and same-origin
+checks; failure attachments retain the actual chain and wrong rendered page.
+Browser cases cover direct navigation, reload, Link navigation and Back/Forward.
+Raw-parameter cases compare with a native Next bypass control instead of assuming
+every Next version exposes encoded params identically.
+
+The fixture shares one `[category]` folder for root dynamics and category articles:
+Next does not allow different dynamic names at that same level. Required catchall
+pages are terminal and have no invalid optional-catchall/root-page sibling.
+
+Use the same feature subset on a known-bad and fixed artifact. A bad artifact must
+fail ordinary assertions because of the wrong page/params or redirect loop;
+installation, build, typecheck, or browser-launch failures are **harness errors**,
+not a successful regression reproduction. There are no expected-failure markers.
+`--repeat 3` performs the initial suite and two extra runs against the same clean
+production build. Run separate consumers with `--next 15.5.9`, `16.1.6`, and
+`16.3.4` for the representative framework matrix.
+
+Keep `result.json`, `playwright.json`, `logs/`, traces/attachments in `test-results/`,
+and the complete `consumer/` directory. These contain artifact provenance, exact
+dependency resolutions, build output, per-test outcomes and failure evidence.
+The existing `test:e2e` workflow is unchanged.

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/[category]/articles/[id]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/[category]/articles/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='category-article' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/[category]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/[category]/page.tsx
@@ -1,0 +1,8 @@
+import { Probe, type PageProps } from '../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  // The shared [category] folder also owns /[category]/articles/[id].
+  // Next requires sibling dynamic routes to use the same parameter name.
+  return <Probe route='root-dynamic' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/catalog/[category]/[...slug]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/catalog/[category]/[...slug]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='catalog' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/fr/[id]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/fr/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='locale-named-dynamic' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/fr/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/fr/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='locale-named-page' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='locale-home' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/posts/[id]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/posts/[id]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='post' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/short/[a]/[b]/page.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/[locale]/short/[a]/[b]/page.tsx
@@ -1,0 +1,6 @@
+import { Probe, type PageProps } from '../../../../probe';
+
+export const dynamic = 'force-dynamic';
+export default function Page(props: PageProps) {
+  return <Probe route='short' {...props} />;
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/layout.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/layout.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from 'react';
+
+export default function Layout({ children }: { children: ReactNode }) {
+  return (
+    <html lang='en'>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/app/probe.tsx
+++ b/tests/apps/next/middleware/packed-regressions/fixture/app/probe.tsx
@@ -1,0 +1,40 @@
+import Link from 'next/link';
+import { headers } from 'next/headers';
+
+export type PageProps = {
+  params: Promise<Record<string, string | string[]>>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export async function Probe({
+  route,
+  params,
+  searchParams,
+}: PageProps & { route: string }) {
+  const values = await params;
+  const query = await searchParams;
+  const requestHeaders = await headers();
+  const links = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    for (const item of Array.isArray(value) ? value : [value]) {
+      if (item !== undefined && key !== 'next') links.append(key, item);
+    }
+  }
+  const next = typeof query.next === 'string' ? query.next : '/fr/hello';
+  return (
+    <main>
+      <h1>{route}</h1>
+      <pre id='route-result'>
+        {JSON.stringify({
+          route,
+          params: values,
+          query,
+          localeHeader: requestHeaders.get('x-generaltranslation-locale'),
+        })}
+      </pre>
+      <Link prefetch={false} href={`${next}?${links}`}>
+        Next route
+      </Link>
+    </main>
+  );
+}

--- a/tests/apps/next/middleware/packed-regressions/fixture/middleware.ts
+++ b/tests/apps/next/middleware/packed-regressions/fixture/middleware.ts
@@ -1,0 +1,54 @@
+import { createNextMiddleware } from 'gt-next/middleware';
+import { NextResponse } from 'next/server';
+
+const dynamicOwnership = {
+  '/[category]': { en: '/[category]', fr: '/[category]' },
+  '/fr/[id]': { en: '/fr/[id]', fr: '/other/[id]' },
+};
+const configurations = {
+  encoded: {
+    '/posts/[id]': { en: '/entries/[id]', fr: '/articles/[id]' },
+    '/[category]/articles/[id]': { en: '/[category]/articles/[id]' },
+  },
+  home: { '/fr': { en: '/fr', fr: '/other' } },
+  dynamic: dynamicOwnership,
+  reverse: Object.fromEntries(Object.entries(dynamicOwnership).reverse()),
+  depth: {
+    '/short/[a]/[b]': {
+      en: '/short/[a]/[b]',
+      fr: '/long/static/[first]/[second]',
+    },
+  },
+  unprefixed: {
+    '/short/[a]/[b]': {
+      en: '/long/static/[first]/[second]',
+      fr: '/autre/[first]/[second]',
+    },
+  },
+  catchall: {
+    '/catalog/[category]/[...slug]/': {
+      en: '/catalog/[category]/[...slug]/',
+      fr: '/catalogue/[category]/[...slug]/',
+    },
+  },
+};
+
+const handlers = Object.fromEntries(
+  Object.entries(configurations).map(([name, pathConfig]) => [
+    name,
+    [false, true].map((prefixDefaultLocale) =>
+      createNextMiddleware({ pathConfig, prefixDefaultLocale })
+    ),
+  ])
+);
+
+type MiddlewareRequest = Parameters<ReturnType<typeof createNextMiddleware>>[0];
+
+export default function middleware(request: MiddlewareRequest) {
+  const scenario = request.nextUrl.searchParams.get('scenario') || 'encoded';
+  if (scenario === 'native') return NextResponse.next();
+  const prefix = request.nextUrl.searchParams.get('prefix') === '0' ? 0 : 1;
+  return (handlers[scenario] || handlers.encoded)[prefix](request);
+}
+
+export const config = { matcher: ['/((?!_next|favicon.ico).*)'] };

--- a/tests/apps/next/middleware/packed-regressions/fixture/next.config.mjs
+++ b/tests/apps/next/middleware/packed-regressions/fixture/next.config.mjs
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+
+const settings = JSON.parse(readFileSync('regression-config.json', 'utf8'));
+
+export default {
+  trailingSlash: settings.trailingSlash,
+  experimental: { cpus: 2 },
+  env: {
+    _GENERALTRANSLATION_I18N_CONFIG_PARAMS: JSON.stringify({
+      defaultLocale: 'en',
+      locales: ['en', 'fr'],
+    }),
+    _GENERALTRANSLATION_GT_SERVICES_ENABLED: 'false',
+    _GENERALTRANSLATION_IGNORE_BROWSER_LOCALES: 'true',
+    _GENERALTRANSLATION_PATH_REGEX: '',
+  },
+};

--- a/tests/apps/next/middleware/packed-regressions/fixture/tsconfig.json
+++ b/tests/apps/next/middleware/packed-regressions/fixture/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "plugins": [{ "name": "next" }]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/tests/apps/next/middleware/packed-regressions/routing.spec.ts
+++ b/tests/apps/next/middleware/packed-regressions/routing.spec.ts
@@ -1,0 +1,363 @@
+import { readFileSync } from 'node:fs';
+import {
+  test,
+  expect,
+  type APIRequestContext,
+  type Page,
+  type TestInfo,
+} from '@playwright/test';
+
+const settings = JSON.parse(readFileSync('regression-config.json', 'utf8'));
+const origin = `http://localhost:${settings.port}`;
+const slash = settings.trailingSlash ? '/' : '';
+type Payload = {
+  route: string;
+  params: Record<string, string | string[]>;
+  query: Record<string, string | string[]>;
+  localeHeader: string | null;
+};
+type Expected = Pick<Payload, 'route' | 'params'>;
+const browserErrors = new WeakMap<Page, string[]>();
+
+test.beforeEach(({ page }) => {
+  const errors: string[] = [];
+  browserErrors.set(page, errors);
+  page.on('pageerror', (error) => errors.push(error.message));
+});
+test.afterEach(async ({ page }, info) => {
+  await info.attach('browser-state', {
+    body: JSON.stringify({ url: page.url(), errors: browserErrors.get(page) }),
+    contentType: 'application/json',
+  });
+  expect(browserErrors.get(page)).toEqual([]);
+});
+
+function url(path: string, scenario: string, prefix = '1', next?: string) {
+  const query = new URLSearchParams({ scenario, prefix });
+  query.append('tag', 'a');
+  query.append('tag', 'b');
+  if (next) query.set('next', next);
+  return `${origin}${path}?${query}`;
+}
+
+function payloadFromHtml(body: string): Payload | null {
+  const value = body.match(/<pre id="route-result">([\s\S]*?)<\/pre>/)?.[1];
+  return value
+    ? JSON.parse(
+        value
+          .replaceAll('&quot;', '"')
+          .replaceAll('&#x27;', "'")
+          .replaceAll('&lt;', '<')
+          .replaceAll('&gt;', '>')
+          .replaceAll('&amp;', '&')
+      )
+    : null;
+}
+
+/** Keep loop evidence bounded and preserve the actual wrong page on failures. */
+async function follow(
+  request: APIRequestContext,
+  start: string,
+  info: TestInfo
+) {
+  const chain: {
+    url: string;
+    status: number;
+    headers: Record<string, string>;
+    payload: Payload | null;
+  }[] = [];
+  const visited = new Set<string>();
+  let current = start;
+  try {
+    for (let hop = 0; hop <= 5; hop++) {
+      expect(
+        new URL(current).origin,
+        'redirect must stay on the reported localhost origin'
+      ).toBe(origin);
+      expect(
+        visited.has(current),
+        `redirect loop: ${JSON.stringify(chain)}`
+      ).toBe(false);
+      visited.add(current);
+      const response = await request.get(current, { maxRedirects: 0 });
+      const headers = response.headers();
+      const entry = {
+        url: current,
+        status: response.status(),
+        headers,
+        payload: payloadFromHtml(await response.text()),
+      };
+      chain.push(entry);
+      if (
+        [301, 302, 303, 307, 308].includes(entry.status) &&
+        headers.location
+      ) {
+        current = new URL(headers.location, current).href;
+      } else {
+        return entry;
+      }
+    }
+    throw new Error(`Redirect cap exceeded: ${JSON.stringify(chain)}`);
+  } finally {
+    await info.attach('http-chain', {
+      body: JSON.stringify(chain, null, 2),
+      contentType: 'application/json',
+    });
+  }
+}
+
+function expectPayload(payload: Payload | null, expected: Expected) {
+  expect(payload).toMatchObject({
+    ...expected,
+    query: { tag: ['a', 'b'] },
+    localeHeader: expected.params.locale,
+  });
+}
+
+async function checkPage(page: Page, expected: Expected) {
+  await expect
+    .poll(async () => {
+      const text = await page.locator('#route-result').textContent();
+      return text ? JSON.parse(text) : null;
+    })
+    .toMatchObject({
+      ...expected,
+      query: { tag: ['a', 'b'] },
+      localeHeader: expected.params.locale,
+    });
+}
+
+async function navigate(
+  page: Page,
+  start: string,
+  first: Expected,
+  second: Expected
+) {
+  await page.goto(start);
+  await checkPage(page, first);
+  await page.getByRole('link', { name: 'Next route', exact: true }).click();
+  await checkPage(page, second);
+  await page.reload();
+  await checkPage(page, second);
+  await page.goBack();
+  await checkPage(page, first);
+  await page.goForward();
+  await checkPage(page, second);
+}
+
+test.describe('encoded', () => {
+  test.skip(!settings.features.includes('encoded'), 'Feature subset');
+  for (const prefix of ['0', '1'])
+    for (const category of ['%66r', 'f%72']) {
+      test(`encoded category ${category}, prefix ${prefix}`, async ({
+        page,
+        request,
+      }, info) => {
+        const start = url(
+          `/fr/${category}/articles/a${slash}`,
+          'encoded',
+          prefix,
+          `/fr/news/articles/b${slash}`
+        );
+        const expected = {
+          route: 'category-article',
+          params: { locale: 'fr', category: 'fr', id: 'a' },
+        };
+        const response = await follow(request, start, info);
+        expect(response.status).toBe(200);
+        expectPayload(response.payload, expected);
+        expect(response.url).toBe(start);
+        await navigate(page, start, expected, {
+          route: 'category-article',
+          params: { locale: 'fr', category: 'news', id: 'b' },
+        });
+      });
+    }
+});
+
+test.describe('ownership', () => {
+  test.skip(!settings.features.includes('ownership'), 'Feature subset');
+  test('locale root is not the locale-named shared page', async ({
+    page,
+    request,
+  }, info) => {
+    const start = url(`/fr${slash}`, 'home');
+    const response = await follow(request, start, info);
+    const expected = { route: 'locale-home', params: { locale: 'fr' } };
+    expect(response.status).toBe(200);
+    expect(response.url).toBe(start);
+    expectPayload(response.payload, expected);
+    await page.goto(start);
+    await checkPage(page, expected);
+    await page.reload();
+    await checkPage(page, expected);
+  });
+  for (const scenario of ['dynamic', 'reverse']) {
+    test(`dynamic ownership in ${scenario} order`, async ({
+      page,
+      request,
+    }, info) => {
+      const start = url(
+        `/fr/hello${slash}`,
+        scenario,
+        '1',
+        `/fr/world${slash}`
+      );
+      const expected = {
+        route: 'root-dynamic',
+        params: { locale: 'fr', category: 'hello' },
+      };
+      const response = await follow(request, start, info);
+      expect(response.status).toBe(200);
+      expect(response.url).toBe(start);
+      expectPayload(response.payload, expected);
+      await navigate(page, start, expected, {
+        route: 'root-dynamic',
+        params: { locale: 'fr', category: 'world' },
+      });
+    });
+  }
+});
+
+test.describe('depth', () => {
+  test.skip(!settings.features.includes('depth'), 'Feature subset');
+  for (const source of ['/fr/short/alpha/beta', '/fr/long/static/alpha/beta']) {
+    test(`source template preserves params from ${source}`, async ({
+      page,
+      request,
+    }, info) => {
+      const start = url(
+        source + slash,
+        'depth',
+        '1',
+        `/fr/long/static/next/value${slash}`
+      );
+      const response = await follow(request, start, info);
+      const expected = {
+        route: 'short',
+        params: { locale: 'fr', a: 'alpha', b: 'beta' },
+      };
+      expect(response.status).toBe(200);
+      expect(new URL(response.url).pathname).toBe(
+        `/fr/long/static/alpha/beta${slash}`
+      );
+      expectPayload(response.payload, expected);
+      await navigate(page, start, expected, {
+        route: 'short',
+        params: { locale: 'fr', a: 'next', b: 'value' },
+      });
+    });
+  }
+  for (const value of ['a%2Fb', 'a%252Fb']) {
+    test(`preserves raw parameter bytes ${value}`, async ({
+      page,
+      request,
+    }, info) => {
+      // Native control avoids assuming every Next version decodes params alike.
+      const control = await follow(
+        request,
+        url(`/fr/short/${value}/beta${slash}`, 'native'),
+        info
+      );
+      expect(control.status).toBe(200);
+      const start = url(`/fr/short/${value}/beta${slash}`, 'depth');
+      const response = await follow(request, start, info);
+      expect(response.status).toBe(200);
+      expect(new URL(response.url).pathname).toBe(
+        `/fr/long/static/${value}/beta${slash}`
+      );
+      const expected = { route: 'short', params: control.payload!.params };
+      expectPayload(response.payload, expected);
+      await page.goto(start);
+      await checkPage(page, expected);
+      await page.reload();
+      await checkPage(page, expected);
+    });
+  }
+  test('unprefixed default alias uses its source template', async ({
+    page,
+    request,
+  }, info) => {
+    const start = url(`/long/static/alpha/beta${slash}`, 'unprefixed', '0');
+    const expected = {
+      route: 'short',
+      params: { locale: 'en', a: 'alpha', b: 'beta' },
+    };
+    const response = await follow(request, start, info);
+    expect(response.status).toBe(200);
+    expect(response.url).toBe(start);
+    expectPayload(response.payload, expected);
+    await page.goto(start);
+    await checkPage(page, expected);
+  });
+  test('locale reset keeps source params and the selected locale cookie', async ({
+    context,
+    page,
+  }, info) => {
+    await context.addCookies([
+      { name: 'generaltranslation.locale', value: 'en', url: origin },
+      { name: 'generaltranslation.locale-reset', value: 'true', url: origin },
+    ]);
+    const response = await follow(
+      context.request,
+      url(`/fr/long/static/alpha/beta${slash}`, 'depth'),
+      info
+    );
+    const expected = {
+      route: 'short',
+      params: { locale: 'en', a: 'alpha', b: 'beta' },
+    };
+    expect(response.status).toBe(200);
+    expect(new URL(response.url).pathname).toBe(`/en/short/alpha/beta${slash}`);
+    expectPayload(response.payload, expected);
+    const cookies = await context.cookies();
+    expect(
+      cookies.find((cookie) => cookie.name === 'generaltranslation.locale')
+        ?.value
+    ).toBe('en');
+    expect(
+      cookies.some(
+        (cookie) => cookie.name === 'generaltranslation.locale-reset'
+      )
+    ).toBe(false);
+    await page.goto(response.url);
+    await checkPage(page, expected);
+    await page.reload();
+    await checkPage(page, expected);
+  });
+});
+
+test.describe('catchall', () => {
+  test.skip(!settings.features.includes('catchall'), 'Feature subset');
+  for (const ending of ['/', '//']) {
+    test(`required catchall with ${ending.length} trailing slash(es)`, async ({
+      page,
+      request,
+    }, info) => {
+      const start = url(
+        `/fr/catalogue/science/one${ending}`,
+        'catchall',
+        '1',
+        '/fr/catalogue/science/one/two/'
+      );
+      const response = await follow(request, start, info);
+      const expected = {
+        route: 'catalog',
+        params: { locale: 'fr', category: 'science', slug: ['one'] },
+      };
+      expect(response.status).toBe(200);
+      expect(new URL(response.url).pathname).toBe('/fr/catalogue/science/one/');
+      expectPayload(response.payload, expected);
+      await navigate(page, start, expected, {
+        route: 'catalog',
+        params: { locale: 'fr', category: 'science', slug: ['one', 'two'] },
+      });
+      const missing = await follow(
+        request,
+        url('/fr/catalog/science/', 'catchall'),
+        info
+      );
+      expect(missing.status).toBe(404);
+    });
+  }
+});

--- a/tests/apps/next/middleware/packed-regressions/run.mjs
+++ b/tests/apps/next/middleware/packed-regressions/run.mjs
@@ -1,0 +1,287 @@
+import assert from 'node:assert/strict';
+import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  closeSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const { values } = parseArgs({
+  options: {
+    manifest: { type: 'string' },
+    artifact: { type: 'string', default: 'head' },
+    features: { type: 'string', default: 'encoded,ownership,depth' },
+    next: { type: 'string', default: '16.3.4' },
+    output: { type: 'string' },
+    port: { type: 'string', default: '4631' },
+    repeat: { type: 'string', default: '3' },
+  },
+});
+assert(values.manifest, 'Provide --manifest with an exact packed artifact.');
+const manifestPath = realpathSync(resolve(values.manifest));
+const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
+const selected = manifest[values.artifact];
+assert(
+  selected?.tarball && selected?.sha256,
+  'Artifact needs tarball and sha256.'
+);
+const tarball = realpathSync(resolve(dirname(manifestPath), selected.tarball));
+const sha256 = (bytes) => createHash('sha256').update(bytes).digest('hex');
+assert.equal(
+  sha256(readFileSync(tarball)),
+  selected.sha256,
+  'Artifact hash mismatch.'
+);
+const features = values.features.split(',');
+assert(
+  features.every((f) =>
+    ['encoded', 'ownership', 'depth', 'catchall'].includes(f)
+  )
+);
+assert(/^\d+\.\d+\.\d+$/.test(values.next), 'Pin an exact Next.js version.');
+const port = Number(values.port);
+const repeat = Number(values.repeat);
+assert(Number.isInteger(port) && port > 1024 && port < 65536);
+assert(Number.isInteger(repeat) && repeat > 0);
+const output = resolve(
+  values.output || join(tmpdir(), `gt-routing-${Date.now()}`)
+);
+assert(
+  !existsSync(output),
+  'Use a fresh output directory to preserve earlier evidence.'
+);
+let ancestor = dirname(output);
+while (!existsSync(ancestor)) ancestor = dirname(ancestor);
+assert.notEqual(
+  spawnSync('git', ['-C', ancestor, 'rev-parse', '--is-inside-work-tree'], {
+    encoding: 'utf8',
+  }).stdout?.trim(),
+  'true',
+  'Consumer output must be outside Git.'
+);
+mkdirSync(output, { recursive: true });
+const consumer = join(output, 'consumer');
+const logs = join(output, 'logs');
+mkdirSync(logs);
+const overrides = {};
+const dependencies = {};
+for (const [name, spec] of Object.entries(manifest.dependencies || {})) {
+  assert(
+    spec.startsWith('file:'),
+    'Dependency overrides must be packed file artifacts.'
+  );
+  const path = realpathSync(resolve(dirname(manifestPath), spec.slice(5)));
+  overrides[name] = `file:${path}`;
+  dependencies[name] = { path, sha256: sha256(readFileSync(path)) };
+}
+const settings = {
+  features,
+  trailingSlash: features.some((f) => f !== 'encoded'),
+  port,
+  repeat,
+};
+const result = {
+  status: 'preparing',
+  // This SHA is supplied by the packer; the runner independently verifies bytes.
+  declaredSourceSha: selected.sha,
+  tarball,
+  sha256: selected.sha256,
+  dependencies,
+  next: values.next,
+  node: process.version,
+  settings,
+  output,
+  runnerSha256: sha256(readFileSync(join(here, 'run.mjs'))),
+  testSha256: sha256(readFileSync(join(here, 'routing.spec.ts'))),
+  fixtureSha256: Object.fromEntries(
+    readdirSync(join(here, 'fixture'), { recursive: true })
+      .filter((path) => statSync(join(here, 'fixture', path)).isFile())
+      .map((path) => [path, sha256(readFileSync(join(here, 'fixture', path)))])
+  ),
+};
+const json = (path, value) =>
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+function run(stage, args) {
+  result.stage = stage;
+  process.stdout.write(`${stage}: ${args.join(' ')}\n`);
+  const fd = openSync(join(logs, `${stage}.log`), 'w');
+  try {
+    const child = spawnSync('pnpm', args, {
+      cwd: consumer,
+      stdio: ['ignore', fd, fd],
+      timeout: stage === 'typecheck' ? 120_000 : 300_000,
+    });
+    assert.equal(
+      child.status,
+      0,
+      `${stage} failed; see ${join(logs, `${stage}.log`)}`
+    );
+  } finally {
+    closeSync(fd);
+  }
+}
+
+try {
+  cpSync(join(here, 'fixture'), consumer, { recursive: true });
+  mkdirSync(join(consumer, 'e2e'));
+  cpSync(join(here, 'routing.spec.ts'), join(consumer, 'e2e/routing.spec.ts'));
+  json(join(consumer, 'regression-config.json'), settings);
+  json(join(consumer, 'package.json'), {
+    name: 'gt-packed-routing-regressions',
+    version: '0.0.0',
+    private: true,
+    scripts: {
+      build: `next build${Number(values.next.split('.')[0]) >= 16 ? ' --webpack' : ''}`,
+      start: `next start -p ${port}`,
+    },
+    dependencies: {
+      'gt-next': `file:${tarball}`,
+      next: values.next,
+      react: '19.2.4',
+      'react-dom': '19.2.4',
+    },
+    devDependencies: {
+      '@playwright/test': '1.57.0',
+      typescript: '5.9.3',
+      '@types/node': '22.19.11',
+      '@types/react': '19.2.14',
+      '@types/react-dom': '19.2.3',
+    },
+    pnpm: { overrides },
+  });
+  writeFileSync(
+    join(consumer, 'playwright.config.ts'),
+    `
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  testDir: './e2e', workers: 1, retries: 0, repeatEach: ${repeat},
+  timeout: 30000, globalTimeout: ${repeat * 180_000}, outputDir: ${JSON.stringify(join(output, 'test-results'))},
+  reporter: [['list'], ['json', {outputFile: ${JSON.stringify(join(output, 'playwright.json'))}}]],
+  use: {baseURL: 'http://localhost:${port}', browserName: 'chromium', headless: true, trace: 'retain-on-failure'},
+  webServer: {command: 'pnpm start', url: 'http://localhost:${port}/fr/', reuseExistingServer: false, timeout: 60000},
+});
+`
+  );
+  run('install', ['install']);
+  result.installedNext = JSON.parse(
+    readFileSync(join(consumer, 'node_modules/next/package.json'), 'utf8')
+  ).version;
+  assert.equal(result.installedNext, values.next);
+  result.pnpm = execFileSync('pnpm', ['--version'], {
+    cwd: consumer,
+    encoding: 'utf8',
+  }).trim();
+  result.resolvedEntry = execFileSync(
+    'node',
+    [
+      '--input-type=module',
+      '-e',
+      "console.log(import.meta.resolve('gt-next/middleware'))",
+    ],
+    { cwd: consumer, encoding: 'utf8' }
+  ).trim();
+  const packageRoot = realpathSync(join(consumer, 'node_modules/gt-next'));
+  const entryRelative = relative(
+    packageRoot,
+    fileURLToPath(result.resolvedEntry)
+  );
+  assert(!entryRelative.startsWith('..') && !isAbsolute(entryRelative));
+  const members = execFileSync('tar', ['-tzf', tarball], { encoding: 'utf8' })
+    .trim()
+    .split('\n');
+  result.middlewareModules = {};
+  for (const member of members.filter((name) =>
+    /^package\/dist\/(middleware-dir\/.*|middleware)\.mjs$/.test(name)
+  )) {
+    const path = member.slice('package/'.length);
+    const packed = execFileSync('tar', ['-xOf', tarball, member]);
+    assert.deepEqual(
+      readFileSync(join(packageRoot, path)),
+      packed,
+      `Installed module differs: ${path}`
+    );
+    result.middlewareModules[path] = sha256(packed);
+  }
+  assert(
+    result.middlewareModules[entryRelative],
+    'Resolved entry must match the packed middleware.'
+  );
+  run('build', ['build']);
+  run('typecheck', ['exec', 'tsc', '--noEmit']);
+  run('browser-install', [
+    'exec',
+    'playwright',
+    'install',
+    'chromium-headless-shell',
+  ]);
+  result.stage = 'tests';
+  const fd = openSync(join(logs, 'tests.log'), 'w');
+  let tests;
+  try {
+    tests = spawnSync('pnpm', ['exec', 'playwright', 'test'], {
+      cwd: consumer,
+      stdio: ['ignore', fd, fd],
+      timeout: repeat * 180_000 + 120_000,
+      killSignal: 'SIGINT',
+    });
+  } finally {
+    closeSync(fd);
+  }
+  const report = JSON.parse(
+    readFileSync(join(output, 'playwright.json'), 'utf8')
+  );
+  result.stats = report.stats;
+  const specs = (suite) => [
+    ...(suite.specs || []),
+    ...(suite.suites || []).flatMap(specs),
+  ];
+  const active = specs(report).filter((spec) =>
+    spec.tests.some((entry) =>
+      entry.results.some((r) => r.status !== 'skipped')
+    )
+  );
+  const runs = active
+    .flatMap((spec) => spec.tests)
+    .filter((entry) => entry.results.some((r) => r.status !== 'skipped'));
+  result.activeCases = new Set(
+    active.map((spec) => `${spec.file}:${spec.line}:${spec.title}`)
+  ).size;
+  result.activeTestRuns = runs.length;
+  result.passedTestRuns = runs.filter(
+    (entry) => entry.results.at(-1)?.status === 'passed'
+  ).length;
+  result.skippedTestRuns = report.stats.skipped;
+  assert(!tests.error, String(tests.error));
+  assert(!report.errors?.length, JSON.stringify(report.errors));
+  const errors = runs.flatMap((entry) =>
+    entry.results.flatMap((r) => r.errors || [])
+  );
+  assert(
+    !errors.some((error) =>
+      /browserType\.launch|Executable doesn't exist/.test(error.message)
+    ),
+    'Browser launch failed; this is not a routing regression reproduction.'
+  );
+  result.status = tests.status === 0 ? 'passed' : 'test-failures';
+  process.exitCode = tests.status === 0 ? 0 : 1;
+} catch (error) {
+  result.status = 'harness-error';
+  result.error = String(error);
+  process.exitCode = 1;
+} finally {
+  json(join(output, 'result.json'), result);
+  process.stdout.write(`${result.status}: ${output}\n`);
+}


### PR DESCRIPTION
## Summary

Turn the middleware regressions found in #2265, #2266, and #2243 into reusable browser E2E tests. Assert actual rendered routes and parameters for encoded locale-like slugs, locale/shared ownership collisions, unequal template depths, and catch-all trailing-slash loops.

Add `test:e2e:packed`, which takes an explicit package manifest, verifies the tarball and installed middleware bytes, and builds an isolated App Router consumer outside Git. Redirect following is bounded; tests retain HTTP chains and browser traces and run with zero retries. Feature subsets and repeated runs let the same assertions compare old and fixed packages.

## Testing

- Frozen suite against Next.js 15.5.9, 16.1.6, and 16.3.4: 171 passing focused runs on fixed artifacts, plus 45 passing combined runs (15 cases repeated three times).
- The same assertions against known-bad artifacts: 42 failures reproduce the manual wrong-route, shifted-parameter, or redirect-loop findings; three insertion-order controls pass. Every consumer built and typechecked before testing.
- `pnpm --filter gt-next-middleware-e2e typecheck`, scoped oxlint/oxfmt, `node --check`, and `git diff --check` pass. Generated apps, raw results, and traces remain outside Git.

## Notes

Based on main; the runner explicitly selects artifacts from the routing branches. This is an opt-in test command, documented in `tests/apps/next/middleware/packed-regressions/README.md`; existing CI does not automatically run the supplied-artifact matrix. No changeset is needed for test infrastructure.
