### PR TITLE
fix(cli): upload existing .xcstrings locales during translate

### DIFF
--- a/.changeset/xcstrings-translate-uploads-slices.md
+++ b/.changeset/xcstrings-translate-uploads-slices.md
@@ -1,0 +1,5 @@
+---
+'gt': patch
+---
+
+`gt translate` now uploads the locales an `.xcstrings` catalog already carries before enqueueing, so existing translations are reused instead of replaced.

--- a/packages/cli/src/cli/commands/upload.ts
+++ b/packages/cli/src/cli/commands/upload.ts
@@ -18,13 +18,7 @@ import { hasValidCredentials } from './utils/validation.js';
 import { runPublishWorkflow } from '../../workflows/publish.js';
 import { aggregateFiles } from '../../formats/files/aggregateFiles.js';
 import { recordWarning } from '../../state/translateWarnings.js';
-import {
-  parseXcstringsCatalog,
-  serializeXcstringsSlice,
-  sliceTranslationCatalog,
-  type XcstringsCatalog,
-} from '../../formats/xcstrings/parseXcstrings.js';
-import { gt } from '../../utils/gt.js';
+import { collectXcstringsTranslations } from '../../formats/xcstrings/sliceTranslations.js';
 
 /**
  * Sends multiple files to the API for translation
@@ -73,17 +67,11 @@ export async function upload(
   // An .xcstrings catalog carries its own translations, so each locale's
   // upload is a slice of the same file rather than a separate translation
   // file. Catalogs aggregateFiles could not parse are already reported.
-  const xcstringsCatalogs = new Map<string, XcstringsCatalog>();
-  if (filePaths.xcstrings) {
-    for (const filePath of filePaths.xcstrings) {
-      const relativePath = getRelative(filePath);
-      if (!sourceFileNames.has(relativePath)) continue;
-      xcstringsCatalogs.set(
-        relativePath,
-        parseXcstringsCatalog(readFile(filePath))
-      );
-    }
-  }
+  const xcstringsTranslations = collectXcstringsTranslations({
+    sourceFiles: allFiles,
+    catalogPaths: filePaths.xcstrings ?? [],
+    locales: settings.locales || [],
+  });
 
   if (allFiles.length === 0) {
     logger.error(
@@ -112,28 +100,15 @@ export async function upload(
   const uploadData = allFiles.map((file) => {
     const sourceFile: FileToUpload = { ...file };
 
-    const translations: FileToUpload[] = [];
+    const translations: FileToUpload[] = [
+      ...(xcstringsTranslations.get(file.fileName) ?? []),
+    ];
     const compositeInfo = compositeJsonFiles.get(file.fileName);
-    const xcstringsCatalog = xcstringsCatalogs.get(file.fileName);
 
     for (const locale of locales) {
-      if (xcstringsCatalog) {
-        // Catalog keys are canonical tags; the configured locale may be an alias.
-        const slice = sliceTranslationCatalog(
-          xcstringsCatalog,
-          gt.resolveCanonicalLocale(locale)
-        );
-        // A locale the catalog does not carry has nothing to upload
-        if (!slice) continue;
-        translations.push({
-          content: serializeXcstringsSlice(slice),
-          fileName: file.fileName,
-          fileFormat: file.transformFormat ?? file.fileFormat,
-          dataFormat: file.dataFormat,
-          locale,
-          fileId: file.fileId,
-          versionId: file.versionId,
-        });
+      if (xcstringsTranslations.has(file.fileName)) {
+        // Already sliced above, one document per locale the catalog carries
+        continue;
       } else if (compositeInfo) {
         // Composite JSON: extract translations from the same source file
         const extracted = extractJson(

--- a/packages/cli/src/formats/xcstrings/__tests__/sliceTranslations.test.ts
+++ b/packages/cli/src/formats/xcstrings/__tests__/sliceTranslations.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FileToUpload } from 'generaltranslation/types';
+
+vi.mock('../../../fs/findFilepath.js', () => ({
+  getRelative: vi.fn((path: string) => path.replace(/^\/repo\//, '')),
+  readFile: vi.fn((path: string) => files[path]),
+}));
+vi.mock('../../../utils/gt.js', () => ({
+  gt: {
+    resolveCanonicalLocale: vi.fn((locale: string) =>
+      locale === 'french' ? 'fr' : locale
+    ),
+  },
+}));
+
+import { collectXcstringsTranslations } from '../sliceTranslations.js';
+
+const CATALOG = '/repo/App/Localizable.xcstrings';
+const files: Record<string, string> = {
+  [CATALOG]: JSON.stringify({
+    sourceLanguage: 'en',
+    strings: {
+      Save: {},
+      greeting: {
+        comment: 'Home',
+        localizations: {
+          en: { stringUnit: { state: 'translated', value: 'Hello' } },
+          de: { stringUnit: { state: 'translated', value: 'Hallo' } },
+          fr: { stringUnit: { state: 'translated', value: 'Bonjour' } },
+        },
+      },
+    },
+    version: '1.0',
+  }),
+};
+
+const source: FileToUpload = {
+  content: '{}',
+  fileName: 'App/Localizable.xcstrings',
+  fileFormat: 'XCSTRINGS',
+  fileId: 'file-1',
+  versionId: 'version-1',
+  locale: 'en',
+};
+
+describe('collectXcstringsTranslations', () => {
+  it('returns one slice per configured locale the catalog carries, keyed by source', () => {
+    const result = collectXcstringsTranslations({
+      sourceFiles: [source],
+      catalogPaths: [CATALOG],
+      locales: ['de', 'fr', 'ja'],
+    });
+    const slices = result.get(source.fileName)!;
+    expect(slices.map((s) => s.locale)).toEqual(['de', 'fr']);
+    for (const slice of slices) {
+      expect(slice).toMatchObject({
+        fileName: source.fileName,
+        fileFormat: 'XCSTRINGS',
+        fileId: 'file-1',
+        versionId: 'version-1',
+      });
+      const parsed = JSON.parse(slice.content);
+      expect(Object.keys(parsed.strings)).toEqual(['greeting']);
+      expect(Object.keys(parsed.strings.greeting.localizations)).toEqual([
+        slice.locale,
+      ]);
+    }
+  });
+
+  it('slices an aliased locale by its canonical tag and labels it with the alias', () => {
+    const result = collectXcstringsTranslations({
+      sourceFiles: [source],
+      catalogPaths: [CATALOG],
+      locales: ['french'],
+    });
+    const [slice] = result.get(source.fileName)!;
+    expect(slice.locale).toBe('french');
+    expect(
+      Object.keys(JSON.parse(slice.content).strings.greeting.localizations)
+    ).toEqual(['fr']);
+  });
+
+  it('skips catalogs that are not among the source files', () => {
+    expect(
+      collectXcstringsTranslations({
+        sourceFiles: [],
+        catalogPaths: [CATALOG],
+        locales: ['de'],
+      }).size
+    ).toBe(0);
+  });
+
+  it('registers a catalog with an empty list when it carries none of the locales', () => {
+    const result = collectXcstringsTranslations({
+      sourceFiles: [source],
+      catalogPaths: [CATALOG],
+      locales: ['ja'],
+    });
+    expect(result.get(source.fileName)).toEqual([]);
+  });
+});

--- a/packages/cli/src/formats/xcstrings/sliceTranslations.ts
+++ b/packages/cli/src/formats/xcstrings/sliceTranslations.ts
@@ -1,0 +1,65 @@
+// An .xcstrings catalog carries its own translations, so the locales it
+// already holds are uploaded as per-locale slices of the same file rather than
+// as separate translation files. Both `gt upload` and `gt translate` need
+// those slices: upload to register them, translate so the run reuses them
+// instead of translating over them.
+
+import { getRelative, readFile } from '../../fs/findFilepath.js';
+import { gt } from '../../utils/gt.js';
+import {
+  parseXcstringsCatalog,
+  serializeXcstringsSlice,
+  sliceTranslationCatalog,
+} from './parseXcstrings.js';
+import type { FileToUpload } from 'generaltranslation/types';
+
+/**
+ * Reads each catalog at `catalogPaths` that is one of `sourceFiles` and
+ * returns, keyed by the source's fileName, one translation document per
+ * configured locale the catalog carries. Every catalog that is a source gets
+ * an entry, empty when it holds none of the locales, so callers can tell a
+ * catalog with nothing to upload from a file that is not a catalog. Catalog
+ * keys are canonical tags, so a configured alias is resolved before slicing
+ * and the slice is uploaded under the alias.
+ *
+ * Catalogs that are not in `sourceFiles` are skipped: aggregateFiles has
+ * already dropped and reported the ones it could not parse.
+ */
+export function collectXcstringsTranslations({
+  sourceFiles,
+  catalogPaths,
+  locales,
+}: {
+  sourceFiles: FileToUpload[];
+  catalogPaths: string[];
+  locales: string[];
+}): Map<string, FileToUpload[]> {
+  const bySourceName = new Map(
+    sourceFiles.map((file) => [file.fileName, file])
+  );
+  const translations = new Map<string, FileToUpload[]>();
+  for (const catalogPath of catalogPaths) {
+    const source = bySourceName.get(getRelative(catalogPath));
+    if (!source) continue;
+    const catalog = parseXcstringsCatalog(readFile(catalogPath));
+    const slices: FileToUpload[] = [];
+    for (const locale of locales) {
+      const slice = sliceTranslationCatalog(
+        catalog,
+        gt.resolveCanonicalLocale(locale)
+      );
+      if (!slice) continue;
+      slices.push({
+        content: serializeXcstringsSlice(slice),
+        fileName: source.fileName,
+        fileFormat: source.transformFormat ?? source.fileFormat,
+        dataFormat: source.dataFormat,
+        locale,
+        fileId: source.fileId,
+        versionId: source.versionId,
+      });
+    }
+    translations.set(source.fileName, slices);
+  }
+  return translations;
+}

