### PR TITLE
fix(next): preserve locale navigation history

### DIFF
--- a/.changeset/locale-navigation-history.md
+++ b/.changeset/locale-navigation-history.md
@@ -1,0 +1,8 @@
+---
+"gt-next": patch
+"gt-react": patch
+---
+
+Use a full browser reload for routed locale changes so middleware redirects preserve coherent page content when navigating Back and Forward. Like the existing default-locale switch, switching to another locale now resets in-memory client state. Same-locale updates and pages without locale routing still refresh server components.
+
+Refresh the browser condition store’s callback when server props provide a new handler, so subsequent locale switches use the currently rendered locale after client navigation.

--- a/packages/next/src/utils/__tests__/client-boundary.test.tsx
+++ b/packages/next/src/utils/__tests__/client-boundary.test.tsx
@@ -146,47 +146,66 @@ describe('Client_GTProvider', () => {
     await act(async () => root.unmount());
   });
 
-  it('reloads the browser page when switching to the default locale', async () => {
+  it.each([
+    ['pt-BR', '/pt-BR', 'en'],
+    ['fr', '/fr/help', 'de'],
+    ['fr', '/portal/fr/help', 'de'],
+    ['en', '/help', 'de'],
+  ])(
+    'reloads when switching from %s at %s to %s',
+    async (currentLocale, pathname, selectedLocale) => {
+      process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
+      mockPathname.mockReturnValue(pathname.replace(/^\/portal(?=\/)/, ''));
+      vi.stubGlobal('location', {
+        pathname,
+        reload: mockReloadBrowserPage,
+      });
+      mockGetI18nConfig.mockReturnValue({
+        determineLocale: vi.fn(([locale]: string[]) => locale),
+        getDefaultLocale: () => 'en',
+        getLocales: () => ['en', 'pt-BR', 'fr', 'de'],
+        isGTServicesEnabled: () => false,
+        resolveAliasLocale: (locale: string) => locale,
+        standardizeLocale: (locale: string) => locale,
+      });
+      const { Client_GTProvider } = await import('../client-boundary');
+      const container = document.createElement('div');
+      const root = createRoot(container);
+
+      await act(async () => {
+        root.render(
+          <Client_GTProvider
+            dictionaries={{}}
+            locale={currentLocale}
+            translations={{}}
+          >
+            content
+          </Client_GTProvider>
+        );
+      });
+
+      const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
+      syncServerContent({
+        enableI18n: true,
+        locale: selectedLocale,
+        region: undefined,
+      });
+
+      expect(mockReloadBrowserPage).toHaveBeenCalledOnce();
+      expect(mockRefreshServerComponents).not.toHaveBeenCalled();
+
+      await act(async () => root.unmount());
+    }
+  );
+
+  it.each([
+    ['en', '/dashboard'],
+    ['fr', '/portal/fr/dashboard'],
+  ])('refreshes same-locale updates for %s at %s', async (locale, pathname) => {
     process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
-    mockPathname.mockReturnValue('/pt-BR');
+    mockPathname.mockReturnValue(pathname.replace(/^\/portal(?=\/)/, ''));
     vi.stubGlobal('location', {
-      pathname: '/pt-BR',
-      reload: mockReloadBrowserPage,
-    });
-    mockGetI18nConfig.mockReturnValue({
-      determineLocale: vi.fn(([locale]: string[]) => locale),
-      getDefaultLocale: () => 'en',
-      getLocales: () => ['en', 'pt-BR'],
-      isGTServicesEnabled: () => false,
-      resolveAliasLocale: (locale: string) => locale,
-      standardizeLocale: (locale: string) => locale,
-    });
-    const { Client_GTProvider } = await import('../client-boundary');
-    const container = document.createElement('div');
-    const root = createRoot(container);
-
-    await act(async () => {
-      root.render(
-        <Client_GTProvider dictionaries={{}} locale='pt-BR' translations={{}}>
-          content
-        </Client_GTProvider>
-      );
-    });
-
-    const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
-    syncServerContent({ enableI18n: true, locale: 'en', region: undefined });
-
-    expect(mockReloadBrowserPage).toHaveBeenCalledOnce();
-    expect(mockRefreshServerComponents).not.toHaveBeenCalled();
-
-    await act(async () => root.unmount());
-  });
-
-  it('refreshes server components when reselecting the default locale on an unprefixed path', async () => {
-    process.env._GENERALTRANSLATION_PATH_REGEX = '.*';
-    mockPathname.mockReturnValue('/dashboard');
-    vi.stubGlobal('location', {
-      pathname: '/dashboard',
+      pathname,
       reload: mockReloadBrowserPage,
     });
     mockGetI18nConfig.mockReturnValue({
@@ -205,14 +224,14 @@ describe('Client_GTProvider', () => {
 
     await act(async () => {
       root.render(
-        <Client_GTProvider dictionaries={{}} locale='en' translations={{}}>
+        <Client_GTProvider dictionaries={{}} locale={locale} translations={{}}>
           content
         </Client_GTProvider>
       );
     });
 
     const syncServerContent = mockGTProvider.mock.calls.at(-1)?.[0]._reload;
-    syncServerContent({ enableI18n: true, locale: 'en', region: undefined });
+    syncServerContent({ enableI18n: true, locale, region: 'CA' });
 
     expect(mockRefreshServerComponents).toHaveBeenCalledOnce();
     expect(mockReloadBrowserPage).not.toHaveBeenCalled();

--- a/packages/next/src/utils/client-boundary.tsx
+++ b/packages/next/src/utils/client-boundary.tsx
@@ -62,28 +62,22 @@ export function Client_GTProvider(props: SharedGTProviderProps) {
       const localeRoutingEnabled =
         getCookieValue(document.cookie, localeRoutingEnabledCookieName) ===
         'true';
-      const defaultLocale = i18nConfig.getDefaultLocale();
-      const locales = i18nConfig.getLocales();
       const currentPathname = globalThis.location.pathname;
       const localeRoutingApplies =
         localeRoutingEnabled &&
         pathnameMatchesRegex(currentPathname, pathRegex);
-      if (localeRoutingApplies && locale === defaultLocale) {
-        const currentPathLocale = resolvePathLocale(
-          currentPathname,
-          i18nConfig,
-          defaultLocale,
-          locales
-        );
-        if (currentPathLocale !== defaultLocale) {
-          reloadBrowserPage();
-          return;
-        }
+      if (
+        localeRoutingApplies &&
+        i18nConfig.resolveAliasLocale(locale) !==
+          i18nConfig.resolveAliasLocale(props.locale)
+      ) {
+        reloadBrowserPage();
+        return;
       }
 
       refreshServerComponents();
     },
-    [refreshServerComponents, reloadBrowserPage]
+    [props.locale, refreshServerComponents, reloadBrowserPage]
   );
   usePathCheck({
     reloadBrowserPage,

--- a/packages/react/src/condition-store/BrowserConditionStore.ts
+++ b/packages/react/src/condition-store/BrowserConditionStore.ts
@@ -129,6 +129,10 @@ export class BrowserConditionStore implements WritableConditionStoreInterface {
     });
   };
 
+  updateReload = (reload: ReloadType): void => {
+    this.customReload = reload;
+  };
+
   /**
    * Condition store updates come from either the server or the client.
    * Trigger this reload when we update a value in the condition store from

--- a/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
+++ b/packages/react/src/condition-store/__tests__/createBrowserConditionStore.test.ts
@@ -49,6 +49,26 @@ describe('createOrUpdateBrowserConditionStore', () => {
     mockCookieNames.enableI18n = 'generaltranslation.enable-i18n';
   });
 
+  it('uses the latest reload callback after a server update', () => {
+    const firstReload = vi.fn();
+    const nextReload = vi.fn();
+    const conditionStore = createOrUpdateBrowserConditionStore({
+      locale: 'fr',
+      _reload: firstReload,
+    });
+    expect(
+      createOrUpdateBrowserConditionStore({ locale: 'de', _reload: nextReload })
+    ).toBe(conditionStore);
+    conditionStore.reload();
+    expect(nextReload).toHaveBeenCalledOnce();
+    expect(firstReload).not.toHaveBeenCalled();
+
+    // Omitting a callback keeps the existing custom reload behavior.
+    createOrUpdateBrowserConditionStore({ locale: 'de' });
+    conditionStore.reload();
+    expect(nextReload).toHaveBeenCalledTimes(2);
+  });
+
   it('uses the enableI18n prop before the persisted cookie', () => {
     mockCookieValues.set('generaltranslation.enable-i18n', 'true');
 

--- a/packages/react/src/condition-store/createBrowserConditionStore.ts
+++ b/packages/react/src/condition-store/createBrowserConditionStore.ts
@@ -41,6 +41,7 @@ export function createOrUpdateBrowserConditionStore(
   if (isBrowserConditionStoreInitialized()) {
     // This represents an update from server
     const conditionStore = getBrowserConditionStore();
+    if (config._reload) conditionStore.updateReload(config._reload);
     conditionStore.updateLocale(locale);
     if (region !== undefined) conditionStore.updateRegion(region);
     conditionStore.updateEnableI18n(enableI18n);


### PR DESCRIPTION
- Keep page content aligned with the URL when navigating Back after a routed locale switch.

## Summary

On Next16.3.4, switching locales through `router.refresh()` and a middleware redirect can leave Back showing the previous locale's URL with the newer locale's content. Extend the existing full-browser-reload behavior from default-locale switches to any routed locale change, comparing the selected locale with the server-rendered locale instead of parsing the pathname.

**Tradeoff:** all routed locale changes now reload the document and reset in-memory client state, including nondefault locale switches.

Update the browser condition store when the provider supplies a new reload callback; otherwise a preceding cross-locale NextLink navigation leaves the callback capturing an old locale. Same-locale, region-only, excluded-path and routing-disabled updates retain server-component refresh behavior.

Fourth PR in the stack, based on #2285 (`e/next-pages-router/preserve-pages-locale-query`). Patch changesets cover `gt-next` and `gt-react`; browser-cookie/navigation behavior does not require a React Native implementation change.

## Testing

- Three locale-switch unit cases and one retained-callback test fail before their respective fixes.
- `pnpm --filter gt-next test:js` — 1,430 passed; `pnpm --filter gt-react test` — 31 passed.
- Both package typechecks/builds passed (`gt-next` JavaScript build; SWC unchanged).
- Paired packed-package Next16.3.4 apps in production and development, with both default configuration and `/portal` plus custom cookie names: baseline reproduces the Back/content mismatch; final candidate passes all 44 primary states. Root/account overrides, canonical localized links, repeated queries, Back/Forward and default/nondefault switches are covered.
- Additional same-locale/region controls retain client state; cross-locale NextLink followed by a locale switch verifies the callback update. An unrelated synthetic cookie survives navigation. Settled idle windows had no continuing requests; finite prefetch activity is recorded separately.
- Exact installed package bytes checked against the local artifacts. GT JavaScript builds used `experimentalCompilerOptions: { type: 'none' }`; no SWC/Rust coverage is claimed.
- Scoped oxlint/oxfmt and `git diff --check` passed.

## Notes

Routed locale changes now perform a full document reload, including nondefault locale changes. This resets in-memory client state, as the existing default-locale switch already did. The URL, query values and cookies are preserved; same-locale and region-only updates continue to preserve client state through a refresh.
