### PR TITLE
fix(next-pages-router): preserve queries when switching locales

### DIFF
--- a/examples/next-pages-router/src/pages/_app.tsx
+++ b/examples/next-pages-router/src/pages/_app.tsx
@@ -12,7 +12,11 @@ export default function App({
       locale={pageProps.locale}
       translations={pageProps.translations}
       _reload={({ locale }) => {
-        void Router.push(Router.pathname, Router.asPath, { locale });
+        void Router.push(
+          { pathname: Router.pathname, query: Router.query },
+          Router.asPath,
+          { locale }
+        );
       }}
     >
       <Component {...pageProps} />

--- a/tests/apps/next-pages-router/pages/_app.tsx
+++ b/tests/apps/next-pages-router/pages/_app.tsx
@@ -12,7 +12,11 @@ export default function App({
       locale={pageProps.locale}
       translations={pageProps.translations}
       _reload={({ locale }) => {
-        void Router.push(Router.pathname, Router.asPath, { locale });
+        void Router.push(
+          { pathname: Router.pathname, query: Router.query },
+          Router.asPath,
+          { locale }
+        );
       }}
     >
       <Component {...pageProps} />

--- a/tests/apps/next-pages-router/pages/catalog/[slug].tsx
+++ b/tests/apps/next-pages-router/pages/catalog/[slug].tsx
@@ -1,0 +1,23 @@
+import type { GetStaticPaths } from 'next';
+import { useRouter } from 'next/router';
+import { LocaleSelector, useLocale, withGTStaticProps } from 'gt-next';
+
+export const getStaticProps = withGTStaticProps();
+
+export const getStaticPaths: GetStaticPaths = async () => ({
+  paths: [],
+  fallback: 'blocking',
+});
+
+export default function CatalogPage() {
+  const router = useRouter();
+  const locale = useLocale();
+
+  return (
+    <main>
+      <p>Client locale: {locale}</p>
+      <LocaleSelector />
+      <pre data-testid='router-query'>{JSON.stringify(router.query)}</pre>
+    </main>
+  );
+}

--- a/tests/apps/test-apps-e2e/e2e/app.spec.ts
+++ b/tests/apps/test-apps-e2e/e2e/app.spec.ts
@@ -44,6 +44,37 @@ test(`${appName} renders local translations and switches locales`, async ({
   }
 });
 
+test('Pages locale switches preserve fallback SSG query state', async ({
+  page,
+}) => {
+  test.skip(app.kind !== 'next-pages');
+  const suffix = '/catalog/fresh.item?tag=one&tag=two&literal=%252F%2B#details';
+  const expectedQuery = {
+    slug: 'fresh.item',
+    tag: ['one', 'two'],
+    literal: '%2F+',
+  };
+
+  await page.goto(suffix);
+  await expect
+    .poll(async () =>
+      JSON.parse(await page.getByTestId('router-query').innerText())
+    )
+    .toEqual(expectedQuery);
+  for (const locale of ['fr', 'zh', 'en']) {
+    await selectLocale(page, locale);
+    await expect(page).toHaveURL(
+      `${app.baseURL}${locale === 'en' ? '' : `/${locale}`}${suffix}`
+    );
+    await expect(page.getByText(`Client locale: ${locale}`)).toBeVisible();
+    await expect
+      .poll(async () =>
+        JSON.parse(await page.getByTestId('router-query').innerText())
+      )
+      .toEqual(expectedQuery);
+  }
+});
+
 async function testReactApp(page: Page) {
   await page.goto('/');
   await expect(page.getByRole('heading', { level: 1 })).toBeVisible();


### PR DESCRIPTION
- Preserve dynamic route parameters, repeated query values, and hashes when switching locales in the Pages Router example.

## Summary

The example's `GTProvider._reload` callback passed only `Router.pathname` as the internal href, so switching locale after fallback SSG could drop values from `Router.query` while leaving them in the visible URL. Pass `{ pathname: Router.pathname, query: Router.query }`, following Next.js locale-transition guidance, in both the shipped example and maintained test app.

Adds a blocking fallback SSG page and an E2E test covering repeated/encoded queries, a hash, and three locale transitions. Third PR in the stack, based on #2284 (`e/multi/honor-client-cookie-names`). No library source changes or changeset needed.

## Testing

- Native old/new callback comparison reproduced the original Next14.2.35 query loss and verified the corrected call.
- Exact proposed Playwright test and existing runtime-error fixtures ran in an isolated harness: old callback failed; corrected callback passed in dev and production (1/1 each).
- Isolated Next14.2.35 fixture `pnpm build` and `pnpm typecheck` passed; fallback route confirmed SSG.
- Scoped oxlint/oxfmt and `git diff --check` passed.
- Version scope: browser verification used Next14.2.35 and the retained GT artifact to match the reported failure. The repository's Next16.2.9 test app and Next15.5.9 example were not fully built in this run.