--- a/packages/cli/src/workflows/__tests__/stage.test.ts
+++ b/packages/cli/src/workflows/__tests__/stage.test.ts
@@ -36,6 +36,21 @@ vi.mock('../steps/UploadSourcesStep.js', () => ({
     wait: vi.fn(),
   })),
 }));
+const { uploadTranslationsRun, collectXcstringsTranslations } = vi.hoisted(
+  () => ({
+    uploadTranslationsRun: vi.fn(async () => []),
+    collectXcstringsTranslations: vi.fn(() => new Map()),
+  })
+);
+vi.mock('../steps/UploadTranslationsStep.js', () => ({
+  UploadTranslationsStep: vi.fn(() => ({
+    run: uploadTranslationsRun,
+    wait: vi.fn(),
+  })),
+}));
+vi.mock('../../formats/xcstrings/sliceTranslations.js', () => ({
+  collectXcstringsTranslations,
+}));
 vi.mock('../steps/SetupStep.js', () => ({
   SetupStep: vi.fn(() => ({ run: vi.fn(), wait: vi.fn() })),
 }));
@@ -169,5 +184,65 @@ describe('runStageFilesWorkflow save-local gate', () => {
     });
 
     expect(userEditDiffsRun).not.toHaveBeenCalled();
+  });
+});
+
+describe('runStageFilesWorkflow catalog translations', () => {
+  const catalog: FileToUpload = {
+    content: '{}',
+    fileName: 'App/Localizable.xcstrings',
+    fileFormat: 'XCSTRINGS',
+    fileId: 'file-2',
+    versionId: 'version-2',
+    locale: 'en',
+  };
+  const catalogSettings = {
+    locales: ['es', 'de'],
+    files: {
+      resolvedPaths: { xcstrings: ['/repo/App/Localizable.xcstrings'] },
+    },
+  } as unknown as Settings;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(collectFonts).mockResolvedValue([]);
+    collectXcstringsTranslations.mockReturnValue(new Map());
+  });
+
+  it('uploads the locales a catalog already carries before enqueueing', async () => {
+    const slice = { ...catalog, content: '{"es":1}', locale: 'es' };
+    collectXcstringsTranslations.mockReturnValue(
+      new Map([[catalog.fileName, [slice]]])
+    );
+
+    await runStageFilesWorkflow({
+      files: [...files, catalog],
+      options,
+      settings: catalogSettings,
+    });
+
+    expect(collectXcstringsTranslations).toHaveBeenCalledWith({
+      sourceFiles: [...files, catalog],
+      catalogPaths: ['/repo/App/Localizable.xcstrings'],
+      locales: ['es', 'de'],
+    });
+    expect(uploadTranslationsRun).toHaveBeenCalledWith({
+      files: [
+        {
+          source: catalog,
+          translations: [{ ...slice, branchId: 'branch-1' }],
+        },
+      ],
+    });
+  });
+
+  it('skips the translations step when no catalog carries a configured locale', async () => {
+    await runStageFilesWorkflow({
+      files: [...files, catalog],
+      options,
+      settings: catalogSettings,
+    });
+
+    expect(uploadTranslationsRun).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/workflows/stage.ts
+++ b/packages/cli/src/workflows/stage.ts
@@ -5,6 +5,8 @@ import { Settings, TranslateFlags } from '../types/index.js';
 import { api } from '../utils/api.js';
 import { EnqueueFilesResult, FileToUpload } from 'generaltranslation/types';
 import { UploadSourcesStep } from './steps/UploadSourcesStep.js';
+import { UploadTranslationsStep } from './steps/UploadTranslationsStep.js';
+import { collectXcstringsTranslations } from '../formats/xcstrings/sliceTranslations.js';
 import { SetupStep } from './steps/SetupStep.js';
 import { EnqueueStep } from './steps/EnqueueStep.js';
 import { BranchStep } from './steps/BranchStep.js';
@@ -64,6 +66,17 @@ export async function runStageFilesWorkflow({
     // then run the upload step
     const uploadedFiles = await uploadStep.run({ files, branchData });
 
+    // An .xcstrings catalog carries its own translations. Upload the locales
+    // it already holds so the run reuses them and fills in the rest; the
+    // server marks a partial locale incomplete so it is still enqueued.
+    // Without this, translate saw only the source slice and translated over
+    // the customer's own work.
+    await uploadCatalogTranslations({
+      files,
+      settings,
+      branchId: branchData.currentBranch.id,
+    });
+
     // optionally run the user edit diffs step (opt-in via --save-local or options.saveLocal)
     if (settings.options?.saveLocal === true) {
       await userEditDiffsStep.run(uploadedFiles);
@@ -107,4 +120,38 @@ export async function runStageFilesWorkflow({
       )
     );
   }
+}
+
+/**
+ * Uploads the per-locale slices of every in-place catalog among `files`, so
+ * enqueue and the translation job see the translations the customer already
+ * has. Runs the upload translations step only when there is something to send.
+ */
+async function uploadCatalogTranslations({
+  files,
+  settings,
+  branchId,
+}: {
+  files: FileToUpload[];
+  settings: Settings;
+  branchId: string;
+}): Promise<void> {
+  const catalogTranslations = collectXcstringsTranslations({
+    sourceFiles: files,
+    catalogPaths: settings.files?.resolvedPaths.xcstrings ?? [],
+    locales: settings.locales,
+  });
+  const withTranslations = files.filter(
+    (source) => (catalogTranslations.get(source.fileName)?.length ?? 0) > 0
+  );
+  if (withTranslations.length === 0) return;
+  const uploadTranslationsStep = new UploadTranslationsStep(api, settings);
+  await uploadTranslationsStep.run({
+    files: withTranslations.map((source) => ({
+      source,
+      translations: catalogTranslations
+        .get(source.fileName)!
+        .map((translation) => ({ ...translation, branchId })),
+    })),
+  });
 }


### PR DESCRIPTION
translate uploads the catalog's own per-locale slices after the source upload, through the same slicer upload uses, so a partially translated catalog is reused and filled in rather than translated over.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR extracts existing translations from in-place `.xcstrings` catalogs and uploads their per-locale slices before translation jobs are enqueued.
- Centralizes catalog slicing for both `gt upload` and staging workflows.
- Preserves configured locale aliases locally while slicing and uploading canonical catalog locales.
- Adds unit coverage for catalog slicing and basic staging behavior, but omits repository-required failure and retry/idempotency cases.
</details>


<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The implementation appears behaviorally sound, but the repository’s explicit failure and retry/idempotency test requirement must be satisfied before merging.

The shared slicer and pre-enqueue upload follow existing file identity and locale-boundary conventions; the remaining actionable issue is missing mandated coverage for malformed catalogs and failed or repeated remote uploads.

**Files Needing Attention:** packages/cli/src/workflows/__tests__/stage.test.ts, packages/cli/src/formats/xcstrings/__tests__/sliceTranslations.test.ts
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/cli/src/formats/xcstrings/sliceTranslations.ts | Introduces shared parsing and serialization of configured locale slices from in-place `.xcstrings` catalogs. |
| packages/cli/src/workflows/stage.ts | Uploads existing catalog translations after source synchronization and before save-local, setup, and enqueue processing. |
| packages/cli/src/cli/commands/upload.ts | Replaces inline `.xcstrings` slicing with the shared helper while retaining the existing upload behavior. |
| packages/cli/src/workflows/__tests__/stage.test.ts | Covers successful and empty catalog-upload paths but lacks required failure and retry/idempotency scenarios. |
| packages/cli/src/formats/xcstrings/__tests__/sliceTranslations.test.ts | Covers locale slicing, aliases, source filtering, and absent locales but not parser or serializer failures. |

</details>


<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Read .xcstrings catalog] --> B[Aggregate source-language slice]
    B --> C[Upload source]
    A --> D[Create existing per-locale slices]
    C --> E[Upload catalog translations]
    D --> E
    E --> F[Optional save-local processing]
    F --> G[Setup project]
    G --> H[Filter completed locales]
    H --> I[Enqueue remaining translation work]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20generaltranslation%2Fgt%20PR%20%232280%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=generaltranslation%2Fgt&pr=2280&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fworkflows%2F__tests__%2Fstage.test.ts%3A212%0A**Required%20failure%20coverage%20missing**%0A%0AThe%20new%20tests%20cover%20successful%20catalog%20slicing%20and%20upload%20plus%20the%20no-op%20case%2C%20but%20they%20do%20not%20cover%20malformed%20catalog%20input%2C%20translation-upload%20failures%2C%20or%20repeated%20execution.%20This%20violates%20the%20repository%20directive%20that%20parsing%2C%20serialization%2C%20and%20cross-system%20writes%20have%20focused%20failure%20and%20retry%2Fidempotency%20tests.%20That%20required%20coverage%20must%20be%20added%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22generaltranslation%2Fgt%22%20on%20the%20existing%20branch%20%22f%2Fxcstrings-translate-uploads-catalog-slices%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22f%2Fxcstrings-translate-uploads-catalog-slices%22.%0A%0A%23%23%23%20Issue%201%0Apackages%2Fcli%2Fsrc%2Fworkflows%2F__tests__%2Fstage.test.ts%3A212%0A**Required%20failure%20coverage%20missing**%0A%0AThe%20new%20tests%20cover%20successful%20catalog%20slicing%20and%20upload%20plus%20the%20no-op%20case%2C%20but%20they%20do%20not%20cover%20malformed%20catalog%20input%2C%20translation-upload%20failures%2C%20or%20repeated%20execution.%20This%20violates%20the%20repository%20directive%20that%20parsing%2C%20serialization%2C%20and%20cross-system%20writes%20have%20focused%20failure%20and%20retry%2Fidempotency%20tests.%20That%20required%20coverage%20must%20be%20added%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=generaltranslation%2Fgt&pr=2280&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
packages/cli/src/workflows/__tests__/stage.test.ts:212
**Required failure coverage missing**

The new tests cover successful catalog slicing and upload plus the no-op case, but they do not cover malformed catalog input, translation-upload failures, or repeated execution. This violates the repository directive that parsing, serialization, and cross-system writes have focused failure and retry/idempotency tests. That required coverage must be added before merging.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(cli): upload existing .xcstrings loc..."](https://github.com/generaltranslation/gt/commit/1acec97cc6ba60f92fda023f0d63c1c75deddfd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62319528)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - Require focused tests when changing parsing or ser... ([source](https://app.greptile.com/generaltranslation/-/custom-context?memory=4a600f31-4141-4102-80aa-4a4cd19da101))
- Knowledge Base — [CLI orchestration and repository workflows](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/cli-orchestration.md)
- Knowledge Base — [Extraction and compilation pipeline](https://app.greptile.com/generaltranslation/-/custom-context/knowledge-base/generaltranslation/gt/-/docs/extraction-and-compilation.md)
</details>


<!-- /greptile_comment -->