### PR TITLE
fix: honor configured client routing cookies

### DIFF
--- a/.changeset/configured-client-routing-cookies.md
+++ b/.changeset/configured-client-routing-cookies.md
@@ -1,0 +1,7 @@
+---
+"gt-next": patch
+"gt-react": patch
+"@generaltranslation/react-core": patch
+---
+
+Honor configured referrer, routing-enabled, and reset locale cookie names on the client as well as in middleware.

--- a/packages/next/src/__tests__/config.test.ts
+++ b/packages/next/src/__tests__/config.test.ts
@@ -180,6 +180,20 @@ describe('withGTConfig', () => {
       );
     });
 
+    it('exposes middleware cookie names to the client', async () => {
+      const withGTConfig = await getWithGTConfig();
+      const headersAndCookies = {
+        referrerLocaleCookieName: 'custom-referrer',
+        localeRoutingEnabledCookieName: 'custom-routing',
+        resetLocaleCookieName: 'custom-reset',
+      };
+      const result = withGTConfig({}, { headersAndCookies });
+      const clientParams = JSON.parse(
+        result.env!.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS as string
+      );
+      expect(clientParams.headersAndCookies).toMatchObject(headersAndCookies);
+    });
+
     it('sets _usingPlugin to true in config params', async () => {
       const withGTConfig = await getWithGTConfig();
       const result = withGTConfig();
@@ -1510,6 +1524,9 @@ describe('withGTConfig', () => {
         headersAndCookies: {
           localeCookieName: expect.any(String),
           enableI18nCookieName: expect.any(String),
+          referrerLocaleCookieName: expect.any(String),
+          localeRoutingEnabledCookieName: expect.any(String),
+          resetLocaleCookieName: expect.any(String),
         },
         _versionId: 'version-id',
         _disableDevHotReload: true,

--- a/packages/next/src/config.ts
+++ b/packages/next/src/config.ts
@@ -676,6 +676,12 @@ export function withGTConfig<TNextConfig extends object = NextConfig>(
     },
     headersAndCookies: {
       localeCookieName: mergedConfig.headersAndCookies?.localeCookieName,
+      referrerLocaleCookieName:
+        mergedConfig.headersAndCookies?.referrerLocaleCookieName,
+      localeRoutingEnabledCookieName:
+        mergedConfig.headersAndCookies?.localeRoutingEnabledCookieName,
+      resetLocaleCookieName:
+        mergedConfig.headersAndCookies?.resetLocaleCookieName,
       enableI18nCookieName:
         mergedConfig.headersAndCookies?.enableI18nCookieName,
     },

--- a/packages/next/src/setup/__tests__/shared.test.ts
+++ b/packages/next/src/setup/__tests__/shared.test.ts
@@ -13,6 +13,7 @@ function setConfigEnv() {
       renderSettings: { timeout: 123 },
       headersAndCookies: {
         localeCookieName: 'custom-locale',
+        resetLocaleCookieName: 'custom-reset',
         enableI18nCookieName: 'custom-enable-i18n',
       },
       maxConcurrentRequests: 1,
@@ -57,6 +58,7 @@ describe('getParams', () => {
       devApiKey: 'dev-key',
       cacheUrl: 'https://cache.example.com',
       localeCookieName: 'custom-locale',
+      resetLocaleCookieName: 'custom-reset',
       enableI18nCookieName: 'custom-enable-i18n',
     });
     expect(nextI18nCacheParams).toMatchObject({

--- a/packages/next/src/setup/shared.ts
+++ b/packages/next/src/setup/shared.ts
@@ -32,6 +32,8 @@ export function getParams(): {
     _disableDevHotReload: clientConfig._disableDevHotReload,
     _tagIds: clientConfig._tagIds,
     localeCookieName: clientConfig.headersAndCookies?.localeCookieName,
+    resetLocaleCookieName:
+      clientConfig.headersAndCookies?.resetLocaleCookieName,
     enableI18nCookieName: clientConfig.headersAndCookies?.enableI18nCookieName,
   };
 

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -64,12 +64,68 @@ describe('Client_GTProvider', () => {
   });
 
   afterEach(() => {
+    delete process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS;
     delete process.env._GENERALTRANSLATION_PATH_REGEX;
+    for (const name of [
+      'custom-routing',
+      'custom-referrer',
+      'generaltranslation.referrer-locale',
+    ]) {
+      document.cookie = `${name}=;max-age=0;path=/`;
+    }
     document.cookie =
       'generaltranslation.locale-routing-enabled=;max-age=0;path=/';
     vi.unstubAllGlobals();
     globalThis.IS_REACT_ACT_ENVIRONMENT = false;
   });
+
+  it.each([true, false])(
+    'uses configured routing=%s and referrer cookies',
+    async (routing) => {
+      process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS =
+        JSON.stringify({
+          headersAndCookies: {
+            referrerLocaleCookieName: 'custom-referrer',
+            localeRoutingEnabledCookieName: 'custom-routing',
+          },
+        });
+      process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
+      document.cookie = `generaltranslation.locale-routing-enabled=${!routing};path=/`;
+      document.cookie = `custom-routing=${routing};path=/`;
+      mockPathname.mockReturnValue('/fr/about');
+      vi.stubGlobal('location', {
+        pathname: '/fr/about',
+        reload: mockReloadBrowserPage,
+      });
+      mockGetI18nConfig.mockReturnValue({
+        determineLocale: ([locale]: string[]) => locale,
+        getDefaultLocale: () => 'en',
+        getLocales: () => ['en', 'fr'],
+        isGTServicesEnabled: () => false,
+        resolveAliasLocale: (locale: string) => locale,
+      });
+      const { Client_GTProvider } = await import('../client-boundary');
+      const root = createRoot(document.createElement('div'));
+      await act(async () => {
+        root.render(
+          <Client_GTProvider locale='fr' translations={{}} dictionaries={{}} />
+        );
+      });
+      expect(document.cookie).toContain('custom-referrer=fr');
+      expect(document.cookie).not.toContain(
+        'generaltranslation.referrer-locale='
+      );
+      const props = mockGTProvider.mock.calls.at(-1)![0] as unknown as {
+        _reload: (state: { locale: string }) => void;
+      };
+      await act(async () => props._reload({ locale: 'en' }));
+      expect(mockReloadBrowserPage).toHaveBeenCalledTimes(routing ? 1 : 0);
+      expect(mockRefreshServerComponents).toHaveBeenCalledTimes(
+        routing ? 0 : 1
+      );
+      await act(async () => root.unmount());
+    }
+  );
 
   it('does not refresh excluded paths when the routing cookie is stale', async () => {
     const { Client_GTProvider } = await import('../client-boundary');

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -22,9 +22,17 @@ import {
   defaultReferrerLocaleCookieName,
 } from './cookies';
 import { compilePathRegex, pathnameMatchesRegex } from './pathRegex';
+import type { HeadersAndCookies } from '../config-dir/props/withGTConfigProps';
 
 // withGTConfig exposes this build-time value to both middleware and client code.
 const pathRegex = compilePathRegex(process.env._GENERALTRANSLATION_PATH_REGEX);
+const {
+  referrerLocaleCookieName = defaultReferrerLocaleCookieName,
+  localeRoutingEnabledCookieName = defaultLocaleRoutingEnabledCookieName,
+}: HeadersAndCookies =
+  JSON.parse(
+    process.env.NEXT_PUBLIC_GENERALTRANSLATION_I18N_CONFIG_PARAMS || '{}'
+  ).headersAndCookies || {};
 
 /**
  * Only need to initalize client. We know server was already
@@ -52,10 +60,8 @@ export function Client_GTProvider(props: SharedGTProviderProps) {
     ({ locale }) => {
       const i18nConfig = getI18nConfig();
       const localeRoutingEnabled =
-        getCookieValue(
-          document.cookie,
-          defaultLocaleRoutingEnabledCookieName
-        ) === 'true';
+        getCookieValue(document.cookie, localeRoutingEnabledCookieName) ===
+        'true';
       const defaultLocale = i18nConfig.getDefaultLocale();
       const locales = i18nConfig.getLocales();
       const currentPathname = globalThis.location.pathname;
@@ -96,14 +102,10 @@ function usePathCheck({
   reloadBrowserPage,
   refreshServerComponents,
   locale,
-  referrerLocaleCookieName = defaultReferrerLocaleCookieName,
-  localeRoutingEnabledCookieName = defaultLocaleRoutingEnabledCookieName,
 }: {
   reloadBrowserPage: () => void;
   refreshServerComponents: () => void;
   locale: string;
-  referrerLocaleCookieName?: string;
-  localeRoutingEnabledCookieName?: string;
 }) {
   const pathname = usePathname();
 
@@ -144,14 +146,7 @@ function usePathCheck({
         }
       }
     }
-  }, [
-    pathname,
-    locale,
-    referrerLocaleCookieName,
-    localeRoutingEnabledCookieName,
-    reloadBrowserPage,
-    refreshServerComponents,
-  ]);
+  }, [pathname, locale, reloadBrowserPage, refreshServerComponents]);
 }
 
 function resolvePathLocale(

--- a/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
+++ b/packages/react-core/src/setup/__tests__/i18nConfig.test.ts
@@ -46,6 +46,9 @@ describe('react i18n config', () => {
 
     const config = initializeI18nConfig({ defaultLocale: 'en' });
 
+    expect(config.getResetLocaleCookieName()).toBe(
+      'generaltranslation.locale-reset'
+    );
     expect(config.getLocaleCookieName()).toBe('generaltranslation.locale');
     expect(config.getRegionCookieName()).toBe('generaltranslation.region');
     expect(config.getEnableI18nCookieName()).toBe(
@@ -61,8 +64,10 @@ describe('react i18n config', () => {
       localeCookieName: 'custom-locale',
       regionCookieName: 'custom-region',
       enableI18nCookieName: 'custom-enable-i18n',
+      resetLocaleCookieName: 'custom-reset',
     });
 
+    expect(config.getResetLocaleCookieName()).toBe('custom-reset');
     expect(config.getLocaleCookieName()).toBe('custom-locale');
     expect(config.getRegionCookieName()).toBe('custom-region');
     expect(config.getEnableI18nCookieName()).toBe('custom-enable-i18n');

--- a/packages/react-core/src/setup/i18nConfig.ts
+++ b/packages/react-core/src/setup/i18nConfig.ts
@@ -9,6 +9,7 @@ import {
   defaultEnableI18nCookieName,
   defaultLocaleCookieName,
   defaultRegionCookieName,
+  defaultResetLocaleCookieName,
 } from './cookieNames';
 
 /**
@@ -22,6 +23,7 @@ type CookieNameConfig = {
   localeCookieName?: string;
   regionCookieName?: string;
   enableI18nCookieName?: string;
+  resetLocaleCookieName?: string;
 };
 
 export type ReactI18nConfigParams = BaseI18nConfigParams & CookieNameConfig;
@@ -36,6 +38,7 @@ export class ReactI18nConfig extends I18nConfig {
   private localeCookieName: string;
   private regionCookieName: string;
   private enableI18nCookieName: string;
+  private resetLocaleCookieName: string;
 
   constructor(
     params: ReactI18nConfigParams = {},
@@ -45,6 +48,8 @@ export class ReactI18nConfig extends I18nConfig {
     validateRenderStrategy(renderStrategy);
     Object.defineProperty(this, reactI18nConfigBrand, { value: true });
     this.renderStrategy = renderStrategy;
+    this.resetLocaleCookieName =
+      params.resetLocaleCookieName ?? defaultResetLocaleCookieName;
     this.localeCookieName = params.localeCookieName ?? defaultLocaleCookieName;
     this.regionCookieName = params.regionCookieName ?? defaultRegionCookieName;
     this.enableI18nCookieName =
@@ -53,6 +58,10 @@ export class ReactI18nConfig extends I18nConfig {
 
   getRenderStrategy(): RenderStrategy {
     return this.renderStrategy;
+  }
+
+  getResetLocaleCookieName(): string {
+    return this.resetLocaleCookieName;
   }
 
   getLocaleCookieName(): string {

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -1,7 +1,4 @@
-import {
-  defaultResetLocaleCookieName,
-  getI18nConfig,
-} from '@generaltranslation/react-core/pure';
+import { getI18nConfig } from '@generaltranslation/react-core/pure';
 import type { WritableConditionStoreParams } from 'gt-i18n/internal';
 import { getCookieValue, setCookieValue } from './cookies';
 import { readBrowserLocale } from './readBrowserLocale';
@@ -67,7 +64,7 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
   setLocale = (locale: LocaleCandidates): void => {
     this.updateLocale(locale);
     setCookieValue({
-      cookieName: defaultResetLocaleCookieName,
+      cookieName: getI18nConfig().getResetLocaleCookieName(),
       value: 'true',
     });
     this.reload();

--- a/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/BrowserConditionStore.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockSetCookieValue = vi.hoisted(() => vi.fn());
 const mockCookieNames = vi.hoisted(() => ({
+  reset: 'generaltranslation.locale-reset',
   locale: 'generaltranslation.locale',
   region: 'generaltranslation.region',
   enableI18n: 'generaltranslation.enable-i18n',
@@ -26,6 +27,7 @@ vi.mock('@generaltranslation/react-core/pure', () => ({
       const resolved = Array.isArray(locale) ? locale[0] : locale;
       return resolved || 'en';
     },
+    getResetLocaleCookieName: () => mockCookieNames.reset,
     getLocaleCookieName: () => mockCookieNames.locale,
     getRegionCookieName: () => mockCookieNames.region,
     getEnableI18nCookieName: () => mockCookieNames.enableI18n,
@@ -37,6 +39,7 @@ import { BrowserConditionStore } from '../BrowserConditionStore';
 describe('BrowserConditionStore', () => {
   beforeEach(() => {
     mockSetCookieValue.mockReset();
+    mockCookieNames.reset = 'generaltranslation.locale-reset';
     mockCookieNames.locale = 'generaltranslation.locale';
     mockCookieNames.region = 'generaltranslation.region';
     mockCookieNames.enableI18n = 'generaltranslation.enable-i18n';
@@ -64,6 +67,7 @@ describe('BrowserConditionStore', () => {
   });
 
   it('uses I18nConfig cookie names', () => {
+    mockCookieNames.reset = 'custom-reset';
     mockCookieNames.locale = 'custom-locale';
     mockCookieNames.region = 'custom-region';
     mockCookieNames.enableI18n = 'custom-enable-i18n';
@@ -90,6 +94,14 @@ describe('BrowserConditionStore', () => {
 
     mockSetCookieValue.mockClear();
     conditionStore.setLocale('es');
+    expect(mockSetCookieValue).toHaveBeenCalledWith({
+      cookieName: 'custom-reset',
+      value: 'true',
+    });
+    expect(mockSetCookieValue).not.toHaveBeenCalledWith({
+      cookieName: 'generaltranslation.locale-reset',
+      value: 'true',
+    });
 
     expect(mockSetCookieValue).toHaveBeenCalledWith({
       cookieName: 'custom-locale',


### PR DESCRIPTION
- Make client locale changes use the same configured cookie names as middleware.

## Summary

Custom reset/referrer/routing cookie names were honored by middleware but client code still used the defaults. Pass the cookie names through the existing public client configuration, use the configured reset name in the browser condition store, and read configured referrer/routing names in the Next client boundary. Existing default names remain unchanged; only cookie names are added to public configuration.

Second PR in the stack, based on #2283 (`e/next/preserve-regional-alias-locale`). Patch changesets cover `gt-next`, `gt-react`, and `@generaltranslation/react-core`; React Native requires no storage change because this reset-cookie protocol is browser-specific.

## Testing

- Confirmed six new/expanded regression expectations fail before the fix across config serialization/setup, the browser boundary, and reset-cookie storage.
- `pnpm --filter gt-next test:js` — 1,426 passed.
- `pnpm --filter gt-react test` — 30 passed; `pnpm --filter @generaltranslation/react-core test` — 82 passed.
- Typecheck and builds for all three affected packages passed (`gt-next` JavaScript build only; SWC unchanged).
- `pnpm check:library-defaults` — validation and 4 tests passed.
- Scoped oxlint/oxfmt and `git diff --check` passed.
- Checks cover configured/default reset names and both configured routing flag values with conflicting default-named cookies. A real-app history comparison using this stack is being prepared separately; no new browser result is claimed here.
